### PR TITLE
Unique member

### DIFF
--- a/src/Blocks.hs
+++ b/src/Blocks.hs
@@ -682,7 +682,7 @@ trustArgInt arg = trustFromJust
 
 -- | Code generation for LPVM instructions.
 cgenLPVM :: ProcName -> [Ident] -> [PrimArg] -> Codegen ()
-cgenLPVM "alloc" [] args@[sizeArg,addrArg] = do
+cgenLPVM "alloc" _ args@[sizeArg,addrArg] = do
           logCodegen $ "lpvm alloc " ++ show sizeArg ++ " " ++ show addrArg
           let (inputs,outputs) = partitionArgs args
           case inputs of
@@ -695,7 +695,7 @@ cgenLPVM "alloc" [] args@[sizeArg,addrArg] = do
               shouldnt $ "alloc instruction with " ++ show (length inputs)
                          ++ " inputs"
 
-cgenLPVM "access" [] args@[addrArg,offsetArg,_,_,val] = do
+cgenLPVM "access" _ args@[addrArg,offsetArg,_,_,val] = do
           logCodegen $ "lpvm access " ++ show addrArg ++ " " ++ show offsetArg
                  ++ " " ++ show val
           baseAddr <- cgenArg addrArg
@@ -747,7 +747,7 @@ cgenLPVM "mutate" _ [_, _, _, destructiveArg, _, _, _] =
       nyi "lpvm mutate instruction with non-constant destructive flag"
 
 
-cgenLPVM "cast" [] args@[inArg,outArg] =
+cgenLPVM "cast" _ args@[inArg,outArg] =
     case partitionArgs args of
         ([inArg],[outArg]) -> do
             inRep <- lift $ typeRep $ argType inArg

--- a/src/Normalise.hs
+++ b/src/Normalise.hs
@@ -345,7 +345,11 @@ completeType modspec (TypeDef params ctors ctorVis) = do
           tagBits tagLimit)
          infos
     let rep = typeRepresentation reps numConsts
-    extraItems <- implicitItems typespec constCtors nonConstCtors' rep
+    isUnique <- tmUniqueness . typeModifiers <$> getModuleInterface
+    extraItems <-
+        if isUnique
+            then return [] -- No implicit procs for unique types
+            else implicitItems typespec constCtors nonConstCtors' rep
     logNormalise $ "Representation of type " ++ showModSpec modspec
                    ++ " is " ++ show rep
     setTypeRep rep

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -283,7 +283,7 @@ processTypeModifier tms unknown  = tms {tmUnknown = tmUnknown tms ++ [unknown]}
 -- location of the list of modifiers.
 processProcModifiers :: [String] -> ProcModifiers
 processProcModifiers = List.foldl (flip processProcModifier)
-                        $ ProcModifiers Det MayInline Pure [] []
+                                  defaultProcModifiers 
 
 -- | Update a collection of ProcModifiers
 processProcModifier :: String -> ProcModifiers -> ProcModifiers

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -835,7 +835,7 @@ data ProcInfo = ProcInfo {
 
 instance Show ProcInfo where
     show (ProcInfo procSpec args detism impurity inRes outRes) =
-        showProcModifiers (ProcModifiers detism MayInline impurity [] [])
+        showProcModifiers (ProcModifiers detism MayInline impurity False [] [])
         ++ show procSpec ++ "(" ++ intercalate "," (show <$> args) ++ ")"
         ++ if Set.null inRes && Set.null outRes
             then ""

--- a/src/Unbranch.hs
+++ b/src/Unbranch.hs
@@ -233,7 +233,7 @@ genProc proto detism stmts = do
     tmpCtr <- gets brTempCtr
     -- call site count will be refilled later
     let procDef = ProcDef name proto (ProcDefSrc stmts) Nothing tmpCtr 0
-                  Map.empty Private detism MayInline Pure NoSuperproc
+                  Map.empty Private detism MayInline Pure False NoSuperproc
     logUnbranch $ "Generating fresh " ++ show detism ++ " proc:"
                   ++ showProcDef 8 procDef
     logUnbranch $ "Unbranched generated " ++ show detism ++ " proc:"

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -86,9 +86,9 @@ module top-level code > public {impure} (0 calls)
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T)) @array:nn:nn
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int) @array:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T)) @array:nn:nn
     wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -235,49 +235,49 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                             drone.gen#2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @drone:nn:nn
                             foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int)
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int) @drone:nn:nn
                             drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @drone:nn:nn
                         foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int)
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int) @drone:nn:nn
                         drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @drone:nn:nn
                     foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int)
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int) @drone:nn:nn
                     drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @drone:nn:nn
                 foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int)
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int) @drone:nn:nn
                 drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
             foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @drone:nn:nn
             drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
         foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @drone:nn:nn
         drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
@@ -288,11 +288,11 @@ drone_init > (3 calls)
 drone_init(?#result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp#5##0:drone.drone_info)
-    foreign lpvm mutate(~tmp#5##0:drone.drone_info, ?tmp#6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:drone.drone_info, ?tmp#7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:drone.drone_info, ?tmp#8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?tmp#5##0:drone.drone_info) @drone:nn:nn
+    foreign lpvm mutate(~tmp#5##0:drone.drone_info, ?tmp#6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~tmp#6##0:drone.drone_info, ?tmp#7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~tmp#7##0:drone.drone_info, ?tmp#8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
 
 
 gen#1 > {inline} (2 calls)
@@ -316,9 +316,9 @@ gen#2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp#0
         foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
         foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
 
 
 
@@ -371,16 +371,16 @@ loop(d##0:drone.drone_info, ch##0:wybe.char, io##0:wybe.phantom, ?io##2:wybe.pha
 
         1:
             wybe.string.print_string<0>("(":wybe.string, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) #14 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#19##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(", ":wybe.string, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) #15 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#22##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(", ":wybe.string, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) #16 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#25##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(") #":wybe.string, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) #17 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#28##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
             drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
@@ -394,16 +394,16 @@ print_info(d##0:drone.drone_info, io##0:wybe.phantom, ?io##9:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>("(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #13 @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @drone:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(", ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #14 @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(", ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #15 @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(") #":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #16 @io:nn:nn
-    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
     foreign c print_int(~tmp#3##0:wybe.int, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
 
@@ -436,14 +436,14 @@ LLVM code       : None
 =(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int)
-    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#count##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int)
-    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#count##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#count##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#count##0:wybe.int) @drone:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -473,13 +473,13 @@ count > public {inline} (0 calls)
 count(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
 count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
 count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
 drone_info > public {inline} (0 calls)
@@ -487,20 +487,20 @@ drone_info > public {inline} (0 calls)
 drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?#result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?#rec##0:drone.drone_info)
-    foreign lpvm mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
-    foreign lpvm mutate(~#rec##3:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?#rec##0:drone.drone_info) @drone:nn:nn
+    foreign lpvm mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~#rec##3:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int) @drone:nn:nn
 drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
 drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, #result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(#result##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access(#result##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
-    foreign lpvm access(~#result##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
+    foreign lpvm access(#result##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#result##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#result##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#result##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int) @drone:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -508,13 +508,13 @@ x > public {inline} (0 calls)
 x(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
 x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
 x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -522,13 +522,13 @@ y > public {inline} (0 calls)
 y(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
 y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
 y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
 z > public {inline} (0 calls)
@@ -536,13 +536,13 @@ z > public {inline} (0 calls)
 z(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
 z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
 z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -550,14 +550,14 @@ z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 ~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @drone:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
@@ -687,9 +687,9 @@ module top-level code > public {impure} (0 calls)
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T)) @array:nn:nn
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int) @array:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T)) @array:nn:nn
     wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -836,49 +836,49 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                             drone.gen#2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @drone:nn:nn
                             foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int)
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int) @drone:nn:nn
                             drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @drone:nn:nn
                         foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int)
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int) @drone:nn:nn
                         drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @drone:nn:nn
                     foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int)
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int) @drone:nn:nn
                     drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @drone:nn:nn
                 foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int)
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int) @drone:nn:nn
                 drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
             foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @drone:nn:nn
             drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
         foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @drone:nn:nn
         drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
@@ -905,49 +905,49 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                             drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @drone:nn:nn
                             foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int)
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int) @drone:nn:nn
                             drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @drone:nn:nn
                         foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int)
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int) @drone:nn:nn
                         drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @drone:nn:nn
                     foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int)
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int) @drone:nn:nn
                     drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @drone:nn:nn
                 foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int)
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int) @drone:nn:nn
                 drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
             foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @drone:nn:nn
             drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
         foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @drone:nn:nn
         drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
@@ -958,11 +958,11 @@ drone_init > (3 calls)
 drone_init(?#result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp#5##0:drone.drone_info)
-    foreign lpvm mutate(~tmp#5##0:drone.drone_info, ?tmp#6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:drone.drone_info, ?tmp#7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:drone.drone_info, ?tmp#8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?tmp#5##0:drone.drone_info) @drone:nn:nn
+    foreign lpvm mutate(~tmp#5##0:drone.drone_info, ?tmp#6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~tmp#6##0:drone.drone_info, ?tmp#7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~tmp#7##0:drone.drone_info, ?tmp#8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
 
 
 gen#1 > {inline} (2 calls)
@@ -986,9 +986,9 @@ gen#2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp#0
         foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
         foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
 
  [6dacb8fd25] [NonAliasedParam 1] :
     case success##0:wybe.bool of
@@ -996,9 +996,9 @@ gen#2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp#0
         foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
         foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
 
 
 
@@ -1062,16 +1062,16 @@ loop(d##0:drone.drone_info, ch##0:wybe.char, io##0:wybe.phantom, ?io##2:wybe.pha
 
         1:
             wybe.string.print_string<0>("(":wybe.string, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) #14 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#19##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(", ":wybe.string, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) #15 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#22##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(", ":wybe.string, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) #16 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#25##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(") #":wybe.string, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) #17 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#28##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
             drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
@@ -1103,16 +1103,16 @@ loop(d##0:drone.drone_info, ch##0:wybe.char, io##0:wybe.phantom, ?io##2:wybe.pha
 
         1:
             wybe.string.print_string<0>("(":wybe.string, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) #14 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#19##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(", ":wybe.string, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) #15 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#22##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(", ":wybe.string, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) #16 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#25##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(") #":wybe.string, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) #17 @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int)
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int) @drone:nn:nn
             foreign c print_int(~tmp#28##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
             drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
@@ -1126,16 +1126,16 @@ print_info(d##0:drone.drone_info, io##0:wybe.phantom, ?io##9:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>("(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #13 @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @drone:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(", ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #14 @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(", ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #15 @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(") #":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #16 @io:nn:nn
-    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
     foreign c print_int(~tmp#3##0:wybe.int, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
 
@@ -1820,14 +1820,14 @@ entry:
 =(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int)
-    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#count##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int)
-    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#count##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#count##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#count##0:wybe.int) @drone:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -1857,13 +1857,13 @@ count > public {inline} (0 calls)
 count(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
 count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
 count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
 drone_info > public {inline} (0 calls)
@@ -1871,20 +1871,20 @@ drone_info > public {inline} (0 calls)
 drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?#result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?#rec##0:drone.drone_info)
-    foreign lpvm mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
-    foreign lpvm mutate(~#rec##3:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?#rec##0:drone.drone_info) @drone:nn:nn
+    foreign lpvm mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int) @drone:nn:nn
+    foreign lpvm mutate(~#rec##3:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int) @drone:nn:nn
 drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
 drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, #result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(#result##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access(#result##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
-    foreign lpvm access(~#result##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
+    foreign lpvm access(#result##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#result##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#result##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#result##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int) @drone:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -1892,13 +1892,13 @@ x > public {inline} (0 calls)
 x(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
 x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
 x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -1906,13 +1906,13 @@ y > public {inline} (0 calls)
 y(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
 y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
 y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
 z > public {inline} (0 calls)
@@ -1920,13 +1920,13 @@ z > public {inline} (0 calls)
 z(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
 z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
 z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -1934,14 +1934,14 @@ z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 ~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @drone:nn:nn
+    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @drone:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -155,9 +155,9 @@ module top-level code > public {impure} (0 calls)
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T)) @array:nn:nn
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int) @array:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T)) @array:nn:nn
     wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -275,9 +275,9 @@ append(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list) @int_list:nn:nn
     int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
@@ -292,8 +292,8 @@ count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int):
         foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         int_list.count<0>(~t##0:int_list.int_list, x##0:wybe.int, ?tmp#2##0:wybe.int) #1 @int_list:nn:nn
         foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
         case ~tmp#4##0:wybe.bool of
@@ -318,12 +318,12 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?#result##0:int_lis
         foreign llvm move(~lst2##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -347,9 +347,9 @@ gen#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:
         int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
         int_list.gen#2<0>(~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
@@ -360,9 +360,9 @@ gen#3 > {inline} (1 calls)
 gen#3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##2:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
     foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
     int_list.gen#2<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
@@ -379,8 +379,8 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -388,9 +388,9 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
 
         1:
             int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -414,8 +414,8 @@ index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?#result#
         foreign llvm move(-1:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_eq(~h##0:wybe.int, x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
         case ~tmp#4##0:wybe.bool of
         0:
@@ -444,19 +444,19 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?#result##0:int
             int_list.insert<0>(~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?#result##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
-            foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-            foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+            foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
             int_list.insert<0>(~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#18##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#18##0:int_list.int_list, ?tmp#19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#18##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#18##0:int_list.int_list, ?tmp#19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list) @int_list:nn:nn
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -472,8 +472,8 @@ lesser(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -481,9 +481,9 @@ lesser(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
 
         1:
             int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -500,16 +500,16 @@ pop(lst##0:int_list.int_list, idx##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
             int_list.pop<0>(~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
         1:
             foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
@@ -528,8 +528,8 @@ print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign c print_int(~h##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
         foreign c putchar(' ':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         int_list.print<0>(~t##0:int_list.int_list, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @int_list:nn:nn
@@ -565,15 +565,15 @@ remove(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_eq(h##0:wybe.int, v##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
         case ~tmp#5##0:wybe.bool of
         0:
             int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
         1:
             foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
@@ -601,11 +601,11 @@ reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:i
         foreign llvm move(~acc##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list) @int_list:nn:nn
         int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
@@ -622,15 +622,15 @@ sort(lst##0:int_list.int_list, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp#3##0:int_list.int_list) #1 @int_list:nn:nn
         int_list.sort<0>[410bae77d3](~tmp#3##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #2 @int_list:nn:nn
         int_list.greater<0>(~t##0:int_list.int_list, h##0:wybe.int, ?tmp#6##0:int_list.int_list) #3 @int_list:nn:nn
         int_list.sort<0>[410bae77d3](~tmp#6##0:int_list.int_list, ?tmp#5##0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list) @int_list:nn:nn
         int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list) #6 @int_list:nn:nn
 
 
@@ -666,16 +666,16 @@ LLVM code       : None
         foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
-        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list)
+        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
-            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list)
+            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int) @int_list:nn:nn
+            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list) @int_list:nn:nn
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -693,9 +693,9 @@ cons > public {inline} (0 calls)
 cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
-    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list) @int_list:nn:nn
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
 cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool):
@@ -709,8 +709,8 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -727,7 +727,7 @@ head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -742,7 +742,7 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -767,7 +767,7 @@ tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe
         foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -782,7 +782,7 @@ tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.i
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
+        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1007,9 +1007,9 @@ module top-level code > public {impure} (0 calls)
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T)) @array:nn:nn
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int) @array:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T)) @array:nn:nn
     wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -1127,14 +1127,14 @@ append(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list) @int_list:nn:nn
     int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list) @int_list:nn:nn
     int_list.extend<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
@@ -1149,8 +1149,8 @@ count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int):
         foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         int_list.count<0>(~t##0:int_list.int_list, x##0:wybe.int, ?tmp#2##0:wybe.int) #1 @int_list:nn:nn
         foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
         case ~tmp#4##0:wybe.bool of
@@ -1175,12 +1175,12 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?#result##0:int_lis
         foreign llvm move(~lst2##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list) @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
@@ -1189,9 +1189,9 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?#result##0:int_lis
         foreign llvm move(~lst2##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         int_list.extend<0>[410bae77d3](~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm mutate(~lst1##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
+        foreign lpvm mutate(~lst1##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -1215,9 +1215,9 @@ gen#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:
         int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
         int_list.gen#2<0>(~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
@@ -1228,9 +1228,9 @@ gen#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:
         int_list.reverse_helper<0>[410bae77d3](~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
         int_list.gen#2<0>[410bae77d3](~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
@@ -1241,9 +1241,9 @@ gen#3 > {inline} (1 calls)
 gen#3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##2:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
     foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
     int_list.gen#2<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
@@ -1260,8 +1260,8 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -1269,9 +1269,9 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
 
         1:
             int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
@@ -1281,8 +1281,8 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_sge(~h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -1290,7 +1290,7 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
 
         1:
             int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -1314,8 +1314,8 @@ index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?#result#
         foreign llvm move(-1:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_eq(~h##0:wybe.int, x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
         case ~tmp#4##0:wybe.bool of
         0:
@@ -1344,19 +1344,19 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?#result##0:int
             int_list.insert<0>(~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?#result##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
-            foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-            foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+            foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
             int_list.insert<0>(~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#18##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#18##0:int_list.int_list, ?tmp#19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#18##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#18##0:int_list.int_list, ?tmp#19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list) @int_list:nn:nn
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list) @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
@@ -1369,16 +1369,16 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?#result##0:int
             int_list.insert<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?#result##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
-            foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+            foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
             int_list.insert<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list) @int_list:nn:nn
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -1394,8 +1394,8 @@ lesser(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -1403,9 +1403,9 @@ lesser(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
 
         1:
             int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -1422,16 +1422,16 @@ pop(lst##0:int_list.int_list, idx##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
             int_list.pop<0>(~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
         1:
             foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
@@ -1444,13 +1444,13 @@ pop(lst##0:int_list.int_list, idx##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
             int_list.pop<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
         1:
             foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
@@ -1469,8 +1469,8 @@ print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign c print_int(~h##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
         foreign c putchar(' ':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         int_list.print<0>(~t##0:int_list.int_list, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @int_list:nn:nn
@@ -1506,15 +1506,15 @@ remove(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_eq(h##0:wybe.int, v##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
         case ~tmp#5##0:wybe.bool of
         0:
             int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
-            foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
         1:
             foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
@@ -1527,13 +1527,13 @@ remove(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_eq(~h##0:wybe.int, v##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
         case ~tmp#5##0:wybe.bool of
         0:
             int_list.remove<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list) @int_list:nn:nn
 
         1:
             foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
@@ -1561,11 +1561,11 @@ reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:i
         foreign llvm move(~acc##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list) @int_list:nn:nn
         int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
@@ -1575,8 +1575,8 @@ reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:i
         foreign llvm move(~acc##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list) @int_list:nn:nn
         int_list.reverse_helper<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
@@ -1593,15 +1593,15 @@ sort(lst##0:int_list.int_list, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp#3##0:int_list.int_list) #1 @int_list:nn:nn
         int_list.sort<0>[410bae77d3](~tmp#3##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #2 @int_list:nn:nn
         int_list.greater<0>(~t##0:int_list.int_list, h##0:wybe.int, ?tmp#6##0:int_list.int_list) #3 @int_list:nn:nn
         int_list.sort<0>[410bae77d3](~tmp#6##0:int_list.int_list, ?tmp#5##0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
-        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list) @int_list:nn:nn
         int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list) #6 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
@@ -1611,13 +1611,13 @@ sort(lst##0:int_list.int_list, ?#result##0:int_list.int_list):
         foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp#3##0:int_list.int_list) #1 @int_list:nn:nn
         int_list.sort<0>[410bae77d3](~tmp#3##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #2 @int_list:nn:nn
         int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~h##0:wybe.int, ?tmp#6##0:int_list.int_list) #3 @int_list:nn:nn
         int_list.sort<0>[410bae77d3](~tmp#6##0:int_list.int_list, ?tmp#5##0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
+        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list) @int_list:nn:nn
         int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list) #6 @int_list:nn:nn
 
 
@@ -2341,16 +2341,16 @@ if.else:
         foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
-        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list)
+        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
-            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list)
+            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int) @int_list:nn:nn
+            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list) @int_list:nn:nn
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -2368,9 +2368,9 @@ cons > public {inline} (0 calls)
 cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
-    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list) @int_list:nn:nn
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
 cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool):
@@ -2384,8 +2384,8 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2402,7 +2402,7 @@ head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -2417,7 +2417,7 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2442,7 +2442,7 @@ tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe
         foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -2457,7 +2457,7 @@ tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.i
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
+        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -35,9 +35,9 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int) @position:nn:nn
     alias1.replicate<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:31:4
     wybe.string.print_string<0>("--- Inside bar: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #13 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -45,7 +45,7 @@ bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
     position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:35:4
     wybe.string.print_string<0>("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #15 @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:37:4
-    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- Inside bar, after calling x(!p2, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) #16 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(101,102):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #17 @io:nn:nn
@@ -59,9 +59,9 @@ baz > public (1 calls)
 baz(io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int) @position:nn:nn
     alias1.replicate<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:50:4
     wybe.string.print_string<0>("--- Inside baz: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) #19 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -69,13 +69,13 @@ baz(io##0:wybe.phantom, ?io##15:wybe.phantom):
     position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:54:4
     wybe.string.print_string<0>("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #21 @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:56:4
-    foreign lpvm access(p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:position.position)
-    foreign lpvm mutate(~tmp#17##0:position.position, ?tmp#18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 33333333:wybe.int)
-    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+    foreign lpvm access(p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#17##0:position.position, ?tmp#18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 33333333:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect p3(33333333,102):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #22 @io:nn:nn
     position.printPosition<0>(tmp#1##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #10 @alias1:60:4
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- Inside baz, after calling x(!p1, 555): ":wybe.string, ~#io##8:wybe.phantom, ?tmp#25##0:wybe.phantom) #23 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(555,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #24 @io:nn:nn
@@ -91,9 +91,9 @@ foo > public (1 calls)
 foo(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int) @position:nn:nn
     alias1.replicate<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:12:4
     wybe.string.print_string<0>("--- Inside foo: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #13 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -101,7 +101,7 @@ foo(io##0:wybe.phantom, ?io##11:wybe.phantom):
     position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:16:4
     wybe.string.print_string<0>("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #15 @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:18:4
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- Inside foo, after calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) #16 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(555,102):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #17 @io:nn:nn
@@ -115,11 +115,11 @@ replicate > public (3 calls)
 replicate(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("random print":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
-    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias1:7:4
@@ -490,10 +490,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -579,10 +579,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -598,16 +598,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -615,13 +615,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -629,13 +629,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -643,10 +643,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -19,9 +19,9 @@ module top-level code > public {impure} (0 calls)
  InterestingCallProperties: []
     wybe.string.print_string<0>("copy a position":wybe.string, ~#io##0:wybe.phantom, ?tmp#3##0:wybe.phantom) #6 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int) @position:nn:nn
     alias2.pcopy<0>(~tmp#0##0:position.position, ?r##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias2:20:2
     wybe.string.print_string<0>("--- After calling pcopy: ":wybe.string, ~#io##2:wybe.phantom, ?tmp#10##0:wybe.phantom) #7 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
@@ -34,13 +34,13 @@ fcopy > public (0 calls)
 fcopy(p1##0:position.position, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
-    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
 
 
 pcopy > public (1 calls)
@@ -48,13 +48,13 @@ pcopy > public (1 calls)
 pcopy(p1##0:position.position, ?p2##2:position.position, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
-    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%p2##2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%p2##2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- Inside pcopy: ":wybe.string, ~#io##0:wybe.phantom, ?tmp#15##0:wybe.phantom) #8 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p2(0,20):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #9 @io:nn:nn
@@ -224,10 +224,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -313,10 +313,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -332,16 +332,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -349,13 +349,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -363,13 +363,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -377,10 +377,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -25,9 +25,9 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
     alias3.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias3:21:4
     wybe.string.print_string<0>("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #13 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -35,7 +35,7 @@ bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
     position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias3:25:4
     wybe.string.print_string<0>("expect p2(2,2):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #15 @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias3:27:4
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- After calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) #16 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(555,1):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #17 @io:nn:nn
@@ -53,8 +53,8 @@ replicate1(p1##0:position.position, ?p2##2:position.position, io##0:wybe.phantom
     foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(1,1):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #10 @io:nn:nn
     position.printPosition<0>(p1##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #2 @alias3:10:4
-    foreign lpvm {noalias} mutate(p1##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%p2##2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm {noalias} mutate(p1##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%p2##2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect p1(1,1):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #11 @io:nn:nn
     position.printPosition<0>(~p1##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #6 @alias3:14:4
     wybe.string.print_string<0>("expect p2(2,2):":wybe.string, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #12 @io:nn:nn
@@ -234,10 +234,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -323,10 +323,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -342,16 +342,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -359,13 +359,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -373,13 +373,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -387,10 +387,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -25,9 +25,9 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @position:nn:nn
     alias4.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias4:15:4
     wybe.string.print_string<0>("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #13 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -35,7 +35,7 @@ bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
     position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias4:19:4
     wybe.string.print_string<0>("expect p2(100,200):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #15 @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias4:21:4
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- After calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) #16 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(555,100):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #17 @io:nn:nn
@@ -49,17 +49,17 @@ replicate1 > public (1 calls)
 replicate1(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("random replicate1":wybe.string, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) #6 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm mutate(~tmp#0##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
-    foreign lpvm mutate(~tmp#19##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm access(~p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#0##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#19##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int) @position:nn:nn
 
   LLVM code       :
 
@@ -225,10 +225,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -314,10 +314,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -333,16 +333,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -350,13 +350,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -364,13 +364,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -378,10 +378,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -26,9 +26,9 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 900:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 900:wybe.int) @position:nn:nn
     alias_cyclic.updateX<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_cyclic:nn:nn
     wybe.string.print_string<0>("p1(100,900):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #6 @io:nn:nn
     position.printPosition<0>(~tmp#0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_cyclic:nn:nn
@@ -42,12 +42,12 @@ updateX(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_cyclic.updateY<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 101:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
@@ -55,12 +55,12 @@ updateX(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 101:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
@@ -75,12 +75,12 @@ updateY(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_cyclic.updateX<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 901:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
@@ -88,12 +88,12 @@ updateY(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 901:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
@@ -279,10 +279,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -368,10 +368,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -387,16 +387,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -404,13 +404,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -418,13 +418,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -432,10 +432,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -33,12 +33,12 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course)
-    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#0##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "intro to cs":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:student.student)
-    foreign lpvm mutate(~tmp#8##0:student.student, ?tmp#9##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9401:wybe.int)
-    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#1##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#0##0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course) @student:nn:nn
+    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#0##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "intro to cs":wybe.string) @student:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:student.student) @student:nn:nn
+    foreign lpvm mutate(~tmp#8##0:student.student, ?tmp#9##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9401:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#1##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#0##0:student.course) @student:nn:nn
     wybe.string.print_string<0>("student1":wybe.string, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) #7 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     student.printStudent<0>(tmp#1##0:student.student, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_data:nn:nn
@@ -166,12 +166,12 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course)
-    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:student.student)
-    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
-    foreign lpvm mutate(~tmp#10##0:student.student, ?tmp#11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course) @student:nn:nn
+    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string) @student:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:student.student) @student:nn:nn
+    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~tmp#10##0:student.student, ?tmp#11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:student.course) @student:nn:nn
     student.printStudent<0>(~tmp#11##0:student.student, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @student:nn:nn
 
 
@@ -181,16 +181,16 @@ printStudent(stu##0:student.student, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>("student id: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
-    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @student:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:student.course)
+    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:student.course) @student:nn:nn
     wybe.string.print_string<0>("course code: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #11 @io:nn:nn
-    foreign lpvm access(tmp#1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm access(tmp#1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @student:nn:nn
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("course name: ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #12 @io:nn:nn
-    foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @student:nn:nn
     wybe.string.print_string<0>(~tmp#3##0:wybe.string, ~#io##5:wybe.phantom, ?tmp#22##0:wybe.phantom) #13 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
@@ -318,10 +318,10 @@ entry:
 =(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#code##0:wybe.int)
-    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#name##0:wybe.string)
-    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#code##0:wybe.int)
-    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#name##0:wybe.string)
+    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#code##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#name##0:wybe.string) @student:nn:nn
+    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#code##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#name##0:wybe.string) @student:nn:nn
     foreign llvm icmp_eq(~#left#code##0:wybe.int, ~#right#code##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -337,13 +337,13 @@ code > public {inline} (0 calls)
 code(#rec##0:student.course, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @student:nn:nn
 code > public {inline} (0 calls)
 1: student.course.code<1>
 code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @student:nn:nn
 
 
 course > public {inline} (0 calls)
@@ -351,16 +351,16 @@ course > public {inline} (0 calls)
 course(code##0:wybe.int, name##0:wybe.string, ?#result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course)
-    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:student.course, ?#result##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course) @student:nn:nn
+    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~#rec##1:student.course, ?#result##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string) @student:nn:nn
 course > public {inline} (6 calls)
 1: student.course.course<1>
 course(?code##0:wybe.int, ?name##0:wybe.string, #result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
-    foreign lpvm access(~#result##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
+    foreign lpvm access(#result##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#result##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string) @student:nn:nn
 
 
 name > public {inline} (0 calls)
@@ -368,13 +368,13 @@ name > public {inline} (0 calls)
 name(#rec##0:student.course, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @student:nn:nn
 name > public {inline} (0 calls)
 1: student.course.name<1>
 name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:student.course, ?#rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm {noalias} mutate(~#rec##0:student.course, ?#rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @student:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -382,10 +382,10 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
 ~=(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
-    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @student:nn:nn
+    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @student:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -572,20 +572,20 @@ if.else:
 =(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#id##0:wybe.int)
-    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#major##0:student.course)
-    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#id##0:wybe.int)
-    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#major##0:student.course)
+    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#id##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#major##0:student.course) @student:nn:nn
+    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#id##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#major##0:student.course) @student:nn:nn
     foreign llvm icmp_eq(~#left#id##0:wybe.int, ~#right#id##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-        foreign lpvm access(~#left#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.string)
-        foreign lpvm access(#right#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int)
-        foreign lpvm access(~#right#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.string)
+        foreign lpvm access(#left#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @student:nn:nn
+        foreign lpvm access(~#left#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.string) @student:nn:nn
+        foreign lpvm access(#right#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int) @student:nn:nn
+        foreign lpvm access(~#right#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.string) @student:nn:nn
         foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
         case ~tmp#13##0:wybe.bool of
         0:
@@ -602,13 +602,13 @@ id > public {inline} (0 calls)
 id(#rec##0:student.student, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @student:nn:nn
 id > public {inline} (0 calls)
 1: student.student.id<1>
 id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @student:nn:nn
 
 
 major > public {inline} (0 calls)
@@ -616,13 +616,13 @@ major > public {inline} (0 calls)
 major(#rec##0:student.student, ?#result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:student.course)
+    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:student.course) @student:nn:nn
 major > public {inline} (0 calls)
 1: student.student.major<1>
 major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:student.student, ?#rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:student.course)
+    foreign lpvm {noalias} mutate(~#rec##0:student.student, ?#rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:student.course) @student:nn:nn
 
 
 student > public {inline} (0 calls)
@@ -630,16 +630,16 @@ student > public {inline} (0 calls)
 student(id##0:wybe.int, major##0:student.course, ?#result##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student)
-    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:student.student, ?#result##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student) @student:nn:nn
+    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~#rec##1:student.student, ?#result##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course) @student:nn:nn
 student > public {inline} (6 calls)
 1: student.student.student<1>
 student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
-    foreign lpvm access(~#result##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
+    foreign lpvm access(#result##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#result##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course) @student:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -647,10 +647,10 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
 ~=(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:student.course)
-    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:student.course)
+    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:student.course) @student:nn:nn
+    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:student.course) @student:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -658,10 +658,10 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp#4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-        foreign lpvm access(~tmp#4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.string)
-        foreign lpvm access(tmp#6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
-        foreign lpvm access(~tmp#6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.string)
+        foreign lpvm access(tmp#4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @student:nn:nn
+        foreign lpvm access(~tmp#4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.string) @student:nn:nn
+        foreign lpvm access(tmp#6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @student:nn:nn
+        foreign lpvm access(~tmp#6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.string) @student:nn:nn
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -26,7 +26,7 @@ foo(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias_des.replicate<0>(?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_des:nn:nn
-    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- after x(!p2, 20000) - expect p2(20000,103):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @io:nn:nn
     position.printPosition<0>(~p2##1:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_des:nn:nn
 
@@ -36,17 +36,17 @@ replicate > public (1 calls)
 replicate(?p2##1:position.position, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:position.position)
-    foreign lpvm mutate(~tmp#8##0:position.position, ?tmp#9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position)
-    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
-    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10000:wybe.int)
-    foreign lpvm access(p1##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#8##0:position.position, ?tmp#9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int) @position:nn:nn
+    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10000:wybe.int) @position:nn:nn
+    foreign lpvm access(p1##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
     foreign llvm add(~tmp#5##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~tmp#1##0:position.position, ?%p2##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#1##0:position.position, ?%p2##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect p1(10000,102):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #12 @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #9 @alias_des:nn:nn
     wybe.string.print_string<0>("expect p2(101,103):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #13 @io:nn:nn
@@ -178,10 +178,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -267,10 +267,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -286,16 +286,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -303,13 +303,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -317,13 +317,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -331,10 +331,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -15,10 +15,10 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pos##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pos##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect pos(200,100):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
     position.printPosition<0>(~pos##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @alias_des2:6:2
 
@@ -93,10 +93,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -182,10 +182,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -201,16 +201,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -218,13 +218,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -232,13 +232,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -246,10 +246,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -16,14 +16,14 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree)
-    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm mutate(~tmp#12##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm alloc(24:wybe.int, ?tmp#16##0:mytree.tree)
-    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#18##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp#18##0:mytree.tree, ?tmp#3##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 222:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#12##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#16##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#18##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 111:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#18##0:mytree.tree, ?tmp#3##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
     alias_fork1.simpleMerge<0>(~tmp#0##0:mytree.tree, ~tmp#3##0:mytree.tree, ?tmp#6##0:mytree.tree) #6 @alias_fork1:18:6
     mytree.printTree1<0>(~tmp#6##0:mytree.tree, "{":wybe.string, ?tmp#21##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) #9 @mytree:nn:nn
     wybe.string.print_string<0>("}":wybe.string, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
@@ -46,38 +46,38 @@ simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?#result##0:mytree.tree):
     foreign llvm icmp_ne(tl##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
     case ~tmp#15##0:wybe.bool of
     0:
-        foreign lpvm alloc(24:wybe.int, ?tmp#19##0:mytree.tree)
-        foreign lpvm mutate(~tmp#19##0:mytree.tree, ?tmp#20##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-        foreign lpvm mutate(~tmp#20##0:mytree.tree, ?tmp#21##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
-        foreign lpvm mutate(~tmp#21##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm alloc(24:wybe.int, ?tmp#19##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#19##0:mytree.tree, ?tmp#20##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#20##0:mytree.tree, ?tmp#21##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#21##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
 
     1:
-        foreign lpvm access(tl##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k1##0:wybe.int)
-        foreign lpvm access(tl##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r1##0:mytree.tree)
+        foreign lpvm access(tl##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k1##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(tl##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r1##0:mytree.tree) @mytree:nn:nn
         foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.bool)
         case ~tmp#17##0:wybe.bool of
         0:
-            foreign lpvm alloc(24:wybe.int, ?tmp#21##0:mytree.tree)
-            foreign lpvm mutate(~tmp#21##0:mytree.tree, ?tmp#22##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-            foreign lpvm mutate(~tmp#22##0:mytree.tree, ?tmp#23##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
-            foreign lpvm mutate(~tmp#23##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+            foreign lpvm alloc(24:wybe.int, ?tmp#21##0:mytree.tree) @mytree:nn:nn
+            foreign lpvm mutate(~tmp#21##0:mytree.tree, ?tmp#22##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+            foreign lpvm mutate(~tmp#22##0:mytree.tree, ?tmp#23##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int) @mytree:nn:nn
+            foreign lpvm mutate(~tmp#23##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
 
         1:
-            foreign lpvm access(tr##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k2##0:wybe.int)
-            foreign lpvm access(tr##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r2##0:mytree.tree)
+            foreign lpvm access(tr##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k2##0:wybe.int) @mytree:nn:nn
+            foreign lpvm access(tr##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r2##0:mytree.tree) @mytree:nn:nn
             foreign llvm icmp_slt(k1##0:wybe.int, k2##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
             case ~tmp#11##0:wybe.bool of
             0:
-                foreign lpvm alloc(24:wybe.int, ?tmp#23##0:mytree.tree)
-                foreign lpvm mutate(~tmp#23##0:mytree.tree, ?tmp#24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tr##0:mytree.tree)
-                foreign lpvm mutate(~tmp#24##0:mytree.tree, ?tmp#25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k1##0:wybe.int)
-                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r1##0:mytree.tree)
+                foreign lpvm alloc(24:wybe.int, ?tmp#23##0:mytree.tree) @mytree:nn:nn
+                foreign lpvm mutate(~tmp#23##0:mytree.tree, ?tmp#24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tr##0:mytree.tree) @mytree:nn:nn
+                foreign lpvm mutate(~tmp#24##0:mytree.tree, ?tmp#25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k1##0:wybe.int) @mytree:nn:nn
+                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r1##0:mytree.tree) @mytree:nn:nn
 
             1:
-                foreign lpvm alloc(24:wybe.int, ?tmp#23##0:mytree.tree)
-                foreign lpvm mutate(~tmp#23##0:mytree.tree, ?tmp#24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
-                foreign lpvm mutate(~tmp#24##0:mytree.tree, ?tmp#25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k2##0:wybe.int)
-                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r2##0:mytree.tree)
+                foreign lpvm alloc(24:wybe.int, ?tmp#23##0:mytree.tree) @mytree:nn:nn
+                foreign lpvm mutate(~tmp#23##0:mytree.tree, ?tmp#24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree) @mytree:nn:nn
+                foreign lpvm mutate(~tmp#24##0:mytree.tree, ?tmp#25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k2##0:wybe.int) @mytree:nn:nn
+                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r2##0:mytree.tree) @mytree:nn:nn
 
 
 
@@ -297,9 +297,9 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##
         foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
 
     1:
-        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
-        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
-        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree)
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree) @mytree:nn:nn
         mytree.printTree1<0>(~l##0:mytree.tree, ~%prefix##0:wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @mytree:nn:nn
         wybe.string.print_string<0>(~prefix##1:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @io:nn:nn
         foreign c print_int(~k##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
@@ -408,18 +408,18 @@ if.else:
         foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
-        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
-        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree)
+        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree) @mytree:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
-            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
-            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree)
+            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree) @mytree:nn:nn
+            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int) @mytree:nn:nn
+            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree) @mytree:nn:nn
             mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
@@ -459,7 +459,7 @@ key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -474,7 +474,7 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -491,7 +491,7 @@ left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -506,7 +506,7 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -516,10 +516,10 @@ node > public {inline} (0 calls)
 node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
-    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
-    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree) @mytree:nn:nn
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
 node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool):
@@ -534,9 +534,9 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -553,7 +553,7 @@ right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -568,7 +568,7 @@ right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#succes
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -16,10 +16,10 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree)
-    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
     alias_fork2.simpleMerge<0>(tmp#0##0:mytree.tree, ?tmp#3##0:mytree.tree) #3 @alias_fork2:11:6
     wybe.string.print_string<0>("expect t -  1 200:":wybe.string, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) #11 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
@@ -33,11 +33,11 @@ module top-level code > public {impure} (0 calls)
         alias_fork2.gen#1<0>(~io##3:wybe.phantom, ~tmp#3##0:mytree.tree, ~tmp#0##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io##4:wybe.phantom) #10
 
     1:
-        foreign lpvm access(~tmp#0##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
-        foreign lpvm alloc(24:wybe.int, ?tmp#27##0:mytree.tree)
-        foreign lpvm mutate(~tmp#27##0:mytree.tree, ?tmp#28##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree)
-        foreign lpvm mutate(~tmp#28##0:mytree.tree, ?tmp#29##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-        foreign lpvm mutate(~tmp#29##0:mytree.tree, ?tmp#4##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm access(~tmp#0##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm alloc(24:wybe.int, ?tmp#27##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#27##0:mytree.tree, ?tmp#28##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#28##0:mytree.tree, ?tmp#29##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#29##0:mytree.tree, ?tmp#4##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
         alias_fork2.gen#1<0>(~io##3:wybe.phantom, ~tmp#3##0:mytree.tree, ~tmp#4##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io##4:wybe.phantom) #9
 
 
@@ -66,10 +66,10 @@ simpleMerge > public (3 calls)
 simpleMerge(tl##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: [(#result##0,tl##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#5##0:mytree.tree)
-    foreign lpvm mutate(~tmp#5##0:mytree.tree, ?tmp#6##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
-    foreign lpvm mutate(~tmp#6##0:mytree.tree, ?tmp#7##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#5##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#5##0:mytree.tree, ?tmp#6##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#6##0:mytree.tree, ?tmp#7##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#7##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
 
   LLVM code       :
 
@@ -298,9 +298,9 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##
         foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
 
     1:
-        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
-        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
-        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree)
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree) @mytree:nn:nn
         mytree.printTree1<0>(~l##0:mytree.tree, ~%prefix##0:wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @mytree:nn:nn
         wybe.string.print_string<0>(~prefix##1:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @io:nn:nn
         foreign c print_int(~k##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
@@ -409,18 +409,18 @@ if.else:
         foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
-        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
-        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree)
+        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree) @mytree:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
-            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
-            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree)
+            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree) @mytree:nn:nn
+            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int) @mytree:nn:nn
+            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree) @mytree:nn:nn
             mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
@@ -460,7 +460,7 @@ key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -475,7 +475,7 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -492,7 +492,7 @@ left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -507,7 +507,7 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -517,10 +517,10 @@ node > public {inline} (0 calls)
 node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
-    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
-    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree) @mytree:nn:nn
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
 node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool):
@@ -535,9 +535,9 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -554,7 +554,7 @@ right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -569,7 +569,7 @@ right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#succes
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -16,14 +16,14 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree)
-    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm alloc(24:wybe.int, ?tmp#15##0:mytree.tree)
-    foreign lpvm mutate(~tmp#15##0:mytree.tree, ?tmp#16##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:mytree.tree)
-    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#15##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#15##0:mytree.tree, ?tmp#16##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
     alias_fork3.simpleSlice<0>(~tmp#0##0:mytree.tree, ?tmp#5##0:mytree.tree) #5 @alias_fork3:15:6
     wybe.string.print_string<0>("expect t - 100:":wybe.string, ~#io##0:wybe.phantom, ?tmp#20##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
@@ -41,13 +41,13 @@ simpleSlice(tr##0:mytree.tree, ?#result##0:mytree.tree):
     foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
     case ~tmp#6##0:wybe.bool of
     0:
-        foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree)
-        foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-        foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, -1:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, -1:wybe.int) @mytree:nn:nn
+        foreign lpvm mutate(~tmp#12##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
 
     1:
-        foreign lpvm access(~tr##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~tr##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
 
 
   LLVM code       :
@@ -209,9 +209,9 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##
         foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
 
     1:
-        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
-        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
-        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree)
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree) @mytree:nn:nn
         mytree.printTree1<0>(~l##0:mytree.tree, ~%prefix##0:wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @mytree:nn:nn
         wybe.string.print_string<0>(~prefix##1:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @io:nn:nn
         foreign c print_int(~k##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
@@ -320,18 +320,18 @@ if.else:
         foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
-        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
-        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree)
+        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree) @mytree:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
-            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
-            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree)
+            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree) @mytree:nn:nn
+            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int) @mytree:nn:nn
+            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree) @mytree:nn:nn
             mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
@@ -371,7 +371,7 @@ key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -386,7 +386,7 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -403,7 +403,7 @@ left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -418,7 +418,7 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -428,10 +428,10 @@ node > public {inline} (0 calls)
 node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
-    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
-    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree) @mytree:nn:nn
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
 node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool):
@@ -446,9 +446,9 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -465,7 +465,7 @@ right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -480,7 +480,7 @@ right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#succes
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -16,9 +16,9 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
     alias_mfoo.foo<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_m:nn:nn
     wybe.string.print_string<0>("expect p1(2,2)":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #8 @io:nn:nn
     position.printPosition<0>(~tmp#0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_m:nn:nn
@@ -109,12 +109,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
  AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -122,12 +122,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -221,43 +221,43 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position,
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
-        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
-        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
         foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         wybe.string.print_string<0>("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
         position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
-        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
-        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
         foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         wybe.string.print_string<0>("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
         position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
@@ -419,10 +419,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -508,10 +508,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -527,16 +527,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -544,13 +544,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -558,13 +558,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -572,10 +572,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -17,12 +17,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
  AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -30,12 +30,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -129,43 +129,43 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position,
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
-        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
-        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
         foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         wybe.string.print_string<0>("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
         position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
-        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
-        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
         foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         wybe.string.print_string<0>("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
         position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
@@ -327,10 +327,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -416,10 +416,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -435,16 +435,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -452,13 +452,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -466,13 +466,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -480,10 +480,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -17,12 +17,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
  AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -30,12 +30,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -129,43 +129,43 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position,
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
-        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
-        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
         foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         wybe.string.print_string<0>("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
         position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
-        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
-        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
         foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         wybe.string.print_string<0>("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
         position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
@@ -327,10 +327,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -416,10 +416,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -435,16 +435,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -452,13 +452,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -466,13 +466,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -480,10 +480,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -16,9 +16,9 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
     alias_mod_param.foo<0>(tmp#0##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_mod_param:nn:nn
     wybe.string.print_string<0>("expect p1(10,10):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @io:nn:nn
     position.printPosition<0>(~tmp#0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_mod_param:nn:nn
@@ -29,7 +29,7 @@ foo > public (1 calls)
 foo(pa##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pa##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign lpvm {noalias} mutate(~%pa##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect pa(1111,10):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #3 @io:nn:nn
     position.printPosition<0>(~pa##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias_mod_param:nn:nn
 
@@ -126,10 +126,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -215,10 +215,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -234,16 +234,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -251,13 +251,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -265,13 +265,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -279,10 +279,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -26,9 +26,9 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int) @position:nn:nn
     alias_multifunc.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc:nn:nn
     wybe.string.print_string<0>("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #17 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -38,7 +38,7 @@ bar(io##0:wybe.phantom, ?io##15:wybe.phantom):
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc:nn:nn
     wybe.string.print_string<0>("expect p3(101,102):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #20 @io:nn:nn
     position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc:nn:nn
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- After calling x(!p1, 555): ":wybe.string, ~#io##8:wybe.phantom, ?tmp#18##0:wybe.phantom) #21 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(555,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #22 @io:nn:nn
@@ -54,11 +54,11 @@ replicate1 > public (1 calls)
 replicate1(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: [(p1##0,p2##0),(p1##0,p3##0),(p2##0,p3##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("random replicate1 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @io:nn:nn
-    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(p1##0:position.position, ?p2##0:position.position) @alias_multifunc:nn:nn
@@ -70,11 +70,11 @@ replicate2 > public (1 calls)
 replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("random replicate2 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
-    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc:nn:nn
@@ -288,10 +288,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -377,10 +377,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -396,16 +396,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -413,13 +413,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -427,13 +427,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -441,10 +441,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -17,9 +17,9 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##16:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
     alias_multifunc1.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc1:19:2
     wybe.string.print_string<0>("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #19 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -29,12 +29,12 @@ module top-level code > public {impure} (0 calls)
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc1:25:2
     wybe.string.print_string<0>("expect p3(10,10):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #22 @io:nn:nn
     position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc1:27:2
-    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2222222:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2222222:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- After calling x(!p2, 2222222): ":wybe.string, ~#io##8:wybe.phantom, ?tmp#18##0:wybe.phantom) #23 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p2(2222222,10):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #24 @io:nn:nn
     position.printPosition<0>(~p2##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias_multifunc1:33:2
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- After calling x(!p1, 11): ":wybe.string, ~#io##11:wybe.phantom, ?tmp#25##0:wybe.phantom) #25 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(11,10):":wybe.string, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #26 @io:nn:nn
@@ -50,7 +50,7 @@ replicate1(p1##0:position.position, ?p2##1:position.position, ?p3##0:position.po
  InterestingCallProperties: []
     alias_multifunc1.replicate2<0>(~p1##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_multifunc1:13:6
     alias_multifunc1.replicate2<0>(p2##0:position.position, ?p3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @alias_multifunc1:14:6
-    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int) @position:nn:nn
 
 
 replicate2 > public (2 calls)
@@ -58,11 +58,11 @@ replicate2 > public (2 calls)
 replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("some noise...":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
-    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc1:8:6
@@ -269,10 +269,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -358,10 +358,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -377,16 +377,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -394,13 +394,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -408,13 +408,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -422,10 +422,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -17,9 +17,9 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
     alias_multifunc2.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc2:20:2
     wybe.string.print_string<0>("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #17 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -29,7 +29,7 @@ module top-level code > public {impure} (0 calls)
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc2:26:2
     wybe.string.print_string<0>("expect p3(10,10):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #20 @io:nn:nn
     position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc2:28:2
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- After calling x(!p1, 11): ":wybe.string, ~#io##8:wybe.phantom, ?tmp#18##0:wybe.phantom) #21 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(11,10):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #22 @io:nn:nn
@@ -47,7 +47,7 @@ replicate1(p1##0:position.position, ?p2##1:position.position, ?p3##0:position.po
  InterestingCallProperties: []
     alias_multifunc2.replicate2<0>(~p1##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_multifunc2:14:6
     alias_multifunc2.replicate2<0>(p2##0:position.position, ?p3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @alias_multifunc2:15:6
-    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int) @position:nn:nn
 
 
 replicate2 > public (2 calls)
@@ -55,11 +55,11 @@ replicate2 > public (2 calls)
 replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("random replicate2 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
-    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc2:9:6
@@ -255,10 +255,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -344,10 +344,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -363,16 +363,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -380,13 +380,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -394,13 +394,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -408,10 +408,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -16,9 +16,9 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
     alias_multifunc3.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc3:17:2
     wybe.string.print_string<0>("--- After calling replicate1:":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #13 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -26,7 +26,7 @@ module top-level code > public {impure} (0 calls)
     position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc3:21:2
     wybe.string.print_string<0>("expect p2(10,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #15 @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc3:23:2
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 999:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 999:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- After called x(!p1, 999):":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) #16 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect p1(999,10):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #17 @io:nn:nn
@@ -41,7 +41,7 @@ replicate1(pa##0:position.position, ?pb##0:position.position, io##0:wybe.phantom
  AliasPairs: [(pa##0,pb##0)]
  InterestingCallProperties: []
     foreign llvm move(pa##0:position.position, ?pb##0:position.position) @alias_multifunc3:6:6
-    foreign lpvm {noalias} mutate(%pa##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign lpvm {noalias} mutate(%pa##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- Inside replicate1:":wybe.string, ~#io##0:wybe.phantom, ?tmp#4##0:wybe.phantom) #6 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect pa(1111,10):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #7 @io:nn:nn
@@ -211,10 +211,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -300,10 +300,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -319,16 +319,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -336,13 +336,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -350,13 +350,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -364,10 +364,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -18,9 +18,9 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##18:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
     alias_multifunc4.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, #io##0:wybe.phantom, ?_:wybe.phantom) #1 @alias_multifunc4:36:2
     wybe.string.print_string<0>("--- After calling replicate1:":wybe.string, ~#io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) #19 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -50,11 +50,11 @@ replicate1(pa##0:position.position, ?pb##1:position.position, ?pc##0:position.po
  AliasPairs: [(pa##0,pc##0)]
  InterestingCallProperties: []
     foreign llvm move(pa##0:position.position, ?pc##0:position.position) @alias_multifunc4:8:6
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
-    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
-    foreign lpvm {noalias} mutate(~pa##0:position.position, ?%pb##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int) @position:nn:nn
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~pa##0:position.position, ?%pb##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @position:nn:nn
 
 
 replicate21 > public (1 calls)
@@ -62,11 +62,11 @@ replicate21 > public (1 calls)
 replicate21(?pb##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int) @position:nn:nn
     foreign llvm move(tmp#0##0:position.position, ?pb##0:position.position) @alias_multifunc4:16:6
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- Inside replicate21, expect pc(1111111111,99999): ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
     position.printPosition<0>(~pc##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @alias_multifunc4:20:6
 
@@ -76,13 +76,13 @@ replicate22 > public (1 calls)
 replicate22(?pb##0:position.position, ?pc##1:position.position, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int) @position:nn:nn
     foreign llvm move(tmp#0##0:position.position, ?pb##0:position.position) @alias_multifunc4:25:6
     wybe.string.print_string<0>("--- Inside replicate22, expect pc(99999,99999):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #6 @io:nn:nn
     position.printPosition<0>(tmp#0##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias_multifunc4:28:6
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #7 @io:nn:nn
     position.printPosition<0>(pc##1:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @alias_multifunc4:32:6
 
@@ -337,10 +337,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -426,10 +426,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -445,16 +445,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -462,13 +462,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -476,13 +476,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -490,10 +490,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -16,12 +16,12 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##18:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:position.position)
-    foreign lpvm mutate(~tmp#8##0:position.position, ?tmp#9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -200:wybe.int)
-    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -201:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#8##0:position.position, ?tmp#9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -200:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -201:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("--- before proc call: ":wybe.string, ~#io##0:wybe.phantom, ?tmp#12##0:wybe.phantom) #22 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect pa(100,101):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #23 @io:nn:nn
@@ -41,7 +41,7 @@ module top-level code > public {impure} (0 calls)
     position.printPosition<0>(r##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #15 @alias_recursion1:34:2
     wybe.string.print_string<0>("--- modify pa^x: ":wybe.string, ~#io##13:wybe.phantom, ?tmp#31##0:wybe.phantom) #30 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, -1000:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, -1000:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect pa(-1000,101):":wybe.string, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #31 @io:nn:nn
     position.printPosition<0>(~pa##1:position.position, ~#io##15:wybe.phantom, ?#io##16:wybe.phantom) #19 @alias_recursion1:39:2
     wybe.string.print_string<0>("expect r still (-200,-201):":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) #32 @io:nn:nn
@@ -53,7 +53,7 @@ if_test > public (2 calls)
 if_test(a##0:position.position, b##0:position.position, ?r##0:position.position):
  AliasPairs: [(a##0,b##0),(a##0,r##0),(b##0,r##0)]
  InterestingCallProperties: []
-    foreign lpvm access(a##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(a##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -250,10 +250,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -339,10 +339,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -358,16 +358,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -375,13 +375,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -389,13 +389,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -403,10 +403,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -17,9 +17,9 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
     alias_scc_proc.foo<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_scc_proc:nn:nn
     wybe.string.print_string<0>("--- After calling foo: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -37,12 +37,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
  AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_scc_proc.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_scc_proc.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_scc_proc:nn:nn
 
     1:
@@ -50,12 +50,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
         alias_scc_proc.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_scc_proc:nn:nn
 
     1:
@@ -70,43 +70,43 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position,
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_scc_proc.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
         alias_scc_proc.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
-        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
-        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
         foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_scc_proc:nn:nn
         wybe.string.print_string<0>("--- Inside foo: expect p3(3,3):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
         position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_scc_proc:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @position:nn:nn
         alias_scc_proc.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
-        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
-        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position) @position:nn:nn
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
         foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_scc_proc:nn:nn
         wybe.string.print_string<0>("--- Inside foo: expect p3(3,3):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
         position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_scc_proc:nn:nn
@@ -372,10 +372,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -461,10 +461,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -480,16 +480,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -497,13 +497,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -511,13 +511,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -525,10 +525,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -34,17 +34,17 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:alias_type1.position)
-    foreign lpvm mutate(~tmp#6##0:alias_type1.position, ?tmp#7##0:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:alias_type1.position, ?tmp#8##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:alias_type1.posrec)
-    foreign lpvm mutate(~tmp#11##0:alias_type1.posrec, ?tmp#12##0:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#12##0:alias_type1.posrec, ?tmp#13##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#8##0:alias_type1.position)
-    foreign lpvm {noalias} mutate(~tmp#8##0:alias_type1.position, ?%pos##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos##1:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:alias_type1.position) @alias_type1:6:25
+    foreign lpvm mutate(~tmp#6##0:alias_type1.position, ?tmp#7##0:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @alias_type1:6:25
+    foreign lpvm mutate(~tmp#7##0:alias_type1.position, ?tmp#8##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @alias_type1:6:25
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:alias_type1.posrec) @alias_type1:8:23
+    foreign lpvm mutate(~tmp#11##0:alias_type1.posrec, ?tmp#12##0:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @alias_type1:8:23
+    foreign lpvm mutate(~tmp#12##0:alias_type1.posrec, ?tmp#13##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#8##0:alias_type1.position) @alias_type1:8:23
+    foreign lpvm {noalias} mutate(~tmp#8##0:alias_type1.position, ?%pos##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int) @alias_type1:6:25
+    foreign lpvm access(~pos##1:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @alias_type1:6:25
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp#13##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~tmp#13##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @alias_type1:8:23
     foreign c print_int(~tmp#3##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
@@ -135,10 +135,10 @@ entry:
 =(#left##0:alias_type1.position, #right##0:alias_type1.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @alias_type1:6:25
+    foreign lpvm access(~#left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @alias_type1:6:25
+    foreign lpvm access(#right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @alias_type1:6:25
+    foreign lpvm access(~#right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @alias_type1:6:25
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -154,16 +154,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.position)
-    foreign lpvm mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type1.position, ?#result##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.position) @alias_type1:6:25
+    foreign lpvm mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @alias_type1:6:25
+    foreign lpvm mutate(~#rec##1:alias_type1.position, ?#result##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @alias_type1:6:25
 position > public {inline} (6 calls)
 1: alias_type1.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @alias_type1:6:25
+    foreign lpvm access(~#result##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @alias_type1:6:25
 
 
 x > public {inline} (0 calls)
@@ -171,13 +171,13 @@ x > public {inline} (0 calls)
 x(#rec##0:alias_type1.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type1:6:25
 x > public {inline} (0 calls)
 1: alias_type1.position.x<1>
 x(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type1:6:25
 
 
 y > public {inline} (0 calls)
@@ -185,13 +185,13 @@ y > public {inline} (0 calls)
 y(#rec##0:alias_type1.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type1:6:25
 y > public {inline} (0 calls)
 1: alias_type1.position.y<1>
 y(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type1:6:25
 
 
 ~= > public {inline} (0 calls)
@@ -199,10 +199,10 @@ y(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.in
 ~=(#left##0:alias_type1.position, #right##0:alias_type1.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @alias_type1:6:25
+    foreign lpvm access(~#left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @alias_type1:6:25
+    foreign lpvm access(#right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @alias_type1:6:25
+    foreign lpvm access(~#right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @alias_type1:6:25
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -386,20 +386,20 @@ if.else:
 =(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type1.position)
-    foreign lpvm access(#right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type1.position)
+    foreign lpvm access(#left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int) @alias_type1:8:23
+    foreign lpvm access(~#left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type1.position) @alias_type1:8:23
+    foreign lpvm access(#right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int) @alias_type1:8:23
+    foreign lpvm access(~#right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type1.position) @alias_type1:8:23
     foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left#p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-        foreign lpvm access(~#left#p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
-        foreign lpvm access(#right#p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int)
-        foreign lpvm access(~#right#p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+        foreign lpvm access(#left#p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @alias_type1:6:25
+        foreign lpvm access(~#left#p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @alias_type1:6:25
+        foreign lpvm access(#right#p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int) @alias_type1:6:25
+        foreign lpvm access(~#right#p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @alias_type1:6:25
         foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
         case ~tmp#13##0:wybe.bool of
         0:
@@ -416,13 +416,13 @@ a > public {inline} (0 calls)
 a(#rec##0:alias_type1.posrec, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type1:8:23
 a > public {inline} (0 calls)
 1: alias_type1.posrec.a<1>
 a(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type1:8:23
 
 
 p > public {inline} (0 calls)
@@ -430,13 +430,13 @@ p > public {inline} (0 calls)
 p(#rec##0:alias_type1.posrec, ?#result##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type1.position)
+    foreign lpvm access(~#rec##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type1.position) @alias_type1:8:23
 p > public {inline} (0 calls)
 1: alias_type1.posrec.p<1>
 p(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type1.position)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type1.position) @alias_type1:8:23
 
 
 posrec > public {inline} (0 calls)
@@ -444,16 +444,16 @@ posrec > public {inline} (0 calls)
 posrec(a##0:wybe.int, p##0:alias_type1.position, ?#result##0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.posrec)
-    foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type1.posrec, ?#result##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type1.position)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.posrec) @alias_type1:8:23
+    foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @alias_type1:8:23
+    foreign lpvm mutate(~#rec##1:alias_type1.posrec, ?#result##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type1.position) @alias_type1:8:23
 posrec > public {inline} (6 calls)
 1: alias_type1.posrec.posrec<1>
 posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-    foreign lpvm access(~#result##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type1.position)
+    foreign lpvm access(#result##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int) @alias_type1:8:23
+    foreign lpvm access(~#result##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type1.position) @alias_type1:8:23
 
 
 ~= > public {inline} (0 calls)
@@ -461,10 +461,10 @@ posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec
 ~=(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:alias_type1.position)
-    foreign lpvm access(#right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:alias_type1.position)
+    foreign lpvm access(#left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @alias_type1:8:23
+    foreign lpvm access(~#left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:alias_type1.position) @alias_type1:8:23
+    foreign lpvm access(#right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @alias_type1:8:23
+    foreign lpvm access(~#right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:alias_type1.position) @alias_type1:8:23
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -472,10 +472,10 @@ posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp#4##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-        foreign lpvm access(~tmp#4##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-        foreign lpvm access(tmp#6##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
-        foreign lpvm access(~tmp#6##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int)
+        foreign lpvm access(tmp#4##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @alias_type1:6:25
+        foreign lpvm access(~tmp#4##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @alias_type1:6:25
+        foreign lpvm access(tmp#6##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @alias_type1:6:25
+        foreign lpvm access(~tmp#6##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int) @alias_type1:6:25
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -34,19 +34,19 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#7##0:alias_type2.position)
-    foreign lpvm mutate(~tmp#7##0:alias_type2.position, ?tmp#8##0:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#8##0:alias_type2.position, ?tmp#9##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#12##0:alias_type2.posrec)
-    foreign lpvm mutate(~tmp#12##0:alias_type2.posrec, ?tmp#13##0:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#9##0:alias_type2.position)
-    foreign lpvm mutate(~tmp#13##0:alias_type2.posrec, ?tmp#14##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#14##0:alias_type2.posrec, ?%rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp#9##0:alias_type2.position, ?%pos##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos##1:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#7##0:alias_type2.position) @alias_type2:2:25
+    foreign lpvm mutate(~tmp#7##0:alias_type2.position, ?tmp#8##0:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @alias_type2:2:25
+    foreign lpvm mutate(~tmp#8##0:alias_type2.position, ?tmp#9##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @alias_type2:2:25
+    foreign lpvm alloc(16:wybe.int, ?tmp#12##0:alias_type2.posrec) @alias_type2:4:23
+    foreign lpvm mutate(~tmp#12##0:alias_type2.posrec, ?tmp#13##0:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#9##0:alias_type2.position) @alias_type2:4:23
+    foreign lpvm mutate(~tmp#13##0:alias_type2.posrec, ?tmp#14##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @alias_type2:4:23
+    foreign lpvm mutate(~tmp#14##0:alias_type2.posrec, ?%rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @alias_type2:4:23
+    foreign lpvm {noalias} mutate(~tmp#9##0:alias_type2.position, ?%pos##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~pos##1:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @alias_type2:2:25
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~rec##1:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type2.position)
-    foreign lpvm access(~tmp#3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(~rec##1:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type2.position) @alias_type2:4:23
+    foreign lpvm access(~tmp#3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @alias_type2:2:25
     foreign c print_int(~tmp#4##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#27##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
@@ -151,10 +151,10 @@ entry:
 =(#left##0:alias_type2.position, #right##0:alias_type2.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~#left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(#right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~#right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @alias_type2:2:25
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -170,16 +170,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.position)
-    foreign lpvm mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type2.position, ?#result##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.position) @alias_type2:2:25
+    foreign lpvm mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @alias_type2:2:25
+    foreign lpvm mutate(~#rec##1:alias_type2.position, ?#result##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @alias_type2:2:25
 position > public {inline} (6 calls)
 1: alias_type2.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~#result##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @alias_type2:2:25
 
 
 x > public {inline} (0 calls)
@@ -187,13 +187,13 @@ x > public {inline} (0 calls)
 x(#rec##0:alias_type2.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type2:2:25
 x > public {inline} (0 calls)
 1: alias_type2.position.x<1>
 x(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type2:2:25
 
 
 y > public {inline} (0 calls)
@@ -201,13 +201,13 @@ y > public {inline} (0 calls)
 y(#rec##0:alias_type2.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type2:2:25
 y > public {inline} (0 calls)
 1: alias_type2.position.y<1>
 y(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type2:2:25
 
 
 ~= > public {inline} (0 calls)
@@ -215,10 +215,10 @@ y(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.in
 ~=(#left##0:alias_type2.position, #right##0:alias_type2.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~#left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(#right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~#right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @alias_type2:2:25
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -402,14 +402,14 @@ if.else:
 =(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type2.position)
-    foreign lpvm access(~#left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type2.position)
-    foreign lpvm access(~#right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
-    foreign lpvm access(#left#p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~#left#p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(#right#p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~#right#p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type2.position) @alias_type2:4:23
+    foreign lpvm access(~#left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int) @alias_type2:4:23
+    foreign lpvm access(#right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type2.position) @alias_type2:4:23
+    foreign lpvm access(~#right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int) @alias_type2:4:23
+    foreign lpvm access(#left#p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~#left#p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(#right#p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~#right#p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @alias_type2:2:25
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
@@ -432,13 +432,13 @@ a > public {inline} (0 calls)
 a(#rec##0:alias_type2.posrec, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type2:4:23
 a > public {inline} (0 calls)
 1: alias_type2.posrec.a<1>
 a(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type2:4:23
 
 
 p > public {inline} (0 calls)
@@ -446,13 +446,13 @@ p > public {inline} (0 calls)
 p(#rec##0:alias_type2.posrec, ?#result##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type2.position)
+    foreign lpvm access(~#rec##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type2.position) @alias_type2:4:23
 p > public {inline} (0 calls)
 1: alias_type2.posrec.p<1>
 p(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type2.position)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type2.position) @alias_type2:4:23
 
 
 posrec > public {inline} (0 calls)
@@ -460,16 +460,16 @@ posrec > public {inline} (0 calls)
 posrec(p##0:alias_type2.position, a##0:wybe.int, ?#result##0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.posrec)
-    foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type2.position)
-    foreign lpvm mutate(~#rec##1:alias_type2.posrec, ?#result##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.posrec) @alias_type2:4:23
+    foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type2.position) @alias_type2:4:23
+    foreign lpvm mutate(~#rec##1:alias_type2.posrec, ?#result##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @alias_type2:4:23
 posrec > public {inline} (6 calls)
 1: alias_type2.posrec.posrec<1>
 posrec(?p##0:alias_type2.position, ?a##0:wybe.int, #result##0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type2.position)
-    foreign lpvm access(~#result##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type2.position) @alias_type2:4:23
+    foreign lpvm access(~#result##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int) @alias_type2:4:23
 
 
 ~= > public {inline} (0 calls)
@@ -477,14 +477,14 @@ posrec(?p##0:alias_type2.position, ?a##0:wybe.int, #result##0:alias_type2.posrec
 ~=(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type2.position)
-    foreign lpvm access(~#left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type2.position)
-    foreign lpvm access(~#right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
-    foreign lpvm access(tmp#3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~tmp#3##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(tmp#5##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~tmp#5##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type2.position) @alias_type2:4:23
+    foreign lpvm access(~#left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @alias_type2:4:23
+    foreign lpvm access(#right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type2.position) @alias_type2:4:23
+    foreign lpvm access(~#right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @alias_type2:4:23
+    foreign lpvm access(tmp#3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~tmp#3##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(tmp#5##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @alias_type2:2:25
+    foreign lpvm access(~tmp#5##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @alias_type2:2:25
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -34,22 +34,22 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:alias_type3.position)
-    foreign lpvm mutate(~tmp#8##0:alias_type3.position, ?tmp#9##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#9##0:alias_type3.position, ?tmp#10##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:alias_type3.posrec)
-    foreign lpvm mutate(~tmp#13##0:alias_type3.posrec, ?tmp#14##0:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##0:alias_type3.position)
-    foreign lpvm mutate(~tmp#14##0:alias_type3.posrec, ?tmp#15##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:alias_type3.position)
-    foreign lpvm mutate(~tmp#18##0:alias_type3.position, ?tmp#19##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp#19##0:alias_type3.position, ?tmp#20##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp#15##0:alias_type3.posrec, ?%rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#20##0:alias_type3.position)
-    foreign lpvm {noalias} mutate(~tmp#10##0:alias_type3.position, ?%pos##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos##1:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:alias_type3.position) @alias_type3:2:25
+    foreign lpvm mutate(~tmp#8##0:alias_type3.position, ?tmp#9##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @alias_type3:2:25
+    foreign lpvm mutate(~tmp#9##0:alias_type3.position, ?tmp#10##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @alias_type3:2:25
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:alias_type3.posrec) @alias_type3:4:23
+    foreign lpvm mutate(~tmp#13##0:alias_type3.posrec, ?tmp#14##0:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm mutate(~tmp#14##0:alias_type3.posrec, ?tmp#15##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @alias_type3:4:23
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:alias_type3.position) @alias_type3:2:25
+    foreign lpvm mutate(~tmp#18##0:alias_type3.position, ?tmp#19##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @alias_type3:2:25
+    foreign lpvm mutate(~tmp#19##0:alias_type3.position, ?tmp#20##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @alias_type3:2:25
+    foreign lpvm {noalias} mutate(~tmp#15##0:alias_type3.posrec, ?%rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#20##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm {noalias} mutate(~tmp#10##0:alias_type3.position, ?%pos##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~pos##1:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @alias_type3:2:25
     foreign c print_int(~tmp#3##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~rec##1:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:alias_type3.position)
-    foreign lpvm access(~tmp#4##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~rec##1:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm access(~tmp#4##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @alias_type3:2:25
     foreign c print_int(~tmp#5##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
@@ -156,10 +156,10 @@ entry:
 =(#left##0:alias_type3.position, #right##0:alias_type3.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~#left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(#right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~#right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @alias_type3:2:25
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -175,16 +175,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.position)
-    foreign lpvm mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type3.position, ?#result##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.position) @alias_type3:2:25
+    foreign lpvm mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @alias_type3:2:25
+    foreign lpvm mutate(~#rec##1:alias_type3.position, ?#result##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @alias_type3:2:25
 position > public {inline} (6 calls)
 1: alias_type3.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~#result##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @alias_type3:2:25
 
 
 x > public {inline} (0 calls)
@@ -192,13 +192,13 @@ x > public {inline} (0 calls)
 x(#rec##0:alias_type3.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type3:2:25
 x > public {inline} (0 calls)
 1: alias_type3.position.x<1>
 x(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type3:2:25
 
 
 y > public {inline} (0 calls)
@@ -206,13 +206,13 @@ y > public {inline} (0 calls)
 y(#rec##0:alias_type3.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type3:2:25
 y > public {inline} (0 calls)
 1: alias_type3.position.y<1>
 y(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type3:2:25
 
 
 ~= > public {inline} (0 calls)
@@ -220,10 +220,10 @@ y(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.in
 ~=(#left##0:alias_type3.position, #right##0:alias_type3.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~#left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(#right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~#right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @alias_type3:2:25
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -407,14 +407,14 @@ if.else:
 =(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type3.position)
-    foreign lpvm access(~#left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type3.position)
-    foreign lpvm access(~#right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
-    foreign lpvm access(#left#p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~#left#p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(#right#p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~#right#p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm access(~#left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int) @alias_type3:4:23
+    foreign lpvm access(#right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm access(~#right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int) @alias_type3:4:23
+    foreign lpvm access(#left#p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~#left#p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(#right#p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~#right#p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @alias_type3:2:25
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
@@ -437,13 +437,13 @@ a > public {inline} (0 calls)
 a(#rec##0:alias_type3.posrec, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type3:4:23
 a > public {inline} (0 calls)
 1: alias_type3.posrec.a<1>
 a(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type3:4:23
 
 
 p > public {inline} (0 calls)
@@ -451,13 +451,13 @@ p > public {inline} (0 calls)
 p(#rec##0:alias_type3.posrec, ?#result##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type3.position)
+    foreign lpvm access(~#rec##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type3.position) @alias_type3:4:23
 p > public {inline} (0 calls)
 1: alias_type3.posrec.p<1>
 p(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type3.position)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type3.position) @alias_type3:4:23
 
 
 posrec > public {inline} (0 calls)
@@ -465,16 +465,16 @@ posrec > public {inline} (0 calls)
 posrec(p##0:alias_type3.position, a##0:wybe.int, ?#result##0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.posrec)
-    foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type3.position)
-    foreign lpvm mutate(~#rec##1:alias_type3.posrec, ?#result##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.posrec) @alias_type3:4:23
+    foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm mutate(~#rec##1:alias_type3.posrec, ?#result##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @alias_type3:4:23
 posrec > public {inline} (6 calls)
 1: alias_type3.posrec.posrec<1>
 posrec(?p##0:alias_type3.position, ?a##0:wybe.int, #result##0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type3.position)
-    foreign lpvm access(~#result##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm access(~#result##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int) @alias_type3:4:23
 
 
 ~= > public {inline} (0 calls)
@@ -482,14 +482,14 @@ posrec(?p##0:alias_type3.position, ?a##0:wybe.int, #result##0:alias_type3.posrec
 ~=(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type3.position)
-    foreign lpvm access(~#left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type3.position)
-    foreign lpvm access(~#right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
-    foreign lpvm access(tmp#3##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~tmp#3##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(tmp#5##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~tmp#5##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm access(~#left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @alias_type3:4:23
+    foreign lpvm access(#right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type3.position) @alias_type3:4:23
+    foreign lpvm access(~#right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @alias_type3:4:23
+    foreign lpvm access(tmp#3##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~tmp#3##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(tmp#5##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @alias_type3:2:25
+    foreign lpvm access(~tmp#5##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @alias_type3:2:25
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -36,12 +36,12 @@ module top-level code > public {impure} (0 calls)
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(2,(alias_type4.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:alias_type4.position)
-    foreign lpvm mutate(~tmp#4##0:alias_type4.position, ?tmp#5##0:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:alias_type4.position, ?tmp#6##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:alias_type4.posrec)
-    foreign lpvm mutate(~tmp#9##0:alias_type4.posrec, ?tmp#10##0:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:alias_type4.position)
-    foreign lpvm mutate(~tmp#10##0:alias_type4.posrec, ?tmp#11##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:alias_type4.position) @alias_type4:2:25
+    foreign lpvm mutate(~tmp#4##0:alias_type4.position, ?tmp#5##0:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @alias_type4:2:25
+    foreign lpvm mutate(~tmp#5##0:alias_type4.position, ?tmp#6##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @alias_type4:2:25
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:alias_type4.posrec) @alias_type4:4:23
+    foreign lpvm mutate(~tmp#9##0:alias_type4.posrec, ?tmp#10##0:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm mutate(~tmp#10##0:alias_type4.posrec, ?tmp#11##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @alias_type4:4:23
     alias_type4.foo<0>[410bae77d3](~tmp#11##0:alias_type4.posrec, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @alias_type4:16:2
 
 
@@ -50,15 +50,15 @@ foo > public (1 calls)
 foo(r1##0:alias_type4.posrec, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:alias_type4.position)
-    foreign lpvm {noalias} mutate(~tmp#0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm {noalias} mutate(~tmp#0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @alias_type4:2:25
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:alias_type4.position)
-    foreign lpvm {noalias} mutate(~tmp#0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm {noalias} mutate(~tmp#0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @alias_type4:2:25
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
@@ -171,10 +171,10 @@ entry:
 =(#left##0:alias_type4.position, #right##0:alias_type4.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~#left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(#right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~#right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @alias_type4:2:25
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -190,16 +190,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.position)
-    foreign lpvm mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type4.position, ?#result##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.position) @alias_type4:2:25
+    foreign lpvm mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @alias_type4:2:25
+    foreign lpvm mutate(~#rec##1:alias_type4.position, ?#result##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @alias_type4:2:25
 position > public {inline} (6 calls)
 1: alias_type4.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~#result##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @alias_type4:2:25
 
 
 x > public {inline} (0 calls)
@@ -207,13 +207,13 @@ x > public {inline} (0 calls)
 x(#rec##0:alias_type4.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type4:2:25
 x > public {inline} (0 calls)
 1: alias_type4.position.x<1>
 x(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type4:2:25
 
 
 y > public {inline} (0 calls)
@@ -221,13 +221,13 @@ y > public {inline} (0 calls)
 y(#rec##0:alias_type4.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type4:2:25
 y > public {inline} (0 calls)
 1: alias_type4.position.y<1>
 y(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type4:2:25
 
 
 ~= > public {inline} (0 calls)
@@ -235,10 +235,10 @@ y(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.in
 ~=(#left##0:alias_type4.position, #right##0:alias_type4.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~#left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(#right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~#right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @alias_type4:2:25
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -422,14 +422,14 @@ if.else:
 =(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type4.position)
-    foreign lpvm access(~#left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type4.position)
-    foreign lpvm access(~#right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
-    foreign lpvm access(#left#p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~#left#p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(#right#p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~#right#p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm access(~#left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int) @alias_type4:4:23
+    foreign lpvm access(#right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm access(~#right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int) @alias_type4:4:23
+    foreign lpvm access(#left#p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~#left#p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(#right#p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~#right#p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @alias_type4:2:25
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
@@ -452,13 +452,13 @@ a > public {inline} (0 calls)
 a(#rec##0:alias_type4.posrec, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type4:4:23
 a > public {inline} (0 calls)
 1: alias_type4.posrec.a<1>
 a(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type4:4:23
 
 
 p > public {inline} (0 calls)
@@ -466,13 +466,13 @@ p > public {inline} (0 calls)
 p(#rec##0:alias_type4.posrec, ?#result##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type4.position)
+    foreign lpvm access(~#rec##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type4.position) @alias_type4:4:23
 p > public {inline} (0 calls)
 1: alias_type4.posrec.p<1>
 p(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type4.position)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type4.position) @alias_type4:4:23
 
 
 posrec > public {inline} (0 calls)
@@ -480,16 +480,16 @@ posrec > public {inline} (0 calls)
 posrec(p##0:alias_type4.position, a##0:wybe.int, ?#result##0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.posrec)
-    foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type4.position)
-    foreign lpvm mutate(~#rec##1:alias_type4.posrec, ?#result##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.posrec) @alias_type4:4:23
+    foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm mutate(~#rec##1:alias_type4.posrec, ?#result##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @alias_type4:4:23
 posrec > public {inline} (6 calls)
 1: alias_type4.posrec.posrec<1>
 posrec(?p##0:alias_type4.position, ?a##0:wybe.int, #result##0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type4.position)
-    foreign lpvm access(~#result##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm access(~#result##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int) @alias_type4:4:23
 
 
 ~= > public {inline} (0 calls)
@@ -497,14 +497,14 @@ posrec(?p##0:alias_type4.position, ?a##0:wybe.int, #result##0:alias_type4.posrec
 ~=(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type4.position)
-    foreign lpvm access(~#left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type4.position)
-    foreign lpvm access(~#right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
-    foreign lpvm access(tmp#3##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~tmp#3##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(tmp#5##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~tmp#5##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm access(~#left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @alias_type4:4:23
+    foreign lpvm access(#right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type4.position) @alias_type4:4:23
+    foreign lpvm access(~#right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @alias_type4:4:23
+    foreign lpvm access(tmp#3##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~tmp#3##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(tmp#5##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @alias_type4:2:25
+    foreign lpvm access(~tmp#5##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @alias_type4:2:25
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -30,13 +30,13 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#21##0:anon_field)
-    foreign lpvm mutate(~tmp#21##0:anon_field, ?tmp#22##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp#22##0:anon_field, ?tmp#23##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#23##0:anon_field, ?tmp#0##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(8:wybe.int, ?tmp#25##0:anon_field)
-    foreign lpvm mutate(~tmp#25##0:anon_field, ?tmp#26##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign llvm or(~tmp#26##0:anon_field, 1:wybe.int, ?tmp#2##0:anon_field)
+    foreign lpvm alloc(24:wybe.int, ?tmp#21##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#21##0:anon_field, ?tmp#22##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#22##0:anon_field, ?tmp#23##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#23##0:anon_field, ?tmp#0##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign lpvm alloc(8:wybe.int, ?tmp#25##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#25##0:anon_field, ?tmp#26##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign llvm or(~tmp#26##0:anon_field, 1:wybe.int, ?tmp#2##0:anon_field) @anon_field:nn:nn
     anon_field.=<0>(~tmp#0##0:anon_field, ~tmp#2##0:anon_field, ?tmp#17##0:wybe.bool) #3 @anon_field:nn:nn
     case ~tmp#17##0:wybe.bool of
     0:
@@ -67,7 +67,7 @@ module top-level code > public {impure} (0 calls)
                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign lpvm access(~#left##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#field##0:wybe.int)
+                foreign lpvm access(~#left##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#field##0:wybe.int) @anon_field:nn:nn
                 foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#22##0:wybe.int)
                 foreign llvm icmp_eq(~tmp#22##0:wybe.int, 2:wybe.int, ?tmp#23##0:wybe.bool)
                 case ~tmp#23##0:wybe.bool of
@@ -75,13 +75,13 @@ module top-level code > public {impure} (0 calls)
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~#right##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#field##0:wybe.int)
+                    foreign lpvm access(~#right##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#field##0:wybe.int) @anon_field:nn:nn
                     foreign llvm icmp_eq(~#left#field##0:wybe.int, ~#right#field##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
         1:
-            foreign lpvm access(~#left##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#bar#1##0:wybe.int)
+            foreign lpvm access(~#left##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#bar#1##0:wybe.int) @anon_field:nn:nn
             foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#19##0:wybe.int)
             foreign llvm icmp_eq(~tmp#19##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.bool)
             case ~tmp#20##0:wybe.bool of
@@ -89,15 +89,15 @@ module top-level code > public {impure} (0 calls)
                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign lpvm access(~#right##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#bar#1##0:wybe.int)
+                foreign lpvm access(~#right##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#bar#1##0:wybe.int) @anon_field:nn:nn
                 foreign llvm icmp_eq(~#left#bar#1##0:wybe.int, ~#right#bar#1##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
     1:
-        foreign lpvm access(#left##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#foo#2##0:wybe.bool)
-        foreign lpvm access(#left##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#foo#1##0:wybe.int)
-        foreign lpvm access(~#left##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#i##0:wybe.int)
+        foreign lpvm access(#left##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#foo#2##0:wybe.bool) @anon_field:nn:nn
+        foreign lpvm access(#left##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#foo#1##0:wybe.int) @anon_field:nn:nn
+        foreign lpvm access(~#left##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#i##0:wybe.int) @anon_field:nn:nn
         foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#16##0:wybe.int)
         foreign llvm icmp_eq(~tmp#16##0:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.bool)
         case ~tmp#17##0:wybe.bool of
@@ -105,9 +105,9 @@ module top-level code > public {impure} (0 calls)
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#foo#2##0:wybe.bool)
-            foreign lpvm access(#right##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#foo#1##0:wybe.int)
-            foreign lpvm access(~#right##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#i##0:wybe.int)
+            foreign lpvm access(#right##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#foo#2##0:wybe.bool) @anon_field:nn:nn
+            foreign lpvm access(#right##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#foo#1##0:wybe.int) @anon_field:nn:nn
+            foreign lpvm access(~#right##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#i##0:wybe.int) @anon_field:nn:nn
             foreign llvm icmp_eq(~#left#foo#1##0:wybe.int, ~#right#foo#1##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
             case ~tmp#2##0:wybe.bool of
             0:
@@ -132,9 +132,9 @@ bar > public {inline} (3 calls)
 bar(bar#1##0:wybe.int, ?#result##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field)
-    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int)
-    foreign llvm or(~#rec##1:anon_field, 1:wybe.int, ?#result##0:anon_field)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int) @anon_field:nn:nn
+    foreign llvm or(~#rec##1:anon_field, 1:wybe.int, ?#result##0:anon_field) @anon_field:nn:nn
 bar > public {inline} (7 calls)
 1: anon_field.bar<1>
 bar(?bar#1##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool):
@@ -148,7 +148,7 @@ bar(?bar#1##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?bar#1##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int)
+        foreign lpvm access(~#result##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -158,9 +158,9 @@ baz > public {inline} (5 calls)
 baz(field##0:wybe.int, ?#result##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field)
-    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~field##0:wybe.int)
-    foreign llvm or(~#rec##1:anon_field, 2:wybe.int, ?#result##0:anon_field)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~field##0:wybe.int) @anon_field:nn:nn
+    foreign llvm or(~#rec##1:anon_field, 2:wybe.int, ?#result##0:anon_field) @anon_field:nn:nn
 baz > public {inline} (5 calls)
 1: anon_field.baz<1>
 baz(?field##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool):
@@ -174,7 +174,7 @@ baz(?field##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?field##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field##0:wybe.int)
+        foreign lpvm access(~#result##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -192,7 +192,7 @@ field(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 field > {inline} (0 calls)
@@ -208,7 +208,7 @@ field(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:anon_field, ?#rec##1:anon_field)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:anon_field, ?#rec##1:anon_field, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:anon_field, ?#rec##1:anon_field, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -218,10 +218,10 @@ foo > public {inline} (14 calls)
 foo(foo#1##0:wybe.int, foo#2##0:wybe.bool, i##0:wybe.int, ?#result##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:anon_field)
-    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#2##0:wybe.bool)
-    foreign lpvm mutate(~#rec##1:anon_field, ?#rec##2:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#1##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:anon_field, ?#result##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#2##0:wybe.bool) @anon_field:nn:nn
+    foreign lpvm mutate(~#rec##1:anon_field, ?#rec##2:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#1##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~#rec##2:anon_field, ?#result##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int) @anon_field:nn:nn
 foo > public {inline} (20 calls)
 1: anon_field.foo<1>
 foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool):
@@ -237,9 +237,9 @@ foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_fie
         foreign llvm move(undef:wybe.int, ?i##0:wybe.int)
 
     1:
-        foreign lpvm access(#result##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#2##0:wybe.bool)
-        foreign lpvm access(#result##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#1##0:wybe.int)
-        foreign lpvm access(~#result##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(#result##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#2##0:wybe.bool) @anon_field:nn:nn
+        foreign lpvm access(#result##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#1##0:wybe.int) @anon_field:nn:nn
+        foreign lpvm access(~#result##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -249,10 +249,10 @@ gen#1 > (2 calls)
 gen#1(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#20##0:anon_field)
-    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#21##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp#21##0:anon_field, ?tmp#22##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#22##0:anon_field, ?tmp#4##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#20##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#21##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#21##0:anon_field, ?tmp#22##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#22##0:anon_field, ?tmp#4##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
     foreign llvm and(~tmp#4##0:wybe.int, 3:wybe.int, ?tmp#24##0:wybe.int)
     foreign llvm icmp_eq(~tmp#24##0:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.bool)
     case ~tmp#25##0:wybe.bool of
@@ -271,14 +271,14 @@ gen#2 > (3 calls)
 gen#2(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#18##0:anon_field)
-    foreign lpvm mutate(~tmp#18##0:anon_field, ?tmp#19##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp#19##0:anon_field, ?tmp#20##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#6##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(24:wybe.int, ?tmp#24##0:anon_field)
-    foreign lpvm mutate(~tmp#24##0:anon_field, ?tmp#25##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp#25##0:anon_field, ?tmp#26##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp#26##0:anon_field, ?tmp#8##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#18##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#18##0:anon_field, ?tmp#19##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#19##0:anon_field, ?tmp#20##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#6##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#24##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#24##0:anon_field, ?tmp#25##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#25##0:anon_field, ?tmp#26##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#26##0:anon_field, ?tmp#8##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
     anon_field.=<0>(~tmp#6##0:anon_field, ~tmp#8##0:anon_field, ?tmp#14##0:wybe.bool) #4 @anon_field:nn:nn
     case ~tmp#14##0:wybe.bool of
     0:
@@ -296,9 +296,9 @@ gen#3 > (2 calls)
 gen#3(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?tmp#15##0:anon_field)
-    foreign lpvm mutate(~tmp#15##0:anon_field, ?tmp#16##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign llvm or(~tmp#16##0:anon_field, 2:wybe.int, ?tmp#11##0:anon_field)
+    foreign lpvm alloc(8:wybe.int, ?tmp#15##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#15##0:anon_field, ?tmp#16##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign llvm or(~tmp#16##0:anon_field, 2:wybe.int, ?tmp#11##0:anon_field) @anon_field:nn:nn
     foreign llvm and(tmp#11##0:wybe.int, 3:wybe.int, ?tmp#18##0:wybe.int)
     foreign llvm icmp_eq(~tmp#18##0:wybe.int, 2:wybe.int, ?tmp#19##0:wybe.bool)
     case ~tmp#19##0:wybe.bool of
@@ -306,7 +306,7 @@ gen#3(io##0:wybe.phantom, ?io##1:wybe.phantom):
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(~tmp#11##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?tmp#10##0:wybe.int)
+        foreign lpvm access(~tmp#11##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?tmp#10##0:wybe.int) @anon_field:nn:nn
         foreign llvm icmp_ne(~tmp#10##0:wybe.int, 2:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
         case ~tmp#13##0:wybe.bool of
         0:
@@ -332,7 +332,7 @@ i(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 i > {inline} (0 calls)
@@ -348,7 +348,7 @@ i(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:wybe
         foreign llvm move(~#rec##0:anon_field, ?#rec##1:anon_field)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -875,10 +875,10 @@ entry:
 =(#left##0:anon_field.quux, #right##0:anon_field.quux, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#quuz#1##0:wybe.int)
-    foreign lpvm access(~#left##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#j##0:wybe.int)
-    foreign lpvm access(#right##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#quuz#1##0:wybe.int)
-    foreign lpvm access(~#right##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#j##0:wybe.int)
+    foreign lpvm access(#left##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#quuz#1##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm access(~#left##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#j##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm access(#right##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#quuz#1##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm access(~#right##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#j##0:wybe.int) @anon_field:nn:nn
     foreign llvm icmp_eq(~#left#quuz#1##0:wybe.int, ~#right#quuz#1##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -894,13 +894,13 @@ j > public {inline} (0 calls)
 j(#rec##0:anon_field.quux, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @anon_field:nn:nn
 j > public {inline} (0 calls)
 1: anon_field.quux.j<1>
 j(#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @anon_field:nn:nn
 
 
 quuz > public {inline} (0 calls)
@@ -908,16 +908,16 @@ quuz > public {inline} (0 calls)
 quuz(quuz#1##0:wybe.int, j##0:wybe.int, ?#result##0:anon_field.quux):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:anon_field.quux)
-    foreign lpvm mutate(~#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~quuz#1##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:anon_field.quux, ?#result##0:anon_field.quux, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~j##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:anon_field.quux) @anon_field:nn:nn
+    foreign lpvm mutate(~#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~quuz#1##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~#rec##1:anon_field.quux, ?#result##0:anon_field.quux, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~j##0:wybe.int) @anon_field:nn:nn
 quuz > public {inline} (6 calls)
 1: anon_field.quux.quuz<1>
 quuz(?quuz#1##0:wybe.int, ?j##0:wybe.int, #result##0:anon_field.quux):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?quuz#1##0:wybe.int)
-    foreign lpvm access(~#result##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int)
+    foreign lpvm access(#result##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?quuz#1##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm access(~#result##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int) @anon_field:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -925,10 +925,10 @@ quuz(?quuz#1##0:wybe.int, ?j##0:wybe.int, #result##0:anon_field.quux):
 ~=(#left##0:anon_field.quux, #right##0:anon_field.quux, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm access(~#left##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm access(#right##0:anon_field.quux, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @anon_field:nn:nn
+    foreign lpvm access(~#right##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @anon_field:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/anon_field_variable.exp
+++ b/test-cases/final-dump/anon_field_variable.exp
@@ -18,8 +18,8 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?tmp#5##0:anon_field_variable(T))
-    foreign lpvm mutate(~tmp#5##0:anon_field_variable(T), ?tmp#0##0:anon_field_variable(wybe.bool), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 0:T)
+    foreign lpvm alloc(8:wybe.int, ?tmp#5##0:anon_field_variable(T)) @anon_field_variable:nn:nn
+    foreign lpvm mutate(~tmp#5##0:anon_field_variable(T), ?tmp#0##0:anon_field_variable(wybe.bool), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 0:T) @anon_field_variable:nn:nn
     foreign llvm and(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int)
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
     case ~tmp#8##0:wybe.bool of
@@ -37,11 +37,11 @@ bar > public {inline} (0 calls)
 bar(bar#1##0:wybe.int, field##0:T, bar#3##0:T, ?#result##0:anon_field_variable(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:anon_field_variable(T))
-    foreign lpvm mutate(~#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:anon_field_variable(T), ?#rec##2:anon_field_variable(T), 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~field##0:T)
-    foreign lpvm mutate(~#rec##2:anon_field_variable(T), ?#rec##3:anon_field_variable(T), 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#3##0:T)
-    foreign llvm or(~#rec##3:anon_field_variable(T), 1:wybe.int, ?#result##0:anon_field_variable(T))
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:anon_field_variable(T)) @anon_field_variable:nn:nn
+    foreign lpvm mutate(~#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int) @anon_field_variable:nn:nn
+    foreign lpvm mutate(~#rec##1:anon_field_variable(T), ?#rec##2:anon_field_variable(T), 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~field##0:T) @anon_field_variable:nn:nn
+    foreign lpvm mutate(~#rec##2:anon_field_variable(T), ?#rec##3:anon_field_variable(T), 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#3##0:T) @anon_field_variable:nn:nn
+    foreign llvm or(~#rec##3:anon_field_variable(T), 1:wybe.int, ?#result##0:anon_field_variable(T)) @anon_field_variable:nn:nn
 bar > public {inline} (0 calls)
 1: anon_field_variable.bar<1>
 bar(?bar#1##0:wybe.int, ?field##0:T, ?bar#3##0:T, #result##0:anon_field_variable(T), ?#success##0:wybe.bool):
@@ -57,9 +57,9 @@ bar(?bar#1##0:wybe.int, ?field##0:T, ?bar#3##0:T, #result##0:anon_field_variable
         foreign llvm move(undef:T, ?bar#3##0:T)
 
     1:
-        foreign lpvm access(#result##0:anon_field_variable(T), -1:wybe.int, 24:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int)
-        foreign lpvm access(#result##0:anon_field_variable(T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?field##0:T)
-        foreign lpvm access(~#result##0:anon_field_variable(T), 15:wybe.int, 24:wybe.int, 1:wybe.int, ?bar#3##0:T)
+        foreign lpvm access(#result##0:anon_field_variable(T), -1:wybe.int, 24:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int) @anon_field_variable:nn:nn
+        foreign lpvm access(#result##0:anon_field_variable(T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?field##0:T) @anon_field_variable:nn:nn
+        foreign lpvm access(~#result##0:anon_field_variable(T), 15:wybe.int, 24:wybe.int, 1:wybe.int, ?bar#3##0:T) @anon_field_variable:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -77,7 +77,7 @@ field(#rec##0:anon_field_variable(T), ?#result##0:T, ?#success##0:wybe.bool):
         foreign llvm move(undef:T, ?#result##0:T)
 
     1:
-        foreign lpvm access(~#rec##0:anon_field_variable(T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:T)
+        foreign lpvm access(~#rec##0:anon_field_variable(T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:T) @anon_field_variable:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 field > {inline} (0 calls)
@@ -93,7 +93,7 @@ field(#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T), #field##0
         foreign llvm move(~#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T))
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T), 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:T)
+        foreign lpvm {noalias} mutate(~#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T), 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:T) @anon_field_variable:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -103,8 +103,8 @@ foo > public {inline} (3 calls)
 foo(foo#1##0:T, ?#result##0:anon_field_variable(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field_variable(T))
-    foreign lpvm mutate(~#rec##0:anon_field_variable(T), ?#result##0:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~foo#1##0:T)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field_variable(T)) @anon_field_variable:nn:nn
+    foreign lpvm mutate(~#rec##0:anon_field_variable(T), ?#result##0:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~foo#1##0:T) @anon_field_variable:nn:nn
 foo > public {inline} (3 calls)
 1: anon_field_variable.foo<1>
 foo(?foo#1##0:T, #result##0:anon_field_variable(T), ?#success##0:wybe.bool):
@@ -118,7 +118,7 @@ foo(?foo#1##0:T, #result##0:anon_field_variable(T), ?#success##0:wybe.bool):
         foreign llvm move(undef:T, ?foo#1##0:T)
 
     1:
-        foreign lpvm access(~#result##0:anon_field_variable(T), 0:wybe.int, 8:wybe.int, 0:wybe.int, ?foo#1##0:T)
+        foreign lpvm access(~#result##0:anon_field_variable(T), 0:wybe.int, 8:wybe.int, 0:wybe.int, ?foo#1##0:T) @anon_field_variable:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -19,16 +19,16 @@ module top-level code > public {impure} (0 calls)
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(8,(caret.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:position.position)
-    foreign lpvm mutate(~tmp#13##0:position.position, ?tmp#14##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:position.position)
-    foreign lpvm mutate(~tmp#17##0:position.position, ?tmp#18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:caret.region)
-    foreign lpvm mutate(~tmp#21##0:caret.region, ?tmp#22##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:position.position)
-    foreign lpvm mutate(~tmp#22##0:caret.region, ?tmp#23##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:position.position)
-    foreign lpvm access(~tmp#2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#13##0:position.position, ?tmp#14##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#17##0:position.position, ?tmp#18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:caret.region) @caret:nn:nn
+    foreign lpvm mutate(~tmp#21##0:caret.region, ?tmp#22##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:position.position) @caret:nn:nn
+    foreign lpvm mutate(~tmp#22##0:caret.region, ?tmp#23##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:position.position) @caret:nn:nn
+    foreign lpvm access(~tmp#2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #11 @io:nn:nn
     foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#32##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#32##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -40,26 +40,26 @@ expand_region > public (0 calls)
 expand_region(reg##0:caret.region, ?reg##4:caret.region, point##0:position.position):
  AliasPairs: [(reg##0,reg##4)]
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(reg##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:position.position)
-    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
-    foreign lpvm access(point##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(reg##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm access(point##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
     wybe.int.min<0>(~tmp#2##0:wybe.int, tmp#4##0:wybe.int, ?tmp#1##0:wybe.int) #4 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp#0##0:position.position, ?%tmp#0##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
-    foreign lpvm mutate(~%reg##0:caret.region, ?%reg##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp#0##1:position.position)
-    foreign lpvm access(tmp#0##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~point##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%tmp#0##0:position.position, ?%tmp#0##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~%reg##0:caret.region, ?%reg##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp#0##1:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#0##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~point##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @position:nn:nn
     wybe.int.min<0>(~tmp#7##0:wybe.int, tmp#9##0:wybe.int, ?tmp#6##0:wybe.int) #11 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~tmp#0##1:position.position, ?%tmp#5##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:wybe.int)
-    foreign lpvm mutate(~%reg##1:caret.region, ?%reg##2:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:position.position)
-    foreign lpvm access(reg##2:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:position.position)
-    foreign lpvm access(tmp#10##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##1:position.position, ?%tmp#5##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~%reg##1:caret.region, ?%reg##2:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:position.position) @caret:nn:nn
+    foreign lpvm access(reg##2:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#10##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @position:nn:nn
     wybe.int.max<0>(~tmp#12##0:wybe.int, ~tmp#4##0:wybe.int, ?tmp#11##0:wybe.int) #18 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp#10##0:position.position, ?%tmp#10##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int)
-    foreign lpvm mutate(~%reg##2:caret.region, ?%reg##3:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##1:position.position)
-    foreign lpvm access(tmp#10##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%tmp#10##0:position.position, ?%tmp#10##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~%reg##2:caret.region, ?%reg##3:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##1:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#10##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int) @position:nn:nn
     wybe.int.max<0>(~tmp#17##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#16##0:wybe.int) #25 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~tmp#10##1:position.position, ?%tmp#15##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#16##0:wybe.int)
-    foreign lpvm mutate(~%reg##3:caret.region, ?%reg##4:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#15##1:position.position)
+    foreign lpvm {noalias} mutate(~tmp#10##1:position.position, ?%tmp#15##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#16##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~%reg##3:caret.region, ?%reg##4:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#15##1:position.position) @caret:nn:nn
 
 
 gen#1 > (2 calls)
@@ -67,20 +67,20 @@ gen#1 > (2 calls)
 gen#1(io##0:wybe.phantom, reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##0:position.position], [tmp#2##0:position.position], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
-    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position)
-    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
     foreign llvm add(~%tmp#5##0:wybe.int, 1:wybe.int, ?%tmp#5##1:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp#6##0:position.position, ?%tmp#6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int)
-    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%tmp#6##0:position.position, ?%tmp#6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int) @position:nn:nn
+    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("now ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #9 @io:nn:nn
     foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
  [6dacb8fd25] [NonAliasedParam 1] :
-    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position)
-    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
     foreign llvm add(~%tmp#5##0:wybe.int, 1:wybe.int, ?%tmp#5##1:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp#6##0:position.position, ?%tmp#6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int)
-    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%tmp#6##0:position.position, ?%tmp#6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int) @position:nn:nn
+    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("now ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #9 @io:nn:nn
     foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
@@ -371,14 +371,14 @@ entry:
 =(#left##0:caret.region, #right##0:caret.region, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lower_left##0:position.position)
-    foreign lpvm access(~#left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#upper_right##0:position.position)
-    foreign lpvm access(#right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lower_left##0:position.position)
-    foreign lpvm access(~#right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#upper_right##0:position.position)
-    foreign lpvm access(#left#lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~#left#lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(#right#lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~#right#lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lower_left##0:position.position) @caret:nn:nn
+    foreign lpvm access(~#left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#upper_right##0:position.position) @caret:nn:nn
+    foreign lpvm access(#right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lower_left##0:position.position) @caret:nn:nn
+    foreign lpvm access(~#right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#upper_right##0:position.position) @caret:nn:nn
+    foreign lpvm access(#left#lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left#lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right#lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right#lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
@@ -391,10 +391,10 @@ entry:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#left#upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.int)
-            foreign lpvm access(~#left#upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
-            foreign lpvm access(#right#upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.int)
-            foreign lpvm access(~#right#upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int)
+            foreign lpvm access(#left#upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.int) @position:nn:nn
+            foreign lpvm access(~#left#upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @position:nn:nn
+            foreign lpvm access(#right#upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.int) @position:nn:nn
+            foreign lpvm access(~#right#upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int) @position:nn:nn
             foreign llvm icmp_eq(~tmp#14##0:wybe.int, ~tmp#16##0:wybe.int, ?tmp#18##0:wybe.bool) @int:nn:nn
             case ~tmp#18##0:wybe.bool of
             0:
@@ -412,13 +412,13 @@ lower_left > public {inline} (0 calls)
 lower_left(#rec##0:caret.region, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:position.position)
+    foreign lpvm access(~#rec##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:position.position) @caret:nn:nn
 lower_left > public {inline} (0 calls)
 1: caret.region.lower_left<1>
 lower_left(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:position.position)
+    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:position.position) @caret:nn:nn
 
 
 region > public {inline} (0 calls)
@@ -426,16 +426,16 @@ region > public {inline} (0 calls)
 region(lower_left##0:position.position, upper_right##0:position.position, ?#result##0:caret.region):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:caret.region)
-    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower_left##0:position.position)
-    foreign lpvm mutate(~#rec##1:caret.region, ?#result##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right##0:position.position)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:caret.region) @caret:nn:nn
+    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower_left##0:position.position) @caret:nn:nn
+    foreign lpvm mutate(~#rec##1:caret.region, ?#result##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right##0:position.position) @caret:nn:nn
 region > public {inline} (6 calls)
 1: caret.region.region<1>
 region(?lower_left##0:position.position, ?upper_right##0:position.position, #result##0:caret.region):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower_left##0:position.position)
-    foreign lpvm access(~#result##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right##0:position.position)
+    foreign lpvm access(#result##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower_left##0:position.position) @caret:nn:nn
+    foreign lpvm access(~#result##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right##0:position.position) @caret:nn:nn
 
 
 upper_right > public {inline} (0 calls)
@@ -443,13 +443,13 @@ upper_right > public {inline} (0 calls)
 upper_right(#rec##0:caret.region, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:position.position)
+    foreign lpvm access(~#rec##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:position.position) @caret:nn:nn
 upper_right > public {inline} (0 calls)
 1: caret.region.upper_right<1>
 upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:position.position)
+    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:position.position) @caret:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -457,14 +457,14 @@ upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.posi
 ~=(#left##0:caret.region, #right##0:caret.region, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:position.position)
-    foreign lpvm access(~#left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm access(#right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:position.position)
-    foreign lpvm access(~#right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position)
-    foreign lpvm access(tmp#3##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~tmp#3##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(tmp#5##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-    foreign lpvm access(~tmp#5##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign lpvm access(#left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:position.position) @caret:nn:nn
+    foreign lpvm access(~#left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:position.position) @caret:nn:nn
+    foreign lpvm access(#right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:position.position) @caret:nn:nn
+    foreign lpvm access(~#right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#3##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~tmp#3##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @position:nn:nn
+    foreign lpvm access(tmp#5##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~tmp#5##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
@@ -479,10 +479,10 @@ upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.posi
             foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(tmp#4##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.int)
-            foreign lpvm access(~tmp#4##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.int)
-            foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
-            foreign lpvm access(~tmp#6##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.int)
+            foreign lpvm access(tmp#4##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.int) @position:nn:nn
+            foreign lpvm access(~tmp#4##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.int) @position:nn:nn
+            foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @position:nn:nn
+            foreign lpvm access(~tmp#6##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.int) @position:nn:nn
             foreign llvm icmp_eq(~tmp#13##0:wybe.int, ~tmp#15##0:wybe.int, ?tmp#17##0:wybe.bool) @int:nn:nn
             case ~tmp#17##0:wybe.bool of
             0:
@@ -749,10 +749,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -838,10 +838,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -857,16 +857,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -874,13 +874,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -888,13 +888,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -902,10 +902,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/cases.exp
+++ b/test-cases/final-dump/cases.exp
@@ -20,7 +20,7 @@ len(lst##0:wybe.list(T), ?#result##0:wybe.int):
         foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @cases:nn:nn
 
     1:
-        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:wybe.list(T))
+        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:wybe.list(T)) @list:nn:nn
         cases.len<0>(~t##0:wybe.list(T), ?tmp#2##0:wybe.int) #1 @cases:nn:nn
         foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
@@ -37,7 +37,7 @@ len2(lst##0:wybe.list(T), ?#result##0:wybe.int):
         foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @cases:nn:nn
 
     1:
-        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:wybe.list(T))
+        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:wybe.list(T)) @list:nn:nn
         cases.len2<0>(~t##0:wybe.list(T), ?tmp#3##0:wybe.int) #1 @cases:nn:nn
         foreign llvm add(~tmp#3##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -26,14 +26,14 @@ AFTER EVERYTHING:
         foreign llvm icmp_eq(~#left##0:constructors, ~#right##0:constructors, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(~#left##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int)
+        foreign lpvm access(~#left##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int) @constructors:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
         case ~tmp#8##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(~#right##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int)
+            foreign lpvm access(~#right##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int) @constructors:nn:nn
             foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -44,8 +44,8 @@ just > public {inline} (0 calls)
 just(value##0:wybe.int, ?#result##0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:constructors)
-    foreign lpvm mutate(~#rec##0:constructors, ?#result##0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:constructors) @constructors:nn:nn
+    foreign lpvm mutate(~#rec##0:constructors, ?#result##0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int) @constructors:nn:nn
 just > public {inline} (8 calls)
 1: constructors.just<1>
 just(?value##0:wybe.int, #result##0:constructors, ?#success##0:wybe.bool):
@@ -58,7 +58,7 @@ just(?value##0:wybe.int, #result##0:constructors, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign lpvm access(~#result##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int) @constructors:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -83,7 +83,7 @@ value(#rec##0:constructors, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @constructors:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 value > public {inline} (0 calls)
@@ -98,7 +98,7 @@ value(#rec##0:constructors, ?#rec##1:constructors, #field##0:wybe.int, ?#success
         foreign llvm move(~#rec##0:constructors, ?#rec##1:constructors)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:constructors, ?#rec##1:constructors, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:constructors, ?#rec##1:constructors, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @constructors:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -27,13 +27,13 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:coordinate.Coordinate)
-    foreign lpvm mutate(~tmp#7##0:coordinate.Coordinate, ?tmp#8##0:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm mutate(~tmp#8##0:coordinate.Coordinate, ?tmp#9##0:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm mutate(~tmp#9##0:coordinate.Coordinate, ?tmp#22##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp#22##0:coordinate.Coordinate, ?%crd1##1:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 8000:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:coordinate.Coordinate) @coordinate:nn:nn
+    foreign lpvm mutate(~tmp#7##0:coordinate.Coordinate, ?tmp#8##0:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @coordinate:nn:nn
+    foreign lpvm mutate(~tmp#8##0:coordinate.Coordinate, ?tmp#9##0:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @coordinate:nn:nn
+    foreign lpvm mutate(~tmp#9##0:coordinate.Coordinate, ?tmp#22##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @coordinate:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#22##0:coordinate.Coordinate, ?%crd1##1:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 8000:wybe.int) @coordinate:nn:nn
     wybe.string.print_string<0>("expect crd1^z=8000: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #9 @io:nn:nn
-    foreign lpvm access(~crd1##1:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm access(~crd1##1:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @coordinate:nn:nn
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("expect crd2^z=1000: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #10 @io:nn:nn
@@ -146,12 +146,12 @@ entry:
 =(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(#left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(~#left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int)
-    foreign lpvm access(#right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(#right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
-    foreign lpvm access(~#right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int)
+    foreign lpvm access(#left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(#left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(~#left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(#right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(#right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(~#right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int) @coordinate:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -174,18 +174,18 @@ Coordinate > public {inline} (0 calls)
 Coordinate(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, ?#result##0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:coordinate.Coordinate)
-    foreign lpvm mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:coordinate.Coordinate, ?#rec##2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:coordinate.Coordinate, ?#result##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:coordinate.Coordinate) @coordinate:nn:nn
+    foreign lpvm mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~x##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm mutate(~#rec##1:coordinate.Coordinate, ?#rec##2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm mutate(~#rec##2:coordinate.Coordinate, ?#result##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z##0:wybe.int) @coordinate:nn:nn
 Coordinate > public {inline} (10 calls)
 1: coordinate.Coordinate.Coordinate<1>
 Coordinate(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, #result##0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(#result##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access(~#result##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(#result##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(#result##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?y##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(~#result##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z##0:wybe.int) @coordinate:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -193,13 +193,13 @@ x > public {inline} (0 calls)
 x(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @coordinate:nn:nn
 x > public {inline} (0 calls)
 1: coordinate.Coordinate.x<1>
 x(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @coordinate:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -207,13 +207,13 @@ y > public {inline} (0 calls)
 y(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @coordinate:nn:nn
 y > public {inline} (0 calls)
 1: coordinate.Coordinate.y<1>
 y(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @coordinate:nn:nn
 
 
 z > public {inline} (0 calls)
@@ -221,13 +221,13 @@ z > public {inline} (0 calls)
 z(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @coordinate:nn:nn
 z > public {inline} (0 calls)
 1: coordinate.Coordinate.z<1>
 z(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @coordinate:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -235,12 +235,12 @@ z(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.
 ~=(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(#left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(~#left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(#right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
-    foreign lpvm access(#right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~#right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(#left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(~#left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(#right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(#right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @coordinate:nn:nn
+    foreign lpvm access(~#right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @coordinate:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
     case ~tmp#9##0:wybe.bool of
     0:

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -18,8 +18,8 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl('a':ctor_char, 1:ctor_char, ?tmp#3##0:ctor_char)
-    foreign llvm or(~tmp#3##0:ctor_char, 512:ctor_char, ?tmp#1##0:ctor_char)
+    foreign llvm shl('a':ctor_char, 1:ctor_char, ?tmp#3##0:ctor_char) @ctor_char:nn:nn
+    foreign llvm or(~tmp#3##0:ctor_char, 512:ctor_char, ?tmp#1##0:ctor_char) @ctor_char:nn:nn
     ctor_char.foo<0>(~tmp#1##0:ctor_char, ?tmp#0##0:wybe.char) #1 @ctor_char:nn:nn
     foreign c putchar(~tmp#0##0:wybe.char, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
@@ -46,7 +46,7 @@ module top-level code > public {impure} (0 calls)
                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign lpvm access(~#left##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#other_ctor#1##0:ctor_char)
+                foreign lpvm access(~#left##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#other_ctor#1##0:ctor_char) @ctor_char:nn:nn
                 foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.bool)
                 case ~tmp#19##0:wybe.bool of
                 0:
@@ -60,16 +60,16 @@ module top-level code > public {impure} (0 calls)
                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~#right##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#other_ctor#1##0:ctor_char)
+                        foreign lpvm access(~#right##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#other_ctor#1##0:ctor_char) @ctor_char:nn:nn
                         ctor_char.=<0>(~#left#other_ctor#1##0:ctor_char, ~#right#other_ctor#1##0:ctor_char, ?#success##0:wybe.bool) #5
 
 
 
 
         1:
-            foreign llvm lshr(~#left##0:ctor_char, 1:ctor_char, ?tmp#12##0:ctor_char)
-            foreign llvm and(~tmp#12##0:ctor_char, 255:ctor_char, ?tmp#13##0:ctor_char)
-            foreign lpvm cast(~tmp#13##0:ctor_char, ?#left#c##0:wybe.char)
+            foreign llvm lshr(~#left##0:ctor_char, 1:ctor_char, ?tmp#12##0:ctor_char) @ctor_char:nn:nn
+            foreign llvm and(~tmp#12##0:ctor_char, 255:ctor_char, ?tmp#13##0:ctor_char) @ctor_char:nn:nn
+            foreign lpvm cast(~tmp#13##0:ctor_char, ?#left#c##0:wybe.char) @ctor_char:nn:nn
             foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
             case ~tmp#15##0:wybe.bool of
             0:
@@ -83,9 +83,9 @@ module top-level code > public {impure} (0 calls)
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign llvm lshr(~#right##0:ctor_char, 1:ctor_char, ?tmp#18##0:ctor_char)
-                    foreign llvm and(~tmp#18##0:ctor_char, 255:ctor_char, ?tmp#19##0:ctor_char)
-                    foreign lpvm cast(~tmp#19##0:ctor_char, ?#right#c##0:wybe.char)
+                    foreign llvm lshr(~#right##0:ctor_char, 1:ctor_char, ?tmp#18##0:ctor_char) @ctor_char:nn:nn
+                    foreign llvm and(~tmp#18##0:ctor_char, 255:ctor_char, ?tmp#19##0:ctor_char) @ctor_char:nn:nn
+                    foreign lpvm cast(~tmp#19##0:ctor_char, ?#right#c##0:wybe.char) @ctor_char:nn:nn
                     foreign llvm icmp_eq(~#left#c##0:wybe.char, ~#right#c##0:wybe.char, ?#success##0:wybe.bool) @char:nn:nn
 
 
@@ -113,9 +113,9 @@ c(#rec##0:ctor_char, ?#result##0:wybe.char, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
         1:
-            foreign llvm lshr(~#rec##0:ctor_char, 1:ctor_char, ?#rec##1:ctor_char)
-            foreign llvm and(~#rec##1:ctor_char, 255:ctor_char, ?#field##0:ctor_char)
-            foreign lpvm cast(~#field##0:ctor_char, ?#result##0:wybe.char)
+            foreign llvm lshr(~#rec##0:ctor_char, 1:ctor_char, ?#rec##1:ctor_char) @ctor_char:nn:nn
+            foreign llvm and(~#rec##1:ctor_char, 255:ctor_char, ?#field##0:ctor_char) @ctor_char:nn:nn
+            foreign lpvm cast(~#field##0:ctor_char, ?#result##0:wybe.char) @ctor_char:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -139,9 +139,9 @@ c(#rec##0:ctor_char, ?#rec##2:ctor_char, #field##0:wybe.char, ?#success##0:wybe.
             foreign llvm move(~#rec##0:ctor_char, ?#rec##2:ctor_char)
 
         1:
-            foreign llvm and(~#rec##0:ctor_char, -511:ctor_char, ?#rec##1:ctor_char)
-            foreign llvm shl(~#field##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
-            foreign llvm or(~#rec##1:ctor_char, ~#temp##0:ctor_char, ?#rec##2:ctor_char)
+            foreign llvm and(~#rec##0:ctor_char, -511:ctor_char, ?#rec##1:ctor_char) @ctor_char:nn:nn
+            foreign llvm shl(~#field##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char) @ctor_char:nn:nn
+            foreign llvm or(~#rec##1:ctor_char, ~#temp##0:ctor_char, ?#rec##2:ctor_char) @ctor_char:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -160,8 +160,8 @@ ctor > {inline} (1 calls)
 ctor(c##0:wybe.char, ?#result##3:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~c##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
-    foreign llvm or(~#temp##0:ctor_char, 512:ctor_char, ?#result##3:ctor_char)
+    foreign llvm shl(~c##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char) @ctor_char:nn:nn
+    foreign llvm or(~#temp##0:ctor_char, 512:ctor_char, ?#result##3:ctor_char) @ctor_char:nn:nn
 ctor > {inline} (13 calls)
 1: ctor_char.ctor<1>
 ctor(?c##0:wybe.char, #result##0:ctor_char, ?#success##0:wybe.bool):
@@ -182,9 +182,9 @@ ctor(?c##0:wybe.char, #result##0:ctor_char, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
-            foreign llvm lshr(~#result##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
-            foreign llvm and(~#temp##0:ctor_char, 255:ctor_char, ?#temp2##0:ctor_char)
-            foreign lpvm cast(~#temp2##0:ctor_char, ?c##0:wybe.char)
+            foreign llvm lshr(~#result##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char) @ctor_char:nn:nn
+            foreign llvm and(~#temp##0:ctor_char, 255:ctor_char, ?#temp2##0:ctor_char) @ctor_char:nn:nn
+            foreign lpvm cast(~#temp2##0:ctor_char, ?c##0:wybe.char) @ctor_char:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -208,9 +208,9 @@ foo(this##0:ctor_char, ?#result##0:wybe.char):
             foreign llvm move('0':wybe.char, ?#result##0:wybe.char) @ctor_char:nn:nn
 
         1:
-            foreign llvm lshr(~this##0:ctor_char, 1:ctor_char, ?tmp#6##0:ctor_char)
-            foreign llvm and(~tmp#6##0:ctor_char, 255:ctor_char, ?tmp#7##0:ctor_char)
-            foreign lpvm cast(~tmp#7##0:ctor_char, ?#result##0:wybe.char)
+            foreign llvm lshr(~this##0:ctor_char, 1:ctor_char, ?tmp#6##0:ctor_char) @ctor_char:nn:nn
+            foreign llvm and(~tmp#6##0:ctor_char, 255:ctor_char, ?tmp#7##0:ctor_char) @ctor_char:nn:nn
+            foreign lpvm cast(~tmp#7##0:ctor_char, ?#result##0:wybe.char) @ctor_char:nn:nn
 
 
 
@@ -220,9 +220,9 @@ other_ctor > public {inline} (0 calls)
 other_ctor(other_ctor#1##0:ctor_char, ?#result##0:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char)
-    foreign lpvm mutate(~#rec##0:ctor_char, ?#rec##1:ctor_char, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char)
-    foreign llvm or(~#rec##1:ctor_char, 1:wybe.int, ?#result##0:ctor_char)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char) @ctor_char:nn:nn
+    foreign lpvm mutate(~#rec##0:ctor_char, ?#rec##1:ctor_char, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char) @ctor_char:nn:nn
+    foreign llvm or(~#rec##1:ctor_char, 1:wybe.int, ?#result##0:ctor_char) @ctor_char:nn:nn
 other_ctor > public {inline} (5 calls)
 1: ctor_char.other_ctor<1>
 other_ctor(?other_ctor#1##0:ctor_char, #result##0:ctor_char, ?#success##0:wybe.bool):
@@ -243,7 +243,7 @@ other_ctor(?other_ctor#1##0:ctor_char, #result##0:ctor_char, ?#success##0:wybe.b
             foreign llvm move(undef:ctor_char, ?other_ctor#1##0:ctor_char)
 
         1:
-            foreign lpvm access(~#result##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char)
+            foreign lpvm access(~#result##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char) @ctor_char:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -20,8 +20,8 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl('a':ctor_char2, 2:ctor_char2, ?tmp#3##0:ctor_char2)
-    foreign llvm or(~tmp#3##0:ctor_char2, 1024:ctor_char2, ?tmp#1##0:ctor_char2)
+    foreign llvm shl('a':ctor_char2, 2:ctor_char2, ?tmp#3##0:ctor_char2) @ctor_char2:1:22
+    foreign llvm or(~tmp#3##0:ctor_char2, 1024:ctor_char2, ?tmp#1##0:ctor_char2) @ctor_char2:1:22
     ctor_char2.foo<0>(~tmp#1##0:ctor_char2, ?tmp#0##0:wybe.char) #1 @ctor_char2:5:10
     foreign c putchar(~tmp#0##0:wybe.char, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
@@ -51,7 +51,7 @@ module top-level code > public {impure} (0 calls)
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~#left##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#another_ctor#1##0:ctor_char2)
+                    foreign lpvm access(~#left##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#another_ctor#1##0:ctor_char2) @ctor_char2:1:53
                     foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.bool)
                     case ~tmp#26##0:wybe.bool of
                     0:
@@ -65,14 +65,14 @@ module top-level code > public {impure} (0 calls)
                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~#right##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#another_ctor#1##0:ctor_char2)
+                            foreign lpvm access(~#right##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#another_ctor#1##0:ctor_char2) @ctor_char2:1:53
                             ctor_char2.=<0>(~#left#another_ctor#1##0:ctor_char2, ~#right#another_ctor#1##0:ctor_char2, ?#success##0:wybe.bool) #8
 
 
 
 
             1:
-                foreign lpvm access(~#left##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#other_ctor#1##0:ctor_char2)
+                foreign lpvm access(~#left##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#other_ctor#1##0:ctor_char2) @ctor_char2:1:37
                 foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.bool)
                 case ~tmp#22##0:wybe.bool of
                 0:
@@ -86,16 +86,16 @@ module top-level code > public {impure} (0 calls)
                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~#right##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#other_ctor#1##0:ctor_char2)
+                        foreign lpvm access(~#right##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#other_ctor#1##0:ctor_char2) @ctor_char2:1:37
                         ctor_char2.=<0>(~#left#other_ctor#1##0:ctor_char2, ~#right#other_ctor#1##0:ctor_char2, ?#success##0:wybe.bool) #5
 
 
 
 
         1:
-            foreign llvm lshr(~#left##0:ctor_char2, 2:ctor_char2, ?tmp#15##0:ctor_char2)
-            foreign llvm and(~tmp#15##0:ctor_char2, 255:ctor_char2, ?tmp#16##0:ctor_char2)
-            foreign lpvm cast(~tmp#16##0:ctor_char2, ?#left#c##0:wybe.char)
+            foreign llvm lshr(~#left##0:ctor_char2, 2:ctor_char2, ?tmp#15##0:ctor_char2) @ctor_char2:1:22
+            foreign llvm and(~tmp#15##0:ctor_char2, 255:ctor_char2, ?tmp#16##0:ctor_char2) @ctor_char2:1:22
+            foreign lpvm cast(~tmp#16##0:ctor_char2, ?#left#c##0:wybe.char) @ctor_char2:1:22
             foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
             case ~tmp#18##0:wybe.bool of
             0:
@@ -109,9 +109,9 @@ module top-level code > public {impure} (0 calls)
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign llvm lshr(~#right##0:ctor_char2, 2:ctor_char2, ?tmp#21##0:ctor_char2)
-                    foreign llvm and(~tmp#21##0:ctor_char2, 255:ctor_char2, ?tmp#22##0:ctor_char2)
-                    foreign lpvm cast(~tmp#22##0:ctor_char2, ?#right#c##0:wybe.char)
+                    foreign llvm lshr(~#right##0:ctor_char2, 2:ctor_char2, ?tmp#21##0:ctor_char2) @ctor_char2:1:22
+                    foreign llvm and(~tmp#21##0:ctor_char2, 255:ctor_char2, ?tmp#22##0:ctor_char2) @ctor_char2:1:22
+                    foreign lpvm cast(~tmp#22##0:ctor_char2, ?#right#c##0:wybe.char) @ctor_char2:1:22
                     foreign llvm icmp_eq(~#left#c##0:wybe.char, ~#right#c##0:wybe.char, ?#success##0:wybe.bool) @char:nn:nn
 
 
@@ -124,9 +124,9 @@ another_ctor > public {inline} (0 calls)
 another_ctor(another_ctor#1##0:ctor_char2, ?#result##0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2)
-    foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~another_ctor#1##0:ctor_char2)
-    foreign llvm or(~#rec##1:ctor_char2, 2:wybe.int, ?#result##0:ctor_char2)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2) @ctor_char2:1:53
+    foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~another_ctor#1##0:ctor_char2) @ctor_char2:1:53
+    foreign llvm or(~#rec##1:ctor_char2, 2:wybe.int, ?#result##0:ctor_char2) @ctor_char2:1:53
 another_ctor > public {inline} (5 calls)
 1: ctor_char2.another_ctor<1>
 another_ctor(?another_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:wybe.bool):
@@ -147,7 +147,7 @@ another_ctor(?another_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:
             foreign llvm move(undef:ctor_char2, ?another_ctor#1##0:ctor_char2)
 
         1:
-            foreign lpvm access(~#result##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor#1##0:ctor_char2)
+            foreign lpvm access(~#result##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor#1##0:ctor_char2) @ctor_char2:1:53
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -173,9 +173,9 @@ c(#rec##0:ctor_char2, ?#result##0:wybe.char, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
         1:
-            foreign llvm lshr(~#rec##0:ctor_char2, 2:ctor_char2, ?#rec##1:ctor_char2)
-            foreign llvm and(~#rec##1:ctor_char2, 255:ctor_char2, ?#field##0:ctor_char2)
-            foreign lpvm cast(~#field##0:ctor_char2, ?#result##0:wybe.char)
+            foreign llvm lshr(~#rec##0:ctor_char2, 2:ctor_char2, ?#rec##1:ctor_char2) @ctor_char2:1:22
+            foreign llvm and(~#rec##1:ctor_char2, 255:ctor_char2, ?#field##0:ctor_char2) @ctor_char2:1:22
+            foreign lpvm cast(~#field##0:ctor_char2, ?#result##0:wybe.char) @ctor_char2:1:22
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -199,9 +199,9 @@ c(#rec##0:ctor_char2, ?#rec##2:ctor_char2, #field##0:wybe.char, ?#success##0:wyb
             foreign llvm move(~#rec##0:ctor_char2, ?#rec##2:ctor_char2)
 
         1:
-            foreign llvm and(~#rec##0:ctor_char2, -1021:ctor_char2, ?#rec##1:ctor_char2)
-            foreign llvm shl(~#field##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
-            foreign llvm or(~#rec##1:ctor_char2, ~#temp##0:ctor_char2, ?#rec##2:ctor_char2)
+            foreign llvm and(~#rec##0:ctor_char2, -1021:ctor_char2, ?#rec##1:ctor_char2) @ctor_char2:1:22
+            foreign llvm shl(~#field##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2) @ctor_char2:1:22
+            foreign llvm or(~#rec##1:ctor_char2, ~#temp##0:ctor_char2, ?#rec##2:ctor_char2) @ctor_char2:1:22
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -220,8 +220,8 @@ ctor > {inline} (1 calls)
 ctor(c##0:wybe.char, ?#result##3:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~c##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
-    foreign llvm or(~#temp##0:ctor_char2, 1024:ctor_char2, ?#result##3:ctor_char2)
+    foreign llvm shl(~c##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2) @ctor_char2:1:22
+    foreign llvm or(~#temp##0:ctor_char2, 1024:ctor_char2, ?#result##3:ctor_char2) @ctor_char2:1:22
 ctor > {inline} (15 calls)
 1: ctor_char2.ctor<1>
 ctor(?c##0:wybe.char, #result##0:ctor_char2, ?#success##0:wybe.bool):
@@ -242,9 +242,9 @@ ctor(?c##0:wybe.char, #result##0:ctor_char2, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
-            foreign llvm lshr(~#result##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
-            foreign llvm and(~#temp##0:ctor_char2, 255:ctor_char2, ?#temp2##0:ctor_char2)
-            foreign lpvm cast(~#temp2##0:ctor_char2, ?c##0:wybe.char)
+            foreign llvm lshr(~#result##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2) @ctor_char2:1:22
+            foreign llvm and(~#temp##0:ctor_char2, 255:ctor_char2, ?#temp2##0:ctor_char2) @ctor_char2:1:22
+            foreign lpvm cast(~#temp2##0:ctor_char2, ?c##0:wybe.char) @ctor_char2:1:22
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -268,9 +268,9 @@ foo(this##0:ctor_char2, ?#result##0:wybe.char):
             foreign llvm move('0':wybe.char, ?#result##0:wybe.char) @ctor_char2:3:1
 
         1:
-            foreign llvm lshr(~this##0:ctor_char2, 2:ctor_char2, ?tmp#6##0:ctor_char2)
-            foreign llvm and(~tmp#6##0:ctor_char2, 255:ctor_char2, ?tmp#7##0:ctor_char2)
-            foreign lpvm cast(~tmp#7##0:ctor_char2, ?#result##0:wybe.char)
+            foreign llvm lshr(~this##0:ctor_char2, 2:ctor_char2, ?tmp#6##0:ctor_char2) @ctor_char2:1:22
+            foreign llvm and(~tmp#6##0:ctor_char2, 255:ctor_char2, ?tmp#7##0:ctor_char2) @ctor_char2:1:22
+            foreign lpvm cast(~tmp#7##0:ctor_char2, ?#result##0:wybe.char) @ctor_char2:1:22
 
 
 
@@ -280,9 +280,9 @@ other_ctor > public {inline} (0 calls)
 other_ctor(other_ctor#1##0:ctor_char2, ?#result##0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2)
-    foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char2)
-    foreign llvm or(~#rec##1:ctor_char2, 1:wybe.int, ?#result##0:ctor_char2)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2) @ctor_char2:1:37
+    foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char2) @ctor_char2:1:37
+    foreign llvm or(~#rec##1:ctor_char2, 1:wybe.int, ?#result##0:ctor_char2) @ctor_char2:1:37
 other_ctor > public {inline} (7 calls)
 1: ctor_char2.other_ctor<1>
 other_ctor(?other_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:wybe.bool):
@@ -303,7 +303,7 @@ other_ctor(?other_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:wybe
             foreign llvm move(undef:ctor_char2, ?other_ctor#1##0:ctor_char2)
 
         1:
-            foreign lpvm access(~#result##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char2)
+            foreign lpvm access(~#result##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char2) @ctor_char2:1:37
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -50,16 +50,16 @@ module top-level code > public {impure} (0 calls)
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(dead_cell_size.bar<0>,fromList [NonAliasedParamCond 0 []])),(7,(dead_cell_size.diff_type<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(8:wybe.int, ?tmp#7##0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp#7##0:dead_cell_size.t, ?tmp#8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?tmp#7##0:dead_cell_size.t) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~tmp#7##0:dead_cell_size.t, ?tmp#8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int) @dead_cell_size:nn:nn
     dead_cell_size.foo<0>(~tmp#8##0:dead_cell_size.t, ?tmp#0##0:dead_cell_size.t) #1 @dead_cell_size:nn:nn
     dead_cell_size.print_t<0>(~tmp#0##0:dead_cell_size.t, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @dead_cell_size:nn:nn
-    foreign lpvm alloc(8:wybe.int, ?tmp#10##0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp#10##0:dead_cell_size.t, ?tmp#11##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?tmp#10##0:dead_cell_size.t) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~tmp#10##0:dead_cell_size.t, ?tmp#11##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int) @dead_cell_size:nn:nn
     dead_cell_size.bar<0>[410bae77d3](~tmp#11##0:dead_cell_size.t, ?tmp#2##0:dead_cell_size.t) #4 @dead_cell_size:nn:nn
     dead_cell_size.print_t<0>(~tmp#2##0:dead_cell_size.t, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @dead_cell_size:nn:nn
-    foreign lpvm alloc(8:wybe.int, ?tmp#13##0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp#13##0:dead_cell_size.t, ?tmp#14##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?tmp#13##0:dead_cell_size.t) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~tmp#13##0:dead_cell_size.t, ?tmp#14##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int) @dead_cell_size:nn:nn
     dead_cell_size.diff_type<0>[410bae77d3](~tmp#14##0:dead_cell_size.t, ?tmp#4##0:dead_cell_size.t2) #7 @dead_cell_size:nn:nn
     dead_cell_size.print_t2<0>(~tmp#4##0:dead_cell_size.t2, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @dead_cell_size:nn:nn
 
@@ -82,10 +82,10 @@ bar(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t):
             foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
         1:
-            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-            foreign lpvm alloc(8:wybe.int, ?tmp#7##0:dead_cell_size.t)
-            foreign lpvm mutate(~tmp#7##0:dead_cell_size.t, ?tmp#8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
-            foreign llvm or(~tmp#8##0:dead_cell_size.t, 2:wybe.int, ?x##1:dead_cell_size.t)
+            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
+            foreign lpvm alloc(8:wybe.int, ?tmp#7##0:dead_cell_size.t) @dead_cell_size:nn:nn
+            foreign lpvm mutate(~tmp#7##0:dead_cell_size.t, ?tmp#8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int) @dead_cell_size:nn:nn
+            foreign llvm or(~tmp#8##0:dead_cell_size.t, 2:wybe.int, ?x##1:dead_cell_size.t) @dead_cell_size:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
@@ -102,7 +102,7 @@ bar(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t):
             foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
         1:
-            foreign llvm or(~x##0:dead_cell_size.t, 2:wybe.int, ?x##1:dead_cell_size.t)
+            foreign llvm or(~x##0:dead_cell_size.t, 2:wybe.int, ?x##1:dead_cell_size.t) @dead_cell_size:nn:nn
 
 
 
@@ -115,37 +115,37 @@ diff_type(x##0:dead_cell_size.t, ?y##0:dead_cell_size.t2):
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool)
     case ~tmp#4##0:wybe.bool of
     0:
-        foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
-        foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+        foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2) @dead_cell_size:nn:nn
+        foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int) @dead_cell_size:nn:nn
 
     1:
         foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#5##0:wybe.int)
         foreign llvm icmp_eq(~tmp#5##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
         case ~tmp#6##0:wybe.bool of
         0:
-            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2) @dead_cell_size:nn:nn
+            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int) @dead_cell_size:nn:nn
 
         1:
-            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
+            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2) @dead_cell_size:nn:nn
+            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int) @dead_cell_size:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool)
     case ~tmp#4##0:wybe.bool of
     0:
-        foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
-        foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+        foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2) @dead_cell_size:nn:nn
+        foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int) @dead_cell_size:nn:nn
 
     1:
         foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#5##0:wybe.int)
         foreign llvm icmp_eq(~tmp#5##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
         case ~tmp#6##0:wybe.bool of
         0:
-            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2) @dead_cell_size:nn:nn
+            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int) @dead_cell_size:nn:nn
 
         1:
             foreign llvm move(~x##0:dead_cell_size.t, ?y##0:dead_cell_size.t2)
@@ -171,12 +171,12 @@ foo(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t):
             foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
         1:
-            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-            foreign lpvm alloc(24:wybe.int, ?tmp#9##0:dead_cell_size.t)
-            foreign lpvm mutate(~tmp#9##0:dead_cell_size.t, ?tmp#10##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~a##0:wybe.int)
-            foreign lpvm mutate(~tmp#10##0:dead_cell_size.t, ?tmp#11##0:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-            foreign lpvm mutate(~tmp#11##0:dead_cell_size.t, ?tmp#12##0:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 3:wybe.int)
-            foreign llvm or(~tmp#12##0:dead_cell_size.t, 1:wybe.int, ?x##1:dead_cell_size.t)
+            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
+            foreign lpvm alloc(24:wybe.int, ?tmp#9##0:dead_cell_size.t) @dead_cell_size:nn:nn
+            foreign lpvm mutate(~tmp#9##0:dead_cell_size.t, ?tmp#10##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~a##0:wybe.int) @dead_cell_size:nn:nn
+            foreign lpvm mutate(~tmp#10##0:dead_cell_size.t, ?tmp#11##0:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @dead_cell_size:nn:nn
+            foreign lpvm mutate(~tmp#11##0:dead_cell_size.t, ?tmp#12##0:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 3:wybe.int) @dead_cell_size:nn:nn
+            foreign llvm or(~tmp#12##0:dead_cell_size.t, 1:wybe.int, ?x##1:dead_cell_size.t) @dead_cell_size:nn:nn
 
 
 
@@ -208,7 +208,7 @@ print_t(x##0:dead_cell_size.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
                         foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
                     1:
-                        foreign lpvm access(~x##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int)
+                        foreign lpvm access(~x##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int) @dead_cell_size:nn:nn
                         wybe.string.print_string<0>("td(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #24 @io:nn:nn
                         foreign c print_int(~a##2:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                         wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #25 @io:nn:nn
@@ -216,9 +216,9 @@ print_t(x##0:dead_cell_size.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
                 1:
-                    foreign lpvm access(x##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?a##1:wybe.int)
-                    foreign lpvm access(x##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?b##0:wybe.int)
-                    foreign lpvm access(~x##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?c##0:wybe.int)
+                    foreign lpvm access(x##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?a##1:wybe.int) @dead_cell_size:nn:nn
+                    foreign lpvm access(x##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?b##0:wybe.int) @dead_cell_size:nn:nn
+                    foreign lpvm access(~x##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?c##0:wybe.int) @dead_cell_size:nn:nn
                     wybe.string.print_string<0>("tc(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #26 @io:nn:nn
                     foreign c print_int(~a##1:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #27 @io:nn:nn
@@ -230,7 +230,7 @@ print_t(x##0:dead_cell_size.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
             1:
-                foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+                foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
                 wybe.string.print_string<0>("tb(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #30 @io:nn:nn
                 foreign c print_int(~a##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                 wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #31 @io:nn:nn
@@ -258,7 +258,7 @@ print_t2(x##0:dead_cell_size.t2, io##0:wybe.phantom, ?io##4:wybe.phantom):
             foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
         1:
-            foreign lpvm access(~x##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+            foreign lpvm access(~x##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
             wybe.string.print_string<0>("t2b(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
             foreign c print_int(~a##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #11 @io:nn:nn
@@ -690,7 +690,7 @@ if.else1:
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~#left##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#td1##0:wybe.int)
+                    foreign lpvm access(~#left##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#td1##0:wybe.int) @dead_cell_size:nn:nn
                     foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.bool)
                     case ~tmp#26##0:wybe.bool of
                     0:
@@ -704,16 +704,16 @@ if.else1:
                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~#right##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#td1##0:wybe.int)
+                            foreign lpvm access(~#right##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#td1##0:wybe.int) @dead_cell_size:nn:nn
                             foreign llvm icmp_eq(~#left#td1##0:wybe.int, ~#right#td1##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
             1:
-                foreign lpvm access(#left##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc1##0:wybe.int)
-                foreign lpvm access(#left##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc2##0:wybe.int)
-                foreign lpvm access(~#left##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc3##0:wybe.int)
+                foreign lpvm access(#left##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc1##0:wybe.int) @dead_cell_size:nn:nn
+                foreign lpvm access(#left##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc2##0:wybe.int) @dead_cell_size:nn:nn
+                foreign lpvm access(~#left##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc3##0:wybe.int) @dead_cell_size:nn:nn
                 foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.bool)
                 case ~tmp#22##0:wybe.bool of
                 0:
@@ -727,9 +727,9 @@ if.else1:
                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(#right##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc1##0:wybe.int)
-                        foreign lpvm access(#right##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc2##0:wybe.int)
-                        foreign lpvm access(~#right##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc3##0:wybe.int)
+                        foreign lpvm access(#right##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc1##0:wybe.int) @dead_cell_size:nn:nn
+                        foreign lpvm access(#right##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc2##0:wybe.int) @dead_cell_size:nn:nn
+                        foreign lpvm access(~#right##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc3##0:wybe.int) @dead_cell_size:nn:nn
                         foreign llvm icmp_eq(~#left#tc1##0:wybe.int, ~#right#tc1##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                         case ~tmp#5##0:wybe.bool of
                         0:
@@ -750,7 +750,7 @@ if.else1:
 
 
         1:
-            foreign lpvm access(~#left##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#tb1##0:wybe.int)
+            foreign lpvm access(~#left##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#tb1##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
             case ~tmp#18##0:wybe.bool of
             0:
@@ -764,7 +764,7 @@ if.else1:
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~#right##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#tb1##0:wybe.int)
+                    foreign lpvm access(~#right##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#tb1##0:wybe.int) @dead_cell_size:nn:nn
                     foreign llvm icmp_eq(~#left#tb1##0:wybe.int, ~#right#tb1##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -785,8 +785,8 @@ tb > public {inline} (0 calls)
 tb(tb1##0:wybe.int, ?#result##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t)
-    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#result##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#result##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int) @dead_cell_size:nn:nn
 tb > public {inline} (14 calls)
 1: dead_cell_size.t.tb<1>
 tb(?tb1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool):
@@ -807,7 +807,7 @@ tb(?tb1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1##0:wybe.int)
+            foreign lpvm access(~#result##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -833,7 +833,7 @@ tb1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -857,7 +857,7 @@ tb1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -868,11 +868,11 @@ tc > public {inline} (0 calls)
 tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?#result##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:dead_cell_size.t)
-    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc1##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:dead_cell_size.t, ?#rec##2:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc2##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:dead_cell_size.t, ?#rec##3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3##0:wybe.int)
-    foreign llvm or(~#rec##3:dead_cell_size.t, 1:wybe.int, ?#result##0:dead_cell_size.t)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:dead_cell_size.t) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc1##0:wybe.int) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~#rec##1:dead_cell_size.t, ?#rec##2:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc2##0:wybe.int) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~#rec##2:dead_cell_size.t, ?#rec##3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3##0:wybe.int) @dead_cell_size:nn:nn
+    foreign llvm or(~#rec##3:dead_cell_size.t, 1:wybe.int, ?#result##0:dead_cell_size.t) @dead_cell_size:nn:nn
 tc > public {inline} (11 calls)
 1: dead_cell_size.t.tc<1>
 tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool):
@@ -897,9 +897,9 @@ tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_si
             foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1##0:wybe.int)
-            foreign lpvm access(#result##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2##0:wybe.int)
-            foreign lpvm access(~#result##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3##0:wybe.int)
+            foreign lpvm access(#result##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1##0:wybe.int) @dead_cell_size:nn:nn
+            foreign lpvm access(#result##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2##0:wybe.int) @dead_cell_size:nn:nn
+            foreign lpvm access(~#result##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -925,7 +925,7 @@ tc1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -949,7 +949,7 @@ tc1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, -1:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, -1:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -975,7 +975,7 @@ tc2(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -999,7 +999,7 @@ tc2(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1025,7 +1025,7 @@ tc3(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1049,7 +1049,7 @@ tc3(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 15:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 15:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1060,9 +1060,9 @@ td > public {inline} (0 calls)
 td(td1##0:wybe.int, ?#result##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t)
-    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1##0:wybe.int)
-    foreign llvm or(~#rec##1:dead_cell_size.t, 2:wybe.int, ?#result##0:dead_cell_size.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1##0:wybe.int) @dead_cell_size:nn:nn
+    foreign llvm or(~#rec##1:dead_cell_size.t, 2:wybe.int, ?#result##0:dead_cell_size.t) @dead_cell_size:nn:nn
 td > public {inline} (5 calls)
 1: dead_cell_size.t.td<1>
 td(?td1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool):
@@ -1083,7 +1083,7 @@ td(?td1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1##0:wybe.int)
+            foreign lpvm access(~#result##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1109,7 +1109,7 @@ td1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1133,7 +1133,7 @@ td1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1764,14 +1764,14 @@ entry:
         foreign llvm icmp_eq(~#left##0:dead_cell_size.t2, ~#right##0:dead_cell_size.t2, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(~#left##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
+        foreign lpvm access(~#left##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int) @dead_cell_size:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
         case ~tmp#8##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(~#right##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
+            foreign lpvm access(~#right##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int) @dead_cell_size:nn:nn
             foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -1789,7 +1789,7 @@ a(#rec##0:dead_cell_size.t2, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @dead_cell_size:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 a > public {inline} (0 calls)
@@ -1804,7 +1804,7 @@ a(#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, #field##0:wybe.int, ?#s
         foreign llvm move(~#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @dead_cell_size:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1822,8 +1822,8 @@ t2b > public {inline} (0 calls)
 t2b(a##0:wybe.int, ?#result##0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t2)
-    foreign lpvm mutate(~#rec##0:dead_cell_size.t2, ?#result##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t2) @dead_cell_size:nn:nn
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t2, ?#result##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int) @dead_cell_size:nn:nn
 t2b > public {inline} (8 calls)
 1: dead_cell_size.t2.t2b<1>
 t2b(?a##0:wybe.int, #result##0:dead_cell_size.t2, ?#success##0:wybe.bool):
@@ -1836,7 +1836,7 @@ t2b(?a##0:wybe.int, #result##0:dead_cell_size.t2, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?a##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+        foreign lpvm access(~#result##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/disjunction.exp
+++ b/test-cases/final-dump/disjunction.exp
@@ -23,11 +23,11 @@ in(e##0:wybe.int, lst##0:wybe.list(wybe.int), ?#success##0:wybe.bool):
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(lst##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(lst##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @list:nn:nn
         foreign llvm icmp_eq(e##0:wybe.int, ~h##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
         case ~tmp#4##0:wybe.bool of
         0:
-            foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.list(wybe.int))
+            foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.list(wybe.int)) @list:nn:nn
             disjunction.in<0>(~e##0:wybe.int, ~tmp#0##0:wybe.list(wybe.int), ?#success##0:wybe.bool) #3 @disjunction:nn:nn
 
         1:
@@ -47,8 +47,8 @@ member(e##0:wybe.int, lst##0:wybe.list(wybe.int), ?#success##0:wybe.bool):
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(lst##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:wybe.list(wybe.int))
+        foreign lpvm access(lst##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_eq(e##0:wybe.int, ~h##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
@@ -71,7 +71,7 @@ saturating_tail(lst##0:wybe.list(T), ?tl##0:wybe.list(T)):
         foreign llvm move(0:2, ?tl##0:wybe.list(T)) @disjunction:nn:nn
 
     1:
-        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tl##0:wybe.list(T))
+        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tl##0:wybe.list(T)) @list:nn:nn
 
 
 
@@ -86,7 +86,7 @@ saturating_tail2(lst##0:wybe.list(T), ?#result##0:wybe.list(T)):
         foreign llvm move(0:wybe.list(T), ?#result##0:wybe.list(T)) @disjunction:nn:nn
 
     1:
-        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.list(T))
+        foreign lpvm access(~lst##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.list(T)) @list:nn:nn
 
 
   LLVM code       :

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -29,12 +29,12 @@ append(x##0:generic_list(T), y##0:generic_list(T), ?#result##0:generic_list(T)):
         foreign llvm move(~y##0:generic_list(T), ?#result##0:generic_list(T)) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(x##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
-        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(x##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T) @generic_list:nn:nn
+        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
         generic_list.append<0>(~t##0:generic_list(T), ~y##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T))
-        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T))
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T)) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T)) @generic_list:nn:nn
 
 
 
@@ -50,7 +50,7 @@ car(#rec##0:generic_list(T), ?#result##0:T, ?#success##0:wybe.bool):
         foreign llvm move(undef:T, ?#result##0:T)
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T)
+        foreign lpvm access(~#rec##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
@@ -65,7 +65,7 @@ car(#rec##0:generic_list(T), ?#rec##1:generic_list(T), #field##0:T, ?#success##0
         foreign llvm move(~#rec##0:generic_list(T), ?#rec##1:generic_list(T))
 
     1:
-        foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T)
+        foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -82,7 +82,7 @@ cdr(#rec##0:generic_list(T), ?#result##0:generic_list(T), ?#success##0:wybe.bool
         foreign llvm move(undef:generic_list(T), ?#result##0:generic_list(T))
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(T))
+        foreign lpvm access(~#rec##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
@@ -97,7 +97,7 @@ cdr(#rec##0:generic_list(T), ?#rec##1:generic_list(T), #field##0:generic_list(T)
         foreign llvm move(~#rec##0:generic_list(T), ?#rec##1:generic_list(T))
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(T))
+        foreign lpvm {noalias} mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -107,9 +107,9 @@ cons > public {inline} (1 calls)
 cons(car##0:T, cdr##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(T))
-    foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T)
-    foreign lpvm mutate(~#rec##1:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(T)) @generic_list:nn:nn
+    foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T) @generic_list:nn:nn
+    foreign lpvm mutate(~#rec##1:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(T)) @generic_list:nn:nn
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
 cons(?car##0:T, ?cdr##0:generic_list(T), #result##0:generic_list(T), ?#success##0:wybe.bool):
@@ -123,8 +123,8 @@ cons(?car##0:T, ?cdr##0:generic_list(T), #result##0:generic_list(T), ?#success##
         foreign llvm move(undef:generic_list(T), ?cdr##0:generic_list(T))
 
     1:
-        foreign lpvm access(#result##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T)
-        foreign lpvm access(~#result##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(T))
+        foreign lpvm access(#result##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T) @generic_list:nn:nn
+        foreign lpvm access(~#result##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -148,7 +148,7 @@ length1(x##0:generic_list(T), acc##0:wybe.int, ?#result##0:wybe.int):
         foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         generic_list.length1<0>(~t##0:generic_list(T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @generic_list:nn:nn
 

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -29,12 +29,12 @@ append(x##0:generic_list(T), y##0:generic_list(T), ?#result##0:generic_list(T)):
         foreign llvm move(~y##0:generic_list(T), ?#result##0:generic_list(T)) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(x##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
-        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(x##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T) @generic_list:nn:nn
+        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
         generic_list.append<0>(~t##0:generic_list(T), ~y##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T))
-        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T))
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T)) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T)) @generic_list:nn:nn
 
 
 
@@ -50,7 +50,7 @@ car(#rec##0:generic_list(T), ?#result##0:T, ?#success##0:wybe.bool):
         foreign llvm move(undef:T, ?#result##0:T)
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T)
+        foreign lpvm access(~#rec##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
@@ -65,7 +65,7 @@ car(#rec##0:generic_list(T), ?#rec##1:generic_list(T), #field##0:T, ?#success##0
         foreign llvm move(~#rec##0:generic_list(T), ?#rec##1:generic_list(T))
 
     1:
-        foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T)
+        foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -82,7 +82,7 @@ cdr(#rec##0:generic_list(T), ?#result##0:generic_list(T), ?#success##0:wybe.bool
         foreign llvm move(undef:generic_list(T), ?#result##0:generic_list(T))
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(T))
+        foreign lpvm access(~#rec##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
@@ -97,7 +97,7 @@ cdr(#rec##0:generic_list(T), ?#rec##1:generic_list(T), #field##0:generic_list(T)
         foreign llvm move(~#rec##0:generic_list(T), ?#rec##1:generic_list(T))
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(T))
+        foreign lpvm {noalias} mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -107,9 +107,9 @@ cons > public {inline} (1 calls)
 cons(car##0:T, cdr##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(T))
-    foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T)
-    foreign lpvm mutate(~#rec##1:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(T)) @generic_list:nn:nn
+    foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T) @generic_list:nn:nn
+    foreign lpvm mutate(~#rec##1:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(T)) @generic_list:nn:nn
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
 cons(?car##0:T, ?cdr##0:generic_list(T), #result##0:generic_list(T), ?#success##0:wybe.bool):
@@ -123,8 +123,8 @@ cons(?car##0:T, ?cdr##0:generic_list(T), #result##0:generic_list(T), ?#success##
         foreign llvm move(undef:generic_list(T), ?cdr##0:generic_list(T))
 
     1:
-        foreign lpvm access(#result##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T)
-        foreign lpvm access(~#result##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(T))
+        foreign lpvm access(#result##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T) @generic_list:nn:nn
+        foreign lpvm access(~#result##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -148,7 +148,7 @@ length1(x##0:generic_list(T), acc##0:wybe.int, ?#result##0:wybe.int):
         foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         generic_list.length1<0>(~t##0:generic_list(T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @generic_list:nn:nn
 
@@ -412,12 +412,12 @@ concat(l1##0:generic_list(T), l2##0:generic_list(T), ?#result##0:generic_list(T)
         foreign llvm move(~l2##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(l1##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
-        foreign lpvm access(~l1##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(l1##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T) @generic_list:nn:nn
+        foreign lpvm access(~l1##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
         generic_use.concat<0>(~t##0:generic_list(T), ~l2##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T))
-        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T))
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T)) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T)) @generic_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
@@ -426,9 +426,9 @@ concat(l1##0:generic_list(T), l2##0:generic_list(T), ?#result##0:generic_list(T)
         foreign llvm move(~l2##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(l1##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(l1##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
         generic_use.concat<0>[410bae77d3](~t##0:generic_list(T), ~l2##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~l1##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T))
+        foreign lpvm mutate(~l1##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T)) @generic_list:nn:nn
 
 
 
@@ -452,9 +452,9 @@ fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?#resul
 
     1:
         foreign llvm sub(hi##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(T))
-        foreign lpvm mutate(~tmp#11##0:generic_list(T), ?tmp#12##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:T)
-        foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(T))
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(T)) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#11##0:generic_list(T), ?tmp#12##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:T) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(T)) @generic_list:nn:nn
         generic_use.fromto1<0>(~lo##0:wybe.int, ~tmp#2##0:wybe.int, ~tmp#3##0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) #3 @generic_use:nn:nn
 
 
@@ -479,12 +479,12 @@ nrev(lst##0:generic_list(T), ?#result##0:generic_list(T)):
         foreign llvm move(0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
-        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T) @generic_list:nn:nn
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
         generic_use.nrev<0>(~t##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(T))
-        foreign lpvm mutate(~tmp#11##0:generic_list(T), ?tmp#12##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
-        foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(T))
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(T)) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#11##0:generic_list(T), ?tmp#12##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(T)) @generic_list:nn:nn
         generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(T), ~tmp#3##0:generic_list(T), ?#result##0:generic_list(T)) #4 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
@@ -494,9 +494,9 @@ nrev(lst##0:generic_list(T), ?#result##0:generic_list(T)):
         foreign llvm move(0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
         generic_use.nrev<0>[410bae77d3](~t##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~lst##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(T))
+        foreign lpvm mutate(~lst##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(T)) @generic_list:nn:nn
         generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(T), ~tmp#3##0:generic_list(T), ?#result##0:generic_list(T)) #4 @generic_use:nn:nn
 
 
@@ -513,8 +513,8 @@ print(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##4:wybe.phantom):
         foreign c putchar(']':wybe.char, ~#io##1:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(wybe.int))
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @generic_list:nn:nn
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(wybe.int)) @generic_list:nn:nn
         foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         generic_use.print_tail<0>(~t##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @generic_use:nn:nn
         foreign c putchar(']':wybe.char, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
@@ -532,8 +532,8 @@ print_tail(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##3:wybe.phanto
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(wybe.int))
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @generic_list:nn:nn
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(wybe.int)) @generic_list:nn:nn
         wybe.string.print_string<0>(", ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
         foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         generic_use.print_tail<0>(~t##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @generic_use:nn:nn
@@ -569,11 +569,11 @@ reverse1(lst##0:generic_list(T), suffix##0:generic_list(T), ?#result##0:generic_
         foreign llvm move(~suffix##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
-        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T))
-        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?tmp#2##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(T))
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T) @generic_list:nn:nn
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T)) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @generic_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?tmp#2##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(T)) @generic_list:nn:nn
         generic_use.reverse1<0>(~t##0:generic_list(T), ~tmp#2##0:generic_list(T), ?#result##0:generic_list(T)) #2 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
@@ -583,8 +583,8 @@ reverse1(lst##0:generic_list(T), suffix##0:generic_list(T), ?#result##0:generic_
         foreign llvm move(~suffix##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
-        foreign lpvm mutate(~lst##0:generic_list(T), ?tmp#2##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(T))
+        foreign lpvm access(lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_list:nn:nn
+        foreign lpvm mutate(~lst##0:generic_list(T), ?tmp#2##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(T)) @generic_list:nn:nn
         generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(T), ~tmp#2##0:generic_list(T), ?#result##0:generic_list(T)) #2 @generic_use:nn:nn
 
 

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -16,12 +16,12 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:position.position)
-    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#10##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#10##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
     import.distance<0>(~tmp#1##0:position.position, ~tmp#2##0:position.position, ?tmp#0##0:wybe.int) #2 @import:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
@@ -32,12 +32,12 @@ distance > public (1 calls)
 distance(p1##0:position.position, p2##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(p2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(p2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
     foreign llvm sub(~tmp#4##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
     foreign c ipow(~tmp#3##0:wybe.int, 2:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-    foreign lpvm access(~p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @position:nn:nn
     foreign llvm sub(~tmp#8##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
     foreign c ipow(~tmp#7##0:wybe.int, 2:wybe.int, ?tmp#6##0:wybe.int) @int:nn:nn
     foreign llvm add(~tmp#2##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
@@ -148,10 +148,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -237,10 +237,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -256,16 +256,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -273,13 +273,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -287,13 +287,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -301,10 +301,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -27,15 +27,15 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:int_list.int_list)
-    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:int_list.int_list, ?tmp#8##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:int_list.int_list)
-    foreign lpvm mutate(~tmp#11##0:int_list.int_list, ?tmp#12##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#8##0:int_list.int_list)
-    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list)
-    foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?tmp#18##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#13##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#7##0:int_list.int_list, ?tmp#8##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#11##0:int_list.int_list, ?tmp#12##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#8##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?tmp#18##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#13##0:int_list.int_list) @int_list:nn:nn
     int_list.print<0>(~tmp#18##0:int_list.int_list, ~#io##0:wybe.phantom, ?tmp#21##0:wybe.phantom) #5 @int_list:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
@@ -51,8 +51,8 @@ print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list) @int_list:nn:nn
         foreign c print_int(~h##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
         foreign c putchar(' ':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         int_list.print<0>(~t##0:int_list.int_list, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @int_list:nn:nn
@@ -182,16 +182,16 @@ entry:
         foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
-        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list)
+        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list) @int_list:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
-            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list)
+            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int) @int_list:nn:nn
+            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list) @int_list:nn:nn
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -209,9 +209,9 @@ cons > public {inline} (0 calls)
 cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
-    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list) @int_list:nn:nn
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
 cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool):
@@ -225,8 +225,8 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int) @int_list:nn:nn
+        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -243,7 +243,7 @@ head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -258,7 +258,7 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -283,7 +283,7 @@ tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe
         foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -298,7 +298,7 @@ tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.i
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
+        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -23,9 +23,9 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_sequence)
-    foreign lpvm mutate(~tmp#5##0:int_sequence, ?tmp#6##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:int_sequence, ?tmp#1##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_sequence) @int_sequence:nn:nn
+    foreign lpvm mutate(~tmp#5##0:int_sequence, ?tmp#6##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @int_sequence:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_sequence, ?tmp#1##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @int_sequence:nn:nn
     int_sequence.gen#1<0>(~io##0:wybe.phantom, ~tmp#1##0:int_sequence, ~tmp#1##0:int_sequence, ?io##1:wybe.phantom) #1 @int_sequence:nn:nn
 
 
@@ -34,16 +34,16 @@ module top-level code > public {impure} (0 calls)
 ..(lower##0:wybe.int, upper##0:wybe.int, ?#result##0:int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_sequence)
-    foreign lpvm mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:int_sequence, ?#result##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_sequence) @int_sequence:nn:nn
+    foreign lpvm mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm mutate(~#rec##1:int_sequence, ?#result##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper##0:wybe.int) @int_sequence:nn:nn
 .. > public {inline} (6 calls)
 1: int_sequence...<1>
 ..(?lower##0:wybe.int, ?upper##0:wybe.int, #result##0:int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower##0:wybe.int)
-    foreign lpvm access(~#result##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper##0:wybe.int)
+    foreign lpvm access(#result##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(~#result##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper##0:wybe.int) @int_sequence:nn:nn
 
 
 = > public {inline} (1 calls)
@@ -51,10 +51,10 @@ module top-level code > public {impure} (0 calls)
 =(#left##0:int_sequence, #right##0:int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lower##0:wybe.int)
-    foreign lpvm access(~#left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#upper##0:wybe.int)
-    foreign lpvm access(#right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lower##0:wybe.int)
-    foreign lpvm access(~#right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#upper##0:wybe.int)
+    foreign lpvm access(#left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lower##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(~#left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#upper##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(#right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lower##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(~#right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#upper##0:wybe.int) @int_sequence:nn:nn
     foreign llvm icmp_eq(~#left#lower##0:wybe.int, ~#right#lower##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -70,8 +70,8 @@ module top-level code > public {impure} (0 calls)
 [|](?head##0:wybe.int, ?tail##0:int_sequence, seq##0:int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 2]
-    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
-    foreign lpvm access(~seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(~seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @int_sequence:nn:nn
     foreign llvm icmp_sle(tmp#0##0:wybe.int, tmp#1##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -82,14 +82,14 @@ module top-level code > public {impure} (0 calls)
     1:
         foreign llvm move(tmp#0##0:wybe.int, ?head##0:wybe.int) @int_sequence:nn:nn
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#19##0:int_sequence)
-        foreign lpvm mutate(~tmp#19##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int)
-        foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#19##0:int_sequence) @int_sequence:nn:nn
+        foreign lpvm mutate(~tmp#19##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int) @int_sequence:nn:nn
+        foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @int_sequence:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
  [785a827a1b] [NonAliasedParam 2] :
-    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
-    foreign lpvm access(seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @int_sequence:nn:nn
     foreign llvm icmp_sle(tmp#0##0:wybe.int, tmp#1##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -100,8 +100,8 @@ module top-level code > public {impure} (0 calls)
     1:
         foreign llvm move(tmp#0##0:wybe.int, ?head##0:wybe.int) @int_sequence:nn:nn
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
-        foreign lpvm mutate(~seq##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int)
-        foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        foreign lpvm mutate(~seq##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int) @int_sequence:nn:nn
+        foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @int_sequence:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -140,13 +140,13 @@ lower > public {inline} (5 calls)
 lower(#rec##0:int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_sequence:nn:nn
 lower > public {inline} (0 calls)
 1: int_sequence.lower<1>
 lower(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @int_sequence:nn:nn
 
 
 upper > public {inline} (4 calls)
@@ -154,13 +154,13 @@ upper > public {inline} (4 calls)
 upper(#rec##0:int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_sequence:nn:nn
 upper > public {inline} (0 calls)
 1: int_sequence.upper<1>
 upper(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @int_sequence:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -168,10 +168,10 @@ upper(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
 ~=(#left##0:int_sequence, #right##0:int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(~#left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(#right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @int_sequence:nn:nn
+    foreign lpvm access(~#right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @int_sequence:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -25,15 +25,15 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_loop.intlist)
-    foreign lpvm mutate(~tmp#8##0:list_loop.intlist, ?tmp#9##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp#9##0:list_loop.intlist, ?tmp#10##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:list_loop.intlist)
-    foreign lpvm mutate(~tmp#13##0:list_loop.intlist, ?tmp#14##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp#14##0:list_loop.intlist, ?tmp#15##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##0:list_loop.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:list_loop.intlist)
-    foreign lpvm mutate(~tmp#18##0:list_loop.intlist, ?tmp#19##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#19##0:list_loop.intlist, ?tmp#20##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#15##0:list_loop.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#8##0:list_loop.intlist, ?tmp#9##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#9##0:list_loop.intlist, ?tmp#10##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#13##0:list_loop.intlist, ?tmp#14##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#14##0:list_loop.intlist, ?tmp#15##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#18##0:list_loop.intlist, ?tmp#19##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#19##0:list_loop.intlist, ?tmp#20##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#15##0:list_loop.intlist) @list_loop:nn:nn
     list_loop.gen#1<0>(~io##0:wybe.phantom, ~tmp#20##0:list_loop.intlist, ~tmp#20##0:list_loop.intlist, ~tmp#15##0:list_loop.intlist, ~tmp#10##0:list_loop.intlist, 0:list_loop.intlist, ~tmp#20##0:list_loop.intlist, ?io##1:wybe.phantom) #4 @list_loop:nn:nn
 
 
@@ -48,8 +48,8 @@ gen#1(io##0:wybe.phantom, l##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tm
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(l##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~l##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l##1:list_loop.intlist)
+        foreign lpvm access(l##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @list_loop:nn:nn
+        foreign lpvm access(~l##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l##1:list_loop.intlist) @list_loop:nn:nn
         foreign c print_int(h##0:wybe.int, ~io##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
         list_loop.gen#3<0>(~h##0:wybe.int, ~tmp#17##0:wybe.phantom, ~l##1:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #2 @list_loop:nn:nn
@@ -77,8 +77,8 @@ gen#3(h##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, l2##0:list_loop
         list_loop.gen#1<0>(~io##0:wybe.phantom, ~l##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #2 @list_loop:nn:nn
 
     1:
-        foreign lpvm access(l2##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h2##0:wybe.int)
-        foreign lpvm access(~l2##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l2##1:list_loop.intlist)
+        foreign lpvm access(l2##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h2##0:wybe.int) @list_loop:nn:nn
+        foreign lpvm access(~l2##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l2##1:list_loop.intlist) @list_loop:nn:nn
         wybe.string.print_string<0>("    ":wybe.string, ~io##0:wybe.phantom, ?tmp#17##0:wybe.phantom) #3 @io:nn:nn
         foreign c print_int(h##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
         wybe.string.print_string<0>(" ":wybe.string, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) #4 @io:nn:nn
@@ -279,16 +279,16 @@ entry:
         foreign llvm icmp_eq(~#left##0:list_loop.intlist, ~#right##0:list_loop.intlist, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
-        foreign lpvm access(~#left##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:list_loop.intlist)
+        foreign lpvm access(#left##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int) @list_loop:nn:nn
+        foreign lpvm access(~#left##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:list_loop.intlist) @list_loop:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
-            foreign lpvm access(~#right##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:list_loop.intlist)
+            foreign lpvm access(#right##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int) @list_loop:nn:nn
+            foreign lpvm access(~#right##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:list_loop.intlist) @list_loop:nn:nn
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -306,9 +306,9 @@ cons > public {inline} (0 calls)
 cons(head##0:wybe.int, tail##0:list_loop.intlist, ?#result##0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:list_loop.intlist)
-    foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:list_loop.intlist, ?#result##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~#rec##1:list_loop.intlist, ?#result##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist) @list_loop:nn:nn
 cons > public {inline} (12 calls)
 1: list_loop.intlist.cons<1>
 cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, #result##0:list_loop.intlist, ?#success##0:wybe.bool):
@@ -322,8 +322,8 @@ cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, #result##0:list_loop.intlist
         foreign llvm move(undef:list_loop.intlist, ?tail##0:list_loop.intlist)
 
     1:
-        foreign lpvm access(#result##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~#result##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:list_loop.intlist)
+        foreign lpvm access(#result##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int) @list_loop:nn:nn
+        foreign lpvm access(~#result##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:list_loop.intlist) @list_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -340,7 +340,7 @@ head(#rec##0:list_loop.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @list_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -355,7 +355,7 @@ head(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:wybe.int, 
         foreign llvm move(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist)
 
     1:
-        foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @list_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -380,7 +380,7 @@ tail(#rec##0:list_loop.intlist, ?#result##0:list_loop.intlist, ?#success##0:wybe
         foreign llvm move(undef:list_loop.intlist, ?#result##0:list_loop.intlist)
 
     1:
-        foreign lpvm access(~#rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_loop.intlist)
+        foreign lpvm access(~#rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_loop.intlist) @list_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -395,7 +395,7 @@ tail(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:list_loop.
         foreign llvm move(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_loop.intlist)
+        foreign lpvm {noalias} mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_loop.intlist) @list_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -29,12 +29,12 @@ append(x##0:list_this(T), y##0:list_this(T), ?#result##0:list_this(T)):
         foreign llvm move(~y##0:list_this(T), ?#result##0:list_this(T)) @list_this:nn:nn
 
     1:
-        foreign lpvm access(x##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
-        foreign lpvm access(~x##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(T))
+        foreign lpvm access(x##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T) @list_this:nn:nn
+        foreign lpvm access(~x##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(T)) @list_this:nn:nn
         list_this.append<0>(~t##0:list_this(T), ~y##0:list_this(T), ?tmp#2##0:list_this(T)) #1 @list_this:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_this(T))
-        foreign lpvm mutate(~tmp#8##0:list_this(T), ?tmp#9##0:list_this(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
-        foreign lpvm mutate(~tmp#9##0:list_this(T), ?#result##0:list_this(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:list_this(T))
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_this(T)) @list_this:nn:nn
+        foreign lpvm mutate(~tmp#8##0:list_this(T), ?tmp#9##0:list_this(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @list_this:nn:nn
+        foreign lpvm mutate(~tmp#9##0:list_this(T), ?#result##0:list_this(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:list_this(T)) @list_this:nn:nn
 
 
 
@@ -50,7 +50,7 @@ car(#rec##0:list_this(T), ?#result##0:T, ?#success##0:wybe.bool):
         foreign llvm move(undef:T, ?#result##0:T)
 
     1:
-        foreign lpvm access(~#rec##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T)
+        foreign lpvm access(~#rec##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T) @list_this:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
@@ -65,7 +65,7 @@ car(#rec##0:list_this(T), ?#rec##1:list_this(T), #field##0:T, ?#success##0:wybe.
         foreign llvm move(~#rec##0:list_this(T), ?#rec##1:list_this(T))
 
     1:
-        foreign lpvm mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T)
+        foreign lpvm mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T) @list_this:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -82,7 +82,7 @@ cdr(#rec##0:list_this(T), ?#result##0:list_this(T), ?#success##0:wybe.bool):
         foreign llvm move(undef:list_this(T), ?#result##0:list_this(T))
 
     1:
-        foreign lpvm access(~#rec##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_this(T))
+        foreign lpvm access(~#rec##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_this(T)) @list_this:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
@@ -97,7 +97,7 @@ cdr(#rec##0:list_this(T), ?#rec##1:list_this(T), #field##0:list_this(T), ?#succe
         foreign llvm move(~#rec##0:list_this(T), ?#rec##1:list_this(T))
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_this(T))
+        foreign lpvm {noalias} mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_this(T)) @list_this:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -107,9 +107,9 @@ cons > public {inline} (1 calls)
 cons(car##0:T, cdr##0:list_this(T), ?#result##0:list_this(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:list_this(T))
-    foreign lpvm mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T)
-    foreign lpvm mutate(~#rec##1:list_this(T), ?#result##0:list_this(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:list_this(T)) @list_this:nn:nn
+    foreign lpvm mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T) @list_this:nn:nn
+    foreign lpvm mutate(~#rec##1:list_this(T), ?#result##0:list_this(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(T)) @list_this:nn:nn
 cons > public {inline} (6 calls)
 1: list_this.cons<1>
 cons(?car##0:T, ?cdr##0:list_this(T), #result##0:list_this(T), ?#success##0:wybe.bool):
@@ -123,8 +123,8 @@ cons(?car##0:T, ?cdr##0:list_this(T), #result##0:list_this(T), ?#success##0:wybe
         foreign llvm move(undef:list_this(T), ?cdr##0:list_this(T))
 
     1:
-        foreign lpvm access(#result##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T)
-        foreign lpvm access(~#result##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(T))
+        foreign lpvm access(#result##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T) @list_this:nn:nn
+        foreign lpvm access(~#result##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(T)) @list_this:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -148,7 +148,7 @@ length1(x##0:list_this(T), acc##0:wybe.int, ?#result##0:wybe.int):
         foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @list_this:nn:nn
 
     1:
-        foreign lpvm access(~x##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(T))
+        foreign lpvm access(~x##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(T)) @list_this:nn:nn
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         list_this.length1<0>(~t##0:list_this(T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @list_this:nn:nn
 

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -31,8 +31,8 @@ gen#1([h##0:wybe.int], io##0:wybe.phantom, lst##0:loop_bug.int_list, t##0:loop_b
         foreign c putchar(']':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
     1:
-        foreign lpvm access(t##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##1:wybe.int)
-        foreign lpvm access(~t##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##1:loop_bug.int_list)
+        foreign lpvm access(t##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##1:wybe.int) @loop_bug:nn:nn
+        foreign lpvm access(~t##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##1:loop_bug.int_list) @loop_bug:nn:nn
         wybe.string.print_string<0>(", ":wybe.string, ~io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) #3 @io:nn:nn
         foreign c print_int(~h##1:wybe.int, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
         loop_bug.gen#1<0>(_:wybe.int, ~tmp#8##0:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##1:loop_bug.int_list, ?io##1:wybe.phantom) #4 @loop_bug:nn:nn
@@ -61,8 +61,8 @@ print(lst##0:loop_bug.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
         foreign c putchar(']':wybe.char, ~#io##1:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
     1:
-        foreign lpvm access(lst##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(lst##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:loop_bug.int_list)
+        foreign lpvm access(lst##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @loop_bug:nn:nn
+        foreign lpvm access(lst##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:loop_bug.int_list) @loop_bug:nn:nn
         foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         loop_bug.gen#1<0>(_:wybe.int, ~io##2:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list, ?io##3:wybe.phantom) #3 @loop_bug:nn:nn
 
@@ -183,16 +183,16 @@ if.else:
         foreign llvm icmp_eq(~#left##0:loop_bug.int_list, ~#right##0:loop_bug.int_list, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
-        foreign lpvm access(~#left##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:loop_bug.int_list)
+        foreign lpvm access(#left##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int) @loop_bug:nn:nn
+        foreign lpvm access(~#left##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:loop_bug.int_list) @loop_bug:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
-            foreign lpvm access(~#right##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:loop_bug.int_list)
+            foreign lpvm access(#right##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int) @loop_bug:nn:nn
+            foreign lpvm access(~#right##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:loop_bug.int_list) @loop_bug:nn:nn
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -210,9 +210,9 @@ cons > public {inline} (0 calls)
 cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?#result##0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:loop_bug.int_list)
-    foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:loop_bug.int_list, ?#result##0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:loop_bug.int_list) @loop_bug:nn:nn
+    foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @loop_bug:nn:nn
+    foreign lpvm mutate(~#rec##1:loop_bug.int_list, ?#result##0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list) @loop_bug:nn:nn
 cons > public {inline} (12 calls)
 1: loop_bug.int_list.cons<1>
 cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, #result##0:loop_bug.int_list, ?#success##0:wybe.bool):
@@ -226,8 +226,8 @@ cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, #result##0:loop_bug.int_list
         foreign llvm move(undef:loop_bug.int_list, ?tail##0:loop_bug.int_list)
 
     1:
-        foreign lpvm access(#result##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~#result##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:loop_bug.int_list)
+        foreign lpvm access(#result##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int) @loop_bug:nn:nn
+        foreign lpvm access(~#result##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:loop_bug.int_list) @loop_bug:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -244,7 +244,7 @@ head(#rec##0:loop_bug.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @loop_bug:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -259,7 +259,7 @@ head(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:wybe.int, 
         foreign llvm move(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list)
 
     1:
-        foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @loop_bug:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -284,7 +284,7 @@ tail(#rec##0:loop_bug.int_list, ?#result##0:loop_bug.int_list, ?#success##0:wybe
         foreign llvm move(undef:loop_bug.int_list, ?#result##0:loop_bug.int_list)
 
     1:
-        foreign lpvm access(~#rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:loop_bug.int_list)
+        foreign lpvm access(~#rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:loop_bug.int_list) @loop_bug:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -299,7 +299,7 @@ tail(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:loop_bug.i
         foreign llvm move(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:loop_bug.int_list)
+        foreign lpvm {noalias} mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:loop_bug.int_list) @loop_bug:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -23,9 +23,9 @@ module top-level code > public {impure} (0 calls)
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T)) @array:nn:nn
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int) @array:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T)) @array:nn:nn
     wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -124,7 +124,7 @@ module top-level code > public {impure} (0 calls)
     foreign llvm move(42:wybe.int, ?#exit_code##1:wybe.int) @command_line:nn:nn
     wybe.string.print_string<0>("hello, world!":wybe.string, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) #5 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(arguments##0:wybe.array(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(arguments##0:wybe.array(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @array:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(" command line argument(s)":wybe.string, ~#io##2:wybe.phantom, ?tmp#11##0:wybe.phantom) #6 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -31,13 +31,13 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp#8##0:mixed_fields)
-    foreign lpvm mutate(~tmp#8##0:mixed_fields, ?tmp#9##0:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'a':wybe.char)
-    foreign lpvm mutate(~tmp#9##0:mixed_fields, ?tmp#10##0:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1:wybe.bool)
-    foreign lpvm mutate(~tmp#10##0:mixed_fields, ?tmp#11##0:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'A':wybe.char)
-    foreign lpvm mutate(~tmp#11##0:mixed_fields, ?tmp#12##0:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp#12##0:mixed_fields, ?tmp#13##0:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 42:wybe.int)
-    foreign lpvm mutate(~tmp#13##0:mixed_fields, ?tmp#0##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 17:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?tmp#8##0:mixed_fields) @mixed_fields:nn:nn
+    foreign lpvm mutate(~tmp#8##0:mixed_fields, ?tmp#9##0:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'a':wybe.char) @mixed_fields:nn:nn
+    foreign lpvm mutate(~tmp#9##0:mixed_fields, ?tmp#10##0:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1:wybe.bool) @mixed_fields:nn:nn
+    foreign lpvm mutate(~tmp#10##0:mixed_fields, ?tmp#11##0:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'A':wybe.char) @mixed_fields:nn:nn
+    foreign lpvm mutate(~tmp#11##0:mixed_fields, ?tmp#12##0:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 3:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm mutate(~tmp#12##0:mixed_fields, ?tmp#13##0:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 42:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm mutate(~tmp#13##0:mixed_fields, ?tmp#0##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 17:wybe.int) @mixed_fields:nn:nn
     mixed_fields.printit<0>(~tmp#0##0:mixed_fields, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @mixed_fields:nn:nn
 
 
@@ -46,18 +46,18 @@ module top-level code > public {impure} (0 calls)
 =(#left##0:mixed_fields, #right##0:mixed_fields, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f2##0:wybe.char)
-    foreign lpvm access(#left##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f4##0:wybe.bool)
-    foreign lpvm access(#left##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f6##0:wybe.char)
-    foreign lpvm access(#left##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f1##0:wybe.int)
-    foreign lpvm access(#left##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f3##0:wybe.int)
-    foreign lpvm access(~#left##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f5##0:wybe.int)
-    foreign lpvm access(#right##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f2##0:wybe.char)
-    foreign lpvm access(#right##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f4##0:wybe.bool)
-    foreign lpvm access(#right##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f6##0:wybe.char)
-    foreign lpvm access(#right##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f1##0:wybe.int)
-    foreign lpvm access(#right##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f3##0:wybe.int)
-    foreign lpvm access(~#right##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f5##0:wybe.int)
+    foreign lpvm access(#left##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f2##0:wybe.char) @mixed_fields:nn:nn
+    foreign lpvm access(#left##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f4##0:wybe.bool) @mixed_fields:nn:nn
+    foreign lpvm access(#left##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f6##0:wybe.char) @mixed_fields:nn:nn
+    foreign lpvm access(#left##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f1##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm access(#left##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f3##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm access(~#left##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f5##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm access(#right##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f2##0:wybe.char) @mixed_fields:nn:nn
+    foreign lpvm access(#right##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f4##0:wybe.bool) @mixed_fields:nn:nn
+    foreign lpvm access(#right##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f6##0:wybe.char) @mixed_fields:nn:nn
+    foreign lpvm access(#right##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f1##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm access(#right##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f3##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm access(~#right##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f5##0:wybe.int) @mixed_fields:nn:nn
     foreign llvm icmp_eq(~#left#f1##0:wybe.int, ~#right#f1##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -101,13 +101,13 @@ f1 > public {inline} (1 calls)
 f1(#rec##0:mixed_fields, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mixed_fields:nn:nn
 f1 > public {inline} (0 calls)
 1: mixed_fields.f1<1>
 f1(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mixed_fields:nn:nn
 
 
 f2 > public {inline} (1 calls)
@@ -115,13 +115,13 @@ f2 > public {inline} (1 calls)
 f2(#rec##0:mixed_fields, ?#result##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.char)
+    foreign lpvm access(~#rec##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.char) @mixed_fields:nn:nn
 f2 > public {inline} (0 calls)
 1: mixed_fields.f2<1>
 f2(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.char)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.char) @mixed_fields:nn:nn
 
 
 f3 > public {inline} (1 calls)
@@ -129,13 +129,13 @@ f3 > public {inline} (1 calls)
 f3(#rec##0:mixed_fields, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mixed_fields:nn:nn
 f3 > public {inline} (0 calls)
 1: mixed_fields.f3<1>
 f3(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mixed_fields:nn:nn
 
 
 f4 > public {inline} (1 calls)
@@ -143,13 +143,13 @@ f4 > public {inline} (1 calls)
 f4(#rec##0:mixed_fields, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.bool)
+    foreign lpvm access(~#rec##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.bool) @mixed_fields:nn:nn
 f4 > public {inline} (0 calls)
 1: mixed_fields.f4<1>
 f4(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 1:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.bool)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 1:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.bool) @mixed_fields:nn:nn
 
 
 f5 > public {inline} (1 calls)
@@ -157,13 +157,13 @@ f5 > public {inline} (1 calls)
 f5(#rec##0:mixed_fields, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mixed_fields:nn:nn
 f5 > public {inline} (0 calls)
 1: mixed_fields.f5<1>
 f5(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mixed_fields:nn:nn
 
 
 f6 > public {inline} (1 calls)
@@ -171,13 +171,13 @@ f6 > public {inline} (1 calls)
 f6(#rec##0:mixed_fields, ?#result##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.char)
+    foreign lpvm access(~#rec##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.char) @mixed_fields:nn:nn
 f6 > public {inline} (0 calls)
 1: mixed_fields.f6<1>
 f6(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 2:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.char)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 2:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.char) @mixed_fields:nn:nn
 
 
 mixed > public {inline} (1 calls)
@@ -185,24 +185,24 @@ mixed > public {inline} (1 calls)
 mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wybe.int, f6##0:wybe.char, ?#result##0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?#rec##0:mixed_fields)
-    foreign lpvm mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f2##0:wybe.char)
-    foreign lpvm mutate(~#rec##1:mixed_fields, ?#rec##2:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f4##0:wybe.bool)
-    foreign lpvm mutate(~#rec##2:mixed_fields, ?#rec##3:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f6##0:wybe.char)
-    foreign lpvm mutate(~#rec##3:mixed_fields, ?#rec##4:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f1##0:wybe.int)
-    foreign lpvm mutate(~#rec##4:mixed_fields, ?#rec##5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3##0:wybe.int)
-    foreign lpvm mutate(~#rec##5:mixed_fields, ?#result##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5##0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?#rec##0:mixed_fields) @mixed_fields:nn:nn
+    foreign lpvm mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f2##0:wybe.char) @mixed_fields:nn:nn
+    foreign lpvm mutate(~#rec##1:mixed_fields, ?#rec##2:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f4##0:wybe.bool) @mixed_fields:nn:nn
+    foreign lpvm mutate(~#rec##2:mixed_fields, ?#rec##3:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f6##0:wybe.char) @mixed_fields:nn:nn
+    foreign lpvm mutate(~#rec##3:mixed_fields, ?#rec##4:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f1##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm mutate(~#rec##4:mixed_fields, ?#rec##5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm mutate(~#rec##5:mixed_fields, ?#result##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5##0:wybe.int) @mixed_fields:nn:nn
 mixed > public {inline} (22 calls)
 1: mixed_fields.mixed<1>
 mixed(?f1##0:wybe.int, ?f2##0:wybe.char, ?f3##0:wybe.int, ?f4##0:wybe.bool, ?f5##0:wybe.int, ?f6##0:wybe.char, #result##0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2##0:wybe.char)
-    foreign lpvm access(#result##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?f4##0:wybe.bool)
-    foreign lpvm access(#result##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?f6##0:wybe.char)
-    foreign lpvm access(#result##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?f1##0:wybe.int)
-    foreign lpvm access(#result##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?f3##0:wybe.int)
-    foreign lpvm access(~#result##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5##0:wybe.int)
+    foreign lpvm access(#result##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2##0:wybe.char) @mixed_fields:nn:nn
+    foreign lpvm access(#result##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?f4##0:wybe.bool) @mixed_fields:nn:nn
+    foreign lpvm access(#result##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?f6##0:wybe.char) @mixed_fields:nn:nn
+    foreign lpvm access(#result##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?f1##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm access(#result##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?f3##0:wybe.int) @mixed_fields:nn:nn
+    foreign lpvm access(~#result##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5##0:wybe.int) @mixed_fields:nn:nn
 
 
 printit > public (1 calls)
@@ -210,22 +210,22 @@ printit > public (1 calls)
 printit(ob##0:mixed_fields, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(ob##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(ob##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @mixed_fields:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.char)
+    foreign lpvm access(ob##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.char) @mixed_fields:nn:nn
     foreign c putchar(~tmp#1##0:wybe.char, ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm access(ob##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @mixed_fields:nn:nn
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##2:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
+    foreign lpvm access(ob##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool) @mixed_fields:nn:nn
     wybe.io.print<5>(~tmp#3##0:wybe.bool, ~#io##3:wybe.phantom, ?tmp#21##0:wybe.phantom) #12 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(ob##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @mixed_fields:nn:nn
     foreign c print_int(~tmp#4##0:wybe.int, ~#io##4:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~ob##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.char)
+    foreign lpvm access(~ob##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.char) @mixed_fields:nn:nn
     foreign c putchar(~tmp#5##0:wybe.char, ~#io##5:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -29,18 +29,18 @@ bar1(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(5,(multi_specz.foo<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position)
-    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position)
-    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:position.position)
-    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#19##0:position.position, ?tmp#3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#19##0:position.position, ?tmp#3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) #10 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     multi_specz.foo<0>[7477e50a09](~tmp#0##0:position.position, ~tmp#1##0:position.position, tmp#2##0:position.position, tmp#3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz:nn:nn
@@ -57,18 +57,18 @@ bar2 > public (1 calls)
 bar2(io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position)
-    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position)
-    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:position.position)
-    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#19##0:position.position, ?tmp#3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#19##0:position.position, ?tmp#3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) #12 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     multi_specz.foo<0>(tmp#0##0:position.position, tmp#1##0:position.position, tmp#2##0:position.position, tmp#3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz:nn:nn
@@ -104,10 +104,10 @@ modifyAndPrint > public (4 calls)
 modifyAndPrint(pos##0:position.position, v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pos##0:position.position, ?%pos##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%pos##0:position.position, ?%pos##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @position:nn:nn
     position.printPosition<0>(~pos##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm {noalias} mutate(~%pos##0:position.position, ?%pos##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%pos##0:position.position, ?%pos##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @position:nn:nn
     position.printPosition<0>(~pos##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz:nn:nn
 
   LLVM code       :
@@ -360,10 +360,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -449,10 +449,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -468,16 +468,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -485,13 +485,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -499,13 +499,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -513,10 +513,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -25,18 +25,18 @@ main(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(5,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp#6##0:multi_specz_cyclic_lib.position, ?tmp#7##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:multi_specz_cyclic_lib.position, ?tmp#0##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp#10##0:multi_specz_cyclic_lib.position, ?tmp#11##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#11##0:multi_specz_cyclic_lib.position, ?tmp#1##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp#14##0:multi_specz_cyclic_lib.position, ?tmp#15##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#15##0:multi_specz_cyclic_lib.position, ?tmp#2##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp#18##0:multi_specz_cyclic_lib.position, ?tmp#19##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#19##0:multi_specz_cyclic_lib.position, ?tmp#3##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~tmp#6##0:multi_specz_cyclic_lib.position, ?tmp#7##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~tmp#7##0:multi_specz_cyclic_lib.position, ?tmp#0##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~tmp#10##0:multi_specz_cyclic_lib.position, ?tmp#11##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~tmp#11##0:multi_specz_cyclic_lib.position, ?tmp#1##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~tmp#14##0:multi_specz_cyclic_lib.position, ?tmp#15##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~tmp#15##0:multi_specz_cyclic_lib.position, ?tmp#2##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~tmp#18##0:multi_specz_cyclic_lib.position, ?tmp#19##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~tmp#19##0:multi_specz_cyclic_lib.position, ?tmp#3##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int) @multi_specz_cyclic_lib:nn:nn
     wybe.string.print_string<0>("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) #10 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     multi_specz_cyclic_lib.foo1<0>[7477e50a09](~tmp#0##0:multi_specz_cyclic_lib.position, ~tmp#1##0:multi_specz_cyclic_lib.position, tmp#2##0:multi_specz_cyclic_lib.position, tmp#3##0:multi_specz_cyclic_lib.position, 3:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz_cyclic_exe:nn:nn
@@ -226,10 +226,10 @@ modifyAndPrint > public (4 calls)
 modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
 
 
@@ -239,10 +239,10 @@ printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -415,10 +415,10 @@ entry:
 =(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -434,16 +434,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -451,13 +451,13 @@ x > public {inline} (0 calls)
 x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -465,13 +465,13 @@ y > public {inline} (0 calls)
 y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -479,10 +479,10 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 ~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -47,7 +47,7 @@ modifyAndPrint > public (4 calls)
 modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
 
 
@@ -57,10 +57,10 @@ printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -183,10 +183,10 @@ entry:
 =(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -202,16 +202,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -219,13 +219,13 @@ x > public {inline} (0 calls)
 x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -233,13 +233,13 @@ y > public {inline} (0 calls)
 y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -247,10 +247,10 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 ~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -47,7 +47,7 @@ modifyAndPrint > public (4 calls)
 modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
 
 
@@ -57,10 +57,10 @@ printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -183,10 +183,10 @@ entry:
 =(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -202,16 +202,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -219,13 +219,13 @@ x > public {inline} (0 calls)
 x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -233,13 +233,13 @@ y > public {inline} (0 calls)
 y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -247,10 +247,10 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 ~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -220,18 +220,18 @@ card > public {inline} (0 calls)
 card(suit##0:multictr.suit, rank##0:multictr.rank, ?#result##3:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~rank##0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card)
-    foreign llvm or(~#temp##1:multictr.card, ~suit##0:multictr.card, ?#result##3:multictr.card)
+    foreign llvm shl(~rank##0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card) @multictr:nn:nn
+    foreign llvm or(~#temp##1:multictr.card, ~suit##0:multictr.card, ?#result##3:multictr.card) @multictr:nn:nn
 card > public {inline} (0 calls)
 1: multictr.card.card<1>
 card(?suit##0:multictr.suit, ?rank##0:multictr.rank, #result##0:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(#result##0:multictr.card, 3:multictr.card, ?#temp2##0:multictr.card)
-    foreign lpvm cast(~#temp2##0:multictr.card, ?suit##0:multictr.suit)
-    foreign llvm lshr(~#result##0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card)
-    foreign llvm and(~#temp##1:multictr.card, 15:multictr.card, ?#temp2##1:multictr.card)
-    foreign lpvm cast(~#temp2##1:multictr.card, ?rank##0:multictr.rank)
+    foreign llvm and(#result##0:multictr.card, 3:multictr.card, ?#temp2##0:multictr.card) @multictr:nn:nn
+    foreign lpvm cast(~#temp2##0:multictr.card, ?suit##0:multictr.suit) @multictr:nn:nn
+    foreign llvm lshr(~#result##0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card) @multictr:nn:nn
+    foreign llvm and(~#temp##1:multictr.card, 15:multictr.card, ?#temp2##1:multictr.card) @multictr:nn:nn
+    foreign lpvm cast(~#temp2##1:multictr.card, ?rank##0:multictr.rank) @multictr:nn:nn
 
 
 rank > public {inline} (0 calls)
@@ -239,17 +239,17 @@ rank > public {inline} (0 calls)
 rank(#rec##0:multictr.card, ?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm lshr(~#rec##0:multictr.card, 2:multictr.card, ?#rec##1:multictr.card)
-    foreign llvm and(~#rec##1:multictr.card, 15:multictr.card, ?#field##0:multictr.card)
-    foreign lpvm cast(~#field##0:multictr.card, ?#result##0:multictr.rank)
+    foreign llvm lshr(~#rec##0:multictr.card, 2:multictr.card, ?#rec##1:multictr.card) @multictr:nn:nn
+    foreign llvm and(~#rec##1:multictr.card, 15:multictr.card, ?#field##0:multictr.card) @multictr:nn:nn
+    foreign lpvm cast(~#field##0:multictr.card, ?#result##0:multictr.rank) @multictr:nn:nn
 rank > public {inline} (0 calls)
 1: multictr.card.rank<1>
 rank(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~#rec##0:multictr.card, -61:multictr.card, ?#rec##1:multictr.card)
-    foreign llvm shl(~#field##0:multictr.card, 2:multictr.card, ?#temp##0:multictr.card)
-    foreign llvm or(~#rec##1:multictr.card, ~#temp##0:multictr.card, ?#rec##2:multictr.card)
+    foreign llvm and(~#rec##0:multictr.card, -61:multictr.card, ?#rec##1:multictr.card) @multictr:nn:nn
+    foreign llvm shl(~#field##0:multictr.card, 2:multictr.card, ?#temp##0:multictr.card) @multictr:nn:nn
+    foreign llvm or(~#rec##1:multictr.card, ~#temp##0:multictr.card, ?#rec##2:multictr.card) @multictr:nn:nn
 
 
 suit > public {inline} (0 calls)
@@ -257,15 +257,15 @@ suit > public {inline} (0 calls)
 suit(#rec##0:multictr.card, ?#result##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~#rec##0:multictr.card, 3:multictr.card, ?#field##0:multictr.card)
-    foreign lpvm cast(~#field##0:multictr.card, ?#result##0:multictr.suit)
+    foreign llvm and(~#rec##0:multictr.card, 3:multictr.card, ?#field##0:multictr.card) @multictr:nn:nn
+    foreign lpvm cast(~#field##0:multictr.card, ?#result##0:multictr.suit) @multictr:nn:nn
 suit > public {inline} (0 calls)
 1: multictr.card.suit<1>
 suit(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~#rec##0:multictr.card, -4:multictr.card, ?#rec##1:multictr.card)
-    foreign llvm or(~#field##0:multictr.card, ~#rec##1:multictr.card, ?#rec##2:multictr.card)
+    foreign llvm and(~#rec##0:multictr.card, -4:multictr.card, ?#rec##1:multictr.card) @multictr:nn:nn
+    foreign llvm or(~#field##0:multictr.card, ~#rec##1:multictr.card, ?#rec##2:multictr.card) @multictr:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -519,7 +519,7 @@ entry:
                                                                                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f17##0:wybe.int)
+                                                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f17##0:wybe.int) @multictr:nn:nn
                                                                                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#142##0:wybe.bool)
                                                                                 case ~tmp#142##0:wybe.bool of
                                                                                 0:
@@ -540,7 +540,7 @@ entry:
                                                                                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                         1:
-                                                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f17##0:wybe.int)
+                                                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f17##0:wybe.int) @multictr:nn:nn
                                                                                             foreign llvm icmp_eq(~#left#f17##0:wybe.int, ~#right#f17##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -548,7 +548,7 @@ entry:
 
 
                                                                         1:
-                                                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f16##0:wybe.int)
+                                                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f16##0:wybe.int) @multictr:nn:nn
                                                                             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#136##0:wybe.bool)
                                                                             case ~tmp#136##0:wybe.bool of
                                                                             0:
@@ -569,7 +569,7 @@ entry:
                                                                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                     1:
-                                                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f16##0:wybe.int)
+                                                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f16##0:wybe.int) @multictr:nn:nn
                                                                                         foreign llvm icmp_eq(~#left#f16##0:wybe.int, ~#right#f16##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -577,7 +577,7 @@ entry:
 
 
                                                                     1:
-                                                                        foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f15##0:wybe.int)
+                                                                        foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f15##0:wybe.int) @multictr:nn:nn
                                                                         foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#130##0:wybe.bool)
                                                                         case ~tmp#130##0:wybe.bool of
                                                                         0:
@@ -598,7 +598,7 @@ entry:
                                                                                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                 1:
-                                                                                    foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f15##0:wybe.int)
+                                                                                    foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f15##0:wybe.int) @multictr:nn:nn
                                                                                     foreign llvm icmp_eq(~#left#f15##0:wybe.int, ~#right#f15##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -606,7 +606,7 @@ entry:
 
 
                                                                 1:
-                                                                    foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f14##0:wybe.int)
+                                                                    foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f14##0:wybe.int) @multictr:nn:nn
                                                                     foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#124##0:wybe.bool)
                                                                     case ~tmp#124##0:wybe.bool of
                                                                     0:
@@ -627,7 +627,7 @@ entry:
                                                                                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f14##0:wybe.int)
+                                                                                foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f14##0:wybe.int) @multictr:nn:nn
                                                                                 foreign llvm icmp_eq(~#left#f14##0:wybe.int, ~#right#f14##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -635,7 +635,7 @@ entry:
 
 
                                                             1:
-                                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f13##0:wybe.int)
+                                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f13##0:wybe.int) @multictr:nn:nn
                                                                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#118##0:wybe.bool)
                                                                 case ~tmp#118##0:wybe.bool of
                                                                 0:
@@ -656,7 +656,7 @@ entry:
                                                                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                         1:
-                                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f13##0:wybe.int)
+                                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f13##0:wybe.int) @multictr:nn:nn
                                                                             foreign llvm icmp_eq(~#left#f13##0:wybe.int, ~#right#f13##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -664,7 +664,7 @@ entry:
 
 
                                                         1:
-                                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f12##0:wybe.int)
+                                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f12##0:wybe.int) @multictr:nn:nn
                                                             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#112##0:wybe.bool)
                                                             case ~tmp#112##0:wybe.bool of
                                                             0:
@@ -685,7 +685,7 @@ entry:
                                                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                     1:
-                                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f12##0:wybe.int)
+                                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f12##0:wybe.int) @multictr:nn:nn
                                                                         foreign llvm icmp_eq(~#left#f12##0:wybe.int, ~#right#f12##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -693,7 +693,7 @@ entry:
 
 
                                                     1:
-                                                        foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f11##0:wybe.int)
+                                                        foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f11##0:wybe.int) @multictr:nn:nn
                                                         foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#106##0:wybe.bool)
                                                         case ~tmp#106##0:wybe.bool of
                                                         0:
@@ -714,7 +714,7 @@ entry:
                                                                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                 1:
-                                                                    foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f11##0:wybe.int)
+                                                                    foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f11##0:wybe.int) @multictr:nn:nn
                                                                     foreign llvm icmp_eq(~#left#f11##0:wybe.int, ~#right#f11##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -722,7 +722,7 @@ entry:
 
 
                                                 1:
-                                                    foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f10##0:wybe.int)
+                                                    foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f10##0:wybe.int) @multictr:nn:nn
                                                     foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#100##0:wybe.bool)
                                                     case ~tmp#100##0:wybe.bool of
                                                     0:
@@ -743,7 +743,7 @@ entry:
                                                                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                             1:
-                                                                foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f10##0:wybe.int)
+                                                                foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f10##0:wybe.int) @multictr:nn:nn
                                                                 foreign llvm icmp_eq(~#left#f10##0:wybe.int, ~#right#f10##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -751,7 +751,7 @@ entry:
 
 
                                             1:
-                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f09##0:wybe.int)
+                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f09##0:wybe.int) @multictr:nn:nn
                                                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#94##0:wybe.bool)
                                                 case ~tmp#94##0:wybe.bool of
                                                 0:
@@ -772,7 +772,7 @@ entry:
                                                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                         1:
-                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f09##0:wybe.int)
+                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f09##0:wybe.int) @multictr:nn:nn
                                                             foreign llvm icmp_eq(~#left#f09##0:wybe.int, ~#right#f09##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -780,7 +780,7 @@ entry:
 
 
                                         1:
-                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f08##0:wybe.int)
+                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f08##0:wybe.int) @multictr:nn:nn
                                             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#88##0:wybe.bool)
                                             case ~tmp#88##0:wybe.bool of
                                             0:
@@ -801,7 +801,7 @@ entry:
                                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                     1:
-                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f08##0:wybe.int)
+                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f08##0:wybe.int) @multictr:nn:nn
                                                         foreign llvm icmp_eq(~#left#f08##0:wybe.int, ~#right#f08##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -810,7 +810,7 @@ entry:
 
 
                                 1:
-                                    foreign lpvm access(~#left##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#left#f07##0:wybe.int)
+                                    foreign lpvm access(~#left##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#left#f07##0:wybe.int) @multictr:nn:nn
                                     foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#82##0:wybe.bool)
                                     case ~tmp#82##0:wybe.bool of
                                     0:
@@ -824,14 +824,14 @@ entry:
                                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                         1:
-                                            foreign lpvm access(~#right##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#right#f07##0:wybe.int)
+                                            foreign lpvm access(~#right##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#right#f07##0:wybe.int) @multictr:nn:nn
                                             foreign llvm icmp_eq(~#left#f07##0:wybe.int, ~#right#f07##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
                             1:
-                                foreign lpvm access(~#left##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#left#f06##0:wybe.int)
+                                foreign lpvm access(~#left##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#left#f06##0:wybe.int) @multictr:nn:nn
                                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#78##0:wybe.bool)
                                 case ~tmp#78##0:wybe.bool of
                                 0:
@@ -845,14 +845,14 @@ entry:
                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access(~#right##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#right#f06##0:wybe.int)
+                                        foreign lpvm access(~#right##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#right#f06##0:wybe.int) @multictr:nn:nn
                                         foreign llvm icmp_eq(~#left#f06##0:wybe.int, ~#right#f06##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
                         1:
-                            foreign lpvm access(~#left##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#left#f05##0:wybe.int)
+                            foreign lpvm access(~#left##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#left#f05##0:wybe.int) @multictr:nn:nn
                             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#74##0:wybe.bool)
                             case ~tmp#74##0:wybe.bool of
                             0:
@@ -866,14 +866,14 @@ entry:
                                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access(~#right##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#right#f05##0:wybe.int)
+                                    foreign lpvm access(~#right##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#right#f05##0:wybe.int) @multictr:nn:nn
                                     foreign llvm icmp_eq(~#left#f05##0:wybe.int, ~#right#f05##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
                     1:
-                        foreign lpvm access(~#left##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#left#f04##0:wybe.int)
+                        foreign lpvm access(~#left##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#left#f04##0:wybe.int) @multictr:nn:nn
                         foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#70##0:wybe.bool)
                         case ~tmp#70##0:wybe.bool of
                         0:
@@ -887,14 +887,14 @@ entry:
                                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                             1:
-                                foreign lpvm access(~#right##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#right#f04##0:wybe.int)
+                                foreign lpvm access(~#right##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#right#f04##0:wybe.int) @multictr:nn:nn
                                 foreign llvm icmp_eq(~#left#f04##0:wybe.int, ~#right#f04##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
                 1:
-                    foreign lpvm access(~#left##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#f03##0:wybe.int)
+                    foreign lpvm access(~#left##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#f03##0:wybe.int) @multictr:nn:nn
                     foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#66##0:wybe.bool)
                     case ~tmp#66##0:wybe.bool of
                     0:
@@ -908,14 +908,14 @@ entry:
                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~#right##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#f03##0:wybe.int)
+                            foreign lpvm access(~#right##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#f03##0:wybe.int) @multictr:nn:nn
                             foreign llvm icmp_eq(~#left#f03##0:wybe.int, ~#right#f03##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
             1:
-                foreign lpvm access(~#left##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#f02##0:wybe.int)
+                foreign lpvm access(~#left##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#f02##0:wybe.int) @multictr:nn:nn
                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#62##0:wybe.bool)
                 case ~tmp#62##0:wybe.bool of
                 0:
@@ -929,14 +929,14 @@ entry:
                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~#right##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#f02##0:wybe.int)
+                        foreign lpvm access(~#right##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#f02##0:wybe.int) @multictr:nn:nn
                         foreign llvm icmp_eq(~#left#f02##0:wybe.int, ~#right#f02##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
         1:
-            foreign lpvm access(~#left##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#f01##0:wybe.int)
+            foreign lpvm access(~#left##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#f01##0:wybe.int) @multictr:nn:nn
             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#58##0:wybe.bool)
             case ~tmp#58##0:wybe.bool of
             0:
@@ -950,7 +950,7 @@ entry:
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~#right##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#f01##0:wybe.int)
+                    foreign lpvm access(~#right##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#f01##0:wybe.int) @multictr:nn:nn
                     foreign llvm icmp_eq(~#left#f01##0:wybe.int, ~#right#f01##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -971,8 +971,8 @@ c01 > public {inline} (0 calls)
 c01(f01##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#result##0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#result##0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int) @multictr:nn:nn
 c01 > public {inline} (40 calls)
 1: multictr.complicated.c01<1>
 c01(?f01##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -993,7 +993,7 @@ c01(?f01##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1004,9 +1004,9 @@ c02 > public {inline} (0 calls)
 c02(f02##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 1:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##1:multictr.complicated, 1:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c02 > public {inline} (35 calls)
 1: multictr.complicated.c02<1>
 c02(?f02##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1027,7 +1027,7 @@ c02(?f02##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1038,9 +1038,9 @@ c03 > public {inline} (0 calls)
 c03(f03##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 2:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##1:multictr.complicated, 2:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c03 > public {inline} (33 calls)
 1: multictr.complicated.c03<1>
 c03(?f03##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1061,7 +1061,7 @@ c03(?f03##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1072,9 +1072,9 @@ c04 > public {inline} (0 calls)
 c04(f04##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 3:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##1:multictr.complicated, 3:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c04 > public {inline} (31 calls)
 1: multictr.complicated.c04<1>
 c04(?f04##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1095,7 +1095,7 @@ c04(?f04##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1106,9 +1106,9 @@ c05 > public {inline} (0 calls)
 c05(f05##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 4:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##1:multictr.complicated, 4:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c05 > public {inline} (29 calls)
 1: multictr.complicated.c05<1>
 c05(?f05##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1129,7 +1129,7 @@ c05(?f05##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1140,9 +1140,9 @@ c06 > public {inline} (0 calls)
 c06(f06##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 5:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##1:multictr.complicated, 5:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c06 > public {inline} (27 calls)
 1: multictr.complicated.c06<1>
 c06(?f06##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1163,7 +1163,7 @@ c06(?f06##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1174,9 +1174,9 @@ c07 > public {inline} (0 calls)
 c07(f07##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 6:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##1:multictr.complicated, 6:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c07 > public {inline} (25 calls)
 1: multictr.complicated.c07<1>
 c07(?f07##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1197,7 +1197,7 @@ c07(?f07##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1208,10 +1208,10 @@ c08 > public {inline} (0 calls)
 c08(f08##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c08 > public {inline} (23 calls)
 1: multictr.complicated.c08<1>
 c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1240,7 +1240,7 @@ c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1252,10 +1252,10 @@ c09 > public {inline} (0 calls)
 c09(f09##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c09 > public {inline} (21 calls)
 1: multictr.complicated.c09<1>
 c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1284,7 +1284,7 @@ c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1296,10 +1296,10 @@ c10 > public {inline} (0 calls)
 c10(f10##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c10 > public {inline} (19 calls)
 1: multictr.complicated.c10<1>
 c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1328,7 +1328,7 @@ c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1340,10 +1340,10 @@ c11 > public {inline} (0 calls)
 c11(f11##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c11 > public {inline} (17 calls)
 1: multictr.complicated.c11<1>
 c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1372,7 +1372,7 @@ c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1384,10 +1384,10 @@ c12 > public {inline} (0 calls)
 c12(f12##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c12 > public {inline} (15 calls)
 1: multictr.complicated.c12<1>
 c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1416,7 +1416,7 @@ c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1428,10 +1428,10 @@ c13 > public {inline} (0 calls)
 c13(f13##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c13 > public {inline} (13 calls)
 1: multictr.complicated.c13<1>
 c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1460,7 +1460,7 @@ c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1472,10 +1472,10 @@ c14 > public {inline} (0 calls)
 c14(f14##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 13:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 13:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c14 > public {inline} (11 calls)
 1: multictr.complicated.c14<1>
 c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1504,7 +1504,7 @@ c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1516,10 +1516,10 @@ c15 > public {inline} (0 calls)
 c15(f15##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 14:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 14:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c15 > public {inline} (9 calls)
 1: multictr.complicated.c15<1>
 c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1548,7 +1548,7 @@ c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1560,10 +1560,10 @@ c16 > public {inline} (0 calls)
 c16(f16##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 15:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 15:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c16 > public {inline} (7 calls)
 1: multictr.complicated.c16<1>
 c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1592,7 +1592,7 @@ c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1604,10 +1604,10 @@ c17 > public {inline} (0 calls)
 c17(f17##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 16:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 16:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
 c17 > public {inline} (5 calls)
 1: multictr.complicated.c17<1>
 c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
@@ -1636,7 +1636,7 @@ c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
             1:
-                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1663,7 +1663,7 @@ f01(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1687,7 +1687,7 @@ f01(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1713,7 +1713,7 @@ f02(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1737,7 +1737,7 @@ f02(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1763,7 +1763,7 @@ f03(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1787,7 +1787,7 @@ f03(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1813,7 +1813,7 @@ f04(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1837,7 +1837,7 @@ f04(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1863,7 +1863,7 @@ f05(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1887,7 +1887,7 @@ f05(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1913,7 +1913,7 @@ f06(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1937,7 +1937,7 @@ f06(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1963,7 +1963,7 @@ f07(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1987,7 +1987,7 @@ f07(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2021,7 +2021,7 @@ f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2054,7 +2054,7 @@ f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2089,7 +2089,7 @@ f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2122,7 +2122,7 @@ f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2157,7 +2157,7 @@ f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2190,7 +2190,7 @@ f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2225,7 +2225,7 @@ f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2258,7 +2258,7 @@ f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2293,7 +2293,7 @@ f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2326,7 +2326,7 @@ f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2361,7 +2361,7 @@ f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2394,7 +2394,7 @@ f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2429,7 +2429,7 @@ f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2462,7 +2462,7 @@ f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2497,7 +2497,7 @@ f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2530,7 +2530,7 @@ f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2565,7 +2565,7 @@ f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2598,7 +2598,7 @@ f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2633,7 +2633,7 @@ f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -2666,7 +2666,7 @@ f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
                 foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -5428,13 +5428,13 @@ metres > public {inline} (0 calls)
 metres(value##0:wybe.float, ?#result##2:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~value##0:multictr.length, ?#result##2:multictr.length)
+    foreign llvm move(~value##0:multictr.length, ?#result##2:multictr.length) @multictr:nn:nn
 metres > public {inline} (0 calls)
 1: multictr.length.metres<1>
 metres(?value##0:wybe.float, #result##0:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~#result##0:multictr.length, ?value##0:wybe.float)
+    foreign lpvm cast(~#result##0:multictr.length, ?value##0:wybe.float) @multictr:nn:nn
 
 
 value > public {inline} (0 calls)
@@ -5442,13 +5442,13 @@ value > public {inline} (0 calls)
 value(#rec##0:multictr.length, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~#rec##0:multictr.length, ?#result##0:wybe.float)
+    foreign lpvm cast(~#rec##0:multictr.length, ?#result##0:wybe.float) @multictr:nn:nn
 value > public {inline} (0 calls)
 1: multictr.length.value<1>
 value([#rec##0:multictr.length], ?#rec##2:multictr.length, #field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~#field##0:multictr.length, ?#rec##2:multictr.length)
+    foreign llvm move(~#field##0:multictr.length, ?#rec##2:multictr.length) @multictr:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -5542,14 +5542,14 @@ entry:
         foreign llvm icmp_eq(~#left##0:multictr.maybe_int, ~#right##0:multictr.maybe_int, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(~#left##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int)
+        foreign lpvm access(~#left##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int) @multictr:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
         case ~tmp#8##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(~#right##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int)
+            foreign lpvm access(~#right##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int) @multictr:nn:nn
             foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -5560,8 +5560,8 @@ just > public {inline} (0 calls)
 just(value##0:wybe.int, ?#result##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.maybe_int)
-    foreign lpvm mutate(~#rec##0:multictr.maybe_int, ?#result##0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.maybe_int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.maybe_int, ?#result##0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int) @multictr:nn:nn
 just > public {inline} (8 calls)
 1: multictr.maybe_int.just<1>
 just(?value##0:wybe.int, #result##0:multictr.maybe_int, ?#success##0:wybe.bool):
@@ -5574,7 +5574,7 @@ just(?value##0:wybe.int, #result##0:multictr.maybe_int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -5599,7 +5599,7 @@ value(#rec##0:multictr.maybe_int, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 value > public {inline} (0 calls)
@@ -5614,7 +5614,7 @@ value(#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, #field##0:wybe.in
         foreign llvm move(~#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -5785,7 +5785,7 @@ entry:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(~#left##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#float_value##0:wybe.float)
+            foreign lpvm access(~#left##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#float_value##0:wybe.float) @multictr:nn:nn
             foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int)
             foreign llvm icmp_eq(~tmp#14##0:wybe.int, 1:wybe.int, ?tmp#15##0:wybe.bool)
             case ~tmp#15##0:wybe.bool of
@@ -5793,13 +5793,13 @@ entry:
                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign lpvm access(~#right##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#float_value##0:wybe.float)
+                foreign lpvm access(~#right##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#float_value##0:wybe.float) @multictr:nn:nn
                 foreign llvm fcmp_eq(~#left#float_value##0:wybe.float, ~#right#float_value##0:wybe.float, ?#success##0:wybe.bool) @float:nn:nn
 
 
 
     1:
-        foreign lpvm access(~#left##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#int_value##0:wybe.int)
+        foreign lpvm access(~#left##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#int_value##0:wybe.int) @multictr:nn:nn
         foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int)
         foreign llvm icmp_eq(~tmp#11##0:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.bool)
         case ~tmp#12##0:wybe.bool of
@@ -5807,7 +5807,7 @@ entry:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(~#right##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#int_value##0:wybe.int)
+            foreign lpvm access(~#right##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#int_value##0:wybe.int) @multictr:nn:nn
             foreign llvm icmp_eq(~#left#int_value##0:wybe.int, ~#right#int_value##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -5818,9 +5818,9 @@ float > public {inline} (0 calls)
 float(float_value##0:wybe.float, ?#result##0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number)
-    foreign lpvm mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value##0:wybe.float)
-    foreign llvm or(~#rec##1:multictr.number, 1:wybe.int, ?#result##0:multictr.number)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value##0:wybe.float) @multictr:nn:nn
+    foreign llvm or(~#rec##1:multictr.number, 1:wybe.int, ?#result##0:multictr.number) @multictr:nn:nn
 float > public {inline} (5 calls)
 1: multictr.number.float<1>
 float(?float_value##0:wybe.float, #result##0:multictr.number, ?#success##0:wybe.bool):
@@ -5834,7 +5834,7 @@ float(?float_value##0:wybe.float, #result##0:multictr.number, ?#success##0:wybe.
         foreign llvm move(undef:wybe.float, ?float_value##0:wybe.float)
 
     1:
-        foreign lpvm access(~#result##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value##0:wybe.float)
+        foreign lpvm access(~#result##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value##0:wybe.float) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -5852,7 +5852,7 @@ float_value(#rec##0:multictr.number, ?#result##0:wybe.float, ?#success##0:wybe.b
         foreign llvm move(undef:wybe.float, ?#result##0:wybe.float)
 
     1:
-        foreign lpvm access(~#rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.float)
+        foreign lpvm access(~#rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.float) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 float_value > public {inline} (0 calls)
@@ -5868,7 +5868,7 @@ float_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.fl
         foreign llvm move(~#rec##0:multictr.number, ?#rec##1:multictr.number)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.float)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.float) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -5878,8 +5878,8 @@ int > public {inline} (0 calls)
 int(int_value##0:wybe.int, ?#result##0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number)
-    foreign lpvm mutate(~#rec##0:multictr.number, ?#result##0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.number, ?#result##0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int) @multictr:nn:nn
 int > public {inline} (10 calls)
 1: multictr.number.int<1>
 int(?int_value##0:wybe.int, #result##0:multictr.number, ?#success##0:wybe.bool):
@@ -5893,7 +5893,7 @@ int(?int_value##0:wybe.int, #result##0:multictr.number, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?int_value##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value##0:wybe.int) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -5911,7 +5911,7 @@ int_value(#rec##0:multictr.number, ?#result##0:wybe.int, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 int_value > public {inline} (0 calls)
@@ -5927,7 +5927,7 @@ int_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.int,
         foreign llvm move(~#rec##0:multictr.number, ?#rec##1:multictr.number)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -6192,13 +6192,13 @@ content > public {inline} (0 calls)
 content(#rec##0:multictr.perhaps, ?#result##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~#rec##0:multictr.perhaps, ?#result##0:multictr.maybe_int)
+    foreign lpvm cast(~#rec##0:multictr.perhaps, ?#result##0:multictr.maybe_int) @multictr:nn:nn
 content > public {inline} (0 calls)
 1: multictr.perhaps.content<1>
 content([#rec##0:multictr.perhaps], ?#rec##2:multictr.perhaps, #field##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~#field##0:multictr.perhaps, ?#rec##2:multictr.perhaps)
+    foreign llvm move(~#field##0:multictr.perhaps, ?#rec##2:multictr.perhaps) @multictr:nn:nn
 
 
 perhaps > public {inline} (0 calls)
@@ -6206,13 +6206,13 @@ perhaps > public {inline} (0 calls)
 perhaps(content##0:multictr.maybe_int, ?#result##2:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~content##0:multictr.perhaps, ?#result##2:multictr.perhaps)
+    foreign llvm move(~content##0:multictr.perhaps, ?#result##2:multictr.perhaps) @multictr:nn:nn
 perhaps > public {inline} (0 calls)
 1: multictr.perhaps.perhaps<1>
 perhaps(?content##0:multictr.maybe_int, #result##0:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~#result##0:multictr.perhaps, ?content##0:multictr.maybe_int)
+    foreign lpvm cast(~#result##0:multictr.perhaps, ?content##0:multictr.maybe_int) @multictr:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -6568,8 +6568,8 @@ entry:
                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign lpvm access(#left##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#left#two_field1##0:wybe.int)
-                foreign lpvm access(~#left##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#left#two_field2##0:wybe.int)
+                foreign lpvm access(#left##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#left#two_field1##0:wybe.int) @multictr:nn:nn
+                foreign lpvm access(~#left##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#left#two_field2##0:wybe.int) @multictr:nn:nn
                 foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
                 case ~tmp#18##0:wybe.bool of
                 0:
@@ -6583,8 +6583,8 @@ entry:
                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(#right##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#right#two_field1##0:wybe.int)
-                        foreign lpvm access(~#right##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#right#two_field2##0:wybe.int)
+                        foreign lpvm access(#right##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#right#two_field1##0:wybe.int) @multictr:nn:nn
+                        foreign lpvm access(~#right##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#right#two_field2##0:wybe.int) @multictr:nn:nn
                         foreign llvm icmp_eq(~#left#two_field1##0:wybe.int, ~#right#two_field1##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                         case ~tmp#5##0:wybe.bool of
                         0:
@@ -6598,7 +6598,7 @@ entry:
 
 
         1:
-            foreign lpvm access(~#left##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#one_field##0:wybe.int)
+            foreign lpvm access(~#left##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#one_field##0:wybe.int) @multictr:nn:nn
             foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
             case ~tmp#14##0:wybe.bool of
             0:
@@ -6612,7 +6612,7 @@ entry:
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~#right##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#one_field##0:wybe.int)
+                    foreign lpvm access(~#right##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#one_field##0:wybe.int) @multictr:nn:nn
                     foreign llvm icmp_eq(~#left#one_field##0:wybe.int, ~#right#one_field##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -6625,8 +6625,8 @@ one > public {inline} (0 calls)
 one(one_field##0:wybe.int, ?#result##0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.simple)
-    foreign lpvm mutate(~#rec##0:multictr.simple, ?#result##0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.simple) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.simple, ?#result##0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int) @multictr:nn:nn
 one > public {inline} (11 calls)
 1: multictr.simple.one<1>
 one(?one_field##0:wybe.int, #result##0:multictr.simple, ?#success##0:wybe.bool):
@@ -6647,7 +6647,7 @@ one(?one_field##0:wybe.int, #result##0:multictr.simple, ?#success##0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
         1:
-            foreign lpvm access(~#result##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -6673,7 +6673,7 @@ one_field(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -6697,7 +6697,7 @@ one_field(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int,
             foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -6708,10 +6708,10 @@ two > public {inline} (0 calls)
 two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?#result##0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.simple)
-    foreign lpvm mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field1##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr.simple, ?#rec##2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.simple, 1:wybe.int, ?#result##0:multictr.simple)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.simple) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field1##0:wybe.int) @multictr:nn:nn
+    foreign lpvm mutate(~#rec##1:multictr.simple, ?#rec##2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2##0:wybe.int) @multictr:nn:nn
+    foreign llvm or(~#rec##2:multictr.simple, 1:wybe.int, ?#result##0:multictr.simple) @multictr:nn:nn
 two > public {inline} (7 calls)
 1: multictr.simple.two<1>
 two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, #result##0:multictr.simple, ?#success##0:wybe.bool):
@@ -6734,8 +6734,8 @@ two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, #result##0:multictr.simple
             foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1##0:wybe.int)
-            foreign lpvm access(~#result##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2##0:wybe.int)
+            foreign lpvm access(#result##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1##0:wybe.int) @multictr:nn:nn
+            foreign lpvm access(~#result##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -6761,7 +6761,7 @@ two_field1(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -6785,7 +6785,7 @@ two_field1(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int
             foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, -1:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, -1:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -6811,7 +6811,7 @@ two_field2(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -6835,7 +6835,7 @@ two_field2(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int
             foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 7:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 7:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~#field##0:wybe.int) @multictr:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -82,9 +82,9 @@ print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
                                     foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
                                 1:
-                                    foreign lpvm access(x##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?a##7:wybe.int)
-                                    foreign lpvm access(x##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?b##0:wybe.int)
-                                    foreign lpvm access(~x##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?c##0:wybe.float)
+                                    foreign lpvm access(x##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?a##7:wybe.int) @multictr2:10:8
+                                    foreign lpvm access(x##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?b##0:wybe.int) @multictr2:10:8
+                                    foreign lpvm access(~x##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?c##0:wybe.float) @multictr2:10:8
                                     wybe.string.print_string<0>("c08(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #45 @io:nn:nn
                                     foreign c print_int(~a##7:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                                     wybe.string.print_string<0>(", ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #46 @io:nn:nn
@@ -96,7 +96,7 @@ print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
                             1:
-                                foreign lpvm access(~x##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?a##6:wybe.int)
+                                foreign lpvm access(~x##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?a##6:wybe.int) @multictr2:9:8
                                 wybe.string.print_string<0>("c07(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #49 @io:nn:nn
                                 foreign c print_int(~a##6:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                                 wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #50 @io:nn:nn
@@ -104,7 +104,7 @@ print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
                         1:
-                            foreign lpvm access(~x##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?a##5:wybe.int)
+                            foreign lpvm access(~x##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?a##5:wybe.int) @multictr2:8:8
                             wybe.string.print_string<0>("c06(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #51 @io:nn:nn
                             foreign c print_int(~a##5:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                             wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #52 @io:nn:nn
@@ -112,7 +112,7 @@ print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
                     1:
-                        foreign lpvm access(~x##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?a##4:wybe.int)
+                        foreign lpvm access(~x##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?a##4:wybe.int) @multictr2:7:8
                         wybe.string.print_string<0>("c05(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #53 @io:nn:nn
                         foreign c print_int(~a##4:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                         wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #54 @io:nn:nn
@@ -120,7 +120,7 @@ print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
                 1:
-                    foreign lpvm access(~x##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?a##3:wybe.int)
+                    foreign lpvm access(~x##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?a##3:wybe.int) @multictr2:6:8
                     wybe.string.print_string<0>("c04(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #55 @io:nn:nn
                     foreign c print_int(~a##3:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                     wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #56 @io:nn:nn
@@ -128,7 +128,7 @@ print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
             1:
-                foreign lpvm access(~x##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int)
+                foreign lpvm access(~x##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int) @multictr2:5:8
                 wybe.string.print_string<0>("c03(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #57 @io:nn:nn
                 foreign c print_int(~a##2:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
                 wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #58 @io:nn:nn
@@ -136,7 +136,7 @@ print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
         1:
-            foreign lpvm access(~x##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?a##1:wybe.int)
+            foreign lpvm access(~x##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?a##1:wybe.int) @multictr2:4:8
             wybe.string.print_string<0>("c03(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #59 @io:nn:nn
             foreign c print_int(~a##1:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
             wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #60 @io:nn:nn
@@ -144,7 +144,7 @@ print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
 
 
     1:
-        foreign lpvm access(~x##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+        foreign lpvm access(~x##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @multictr2:3:8
         wybe.string.print_string<0>("c01(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #61 @io:nn:nn
         foreign c print_int(~a##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         wybe.string.print_string<0>(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #62 @io:nn:nn
@@ -487,9 +487,9 @@ if.else7:
                                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access(#left##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_a##0:wybe.int)
-                                    foreign lpvm access(#left##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_b##0:wybe.int)
-                                    foreign lpvm access(~#left##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_c##0:wybe.float)
+                                    foreign lpvm access(#left##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_a##0:wybe.int) @multictr2:10:8
+                                    foreign lpvm access(#left##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_b##0:wybe.int) @multictr2:10:8
+                                    foreign lpvm access(~#left##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_c##0:wybe.float) @multictr2:10:8
                                     foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#52##0:wybe.int)
                                     foreign llvm icmp_eq(~tmp#52##0:wybe.int, 7:wybe.int, ?tmp#53##0:wybe.bool)
                                     case ~tmp#53##0:wybe.bool of
@@ -497,9 +497,9 @@ if.else7:
                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access(#right##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_a##0:wybe.int)
-                                        foreign lpvm access(#right##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_b##0:wybe.int)
-                                        foreign lpvm access(~#right##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_c##0:wybe.float)
+                                        foreign lpvm access(#right##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_a##0:wybe.int) @multictr2:10:8
+                                        foreign lpvm access(#right##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_b##0:wybe.int) @multictr2:10:8
+                                        foreign lpvm access(~#right##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_c##0:wybe.float) @multictr2:10:8
                                         foreign llvm icmp_eq(~#left#f08_a##0:wybe.int, ~#right#f08_a##0:wybe.int, ?tmp#16##0:wybe.bool) @int:nn:nn
                                         case ~tmp#16##0:wybe.bool of
                                         0:
@@ -519,7 +519,7 @@ if.else7:
 
 
                             1:
-                                foreign lpvm access(~#left##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#left#f07##0:wybe.int)
+                                foreign lpvm access(~#left##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#left#f07##0:wybe.int) @multictr2:9:8
                                 foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#49##0:wybe.int)
                                 foreign llvm icmp_eq(~tmp#49##0:wybe.int, 6:wybe.int, ?tmp#50##0:wybe.bool)
                                 case ~tmp#50##0:wybe.bool of
@@ -527,13 +527,13 @@ if.else7:
                                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access(~#right##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#right#f07##0:wybe.int)
+                                    foreign lpvm access(~#right##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#right#f07##0:wybe.int) @multictr2:9:8
                                     foreign llvm icmp_eq(~#left#f07##0:wybe.int, ~#right#f07##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
                         1:
-                            foreign lpvm access(~#left##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#left#f06##0:wybe.int)
+                            foreign lpvm access(~#left##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#left#f06##0:wybe.int) @multictr2:8:8
                             foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#46##0:wybe.int)
                             foreign llvm icmp_eq(~tmp#46##0:wybe.int, 5:wybe.int, ?tmp#47##0:wybe.bool)
                             case ~tmp#47##0:wybe.bool of
@@ -541,13 +541,13 @@ if.else7:
                                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                             1:
-                                foreign lpvm access(~#right##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#right#f06##0:wybe.int)
+                                foreign lpvm access(~#right##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#right#f06##0:wybe.int) @multictr2:8:8
                                 foreign llvm icmp_eq(~#left#f06##0:wybe.int, ~#right#f06##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
                     1:
-                        foreign lpvm access(~#left##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#left#f05##0:wybe.int)
+                        foreign lpvm access(~#left##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#left#f05##0:wybe.int) @multictr2:7:8
                         foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#43##0:wybe.int)
                         foreign llvm icmp_eq(~tmp#43##0:wybe.int, 4:wybe.int, ?tmp#44##0:wybe.bool)
                         case ~tmp#44##0:wybe.bool of
@@ -555,13 +555,13 @@ if.else7:
                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~#right##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#right#f05##0:wybe.int)
+                            foreign lpvm access(~#right##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#right#f05##0:wybe.int) @multictr2:7:8
                             foreign llvm icmp_eq(~#left#f05##0:wybe.int, ~#right#f05##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
                 1:
-                    foreign lpvm access(~#left##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#left#f04##0:wybe.int)
+                    foreign lpvm access(~#left##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#left#f04##0:wybe.int) @multictr2:6:8
                     foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#40##0:wybe.int)
                     foreign llvm icmp_eq(~tmp#40##0:wybe.int, 3:wybe.int, ?tmp#41##0:wybe.bool)
                     case ~tmp#41##0:wybe.bool of
@@ -569,13 +569,13 @@ if.else7:
                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~#right##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#right#f04##0:wybe.int)
+                        foreign lpvm access(~#right##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#right#f04##0:wybe.int) @multictr2:6:8
                         foreign llvm icmp_eq(~#left#f04##0:wybe.int, ~#right#f04##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
             1:
-                foreign lpvm access(~#left##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#f03##0:wybe.int)
+                foreign lpvm access(~#left##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#f03##0:wybe.int) @multictr2:5:8
                 foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#37##0:wybe.int)
                 foreign llvm icmp_eq(~tmp#37##0:wybe.int, 2:wybe.int, ?tmp#38##0:wybe.bool)
                 case ~tmp#38##0:wybe.bool of
@@ -583,13 +583,13 @@ if.else7:
                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~#right##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#f03##0:wybe.int)
+                    foreign lpvm access(~#right##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#f03##0:wybe.int) @multictr2:5:8
                     foreign llvm icmp_eq(~#left#f03##0:wybe.int, ~#right#f03##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
         1:
-            foreign lpvm access(~#left##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#f02##0:wybe.int)
+            foreign lpvm access(~#left##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#f02##0:wybe.int) @multictr2:4:8
             foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#34##0:wybe.int)
             foreign llvm icmp_eq(~tmp#34##0:wybe.int, 1:wybe.int, ?tmp#35##0:wybe.bool)
             case ~tmp#35##0:wybe.bool of
@@ -597,13 +597,13 @@ if.else7:
                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign lpvm access(~#right##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#f02##0:wybe.int)
+                foreign lpvm access(~#right##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#f02##0:wybe.int) @multictr2:4:8
                 foreign llvm icmp_eq(~#left#f02##0:wybe.int, ~#right#f02##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
     1:
-        foreign lpvm access(~#left##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#f01##0:wybe.int)
+        foreign lpvm access(~#left##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#f01##0:wybe.int) @multictr2:3:8
         foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#31##0:wybe.int)
         foreign llvm icmp_eq(~tmp#31##0:wybe.int, 0:wybe.int, ?tmp#32##0:wybe.bool)
         case ~tmp#32##0:wybe.bool of
@@ -611,7 +611,7 @@ if.else7:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(~#right##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#f01##0:wybe.int)
+            foreign lpvm access(~#right##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#f01##0:wybe.int) @multictr2:3:8
             foreign llvm icmp_eq(~#left#f01##0:wybe.int, ~#right#f01##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
@@ -622,8 +622,8 @@ c01 > public {inline} (0 calls)
 c01(f01##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?#result##0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:3:8
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#result##0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int) @multictr2:3:8
 c01 > public {inline} (24 calls)
 1: multictr2.t.c01<1>
 c01(?f01##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
@@ -637,7 +637,7 @@ c01(?f01##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int) @multictr2:3:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -647,9 +647,9 @@ c02 > public {inline} (0 calls)
 c02(f02##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 1:wybe.int, ?#result##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:4:8
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int) @multictr2:4:8
+    foreign llvm or(~#rec##1:multictr2.t, 1:wybe.int, ?#result##0:multictr2.t) @multictr2:4:8
 c02 > public {inline} (19 calls)
 1: multictr2.t.c02<1>
 c02(?f02##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
@@ -663,7 +663,7 @@ c02(?f02##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int) @multictr2:4:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -673,9 +673,9 @@ c03 > public {inline} (0 calls)
 c03(f03##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 2:wybe.int, ?#result##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:5:8
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int) @multictr2:5:8
+    foreign llvm or(~#rec##1:multictr2.t, 2:wybe.int, ?#result##0:multictr2.t) @multictr2:5:8
 c03 > public {inline} (17 calls)
 1: multictr2.t.c03<1>
 c03(?f03##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
@@ -689,7 +689,7 @@ c03(?f03##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int) @multictr2:5:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -699,9 +699,9 @@ c04 > public {inline} (0 calls)
 c04(f04##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 3:wybe.int, ?#result##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:6:8
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int) @multictr2:6:8
+    foreign llvm or(~#rec##1:multictr2.t, 3:wybe.int, ?#result##0:multictr2.t) @multictr2:6:8
 c04 > public {inline} (15 calls)
 1: multictr2.t.c04<1>
 c04(?f04##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
@@ -715,7 +715,7 @@ c04(?f04##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int) @multictr2:6:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -725,9 +725,9 @@ c05 > public {inline} (0 calls)
 c05(f05##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 4:wybe.int, ?#result##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:7:8
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int) @multictr2:7:8
+    foreign llvm or(~#rec##1:multictr2.t, 4:wybe.int, ?#result##0:multictr2.t) @multictr2:7:8
 c05 > public {inline} (13 calls)
 1: multictr2.t.c05<1>
 c05(?f05##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
@@ -741,7 +741,7 @@ c05(?f05##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int) @multictr2:7:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -751,9 +751,9 @@ c06 > public {inline} (0 calls)
 c06(f06##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 5:wybe.int, ?#result##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:8:8
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int) @multictr2:8:8
+    foreign llvm or(~#rec##1:multictr2.t, 5:wybe.int, ?#result##0:multictr2.t) @multictr2:8:8
 c06 > public {inline} (11 calls)
 1: multictr2.t.c06<1>
 c06(?f06##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
@@ -767,7 +767,7 @@ c06(?f06##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int) @multictr2:8:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -777,9 +777,9 @@ c07 > public {inline} (0 calls)
 c07(f07##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 6:wybe.int, ?#result##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:9:8
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int) @multictr2:9:8
+    foreign llvm or(~#rec##1:multictr2.t, 6:wybe.int, ?#result##0:multictr2.t) @multictr2:9:8
 c07 > public {inline} (9 calls)
 1: multictr2.t.c07<1>
 c07(?f07##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
@@ -793,7 +793,7 @@ c07(?f07##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
-        foreign lpvm access(~#result##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int) @multictr2:9:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -803,11 +803,11 @@ c08 > public {inline} (0 calls)
 c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_a##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:multictr2.t, ?#rec##2:multictr2.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_b##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:multictr2.t, ?#rec##3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c##0:wybe.float)
-    foreign llvm or(~#rec##3:multictr2.t, 7:wybe.int, ?#result##0:multictr2.t)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:multictr2.t) @multictr2:10:8
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_a##0:wybe.int) @multictr2:10:8
+    foreign lpvm mutate(~#rec##1:multictr2.t, ?#rec##2:multictr2.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_b##0:wybe.int) @multictr2:10:8
+    foreign lpvm mutate(~#rec##2:multictr2.t, ?#rec##3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c##0:wybe.float) @multictr2:10:8
+    foreign llvm or(~#rec##3:multictr2.t, 7:wybe.int, ?#result##0:multictr2.t) @multictr2:10:8
 c08 > public {inline} (9 calls)
 1: multictr2.t.c08<1>
 c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, #result##0:multictr2.t, ?#success##0:wybe.bool):
@@ -823,9 +823,9 @@ c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, #result##0:mul
         foreign llvm move(undef:wybe.float, ?f08_c##0:wybe.float)
 
     1:
-        foreign lpvm access(#result##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a##0:wybe.int)
-        foreign lpvm access(#result##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b##0:wybe.int)
-        foreign lpvm access(~#result##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c##0:wybe.float)
+        foreign lpvm access(#result##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a##0:wybe.int) @multictr2:10:8
+        foreign lpvm access(#result##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b##0:wybe.int) @multictr2:10:8
+        foreign lpvm access(~#result##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c##0:wybe.float) @multictr2:10:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -843,7 +843,7 @@ f01(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multictr2:3:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f01 > public {inline} (0 calls)
@@ -859,7 +859,7 @@ f01(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multictr2:3:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -877,7 +877,7 @@ f02(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @multictr2:4:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f02 > public {inline} (0 calls)
@@ -893,7 +893,7 @@ f02(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.int) @multictr2:4:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -911,7 +911,7 @@ f03(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int) @multictr2:5:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f03 > public {inline} (0 calls)
@@ -927,7 +927,7 @@ f03(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int) @multictr2:5:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -945,7 +945,7 @@ f04(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int) @multictr2:6:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f04 > public {inline} (0 calls)
@@ -961,7 +961,7 @@ f04(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~#field##0:wybe.int) @multictr2:6:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -979,7 +979,7 @@ f05(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int) @multictr2:7:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f05 > public {inline} (0 calls)
@@ -995,7 +995,7 @@ f05(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~#field##0:wybe.int) @multictr2:7:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1013,7 +1013,7 @@ f06(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int) @multictr2:8:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f06 > public {inline} (0 calls)
@@ -1029,7 +1029,7 @@ f06(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~#field##0:wybe.int) @multictr2:8:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1047,7 +1047,7 @@ f07(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int) @multictr2:9:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f07 > public {inline} (0 calls)
@@ -1063,7 +1063,7 @@ f07(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~#field##0:wybe.int) @multictr2:9:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1081,7 +1081,7 @@ f08_a(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr2:10:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f08_a > public {inline} (0 calls)
@@ -1097,7 +1097,7 @@ f08_a(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -7:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -7:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr2:10:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1115,7 +1115,7 @@ f08_b(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr2:10:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f08_b > public {inline} (0 calls)
@@ -1131,7 +1131,7 @@ f08_b(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 1:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 1:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.int) @multictr2:10:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1149,7 +1149,7 @@ f08_c(#rec##0:multictr2.t, ?#result##0:wybe.float, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.float, ?#result##0:wybe.float)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.float)
+        foreign lpvm access(~#rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.float) @multictr2:10:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f08_c > public {inline} (0 calls)
@@ -1165,7 +1165,7 @@ f08_c(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.float, ?#success
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 9:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.float)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 9:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.float) @multictr2:10:8
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -55,16 +55,16 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
         foreign llvm icmp_eq(~#left##0:mutual_type.a, ~#right##0:mutual_type.a, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#ahead##0:wybe.int)
-        foreign lpvm access(~#left##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#atail##0:mutual_type.b)
+        foreign lpvm access(#left##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#ahead##0:wybe.int) @mutual_type:nn:nn
+        foreign lpvm access(~#left##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#atail##0:mutual_type.b) @mutual_type:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#ahead##0:wybe.int)
-            foreign lpvm access(~#right##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#atail##0:mutual_type.b)
+            foreign lpvm access(#right##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#ahead##0:wybe.int) @mutual_type:nn:nn
+            foreign lpvm access(~#right##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#atail##0:mutual_type.b) @mutual_type:nn:nn
             foreign llvm icmp_eq(~#left#ahead##0:wybe.int, ~#right#ahead##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -82,9 +82,9 @@ a > public {inline} (0 calls)
 a(ahead##0:wybe.int, atail##0:mutual_type.b, ?#result##0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.a)
-    foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:mutual_type.a, ?#result##0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.a) @mutual_type:nn:nn
+    foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead##0:wybe.int) @mutual_type:nn:nn
+    foreign lpvm mutate(~#rec##1:mutual_type.a, ?#result##0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b) @mutual_type:nn:nn
 a > public {inline} (12 calls)
 1: mutual_type.a.a<1>
 a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, #result##0:mutual_type.a, ?#success##0:wybe.bool):
@@ -98,8 +98,8 @@ a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, #result##0:mutual_type.a, ?#succe
         foreign llvm move(undef:mutual_type.b, ?atail##0:mutual_type.b)
 
     1:
-        foreign lpvm access(#result##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead##0:wybe.int)
-        foreign lpvm access(~#result##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail##0:mutual_type.b)
+        foreign lpvm access(#result##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead##0:wybe.int) @mutual_type:nn:nn
+        foreign lpvm access(~#result##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail##0:mutual_type.b) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -116,7 +116,7 @@ ahead(#rec##0:mutual_type.a, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 ahead > public {inline} (0 calls)
@@ -131,7 +131,7 @@ ahead(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:wybe.int, ?#succe
         foreign llvm move(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a)
 
     1:
-        foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -148,7 +148,7 @@ atail(#rec##0:mutual_type.a, ?#result##0:mutual_type.b, ?#success##0:wybe.bool):
         foreign llvm move(undef:mutual_type.b, ?#result##0:mutual_type.b)
 
     1:
-        foreign lpvm access(~#rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.b)
+        foreign lpvm access(~#rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.b) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 atail > public {inline} (0 calls)
@@ -163,7 +163,7 @@ atail(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:mutual_type.b, ?#
         foreign llvm move(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:mutual_type.b)
+        foreign lpvm {noalias} mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:mutual_type.b) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -405,16 +405,16 @@ entry:
         foreign llvm icmp_eq(~#left##0:mutual_type.b, ~#right##0:mutual_type.b, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#bhead##0:wybe.int)
-        foreign lpvm access(~#left##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#btail##0:mutual_type.a)
+        foreign lpvm access(#left##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#bhead##0:wybe.int) @mutual_type:nn:nn
+        foreign lpvm access(~#left##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#btail##0:mutual_type.a) @mutual_type:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#bhead##0:wybe.int)
-            foreign lpvm access(~#right##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#btail##0:mutual_type.a)
+            foreign lpvm access(#right##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#bhead##0:wybe.int) @mutual_type:nn:nn
+            foreign lpvm access(~#right##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#btail##0:mutual_type.a) @mutual_type:nn:nn
             foreign llvm icmp_eq(~#left#bhead##0:wybe.int, ~#right#bhead##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -432,9 +432,9 @@ b > public {inline} (0 calls)
 b(bhead##0:wybe.int, btail##0:mutual_type.a, ?#result##0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.b)
-    foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:mutual_type.b, ?#result##0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.b) @mutual_type:nn:nn
+    foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead##0:wybe.int) @mutual_type:nn:nn
+    foreign lpvm mutate(~#rec##1:mutual_type.b, ?#result##0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a) @mutual_type:nn:nn
 b > public {inline} (12 calls)
 1: mutual_type.b.b<1>
 b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, #result##0:mutual_type.b, ?#success##0:wybe.bool):
@@ -448,8 +448,8 @@ b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, #result##0:mutual_type.b, ?#succe
         foreign llvm move(undef:mutual_type.a, ?btail##0:mutual_type.a)
 
     1:
-        foreign lpvm access(#result##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead##0:wybe.int)
-        foreign lpvm access(~#result##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail##0:mutual_type.a)
+        foreign lpvm access(#result##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead##0:wybe.int) @mutual_type:nn:nn
+        foreign lpvm access(~#result##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail##0:mutual_type.a) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -466,7 +466,7 @@ bhead(#rec##0:mutual_type.b, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 bhead > public {inline} (0 calls)
@@ -481,7 +481,7 @@ bhead(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:wybe.int, ?#succe
         foreign llvm move(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b)
 
     1:
-        foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -498,7 +498,7 @@ btail(#rec##0:mutual_type.b, ?#result##0:mutual_type.a, ?#success##0:wybe.bool):
         foreign llvm move(undef:mutual_type.a, ?#result##0:mutual_type.a)
 
     1:
-        foreign lpvm access(~#rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.a)
+        foreign lpvm access(~#rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.a) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 btail > public {inline} (0 calls)
@@ -513,7 +513,7 @@ btail(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:mutual_type.a, ?#
         foreign llvm move(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:mutual_type.a)
+        foreign lpvm {noalias} mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:mutual_type.a) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -44,9 +44,9 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##
         foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
 
     1:
-        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
-        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
-        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree)
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree) @mytree:nn:nn
         mytree.printTree1<0>(~l##0:mytree.tree, ~%prefix##0:wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @mytree:nn:nn
         wybe.string.print_string<0>(~prefix##1:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @io:nn:nn
         foreign c print_int(~k##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
@@ -155,18 +155,18 @@ if.else:
         foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
-        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
-        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree)
+        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree) @mytree:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
-            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
-            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree)
+            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree) @mytree:nn:nn
+            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int) @mytree:nn:nn
+            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree) @mytree:nn:nn
             mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
@@ -206,7 +206,7 @@ key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -221,7 +221,7 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -238,7 +238,7 @@ left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -253,7 +253,7 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -263,10 +263,10 @@ node > public {inline} (0 calls)
 node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
-    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
-    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @mytree:nn:nn
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree) @mytree:nn:nn
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
 node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool):
@@ -281,9 +281,9 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -300,7 +300,7 @@ right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -315,7 +315,7 @@ right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#succes
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -77,10 +77,10 @@ entry:
 =(#left##0:person1.person, #right##0:person1.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
-    foreign lpvm access(~#left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
-    foreign lpvm access(#right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
-    foreign lpvm access(~#right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign lpvm access(#left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string) @person1:1:23
+    foreign lpvm access(~#left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person1:1:23
+    foreign lpvm access(#right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person1:1:23
+    foreign lpvm access(~#right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person1:1:23
     wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
     case ~tmp#1##0:wybe.bool of
     0:
@@ -96,13 +96,13 @@ firstname > public {inline} (0 calls)
 firstname(#rec##0:person1.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person1:1:23
 firstname > public {inline} (0 calls)
 1: person1.person.firstname<1>
 firstname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person1:1:23
 
 
 lastname > public {inline} (0 calls)
@@ -110,13 +110,13 @@ lastname > public {inline} (0 calls)
 lastname(#rec##0:person1.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person1:1:23
 lastname > public {inline} (0 calls)
 1: person1.person.lastname<1>
 lastname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person1:1:23
 
 
 person > public {inline} (0 calls)
@@ -124,16 +124,16 @@ person > public {inline} (0 calls)
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:person1.person)
-    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person1.person, ?#result##0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person1.person) @person1:1:23
+    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person1:1:23
+    foreign lpvm mutate(~#rec##1:person1.person, ?#result##0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person1:1:23
 person > public {inline} (6 calls)
 1: person1.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~#result##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string) @person1:1:23
+    foreign lpvm access(~#result##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person1:1:23
 
 
 ~= > public {inline} (0 calls)
@@ -141,10 +141,10 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.p
 ~=(#left##0:person1.person, #right##0:person1.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
-    foreign lpvm access(~#left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
-    foreign lpvm access(#right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
-    foreign lpvm access(~#right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign lpvm access(#left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @person1:1:23
+    foreign lpvm access(~#left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person1:1:23
+    foreign lpvm access(#right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person1:1:23
+    foreign lpvm access(~#right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person1:1:23
     wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -85,10 +85,10 @@ entry:
 =(#left##0:person2.person, #right##0:person2.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
-    foreign lpvm access(~#left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
-    foreign lpvm access(#right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
-    foreign lpvm access(~#right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign lpvm access(#left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string) @person2:1:23
+    foreign lpvm access(~#left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person2:1:23
+    foreign lpvm access(#right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person2:1:23
+    foreign lpvm access(~#right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person2:1:23
     wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
     case ~tmp#1##0:wybe.bool of
     0:
@@ -104,13 +104,13 @@ firstname > public {inline} (0 calls)
 firstname(#rec##0:person2.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person2:1:23
 firstname > public {inline} (0 calls)
 1: person2.person.firstname<1>
 firstname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person2:1:23
 
 
 lastname > public {inline} (0 calls)
@@ -118,13 +118,13 @@ lastname > public {inline} (0 calls)
 lastname(#rec##0:person2.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person2:1:23
 lastname > public {inline} (0 calls)
 1: person2.person.lastname<1>
 lastname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person2:1:23
 
 
 person > public {inline} (0 calls)
@@ -132,16 +132,16 @@ person > public {inline} (0 calls)
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:person2.person)
-    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person2.person, ?#result##0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person2.person) @person2:1:23
+    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person2:1:23
+    foreign lpvm mutate(~#rec##1:person2.person, ?#result##0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person2:1:23
 person > public {inline} (6 calls)
 1: person2.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~#result##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string) @person2:1:23
+    foreign lpvm access(~#result##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person2:1:23
 
 
 ~= > public {inline} (0 calls)
@@ -149,10 +149,10 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.p
 ~=(#left##0:person2.person, #right##0:person2.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
-    foreign lpvm access(~#left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
-    foreign lpvm access(#right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
-    foreign lpvm access(~#right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign lpvm access(#left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @person2:1:23
+    foreign lpvm access(~#left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person2:1:23
+    foreign lpvm access(#right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person2:1:23
+    foreign lpvm access(~#right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person2:1:23
     wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -85,10 +85,10 @@ entry:
 =(#left##0:person3.person, #right##0:person3.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
-    foreign lpvm access(~#left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
-    foreign lpvm access(#right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
-    foreign lpvm access(~#right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign lpvm access(#left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string) @person3:1:23
+    foreign lpvm access(~#left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person3:1:23
+    foreign lpvm access(#right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person3:1:23
+    foreign lpvm access(~#right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person3:1:23
     wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
     case ~tmp#1##0:wybe.bool of
     0:
@@ -104,13 +104,13 @@ firstname > public {inline} (0 calls)
 firstname(#rec##0:person3.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person3:1:23
 firstname > public {inline} (0 calls)
 1: person3.person.firstname<1>
 firstname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person3:1:23
 
 
 lastname > public {inline} (0 calls)
@@ -118,13 +118,13 @@ lastname > public {inline} (0 calls)
 lastname(#rec##0:person3.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person3:1:23
 lastname > public {inline} (0 calls)
 1: person3.person.lastname<1>
 lastname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person3:1:23
 
 
 person > public {inline} (0 calls)
@@ -132,16 +132,16 @@ person > public {inline} (0 calls)
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:person3.person)
-    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person3.person, ?#result##0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person3.person) @person3:1:23
+    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person3:1:23
+    foreign lpvm mutate(~#rec##1:person3.person, ?#result##0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person3:1:23
 person > public {inline} (6 calls)
 1: person3.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~#result##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string) @person3:1:23
+    foreign lpvm access(~#result##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person3:1:23
 
 
 ~= > public {inline} (0 calls)
@@ -149,10 +149,10 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.p
 ~=(#left##0:person3.person, #right##0:person3.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
-    foreign lpvm access(~#left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
-    foreign lpvm access(#right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
-    foreign lpvm access(~#right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign lpvm access(#left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @person3:1:23
+    foreign lpvm access(~#left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person3:1:23
+    foreign lpvm access(#right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person3:1:23
+    foreign lpvm access(~#right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person3:1:23
     wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -85,10 +85,10 @@ entry:
 =(#left##0:person4.person, #right##0:person4.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
-    foreign lpvm access(~#left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
-    foreign lpvm access(#right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
-    foreign lpvm access(~#right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign lpvm access(#left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string) @person4:1:23
+    foreign lpvm access(~#left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person4:1:23
+    foreign lpvm access(#right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person4:1:23
+    foreign lpvm access(~#right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person4:1:23
     wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
     case ~tmp#1##0:wybe.bool of
     0:
@@ -104,13 +104,13 @@ firstname > public {inline} (0 calls)
 firstname(#rec##0:person4.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person4:1:23
 firstname > public {inline} (0 calls)
 1: person4.person.firstname<1>
 firstname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person4:1:23
 
 
 lastname > public {inline} (0 calls)
@@ -118,13 +118,13 @@ lastname > public {inline} (0 calls)
 lastname(#rec##0:person4.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person4:1:23
 lastname > public {inline} (0 calls)
 1: person4.person.lastname<1>
 lastname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person4:1:23
 
 
 person > public {inline} (0 calls)
@@ -132,16 +132,16 @@ person > public {inline} (0 calls)
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:person4.person)
-    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person4.person, ?#result##0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person4.person) @person4:1:23
+    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person4:1:23
+    foreign lpvm mutate(~#rec##1:person4.person, ?#result##0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person4:1:23
 person > public {inline} (6 calls)
 1: person4.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~#result##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string) @person4:1:23
+    foreign lpvm access(~#result##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person4:1:23
 
 
 ~= > public {inline} (0 calls)
@@ -149,10 +149,10 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.p
 ~=(#left##0:person4.person, #right##0:person4.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
-    foreign lpvm access(~#left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
-    foreign lpvm access(#right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
-    foreign lpvm access(~#right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign lpvm access(#left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @person4:1:23
+    foreign lpvm access(~#left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person4:1:23
+    foreign lpvm access(#right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person4:1:23
+    foreign lpvm access(~#right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person4:1:23
     wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -33,8 +33,8 @@ update_both > {inline} (1 calls)
 update_both(p1##0:person5.person, ?p1##1:person5.person, p2##0:person5.person, ?p2##1:person5.person, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~%p1##0:person5.person, ?%p1##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Amy":wybe.string)
-    foreign lpvm mutate(~%p2##0:person5.person, ?%p2##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Bob":wybe.string)
+    foreign lpvm mutate(~%p1##0:person5.person, ?%p1##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Amy":wybe.string) @person5:1:23
+    foreign lpvm mutate(~%p2##0:person5.person, ?%p2##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Bob":wybe.string) @person5:1:23
 
   LLVM code       :
 
@@ -134,10 +134,10 @@ entry:
 =(#left##0:person5.person, #right##0:person5.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
-    foreign lpvm access(~#left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
-    foreign lpvm access(#right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
-    foreign lpvm access(~#right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign lpvm access(#left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string) @person5:1:23
+    foreign lpvm access(~#left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person5:1:23
+    foreign lpvm access(#right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person5:1:23
+    foreign lpvm access(~#right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person5:1:23
     wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
     case ~tmp#1##0:wybe.bool of
     0:
@@ -153,13 +153,13 @@ firstname > public {inline} (0 calls)
 firstname(#rec##0:person5.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person5:1:23
 firstname > public {inline} (0 calls)
 1: person5.person.firstname<1>
 firstname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person5:1:23
 
 
 lastname > public {inline} (0 calls)
@@ -167,13 +167,13 @@ lastname > public {inline} (0 calls)
 lastname(#rec##0:person5.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person5:1:23
 lastname > public {inline} (0 calls)
 1: person5.person.lastname<1>
 lastname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person5:1:23
 
 
 person > public {inline} (0 calls)
@@ -181,16 +181,16 @@ person > public {inline} (0 calls)
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:person5.person)
-    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person5.person, ?#result##0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person5.person) @person5:1:23
+    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person5:1:23
+    foreign lpvm mutate(~#rec##1:person5.person, ?#result##0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person5:1:23
 person > public {inline} (6 calls)
 1: person5.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~#result##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string) @person5:1:23
+    foreign lpvm access(~#result##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person5:1:23
 
 
 ~= > public {inline} (0 calls)
@@ -198,10 +198,10 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.p
 ~=(#left##0:person5.person, #right##0:person5.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
-    foreign lpvm access(~#left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
-    foreign lpvm access(#right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
-    foreign lpvm access(~#right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign lpvm access(#left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @person5:1:23
+    foreign lpvm access(~#left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person5:1:23
+    foreign lpvm access(#right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person5:1:23
+    foreign lpvm access(~#right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person5:1:23
     wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -25,10 +25,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -114,10 +114,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -133,16 +133,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -150,13 +150,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -164,13 +164,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -178,10 +178,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -25,10 +25,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -114,10 +114,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -133,16 +133,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -150,13 +150,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -164,13 +164,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -178,10 +178,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -358,10 +358,10 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
-    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 112:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int) @position:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 112:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect posA(111,112):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @io:nn:nn
     position.printPosition<0>(~posA##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @position1:8:2
 

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -25,10 +25,10 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #7 @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
     foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) #9 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
@@ -114,10 +114,10 @@ entry:
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -133,16 +133,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
-    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
 position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -150,13 +150,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -164,13 +164,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -178,10 +178,10 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @position:nn:nn
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @position:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -358,15 +358,15 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
-    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position)
-    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 333:wybe.int)
-    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 333:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect posA(111,222):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
     position.printPosition<0>(tmp#0##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @position2:7:2
-    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("expect posA(111,20000):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #11 @io:nn:nn
     position.printPosition<0>(~posA##1:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @position2:11:2
     wybe.string.print_string<0>("expect posB(333,222):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #12 @io:nn:nn

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -54,10 +54,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 =(#left##0:position_float.position, #right##0:position_float.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.float)
-    foreign lpvm access(~#left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.float)
-    foreign lpvm access(#right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.float)
-    foreign lpvm access(~#right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.float)
+    foreign lpvm access(#left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.float) @position_float:nn:nn
+    foreign lpvm access(~#left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.float) @position_float:nn:nn
+    foreign lpvm access(#right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.float) @position_float:nn:nn
+    foreign lpvm access(~#right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.float) @position_float:nn:nn
     foreign llvm fcmp_eq(~#left#x##0:wybe.float, ~#right#x##0:wybe.float, ?tmp#1##0:wybe.bool) @float:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -73,16 +73,16 @@ position > public {inline} (0 calls)
 position(x##0:wybe.float, y##0:wybe.float, ?#result##0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:position_float.position)
-    foreign lpvm mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.float)
-    foreign lpvm mutate(~#rec##1:position_float.position, ?#result##0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.float)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position_float.position) @position_float:nn:nn
+    foreign lpvm mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.float) @position_float:nn:nn
+    foreign lpvm mutate(~#rec##1:position_float.position, ?#result##0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.float) @position_float:nn:nn
 position > public {inline} (6 calls)
 1: position_float.position.position<1>
 position(?x##0:wybe.float, ?y##0:wybe.float, #result##0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.float)
-    foreign lpvm access(~#result##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.float)
+    foreign lpvm access(#result##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.float) @position_float:nn:nn
+    foreign lpvm access(~#result##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.float) @position_float:nn:nn
 
 
 x > public {inline} (0 calls)
@@ -90,13 +90,13 @@ x > public {inline} (0 calls)
 x(#rec##0:position_float.position, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.float)
+    foreign lpvm access(~#rec##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.float) @position_float:nn:nn
 x > public {inline} (0 calls)
 1: position_float.position.x<1>
 x(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.float)
+    foreign lpvm {noalias} mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.float) @position_float:nn:nn
 
 
 y > public {inline} (0 calls)
@@ -104,13 +104,13 @@ y > public {inline} (0 calls)
 y(#rec##0:position_float.position, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.float)
+    foreign lpvm access(~#rec##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.float) @position_float:nn:nn
 y > public {inline} (0 calls)
 1: position_float.position.y<1>
 y(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.float)
+    foreign lpvm {noalias} mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.float) @position_float:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -118,10 +118,10 @@ y(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:w
 ~=(#left##0:position_float.position, #right##0:position_float.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.float)
-    foreign lpvm access(~#left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.float)
-    foreign lpvm access(#right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.float)
-    foreign lpvm access(~#right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.float)
+    foreign lpvm access(#left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.float) @position_float:nn:nn
+    foreign lpvm access(~#left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.float) @position_float:nn:nn
+    foreign lpvm access(#right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.float) @position_float:nn:nn
+    foreign lpvm access(~#right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.float) @position_float:nn:nn
     foreign llvm fcmp_eq(~tmp#3##0:wybe.float, ~tmp#5##0:wybe.float, ?tmp#7##0:wybe.bool) @float:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -95,16 +95,16 @@ gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
         case ~tmp#15##0:wybe.bool of
         0:
             foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
         1:
-            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int)
-            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int))
+            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int) @list:nn:nn
+            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int)) @list:nn:nn
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
             foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
@@ -125,8 +125,8 @@ gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -151,8 +151,8 @@ gen#11(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -177,8 +177,8 @@ gen#12(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -259,16 +259,16 @@ gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
         case ~tmp#15##0:wybe.bool of
         0:
             foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
         1:
-            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int)
-            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int))
+            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int) @list:nn:nn
+            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int)) @list:nn:nn
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
             foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
@@ -289,8 +289,8 @@ gen#4(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#4##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#4##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##1:wybe.list(wybe.int)) @list:nn:nn
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
         stmt_for.gen#4<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
@@ -308,8 +308,8 @@ gen#5(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -368,8 +368,8 @@ gen#8(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -394,8 +394,8 @@ gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
         foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -418,17 +418,17 @@ irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_
     case ~tmp#4##0:wybe.bool of
     0:
         foreign llvm add(~end##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(24:wybe.int, ?tmp#12##0:stmt_for.int_sequence)
-        foreign lpvm mutate(~tmp#12##0:stmt_for.int_sequence, ?tmp#13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
-        foreign lpvm mutate(~tmp#13##0:stmt_for.int_sequence, ?tmp#14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm alloc(24:wybe.int, ?tmp#12##0:stmt_for.int_sequence) @stmt_for:nn:nn
+        foreign lpvm mutate(~tmp#12##0:stmt_for.int_sequence, ?tmp#13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int) @stmt_for:nn:nn
+        foreign lpvm mutate(~tmp#13##0:stmt_for.int_sequence, ?tmp#14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int) @stmt_for:nn:nn
+        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @stmt_for:nn:nn
 
     1:
         foreign llvm sub(~end##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(24:wybe.int, ?tmp#12##0:stmt_for.int_sequence)
-        foreign lpvm mutate(~tmp#12##0:stmt_for.int_sequence, ?tmp#13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
-        foreign lpvm mutate(~tmp#13##0:stmt_for.int_sequence, ?tmp#14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm alloc(24:wybe.int, ?tmp#12##0:stmt_for.int_sequence) @stmt_for:nn:nn
+        foreign lpvm mutate(~tmp#12##0:stmt_for.int_sequence, ?tmp#13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int) @stmt_for:nn:nn
+        foreign lpvm mutate(~tmp#13##0:stmt_for.int_sequence, ?tmp#14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int) @stmt_for:nn:nn
+        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @stmt_for:nn:nn
 
 
 
@@ -437,24 +437,24 @@ multiple_generator > public (1 calls)
 multiple_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:T)
-    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#6##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
-    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#4##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#6##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#4##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
@@ -472,24 +472,24 @@ shortest_generator_termination > public (1 calls)
 shortest_generator_termination(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
-    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#6##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#6##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#3<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
@@ -498,15 +498,15 @@ single_generator > public (1 calls)
 single_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#8##0:wybe.list(T), ?tmp#9##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#12##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#13##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#17##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#8##0:wybe.list(T), ?tmp#9##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#12##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#13##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#17##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#4<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
 
 
@@ -515,18 +515,18 @@ using_break > public (1 calls)
 using_break(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#5<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
@@ -553,18 +553,18 @@ using_next > public (1 calls)
 using_next(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#8<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
@@ -573,18 +573,18 @@ using_unless > public (1 calls)
 using_unless(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
@@ -593,18 +593,18 @@ using_until > public (1 calls)
 using_until(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#10<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
@@ -613,18 +613,18 @@ using_when > public (1 calls)
 using_when(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#11<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
@@ -633,18 +633,18 @@ using_while > public (1 calls)
 using_while(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
     stmt_for.gen#12<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
@@ -671,10 +671,10 @@ xrange > public (3 calls)
 xrange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#4##0:stmt_for.int_sequence)
-    foreign lpvm mutate(~tmp#4##0:stmt_for.int_sequence, ?tmp#5##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:stmt_for.int_sequence, ?tmp#6##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#4##0:stmt_for.int_sequence) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#4##0:stmt_for.int_sequence, ?tmp#5##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#5##0:stmt_for.int_sequence, ?tmp#6##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#6##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int) @stmt_for:nn:nn
 
   LLVM code       :
 
@@ -1738,12 +1738,12 @@ entry:
 =(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#start##0:wybe.int)
-    foreign lpvm access(#left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#stride##0:wybe.int)
-    foreign lpvm access(~#left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#end##0:wybe.int)
-    foreign lpvm access(#right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#start##0:wybe.int)
-    foreign lpvm access(#right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#stride##0:wybe.int)
-    foreign lpvm access(~#right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#end##0:wybe.int)
+    foreign lpvm access(#left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#start##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(#left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#stride##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(~#left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#end##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(#right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#start##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(#right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#stride##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(~#right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#end##0:wybe.int) @stmt_for:nn:nn
     foreign llvm icmp_eq(~#left#start##0:wybe.int, ~#right#start##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -1766,9 +1766,9 @@ entry:
 [|](?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, current##0:stmt_for.int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(current##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?s##0:wybe.int)
-    foreign lpvm access(current##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?st##0:wybe.int)
-    foreign lpvm access(~current##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?en##0:wybe.int)
+    foreign lpvm access(current##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?s##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(current##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?st##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(~current##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?en##0:wybe.int) @stmt_for:nn:nn
     foreign llvm icmp_slt(st##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
@@ -1802,13 +1802,13 @@ end > public {inline} (0 calls)
 end(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_for:nn:nn
 end > public {inline} (0 calls)
 1: stmt_for.int_sequence.end<1>
 end(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_for:nn:nn
 
 
 gen#1 > (2 calls)
@@ -1818,10 +1818,10 @@ gen#1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:w
  InterestingCallProperties: []
     foreign llvm move(s##0:wybe.int, ?value##0:wybe.int) @stmt_for:nn:nn
     foreign llvm add(~s##0:wybe.int, st##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:stmt_for.int_sequence)
-    foreign lpvm mutate(~tmp#7##0:stmt_for.int_sequence, ?tmp#8##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
-    foreign lpvm mutate(~tmp#8##0:stmt_for.int_sequence, ?tmp#9##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st##0:wybe.int)
-    foreign lpvm mutate(~tmp#9##0:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:stmt_for.int_sequence) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#7##0:stmt_for.int_sequence, ?tmp#8##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#8##0:stmt_for.int_sequence, ?tmp#9##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#9##0:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en##0:wybe.int) @stmt_for:nn:nn
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -1830,18 +1830,18 @@ int_sequence > public {inline} (1 calls)
 int_sequence(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_for.int_sequence)
-    foreign lpvm mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:stmt_for.int_sequence, ?#rec##2:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_for.int_sequence) @stmt_for:nn:nn
+    foreign lpvm mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm mutate(~#rec##1:stmt_for.int_sequence, ?#rec##2:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm mutate(~#rec##2:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int) @stmt_for:nn:nn
 int_sequence > public {inline} (16 calls)
 1: stmt_for.int_sequence.int_sequence<1>
 int_sequence(?start##0:wybe.int, ?stride##0:wybe.int, ?end##0:wybe.int, #result##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?start##0:wybe.int)
-    foreign lpvm access(#result##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?stride##0:wybe.int)
-    foreign lpvm access(~#result##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end##0:wybe.int)
+    foreign lpvm access(#result##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?start##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(#result##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?stride##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(~#result##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end##0:wybe.int) @stmt_for:nn:nn
 
 
 start > public {inline} (0 calls)
@@ -1849,13 +1849,13 @@ start > public {inline} (0 calls)
 start(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_for:nn:nn
 start > public {inline} (0 calls)
 1: stmt_for.int_sequence.start<1>
 start(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_for:nn:nn
 
 
 stride > public {inline} (0 calls)
@@ -1863,13 +1863,13 @@ stride > public {inline} (0 calls)
 stride(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_for:nn:nn
 stride > public {inline} (0 calls)
 1: stmt_for.int_sequence.stride<1>
 stride(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_for:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -1877,12 +1877,12 @@ stride(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:
 ~=(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(#left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(~#left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(#right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
-    foreign lpvm access(#right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~#right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(#left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(~#left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(#right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(#right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm access(~#right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @stmt_for:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
     case ~tmp#9##0:wybe.bool of
     0:

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -27,10 +27,10 @@ foobar > (0 calls)
 foobar(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#8##0:stmt_if.tree)
-    foreign lpvm mutate(~tmp#8##0:stmt_if.tree, ?tmp#9##0:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
-    foreign lpvm mutate(~tmp#9##0:stmt_if.tree, ?tmp#10##0:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#10##0:stmt_if.tree, ?tmp#11##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#8##0:stmt_if.tree) @stmt_if:nn:nn
+    foreign lpvm mutate(~tmp#8##0:stmt_if.tree, ?tmp#9##0:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree) @stmt_if:nn:nn
+    foreign lpvm mutate(~tmp#9##0:stmt_if.tree, ?tmp#10##0:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @stmt_if:nn:nn
+    foreign lpvm mutate(~tmp#10##0:stmt_if.tree, ?tmp#11##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree) @stmt_if:nn:nn
     stmt_if.lookup<0>(1:wybe.int, tmp#11##0:stmt_if.tree, ?tmp#4##0:wybe.bool) #3 @stmt_if:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
@@ -73,9 +73,9 @@ lookup(key##0:wybe.int, tree##0:stmt_if.tree, ?result##0:wybe.bool):
         foreign llvm move(0:wybe.bool, ?result##0:wybe.bool) @stmt_if:nn:nn
 
     1:
-        foreign lpvm access(tree##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
-        foreign lpvm access(tree##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?nodekey##0:wybe.int)
-        foreign lpvm access(~tree##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
+        foreign lpvm access(tree##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree) @stmt_if:nn:nn
+        foreign lpvm access(tree##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?nodekey##0:wybe.int) @stmt_if:nn:nn
+        foreign lpvm access(~tree##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm icmp_eq(key##0:wybe.int, nodekey##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
         case ~tmp#3##0:wybe.bool of
         0:
@@ -247,18 +247,18 @@ if.else2:
         foreign llvm icmp_eq(~#left##0:stmt_if.tree, ~#right##0:stmt_if.tree, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:stmt_if.tree)
-        foreign lpvm access(#left##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
-        foreign lpvm access(~#left##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:stmt_if.tree)
+        foreign lpvm access(#left##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:stmt_if.tree) @stmt_if:nn:nn
+        foreign lpvm access(#left##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int) @stmt_if:nn:nn
+        foreign lpvm access(~#left##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:stmt_if.tree)
-            foreign lpvm access(#right##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
-            foreign lpvm access(~#right##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:stmt_if.tree)
+            foreign lpvm access(#right##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:stmt_if.tree) @stmt_if:nn:nn
+            foreign lpvm access(#right##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int) @stmt_if:nn:nn
+            foreign lpvm access(~#right##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:stmt_if.tree) @stmt_if:nn:nn
             stmt_if.tree.=<0>(~#left#left##0:stmt_if.tree, ~#right#left##0:stmt_if.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
@@ -298,7 +298,7 @@ key(#rec##0:stmt_if.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -313,7 +313,7 @@ key(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:wybe.int, ?#success##
         foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -330,7 +330,7 @@ left(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:stmt_if.tree, ?#result##0:stmt_if.tree)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -345,7 +345,7 @@ left(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?#succ
         foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if.tree)
+        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -355,10 +355,10 @@ node > public {inline} (0 calls)
 node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?#result##0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_if.tree)
-    foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if.tree)
-    foreign lpvm mutate(~#rec##1:stmt_if.tree, ?#rec##2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:stmt_if.tree, ?#result##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_if.tree) @stmt_if:nn:nn
+    foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if.tree) @stmt_if:nn:nn
+    foreign lpvm mutate(~#rec##1:stmt_if.tree, ?#rec##2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @stmt_if:nn:nn
+    foreign lpvm mutate(~#rec##2:stmt_if.tree, ?#result##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree) @stmt_if:nn:nn
 node > public {inline} (16 calls)
 1: stmt_if.tree.node<1>
 node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, #result##0:stmt_if.tree, ?#success##0:wybe.bool):
@@ -373,9 +373,9 @@ node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, #result##0
         foreign llvm move(undef:stmt_if.tree, ?right##0:stmt_if.tree)
 
     1:
-        foreign lpvm access(#result##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
-        foreign lpvm access(#result##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~#result##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
+        foreign lpvm access(#result##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree) @stmt_if:nn:nn
+        foreign lpvm access(#result##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int) @stmt_if:nn:nn
+        foreign lpvm access(~#result##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -392,7 +392,7 @@ right(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:stmt_if.tree, ?#result##0:stmt_if.tree)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -407,7 +407,7 @@ right(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?#suc
         foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if.tree)
+        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -28,10 +28,10 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:stmt_if2.tree)
-    foreign lpvm mutate(~tmp#7##0:stmt_if2.tree, ?tmp#8##0:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
-    foreign lpvm mutate(~tmp#8##0:stmt_if2.tree, ?tmp#9##0:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#9##0:stmt_if2.tree, ?tmp#10##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:stmt_if2.tree) @stmt_if2:3:29
+    foreign lpvm mutate(~tmp#7##0:stmt_if2.tree, ?tmp#8##0:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree) @stmt_if2:3:29
+    foreign lpvm mutate(~tmp#8##0:stmt_if2.tree, ?tmp#9##0:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @stmt_if2:3:29
+    foreign lpvm mutate(~tmp#9##0:stmt_if2.tree, ?tmp#10##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree) @stmt_if2:3:29
     stmt_if2.lookup<0>(1:wybe.int, ~tmp#10##0:stmt_if2.tree, ?tmp#3##0:wybe.bool) #3 @stmt_if2:17:5
     case ~tmp#3##0:wybe.bool of
     0:
@@ -64,9 +64,9 @@ lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?#result##0:wybe.bool):
             foreign llvm move(0:wybe.bool, ?#result##0:wybe.bool) @stmt_if2:5:5
 
         1:
-            foreign lpvm access(tree##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:stmt_if2.tree)
-            foreign lpvm access(tree##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
-            foreign lpvm access(~tree##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:stmt_if2.tree)
+            foreign lpvm access(tree##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:stmt_if2.tree) @stmt_if2:3:29
+            foreign lpvm access(tree##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int) @stmt_if2:3:29
+            foreign lpvm access(~tree##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:stmt_if2.tree) @stmt_if2:3:29
             foreign llvm icmp_eq(k##0:wybe.int, key##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
             case ~tmp#11##0:wybe.bool of
             0:
@@ -212,18 +212,18 @@ if.else3:
         foreign llvm icmp_eq(~#left##0:stmt_if2.tree, ~#right##0:stmt_if2.tree, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:stmt_if2.tree)
-        foreign lpvm access(#left##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
-        foreign lpvm access(~#left##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:stmt_if2.tree)
+        foreign lpvm access(#left##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:stmt_if2.tree) @stmt_if2:3:29
+        foreign lpvm access(#left##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int) @stmt_if2:3:29
+        foreign lpvm access(~#left##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:stmt_if2.tree) @stmt_if2:3:29
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:stmt_if2.tree)
-            foreign lpvm access(#right##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
-            foreign lpvm access(~#right##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:stmt_if2.tree)
+            foreign lpvm access(#right##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:stmt_if2.tree) @stmt_if2:3:29
+            foreign lpvm access(#right##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int) @stmt_if2:3:29
+            foreign lpvm access(~#right##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:stmt_if2.tree) @stmt_if2:3:29
             stmt_if2.tree.=<0>(~#left#left##0:stmt_if2.tree, ~#right#left##0:stmt_if2.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
@@ -263,7 +263,7 @@ key(#rec##0:stmt_if2.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_if2:3:29
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -278,7 +278,7 @@ key(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:wybe.int, ?#success
         foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_if2:3:29
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -295,7 +295,7 @@ left(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:stmt_if2.tree, ?#result##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree) @stmt_if2:3:29
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -310,7 +310,7 @@ left(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?#s
         foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if2.tree)
+        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if2.tree) @stmt_if2:3:29
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -320,10 +320,10 @@ node > public {inline} (0 calls)
 node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?#result##0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_if2.tree)
-    foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if2.tree)
-    foreign lpvm mutate(~#rec##1:stmt_if2.tree, ?#rec##2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:stmt_if2.tree, ?#result##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_if2.tree) @stmt_if2:3:29
+    foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if2.tree) @stmt_if2:3:29
+    foreign lpvm mutate(~#rec##1:stmt_if2.tree, ?#rec##2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @stmt_if2:3:29
+    foreign lpvm mutate(~#rec##2:stmt_if2.tree, ?#result##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree) @stmt_if2:3:29
 node > public {inline} (16 calls)
 1: stmt_if2.tree.node<1>
 node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, #result##0:stmt_if2.tree, ?#success##0:wybe.bool):
@@ -338,9 +338,9 @@ node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, #result#
         foreign llvm move(undef:stmt_if2.tree, ?right##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(#result##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if2.tree)
-        foreign lpvm access(#result##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~#result##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if2.tree)
+        foreign lpvm access(#result##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if2.tree) @stmt_if2:3:29
+        foreign lpvm access(#result##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int) @stmt_if2:3:29
+        foreign lpvm access(~#result##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if2.tree) @stmt_if2:3:29
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -357,7 +357,7 @@ right(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?#success##0:wybe.bool):
         foreign llvm move(undef:stmt_if2.tree, ?#result##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree) @stmt_if2:3:29
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -372,7 +372,7 @@ right(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?#
         foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if2.tree)
+        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if2.tree) @stmt_if2:3:29
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -25,9 +25,9 @@ module top-level code > public {impure} (0 calls)
     wybe.string.,,<0>("abc":wybe.string, "abc":wybe.string, ?tmp#0##0:wybe.string) #4 @string:nn:nn
     wybe.string.print_string<0>(~tmp#0##0:wybe.string, ~#io##4:wybe.phantom, ?tmp#46##0:wybe.phantom) #65 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign llvm shl('a':wybe.string, 2:wybe.string, ?tmp#104##0:wybe.string)
-    foreign llvm or(~tmp#104##0:wybe.string, 1024:wybe.string, ?tmp#105##0:wybe.string)
-    foreign llvm or(~tmp#105##0:wybe.string, 3:wybe.string, ?tmp#1##0:wybe.string)
+    foreign llvm shl('a':wybe.string, 2:wybe.string, ?tmp#104##0:wybe.string) @string:nn:nn
+    foreign llvm or(~tmp#104##0:wybe.string, 1024:wybe.string, ?tmp#105##0:wybe.string) @string:nn:nn
+    foreign llvm or(~tmp#105##0:wybe.string, 3:wybe.string, ?tmp#1##0:wybe.string) @string:nn:nn
     wybe.string.print_string<0>(tmp#1##0:wybe.string, ~#io##5:wybe.phantom, ?tmp#52##0:wybe.phantom) #66 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#52##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     wybe.range.construct<0>(1:wybe.int, 3:wybe.int, 100:wybe.int, ?tmp#3##0:wybe.range) #67 @range:nn:nn
@@ -42,9 +42,9 @@ module top-level code > public {impure} (0 calls)
     foreign c putchar('\n':wybe.char, ~tmp#64##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     foreign c print_string(c"\nTESTING CONVERSION TO c_string":wybe.c_string, ~#io##8:wybe.phantom, ?tmp#67##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#67##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    foreign llvm shl('d':wybe.string, 2:wybe.string, ?tmp#69##0:wybe.string)
-    foreign llvm or(~tmp#69##0:wybe.string, 1024:wybe.string, ?tmp#70##0:wybe.string)
-    foreign llvm or(~tmp#70##0:wybe.string, 3:wybe.string, ?tmp#10##0:wybe.string)
+    foreign llvm shl('d':wybe.string, 2:wybe.string, ?tmp#69##0:wybe.string) @string:nn:nn
+    foreign llvm or(~tmp#69##0:wybe.string, 1024:wybe.string, ?tmp#70##0:wybe.string) @string:nn:nn
+    foreign llvm or(~tmp#70##0:wybe.string, 3:wybe.string, ?tmp#10##0:wybe.string) @string:nn:nn
     wybe.range...<0>(1:wybe.int, 2:wybe.int, ?tmp#12##0:wybe.range) #18 @string:nn:nn
     wybe.string.[]<1>("efg":wybe.string, ~tmp#12##0:wybe.range, ?tmp#11##0:wybe.string) #19 @string:nn:nn
     wybe.string.,,<0>(~tmp#10##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#9##0:wybe.string) #20 @string:nn:nn
@@ -81,12 +81,12 @@ module top-level code > public {impure} (0 calls)
     string.test_index<0>(~tmp#21##0:wybe.string, 2:wybe.int, ~#io##26:wybe.phantom, ?#io##27:wybe.phantom) #50 @string:nn:nn
     wybe.string.,,<0>("abc":wybe.string, tmp#1##0:wybe.string, ?tmp#23##0:wybe.string) #52 @string:nn:nn
     string.test_index<0>(~tmp#23##0:wybe.string, 2:wybe.int, ~#io##27:wybe.phantom, ?#io##28:wybe.phantom) #53 @string:nn:nn
-    foreign llvm shl('b':wybe.string, 2:wybe.string, ?tmp#107##0:wybe.string)
-    foreign llvm or(~tmp#107##0:wybe.string, 1024:wybe.string, ?tmp#108##0:wybe.string)
-    foreign llvm or(~tmp#108##0:wybe.string, 3:wybe.string, ?tmp#29##0:wybe.string)
-    foreign llvm shl('c':wybe.string, 2:wybe.string, ?tmp#110##0:wybe.string)
-    foreign llvm or(~tmp#110##0:wybe.string, 1024:wybe.string, ?tmp#111##0:wybe.string)
-    foreign llvm or(~tmp#111##0:wybe.string, 3:wybe.string, ?tmp#30##0:wybe.string)
+    foreign llvm shl('b':wybe.string, 2:wybe.string, ?tmp#107##0:wybe.string) @string:nn:nn
+    foreign llvm or(~tmp#107##0:wybe.string, 1024:wybe.string, ?tmp#108##0:wybe.string) @string:nn:nn
+    foreign llvm or(~tmp#108##0:wybe.string, 3:wybe.string, ?tmp#29##0:wybe.string) @string:nn:nn
+    foreign llvm shl('c':wybe.string, 2:wybe.string, ?tmp#110##0:wybe.string) @string:nn:nn
+    foreign llvm or(~tmp#110##0:wybe.string, 1024:wybe.string, ?tmp#111##0:wybe.string) @string:nn:nn
+    foreign llvm or(~tmp#111##0:wybe.string, 3:wybe.string, ?tmp#30##0:wybe.string) @string:nn:nn
     wybe.string.,,<0>(~tmp#29##0:wybe.string, ~tmp#30##0:wybe.string, ?tmp#28##0:wybe.string) #57 @string:nn:nn
     wybe.string.,,<0>(~tmp#1##0:wybe.string, ~tmp#28##0:wybe.string, ?tmp#26##0:wybe.string) #58 @string:nn:nn
     wybe.range...<0>(0:wybe.int, 2:wybe.int, ?tmp#31##0:wybe.range) #59 @string:nn:nn

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -35,12 +35,12 @@ module top-level code > public {impure} (0 calls)
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course)
-    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:student.student)
-    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
-    foreign lpvm mutate(~tmp#10##0:student.student, ?tmp#11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course) @student:nn:nn
+    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string) @student:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:student.student) @student:nn:nn
+    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~tmp#10##0:student.student, ?tmp#11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:student.course) @student:nn:nn
     student.printStudent<0>(~tmp#11##0:student.student, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @student:nn:nn
 
 
@@ -50,16 +50,16 @@ printStudent(stu##0:student.student, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     wybe.string.print_string<0>("student id: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #10 @io:nn:nn
-    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @student:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:student.course)
+    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:student.course) @student:nn:nn
     wybe.string.print_string<0>("course code: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #11 @io:nn:nn
-    foreign lpvm access(tmp#1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm access(tmp#1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @student:nn:nn
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>("course name: ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #12 @io:nn:nn
-    foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @student:nn:nn
     wybe.string.print_string<0>(~tmp#3##0:wybe.string, ~#io##5:wybe.phantom, ?tmp#22##0:wybe.phantom) #13 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
@@ -187,10 +187,10 @@ entry:
 =(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#code##0:wybe.int)
-    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#name##0:wybe.string)
-    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#code##0:wybe.int)
-    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#name##0:wybe.string)
+    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#code##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#name##0:wybe.string) @student:nn:nn
+    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#code##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#name##0:wybe.string) @student:nn:nn
     foreign llvm icmp_eq(~#left#code##0:wybe.int, ~#right#code##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -206,13 +206,13 @@ code > public {inline} (0 calls)
 code(#rec##0:student.course, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @student:nn:nn
 code > public {inline} (0 calls)
 1: student.course.code<1>
 code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @student:nn:nn
 
 
 course > public {inline} (0 calls)
@@ -220,16 +220,16 @@ course > public {inline} (0 calls)
 course(code##0:wybe.int, name##0:wybe.string, ?#result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course)
-    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:student.course, ?#result##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course) @student:nn:nn
+    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~#rec##1:student.course, ?#result##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string) @student:nn:nn
 course > public {inline} (6 calls)
 1: student.course.course<1>
 course(?code##0:wybe.int, ?name##0:wybe.string, #result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
-    foreign lpvm access(~#result##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
+    foreign lpvm access(#result##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#result##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string) @student:nn:nn
 
 
 name > public {inline} (0 calls)
@@ -237,13 +237,13 @@ name > public {inline} (0 calls)
 name(#rec##0:student.course, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
+    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @student:nn:nn
 name > public {inline} (0 calls)
 1: student.course.name<1>
 name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:student.course, ?#rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
+    foreign lpvm {noalias} mutate(~#rec##0:student.course, ?#rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @student:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -251,10 +251,10 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
 ~=(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
-    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @student:nn:nn
+    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @student:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -441,20 +441,20 @@ if.else:
 =(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#id##0:wybe.int)
-    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#major##0:student.course)
-    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#id##0:wybe.int)
-    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#major##0:student.course)
+    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#id##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#major##0:student.course) @student:nn:nn
+    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#id##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#major##0:student.course) @student:nn:nn
     foreign llvm icmp_eq(~#left#id##0:wybe.int, ~#right#id##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
-        foreign lpvm access(~#left#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.string)
-        foreign lpvm access(#right#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int)
-        foreign lpvm access(~#right#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.string)
+        foreign lpvm access(#left#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int) @student:nn:nn
+        foreign lpvm access(~#left#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.string) @student:nn:nn
+        foreign lpvm access(#right#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int) @student:nn:nn
+        foreign lpvm access(~#right#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.string) @student:nn:nn
         foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
         case ~tmp#13##0:wybe.bool of
         0:
@@ -471,13 +471,13 @@ id > public {inline} (0 calls)
 id(#rec##0:student.student, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @student:nn:nn
 id > public {inline} (0 calls)
 1: student.student.id<1>
 id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @student:nn:nn
 
 
 major > public {inline} (0 calls)
@@ -485,13 +485,13 @@ major > public {inline} (0 calls)
 major(#rec##0:student.student, ?#result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:student.course)
+    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:student.course) @student:nn:nn
 major > public {inline} (0 calls)
 1: student.student.major<1>
 major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:student.student, ?#rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:student.course)
+    foreign lpvm {noalias} mutate(~#rec##0:student.student, ?#rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:student.course) @student:nn:nn
 
 
 student > public {inline} (0 calls)
@@ -499,16 +499,16 @@ student > public {inline} (0 calls)
 student(id##0:wybe.int, major##0:student.course, ?#result##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student)
-    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:student.student, ?#result##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student) @student:nn:nn
+    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int) @student:nn:nn
+    foreign lpvm mutate(~#rec##1:student.student, ?#result##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course) @student:nn:nn
 student > public {inline} (6 calls)
 1: student.student.student<1>
 student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
-    foreign lpvm access(~#result##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
+    foreign lpvm access(#result##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#result##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course) @student:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -516,10 +516,10 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
 ~=(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:student.course)
-    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:student.course)
+    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:student.course) @student:nn:nn
+    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @student:nn:nn
+    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:student.course) @student:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
@@ -527,10 +527,10 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp#4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
-        foreign lpvm access(~tmp#4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.string)
-        foreign lpvm access(tmp#6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
-        foreign lpvm access(~tmp#6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.string)
+        foreign lpvm access(tmp#4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @student:nn:nn
+        foreign lpvm access(~tmp#4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.string) @student:nn:nn
+        foreign lpvm access(tmp#6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @student:nn:nn
+        foreign lpvm access(~tmp#6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.string) @student:nn:nn
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -45,10 +45,10 @@ find_test(modulus##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(8,(test_loop.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(24:wybe.int, ?tmp#5##0:test_loop.int_seq)
-    foreign lpvm mutate(~tmp#5##0:test_loop.int_seq, ?tmp#6##0:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:test_loop.int_seq, ?tmp#7##0:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:test_loop.int_seq, ?tmp#8##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#5##0:test_loop.int_seq) @test_loop:nn:nn
+    foreign lpvm mutate(~tmp#5##0:test_loop.int_seq, ?tmp#6##0:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @test_loop:nn:nn
+    foreign lpvm mutate(~tmp#6##0:test_loop.int_seq, ?tmp#7##0:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @test_loop:nn:nn
+    foreign lpvm mutate(~tmp#7##0:test_loop.int_seq, ?tmp#8##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 10:wybe.int) @test_loop:nn:nn
     test_loop.gen#1<0>[6dacb8fd25](modulus##0:wybe.int, ~tmp#8##0:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #8 @test_loop:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -286,12 +286,12 @@ if.else1:
 =(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#low##0:wybe.int)
-    foreign lpvm access(#left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#step##0:wybe.int)
-    foreign lpvm access(~#left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#high##0:wybe.int)
-    foreign lpvm access(#right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#low##0:wybe.int)
-    foreign lpvm access(#right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#step##0:wybe.int)
-    foreign lpvm access(~#right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#high##0:wybe.int)
+    foreign lpvm access(#left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#low##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(#left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#step##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(~#left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#high##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(#right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#low##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(#right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#step##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(~#right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#high##0:wybe.int) @test_loop:nn:nn
     foreign llvm icmp_eq(~#left#low##0:wybe.int, ~#right#low##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -314,13 +314,13 @@ high > public {inline} (0 calls)
 high(#rec##0:test_loop.int_seq, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @test_loop:nn:nn
 high > public {inline} (0 calls)
 1: test_loop.int_seq.high<1>
 high(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @test_loop:nn:nn
 
 
 int_seq > public {inline} (0 calls)
@@ -328,18 +328,18 @@ int_seq > public {inline} (0 calls)
 int_seq(low##0:wybe.int, step##0:wybe.int, high##0:wybe.int, ?#result##0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:test_loop.int_seq)
-    foreign lpvm mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~low##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:test_loop.int_seq, ?#rec##2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:test_loop.int_seq, ?#result##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:test_loop.int_seq) @test_loop:nn:nn
+    foreign lpvm mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~low##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm mutate(~#rec##1:test_loop.int_seq, ?#rec##2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm mutate(~#rec##2:test_loop.int_seq, ?#result##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high##0:wybe.int) @test_loop:nn:nn
 int_seq > public {inline} (13 calls)
 1: test_loop.int_seq.int_seq<1>
 int_seq(?low##0:wybe.int, ?step##0:wybe.int, ?high##0:wybe.int, #result##0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#result##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low##0:wybe.int)
-    foreign lpvm access(#result##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
-    foreign lpvm access(~#result##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high##0:wybe.int)
+    foreign lpvm access(#result##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(#result##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(~#result##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high##0:wybe.int) @test_loop:nn:nn
 
 
 low > public {inline} (0 calls)
@@ -347,13 +347,13 @@ low > public {inline} (0 calls)
 low(#rec##0:test_loop.int_seq, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @test_loop:nn:nn
 low > public {inline} (1 calls)
 1: test_loop.int_seq.low<1>
 low(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @test_loop:nn:nn
 
 
 seq_next > public (0 calls)
@@ -361,9 +361,9 @@ seq_next > public (0 calls)
 seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: [(seq##0,seq##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int)
-    foreign lpvm access(seq##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
-    foreign lpvm access(seq##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit##0:wybe.int)
+    foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(seq##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(seq##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit##0:wybe.int) @test_loop:nn:nn
     foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -372,13 +372,13 @@ seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, 
 
     1:
         foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#0##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#0##0:wybe.int) @test_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int)
-    foreign lpvm access(seq##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
-    foreign lpvm access(seq##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit##0:wybe.int)
+    foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(seq##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(seq##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit##0:wybe.int) @test_loop:nn:nn
     foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -387,7 +387,7 @@ seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, 
 
     1:
         foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#0##0:wybe.int)
+        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#0##0:wybe.int) @test_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -397,13 +397,13 @@ step > public {inline} (0 calls)
 step(#rec##0:test_loop.int_seq, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @test_loop:nn:nn
 step > public {inline} (0 calls)
 1: test_loop.int_seq.step<1>
 step(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @test_loop:nn:nn
 
 
 ~= > public {inline} (0 calls)
@@ -411,12 +411,12 @@ step(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
 ~=(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(#left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
-    foreign lpvm access(#left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
-    foreign lpvm access(~#left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
-    foreign lpvm access(#right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
-    foreign lpvm access(#right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
-    foreign lpvm access(~#right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(#left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(~#left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(#right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(#right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @test_loop:nn:nn
+    foreign lpvm access(~#right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @test_loop:nn:nn
     foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
     case ~tmp#9##0:wybe.bool of
     0:

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -39,23 +39,23 @@ lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?#success##0:wybe
         foreign llvm move(undef:wybe.int, ?result##0:wybe.int)
 
     1:
-        foreign lpvm access(map##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+        foreign lpvm access(map##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @tests:nn:nn
         foreign llvm icmp_eq(key##0:wybe.int, tmp#0##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
         case ~tmp#13##0:wybe.bool of
         0:
             foreign llvm icmp_slt(key##0:wybe.int, ~tmp#0##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
             case ~tmp#11##0:wybe.bool of
             0:
-                foreign lpvm access(~map##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:tests.map)
+                foreign lpvm access(~map##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:tests.map) @tests:nn:nn
                 tests.lookup<0>(~key##0:wybe.int, ~tmp#4##0:tests.map, ?result##0:wybe.int, ?#success##0:wybe.bool) #8 @tests:nn:nn
 
             1:
-                foreign lpvm access(~map##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:tests.map)
+                foreign lpvm access(~map##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:tests.map) @tests:nn:nn
                 tests.lookup<0>(~key##0:wybe.int, ~tmp#3##0:tests.map, ?result##0:wybe.int, ?#success##0:wybe.bool) #6 @tests:nn:nn
 
 
         1:
-            foreign lpvm access(~map##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?result##0:wybe.int)
+            foreign lpvm access(~map##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?result##0:wybe.int) @tests:nn:nn
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -212,20 +212,20 @@ entry:
         foreign llvm icmp_eq(~#left##0:tests.map, ~#right##0:tests.map, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#left##0:tests.map)
-        foreign lpvm access(#left##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
-        foreign lpvm access(#left##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int)
-        foreign lpvm access(~#left##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#right##0:tests.map)
+        foreign lpvm access(#left##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#left##0:tests.map) @tests:nn:nn
+        foreign lpvm access(#left##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int) @tests:nn:nn
+        foreign lpvm access(#left##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int) @tests:nn:nn
+        foreign lpvm access(~#left##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#right##0:tests.map) @tests:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.bool)
         case ~tmp#11##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#left##0:tests.map)
-            foreign lpvm access(#right##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
-            foreign lpvm access(#right##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int)
-            foreign lpvm access(~#right##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#right##0:tests.map)
+            foreign lpvm access(#right##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#left##0:tests.map) @tests:nn:nn
+            foreign lpvm access(#right##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int) @tests:nn:nn
+            foreign lpvm access(#right##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int) @tests:nn:nn
+            foreign lpvm access(~#right##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#right##0:tests.map) @tests:nn:nn
             tests.map.=<0>(~#left#left##0:tests.map, ~#right#left##0:tests.map, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
@@ -272,7 +272,7 @@ key(#rec##0:tests.map, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -287,7 +287,7 @@ key(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?#success##0:wybe
         foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -304,7 +304,7 @@ left(#rec##0:tests.map, ?#result##0:tests.map, ?#success##0:wybe.bool):
         foreign llvm move(undef:tests.map, ?#result##0:tests.map)
 
     1:
-        foreign lpvm access(~#rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map)
+        foreign lpvm access(~#rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -319,7 +319,7 @@ left(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?#success##0:wy
         foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:tests.map)
+        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:tests.map) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -329,11 +329,11 @@ node > public {inline} (0 calls)
 node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, ?#result##0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?#rec##0:tests.map)
-    foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~left##0:tests.map)
-    foreign lpvm mutate(~#rec##1:tests.map, ?#rec##2:tests.map, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:tests.map, ?#rec##3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value##0:wybe.int)
-    foreign lpvm mutate(~#rec##3:tests.map, ?#result##0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map)
+    foreign lpvm alloc(32:wybe.int, ?#rec##0:tests.map) @tests:nn:nn
+    foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~left##0:tests.map) @tests:nn:nn
+    foreign lpvm mutate(~#rec##1:tests.map, ?#rec##2:tests.map, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~key##0:wybe.int) @tests:nn:nn
+    foreign lpvm mutate(~#rec##2:tests.map, ?#rec##3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value##0:wybe.int) @tests:nn:nn
+    foreign lpvm mutate(~#rec##3:tests.map, ?#result##0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map) @tests:nn:nn
 node > public {inline} (20 calls)
 1: tests.map.node<1>
 node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, #result##0:tests.map, ?#success##0:wybe.bool):
@@ -349,10 +349,10 @@ node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.m
         foreign llvm move(undef:tests.map, ?right##0:tests.map)
 
     1:
-        foreign lpvm access(#result##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?left##0:tests.map)
-        foreign lpvm access(#result##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(#result##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value##0:wybe.int)
-        foreign lpvm access(~#result##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right##0:tests.map)
+        foreign lpvm access(#result##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?left##0:tests.map) @tests:nn:nn
+        foreign lpvm access(#result##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key##0:wybe.int) @tests:nn:nn
+        foreign lpvm access(#result##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value##0:wybe.int) @tests:nn:nn
+        foreign lpvm access(~#result##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right##0:tests.map) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -369,7 +369,7 @@ right(#rec##0:tests.map, ?#result##0:tests.map, ?#success##0:wybe.bool):
         foreign llvm move(undef:tests.map, ?#result##0:tests.map)
 
     1:
-        foreign lpvm access(~#rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map)
+        foreign lpvm access(~#rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -384,7 +384,7 @@ right(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?#success##0:w
         foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:tests.map)
+        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:tests.map) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -401,7 +401,7 @@ value(#rec##0:tests.map, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 value > public {inline} (0 calls)
@@ -416,7 +416,7 @@ value(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?#success##0:wy
         foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -26,21 +26,21 @@ module top-level code > public {impure} (0 calls)
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(7,(thistype.concat<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:thistype)
-    foreign lpvm mutate(~tmp#11##0:thistype, ?tmp#12##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp#12##0:thistype, ?tmp#2##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:thistype)
-    foreign lpvm mutate(~tmp#15##0:thistype, ?tmp#16##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp#16##0:thistype, ?tmp#1##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:thistype)
-    foreign lpvm mutate(~tmp#19##0:thistype, ?tmp#20##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#20##0:thistype, ?tmp#0##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:thistype)
-    foreign lpvm mutate(~tmp#23##0:thistype, ?tmp#24##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp#24##0:thistype, ?tmp#5##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:thistype)
-    foreign lpvm mutate(~tmp#27##0:thistype, ?tmp#28##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#28##0:thistype, ?tmp#4##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:thistype) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#11##0:thistype, ?tmp#12##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#12##0:thistype, ?tmp#2##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype) @thistype:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:thistype) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#15##0:thistype, ?tmp#16##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#16##0:thistype, ?tmp#1##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype) @thistype:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:thistype) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#19##0:thistype, ?tmp#20##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#20##0:thistype, ?tmp#0##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:thistype) @thistype:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:thistype) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#23##0:thistype, ?tmp#24##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#24##0:thistype, ?tmp#5##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype) @thistype:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:thistype) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#27##0:thistype, ?tmp#28##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @thistype:nn:nn
+    foreign lpvm mutate(~tmp#28##0:thistype, ?tmp#4##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:thistype) @thistype:nn:nn
     thistype.concat<0>[410bae77d3](~tmp#0##0:thistype, ~tmp#4##0:thistype, ?tmp#8##0:thistype) #7 @thistype:nn:nn
     thistype.length<0>(~tmp#8##0:thistype, ?tmp#7##0:wybe.int) #8 @thistype:nn:nn
     foreign c print_int(~tmp#7##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @io:nn:nn
@@ -58,16 +58,16 @@ module top-level code > public {impure} (0 calls)
         foreign llvm icmp_eq(~#left##0:thistype, ~#right##0:thistype, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
-        foreign lpvm access(~#left##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:thistype)
+        foreign lpvm access(#left##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int) @thistype:nn:nn
+        foreign lpvm access(~#left##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:thistype) @thistype:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
-            foreign lpvm access(~#right##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:thistype)
+            foreign lpvm access(#right##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int) @thistype:nn:nn
+            foreign lpvm access(~#right##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:thistype) @thistype:nn:nn
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -92,12 +92,12 @@ concat(x##0:thistype, y##0:thistype, ?#result##0:thistype):
         foreign llvm move(~y##0:thistype, ?#result##0:thistype) @thistype:nn:nn
 
     1:
-        foreign lpvm access(x##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
+        foreign lpvm access(x##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @thistype:nn:nn
+        foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype) @thistype:nn:nn
         thistype.concat<0>(~t##0:thistype, ~y##0:thistype, ?tmp#2##0:thistype) #1 @thistype:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:thistype)
-        foreign lpvm mutate(~tmp#8##0:thistype, ?tmp#9##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:thistype) @thistype:nn:nn
+        foreign lpvm mutate(~tmp#8##0:thistype, ?tmp#9##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @thistype:nn:nn
+        foreign lpvm mutate(~tmp#9##0:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype) @thistype:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
@@ -106,9 +106,9 @@ concat(x##0:thistype, y##0:thistype, ?#result##0:thistype):
         foreign llvm move(~y##0:thistype, ?#result##0:thistype) @thistype:nn:nn
 
     1:
-        foreign lpvm access(x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
+        foreign lpvm access(x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype) @thistype:nn:nn
         thistype.concat<0>[410bae77d3](~t##0:thistype, ~y##0:thistype, ?tmp#2##0:thistype) #1 @thistype:nn:nn
-        foreign lpvm mutate(~x##0:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
+        foreign lpvm mutate(~x##0:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype) @thistype:nn:nn
 
 
 
@@ -117,9 +117,9 @@ cons > public {inline} (6 calls)
 cons(head##0:wybe.int, tail##0:thistype, ?#result##0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:thistype)
-    foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:thistype) @thistype:nn:nn
+    foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @thistype:nn:nn
+    foreign lpvm mutate(~#rec##1:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype) @thistype:nn:nn
 cons > public {inline} (18 calls)
 1: thistype.cons<1>
 cons(?head##0:wybe.int, ?tail##0:thistype, #result##0:thistype, ?#success##0:wybe.bool):
@@ -133,8 +133,8 @@ cons(?head##0:wybe.int, ?tail##0:thistype, #result##0:thistype, ?#success##0:wyb
         foreign llvm move(undef:thistype, ?tail##0:thistype)
 
     1:
-        foreign lpvm access(#result##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~#result##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:thistype)
+        foreign lpvm access(#result##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int) @thistype:nn:nn
+        foreign lpvm access(~#result##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:thistype) @thistype:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -151,7 +151,7 @@ head(#rec##0:thistype, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @thistype:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -166,7 +166,7 @@ head(#rec##0:thistype, ?#rec##1:thistype, #field##0:wybe.int, ?#success##0:wybe.
         foreign llvm move(~#rec##0:thistype, ?#rec##1:thistype)
 
     1:
-        foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @thistype:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -182,7 +182,7 @@ length(x##0:thistype, ?#result##0:wybe.int):
         foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @thistype:nn:nn
 
     1:
-        foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
+        foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype) @thistype:nn:nn
         thistype.length<0>(~t##0:thistype, ?tmp#2##0:wybe.int) #1 @thistype:nn:nn
         foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
@@ -208,7 +208,7 @@ tail(#rec##0:thistype, ?#result##0:thistype, ?#success##0:wybe.bool):
         foreign llvm move(undef:thistype, ?#result##0:thistype)
 
     1:
-        foreign lpvm access(~#rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:thistype)
+        foreign lpvm access(~#rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:thistype) @thistype:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -223,7 +223,7 @@ tail(#rec##0:thistype, ?#rec##1:thistype, #field##0:thistype, ?#success##0:wybe.
         foreign llvm move(~#rec##0:thistype, ?#rec##1:thistype)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:thistype, ?#rec##1:thistype, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:thistype)
+        foreign lpvm {noalias} mutate(~#rec##0:thistype, ?#rec##1:thistype, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:thistype) @thistype:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -35,9 +35,9 @@ foo > (12 calls)
 foo(x##0:T, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#5##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:T)
-    foreign lpvm mutate(~tmp#6##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     wybe.list.length1<0>(~tmp#0##0:wybe.list(T), 0:wybe.int, ?tmp#2##0:wybe.int) #4 @list:nn:nn
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
@@ -48,9 +48,9 @@ foo2 > (18 calls)
 foo2(x##0:T0, ?y##0:T0, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#6##0:wybe.list(T), ?tmp#7##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:T)
-    foreign lpvm mutate(~tmp#7##0:wybe.list(T), ?tmp#0##0:wybe.list(T0), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:wybe.list(T), ?tmp#7##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#7##0:wybe.list(T), ?tmp#0##0:wybe.list(T0), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
@@ -58,7 +58,7 @@ foo2(x##0:T0, ?y##0:T0, ?#success##0:wybe.bool):
         foreign llvm move(undef:T, ?y##0:T0)
 
     1:
-        foreign lpvm access(~tmp#0##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:T0)
+        foreign lpvm access(~tmp#0##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:T0) @list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -28,21 +28,21 @@ module top-level code > public {impure} (0 calls)
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(7,(type_list.,,<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:type_list.intlist)
-    foreign lpvm mutate(~tmp#11##0:type_list.intlist, ?tmp#12##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp#12##0:type_list.intlist, ?tmp#13##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:type_list.intlist)
-    foreign lpvm mutate(~tmp#16##0:type_list.intlist, ?tmp#17##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp#17##0:type_list.intlist, ?tmp#18##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#13##0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:type_list.intlist)
-    foreign lpvm mutate(~tmp#21##0:type_list.intlist, ?tmp#22##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#22##0:type_list.intlist, ?tmp#23##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#18##0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:type_list.intlist)
-    foreign lpvm mutate(~tmp#26##0:type_list.intlist, ?tmp#27##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp#27##0:type_list.intlist, ?tmp#28##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:type_list.intlist)
-    foreign lpvm mutate(~tmp#31##0:type_list.intlist, ?tmp#32##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp#32##0:type_list.intlist, ?tmp#33##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#28##0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#11##0:type_list.intlist, ?tmp#12##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#12##0:type_list.intlist, ?tmp#13##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#16##0:type_list.intlist, ?tmp#17##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#17##0:type_list.intlist, ?tmp#18##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#13##0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#21##0:type_list.intlist, ?tmp#22##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#22##0:type_list.intlist, ?tmp#23##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#18##0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#26##0:type_list.intlist, ?tmp#27##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#27##0:type_list.intlist, ?tmp#28##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#31##0:type_list.intlist, ?tmp#32##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @type_list:nn:nn
+    foreign lpvm mutate(~tmp#32##0:type_list.intlist, ?tmp#33##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#28##0:type_list.intlist) @type_list:nn:nn
     type_list.,,<0>[410bae77d3](~tmp#23##0:type_list.intlist, ~tmp#33##0:type_list.intlist, ?tmp#8##0:type_list.intlist) #7 @type_list:nn:nn
     type_list.length<0>(~tmp#8##0:type_list.intlist, ?tmp#7##0:wybe.int) #8 @type_list:nn:nn
     foreign c print_int(~tmp#7##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
@@ -60,12 +60,12 @@ module top-level code > public {impure} (0 calls)
         foreign llvm move(~y##0:type_list.intlist, ?#result##0:type_list.intlist) @type_list:nn:nn
 
     1:
-        foreign lpvm access(x##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
-        foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
+        foreign lpvm access(x##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @type_list:nn:nn
+        foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist) @type_list:nn:nn
         type_list.,,<0>(~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp#2##0:type_list.intlist) #1 @type_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:type_list.intlist)
-        foreign lpvm mutate(~tmp#8##0:type_list.intlist, ?tmp#9##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist)
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:type_list.intlist) @type_list:nn:nn
+        foreign lpvm mutate(~tmp#8##0:type_list.intlist, ?tmp#9##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @type_list:nn:nn
+        foreign lpvm mutate(~tmp#9##0:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist) @type_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
@@ -74,9 +74,9 @@ module top-level code > public {impure} (0 calls)
         foreign llvm move(~y##0:type_list.intlist, ?#result##0:type_list.intlist) @type_list:nn:nn
 
     1:
-        foreign lpvm access(x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
+        foreign lpvm access(x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist) @type_list:nn:nn
         type_list.,,<0>[410bae77d3](~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp#2##0:type_list.intlist) #1 @type_list:nn:nn
-        foreign lpvm mutate(~x##0:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist)
+        foreign lpvm mutate(~x##0:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist) @type_list:nn:nn
 
 
 
@@ -91,7 +91,7 @@ length(x##0:type_list.intlist, ?#result##0:wybe.int):
         foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @type_list:nn:nn
 
     1:
-        foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
+        foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist) @type_list:nn:nn
         type_list.length<0>(~t##0:type_list.intlist, ?tmp#2##0:wybe.int) #1 @type_list:nn:nn
         foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
@@ -266,16 +266,16 @@ if.else:
         foreign llvm icmp_eq(~#left##0:type_list.intlist, ~#right##0:type_list.intlist, ?#success##0:wybe.bool)
 
     1:
-        foreign lpvm access(#left##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
-        foreign lpvm access(~#left##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:type_list.intlist)
+        foreign lpvm access(#left##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int) @type_list:nn:nn
+        foreign lpvm access(~#left##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:type_list.intlist) @type_list:nn:nn
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign lpvm access(#right##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
-            foreign lpvm access(~#right##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:type_list.intlist)
+            foreign lpvm access(#right##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int) @type_list:nn:nn
+            foreign lpvm access(~#right##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:type_list.intlist) @type_list:nn:nn
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
@@ -293,9 +293,9 @@ cons > public {inline} (0 calls)
 cons(head##0:wybe.int, tail##0:type_list.intlist, ?#result##0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:type_list.intlist)
-    foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:type_list.intlist) @type_list:nn:nn
+    foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @type_list:nn:nn
+    foreign lpvm mutate(~#rec##1:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist) @type_list:nn:nn
 cons > public {inline} (12 calls)
 1: type_list.intlist.cons<1>
 cons(?head##0:wybe.int, ?tail##0:type_list.intlist, #result##0:type_list.intlist, ?#success##0:wybe.bool):
@@ -309,8 +309,8 @@ cons(?head##0:wybe.int, ?tail##0:type_list.intlist, #result##0:type_list.intlist
         foreign llvm move(undef:type_list.intlist, ?tail##0:type_list.intlist)
 
     1:
-        foreign lpvm access(#result##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~#result##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:type_list.intlist)
+        foreign lpvm access(#result##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int) @type_list:nn:nn
+        foreign lpvm access(~#result##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:type_list.intlist) @type_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -327,7 +327,7 @@ head(#rec##0:type_list.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
+        foreign lpvm access(~#rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @type_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -342,7 +342,7 @@ head(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:wybe.int, 
         foreign llvm move(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist)
 
     1:
-        foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @type_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -367,7 +367,7 @@ tail(#rec##0:type_list.intlist, ?#result##0:type_list.intlist, ?#success##0:wybe
         foreign llvm move(undef:type_list.intlist, ?#result##0:type_list.intlist)
 
     1:
-        foreign lpvm access(~#rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:type_list.intlist)
+        foreign lpvm access(~#rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:type_list.intlist) @type_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -382,7 +382,7 @@ tail(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:type_list.
         foreign llvm move(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist)
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:type_list.intlist)
+        foreign lpvm {noalias} mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:type_list.intlist) @type_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/unbranch_bug.exp
+++ b/test-cases/final-dump/unbranch_bug.exp
@@ -43,7 +43,7 @@ gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(5), ?io##1:w
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(5))
+        foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(5)) @list:nn:nn
         unbranch_bug.gen#3<0>(~io##0:wybe.phantom, ~tmp#0##1:wybe.list(4), ~tmp#1##0:wybe.list(5), ?io##1:wybe.phantom) #1 @unbranch_bug:nn:nn
 
 

--- a/test-cases/final-dump/unique_member.exp
+++ b/test-cases/final-dump/unique_member.exp
@@ -1,0 +1,3 @@
+Error detected during uniqueness checking of module(s) unique_member, unique_member.ty
+[91mfinal-dump/unique_member.wybe:3:15: Unique constructor argument uniq of non-unique type
+[0m

--- a/test-cases/final-dump/unique_member.wybe
+++ b/test-cases/final-dump/unique_member.wybe
@@ -1,0 +1,7 @@
+representation is {unique} 32 bit signed
+
+type ty { pub ctor(uniq:unique_member) }
+
+?data = ctor(0:_)
+?uniq0 = data^uniq
+?uniq1 = data^uniq

--- a/test-cases/final-dump/unique_pos_error.exp
+++ b/test-cases/final-dump/unique_pos_error.exp
@@ -1,0 +1,3 @@
+Error detected during uniqueness checking of module(s) unique_pos_error, unique_pos_error.unique_position
+[91mfinal-dump/unique_pos_error.wybe:15:16: Reuse of unique variable p:unique_pos_error.unique_position
+[0m

--- a/test-cases/final-dump/unique_pos_error.wybe
+++ b/test-cases/final-dump/unique_pos_error.wybe
@@ -1,0 +1,16 @@
+pub type {unique} unique_position { pub unique_position(x:int, y:int) }
+
+pub def printPosition(pos:unique_position) use !io {
+    pos = unique_position(?x, ?y)
+    !print(" (")
+    !print(x)
+    !print(",")
+    !print(y)
+    !println(")")
+}
+
+?p = unique_position(3,4)
+?p2 = p
+!p2^x = 5
+!printPosition(p)
+!printPosition(p2)

--- a/test-cases/final-dump/unique_position.exp
+++ b/test-cases/final-dump/unique_position.exp
@@ -1,0 +1,280 @@
+======================================================================
+AFTER EVERYTHING:
+ Module unique_position
+  representation  : (not a type)
+  public submods  : unique_position -> unique_position.unique_position
+  public resources: 
+  public procs    : unique_position.<0>
+                    unique_position.printPosition<0>
+                    unique_position.unique_position.unique_position<0>
+                    unique_position.unique_position.unique_position<1>
+                    unique_position.unique_position.x<0>
+                    unique_position.unique_position.x<1>
+                    unique_position.unique_position.y<0>
+                    unique_position.unique_position.y<1>
+  imports         : public use unique_position.unique_position
+                    use wybe
+  resources       : 
+  submodules      : unique_position.unique_position
+  procs           : 
+
+module top-level code > public {impure} (0 calls)
+0: unique_position.<0>
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:unique_position.unique_position) @unique_position:nn:nn
+    foreign lpvm mutate(~tmp#3##0:unique_position.unique_position, ?tmp#4##0:unique_position.unique_position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @unique_position:nn:nn
+    foreign lpvm mutate(~tmp#4##0:unique_position.unique_position, ?tmp#5##0:unique_position.unique_position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int) @unique_position:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#5##0:unique_position.unique_position, ?%p2##1:unique_position.unique_position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:wybe.int) @unique_position:nn:nn
+    unique_position.printPosition<0>(~p2##1:unique_position.unique_position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @unique_position:nn:nn
+
+
+printPosition > public (1 calls)
+0: unique_position.printPosition<0>
+printPosition(pos##0:unique_position.unique_position, io##0:wybe.phantom, ?io##5:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign lpvm {unique} access(pos##0:unique_position.unique_position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @unique_position:nn:nn
+    foreign lpvm {unique} access(~pos##0:unique_position.unique_position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @unique_position:nn:nn
+    wybe.string.print_string<0>(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #6 @io:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    wybe.string.print_string<0>(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #7 @io:nn:nn
+    foreign c print_int(~y##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    wybe.string.print_string<0>(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#11##0:wybe.phantom) #8 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+
+  LLVM code       :
+
+; ModuleID = 'unique_position'
+
+
+ 
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+@unique_position.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @unique_position.22 to i64) }
+
+
+@unique_position.22 =    constant [?? x i8] c")\00"
+
+
+@unique_position.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @unique_position.20 to i64) }
+
+
+@unique_position.20 =    constant [?? x i8] c",\00"
+
+
+@unique_position.19 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @unique_position.18 to i64) }
+
+
+@unique_position.18 =    constant [?? x i8] c" (\00"
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"unique_position.<0>"()    {
+entry:
+  %1 = trunc i64 16 to i32  
+  %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
+  %3 = ptrtoint i8* %2 to i64 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = getelementptr  i64, i64* %4, i64 0 
+  store  i64 3, i64* %5 
+  %6 = add   i64 %3, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = getelementptr  i64, i64* %7, i64 0 
+  store  i64 4, i64* %8 
+  %9 = inttoptr i64 %3 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  store  i64 5, i64* %10 
+  tail call fastcc  void  @"unique_position.printPosition<0>"(i64  %3)  
+  ret void 
+}
+
+
+define external fastcc  void @"unique_position.printPosition<0>"(i64  %"pos##0")    {
+entry:
+  %11 = inttoptr i64 %"pos##0" to i64* 
+  %12 = getelementptr  i64, i64* %11, i64 0 
+  %13 = load  i64, i64* %12 
+  %14 = add   i64 %"pos##0", 8 
+  %15 = inttoptr i64 %14 to i64* 
+  %16 = getelementptr  i64, i64* %15, i64 0 
+  %17 = load  i64, i64* %16 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @unique_position.19, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %13)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @unique_position.21, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @unique_position.23, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+--------------------------------------------------
+ Module unique_position.unique_position
+ modifiers       : {unique} 
+  representation  : address
+  public submods  : 
+  public resources: 
+  public procs    : unique_position.unique_position.unique_position<0>
+                    unique_position.unique_position.unique_position<1>
+                    unique_position.unique_position.x<0>
+                    unique_position.unique_position.x<1>
+                    unique_position.unique_position.y<0>
+                    unique_position.unique_position.y<1>
+  imports         : use unique_position
+                    use wybe
+  resources       : 
+  procs           : 
+
+unique_position > public {inline} (0 calls)
+0: unique_position.unique_position.unique_position<0>
+unique_position(x##0:wybe.int, y##0:wybe.int, ?#result##0:unique_position.unique_position):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:unique_position.unique_position) @unique_position:nn:nn
+    foreign lpvm mutate(~#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @unique_position:nn:nn
+    foreign lpvm mutate(~#rec##1:unique_position.unique_position, ?#result##0:unique_position.unique_position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @unique_position:nn:nn
+unique_position > public {inline} (0 calls)
+1: unique_position.unique_position.unique_position<1>
+unique_position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:unique_position.unique_position):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign lpvm {unique} access(#result##0:unique_position.unique_position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @unique_position:nn:nn
+    foreign lpvm {unique} access(~#result##0:unique_position.unique_position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @unique_position:nn:nn
+
+
+x > public {inline} (0 calls)
+0: unique_position.unique_position.x<0>
+x(#rec##0:unique_position.unique_position, ?#result##0:wybe.int):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign lpvm access(~#rec##0:unique_position.unique_position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @unique_position:nn:nn
+x > public {inline} (0 calls)
+1: unique_position.unique_position.x<1>
+x(#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, #field##0:wybe.int):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign lpvm {noalias} mutate(~#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @unique_position:nn:nn
+
+
+y > public {inline} (0 calls)
+0: unique_position.unique_position.y<0>
+y(#rec##0:unique_position.unique_position, ?#result##0:wybe.int):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign lpvm access(~#rec##0:unique_position.unique_position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @unique_position:nn:nn
+y > public {inline} (0 calls)
+1: unique_position.unique_position.y<1>
+y(#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, #field##0:wybe.int):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign lpvm {noalias} mutate(~#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @unique_position:nn:nn
+
+  LLVM code       :
+
+; ModuleID = 'unique_position.unique_position'
+
+
+ 
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  i64 @"unique_position.unique_position.unique_position<0>"(i64  %"x##0", i64  %"y##0")    {
+entry:
+  %1 = trunc i64 16 to i32  
+  %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
+  %3 = ptrtoint i8* %2 to i64 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = getelementptr  i64, i64* %4, i64 0 
+  store  i64 %"x##0", i64* %5 
+  %6 = add   i64 %3, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = getelementptr  i64, i64* %7, i64 0 
+  store  i64 %"y##0", i64* %8 
+  ret i64 %3 
+}
+
+
+define external fastcc  {i64, i64} @"unique_position.unique_position.unique_position<1>"(i64  %"#result##0")    {
+entry:
+  %9 = inttoptr i64 %"#result##0" to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"#result##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = getelementptr  i64, i64* %13, i64 0 
+  %15 = load  i64, i64* %14 
+  %16 = insertvalue {i64, i64} undef, i64 %11, 0 
+  %17 = insertvalue {i64, i64} %16, i64 %15, 1 
+  ret {i64, i64} %17 
+}
+
+
+define external fastcc  i64 @"unique_position.unique_position.x<0>"(i64  %"#rec##0")    {
+entry:
+  %18 = inttoptr i64 %"#rec##0" to i64* 
+  %19 = getelementptr  i64, i64* %18, i64 0 
+  %20 = load  i64, i64* %19 
+  ret i64 %20 
+}
+
+
+define external fastcc  i64 @"unique_position.unique_position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+entry:
+  %21 = trunc i64 16 to i32  
+  %22 = tail call ccc  i8*  @wybe_malloc(i32  %21)  
+  %23 = ptrtoint i8* %22 to i64 
+  %24 = inttoptr i64 %23 to i8* 
+  %25 = inttoptr i64 %"#rec##0" to i8* 
+  %26 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %24, i8*  %25, i32  %26, i1  0)  
+  %27 = inttoptr i64 %23 to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  store  i64 %"#field##0", i64* %28 
+  ret i64 %23 
+}
+
+
+define external fastcc  i64 @"unique_position.unique_position.y<0>"(i64  %"#rec##0")    {
+entry:
+  %29 = add   i64 %"#rec##0", 8 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = getelementptr  i64, i64* %30, i64 0 
+  %32 = load  i64, i64* %31 
+  ret i64 %32 
+}
+
+
+define external fastcc  i64 @"unique_position.unique_position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+entry:
+  %33 = trunc i64 16 to i32  
+  %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
+  %35 = ptrtoint i8* %34 to i64 
+  %36 = inttoptr i64 %35 to i8* 
+  %37 = inttoptr i64 %"#rec##0" to i8* 
+  %38 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i1  0)  
+  %39 = add   i64 %35, 8 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  store  i64 %"#field##0", i64* %41 
+  ret i64 %35 
+}

--- a/test-cases/final-dump/unique_position.wybe
+++ b/test-cases/final-dump/unique_position.wybe
@@ -1,0 +1,15 @@
+pub type {unique} unique_position { pub unique_position(x:int, y:int) }
+
+pub def printPosition(pos:unique_position) use !io {
+    pos = unique_position(?x, ?y)
+    !print(" (")
+    !print(x)
+    !print(",")
+    !print(y)
+    !println(")")
+}
+
+?p = unique_position(3,4)
+?p2 = p
+!p2^x = 5
+!printPosition(p2)

--- a/update-exp
+++ b/update-exp
@@ -86,6 +86,7 @@ updatefile () {
 }
 
 if [ $# -eq 0 ] ; then
+    make || exit 1
     make test
     for f in test-cases/final-dump/*.wybe ; do
         updatefile "$f"


### PR DESCRIPTION
Allow unique structure types.  Unique structure types do not support implicit equality and disequality, since they are not very useful for unique types.  Deconstructors for unique types are generated specially so that they do not cause uniqueness errors when being compiled.  This works by making use of a new `unique` flag for foreign instructions, which stops a subsequent use of a variable being reported as a uniqueness error (although the use is still noted).

This closes #227.

The suggestion in #225 is incorrect, since it would allow accessing the same member twice.  In the case of a unique type nested within another unique type, this would allow an aliased unique value to go undetected.  What this PR implements is more constrained, only allowing the access instructions in a deconstructor not to cause a unique access error.  This should be safe, since a structure cannot have repeated unique elements, as constructing it would cause a uniqueness error, and I believe this will be enough to make unique structure marginally useful, so I consider this to close #225.