### PR TITLE
fix more cases of bug 228

### DIFF
--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -803,8 +803,7 @@ compileModSCC mspecs = do
     mapM_ (transformModuleProcs canonicaliseProcResources)  mspecs
     stopOnError $ "processing resources for module(s) " ++ showModSpecs mspecs
     typeCheckModSCC mspecs
-    stopOnError $ "type checking of module(s) "
-                  ++ showModSpecs mspecs
+    stopOnError $ "type checking of module(s) " ++ showModSpecs mspecs
     logDump Types Unbranch "TYPE CHECK"
     mapM_ (transformModuleProcs transformProcResources)  mspecs
     stopOnError $ "resource checking of module(s) "

--- a/src/Resources.hs
+++ b/src/Resources.hs
@@ -6,8 +6,9 @@
 --           : LICENSE in the root directory of this project.
 
 
-module Resources (resourceCheckMod, canonicaliseProcResources,
-                  transformProcResources, specialResourcesSet) where
+module Resources (resourceCheckMod, canonicaliseProcResources, 
+                  canonicaliseResourceSpec, transformProcResources,
+                  specialResourcesSet) where
 
 import           AST
 import           Control.Monad
@@ -66,7 +67,7 @@ checkOneResource rspec impln@(SimpleResource ty init pos) = do
 
 ------------- Canonicalising resources in proc definitions ---------
 
--- |Make sure all resource for the specified proc are module qualified,
+-- |Make sure all resources for the specified proc are module qualified,
 --  making them canonical.
 canonicaliseProcResources :: ProcDef -> Int -> Compiler ProcDef
 canonicaliseProcResources pd _ = do

--- a/test-cases/final-dump/bug228.exp
+++ b/test-cases/final-dump/bug228.exp
@@ -1,3 +1,6 @@
 Error detected during type checking of module(s) bug228
 [91mfinal-dump/bug228.wybe:3:6: Resource wybe.io.io not in scope at call to proc read
+[0m[91mfinal-dump/bug228.wybe:14:1: Inconsistent type of resource bar in use statement 
+[0m[91mfinal-dump/bug228.wybe:16:6: No matching mode in call to println
+[0m[91mfinal-dump/bug228.wybe:19:2: No matching mode in call to println
 [0m

--- a/test-cases/final-dump/bug228.wybe
+++ b/test-cases/final-dump/bug228.wybe
@@ -4,3 +4,16 @@ def foo(?s:string) {
 }
 
 !println(foo)
+
+
+resource bar:int
+
+def use_bar use ?bar { ?bar = 1 }
+
+?bar = "1.0"
+use bar in {
+    !use_bar
+    !println(bar)
+}
+
+!println(bar)

--- a/test-cases/final-dump/bug228_ok.exp
+++ b/test-cases/final-dump/bug228_ok.exp
@@ -1,0 +1,48 @@
+======================================================================
+AFTER EVERYTHING:
+ Module bug228_ok
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : bug228_ok.<0>
+  imports         : use wybe
+  resources       : foo: fromList [(bug228_ok.foo,wybe.int @bug228_ok:1:1)]
+  procs           : 
+
+module top-level code > public {inline,impure} (0 calls)
+0: bug228_ok.<0>
+(io##0:wybe.phantom, [?io##0:wybe.phantom]):
+ AliasPairs: []
+ InterestingCallProperties: []
+
+
+use_foo > {inline} (1 calls)
+0: bug228_ok.use_foo<0>
+use_foo(foo##0:wybe.int, [?foo##0:wybe.int]):
+ AliasPairs: []
+ InterestingCallProperties: []
+
+  LLVM code       :
+
+; ModuleID = 'bug228_ok'
+
+
+ 
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"bug228_ok.<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"bug228_ok.use_foo<0>"(i64  %"foo##0")    {
+entry:
+  ret void 
+}

--- a/test-cases/final-dump/bug228_ok.wybe
+++ b/test-cases/final-dump/bug228_ok.wybe
@@ -1,0 +1,8 @@
+resource foo:int
+
+def use_foo use !foo { pass }
+
+use foo in {
+    ?foo = 1
+    !use_foo
+}


### PR DESCRIPTION
 canonicalise resource specs in use statements.  Check for type conststency of variables promoted to resources.

Closes #228.  I hope.
