### PR TITLE
Added GlobalFlow inference

### DIFF
--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -59,7 +59,7 @@ module top-level code > {terminal,inline,impure} (0 calls)
     foreign lpvm store(~%argv##0:wybe.array.raw_array(wybe.c_string), <<command_line.argv>>:wybe.array.raw_array(wybe.c_string))
     foreign c {impure} gc_init @memory_management:nn:nn
     foreign lpvm store(0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    command_line.<0><{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}> #2
+    command_line.<0><{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}> #2
     drone.<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
     foreign lpvm load(<<command_line.exit_code>>:wybe.int, ?%exit_code##0:wybe.int)
     foreign c {semipure,terminal} exit(exit_code##0:wybe.int)
@@ -87,7 +87,7 @@ LLVM code       : None
 
 module top-level code > public {impure} (0 calls)
 0: command_line.<0>
-()<{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}>:
+()<{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(1,(wybe.array.[|]<0>,fromList [NonAliasedParamCond 2 []]))]
@@ -112,7 +112,7 @@ module top-level code > public {impure} (0 calls)
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code##0:wybe.int)<{<<command_line.exit_code>>}; {<<command_line.exit_code>>}>:
+set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm store(~code##0:wybe.int, <<command_line.exit_code>>:wybe.int) @command_line:nn:nn
@@ -682,7 +682,7 @@ module top-level code > {terminal,inline,impure} (0 calls)
     foreign lpvm store(~%argv##0:wybe.array.raw_array(wybe.c_string), <<command_line.argv>>:wybe.array.raw_array(wybe.c_string))
     foreign c {impure} gc_init @memory_management:nn:nn
     foreign lpvm store(0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    command_line.<0><{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}> #2
+    command_line.<0><{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}> #2
     drone.<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
     foreign lpvm load(<<command_line.exit_code>>:wybe.int, ?%exit_code##0:wybe.int)
     foreign c {semipure,terminal} exit(exit_code##0:wybe.int)
@@ -754,7 +754,7 @@ entry:
 
 module top-level code > public {impure} (0 calls)
 0: command_line.<0>
-()<{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}>:
+()<{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(1,(wybe.array.[|]<0>,fromList [NonAliasedParamCond 2 []]))]
@@ -779,7 +779,7 @@ module top-level code > public {impure} (0 calls)
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code##0:wybe.int)<{<<command_line.exit_code>>}; {<<command_line.exit_code>>}>:
+set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm store(~code##0:wybe.int, <<command_line.exit_code>>:wybe.int) @command_line:nn:nn

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -128,7 +128,7 @@ module top-level code > {terminal,inline,impure} (0 calls)
     foreign lpvm store(~%argv##0:wybe.array.raw_array(wybe.c_string), <<command_line.argv>>:wybe.array.raw_array(wybe.c_string))
     foreign c {impure} gc_init @memory_management:nn:nn
     foreign lpvm store(0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    command_line.<0><{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}> #2
+    command_line.<0><{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}> #2
     int_list_test.<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
     foreign lpvm load(<<command_line.exit_code>>:wybe.int, ?%exit_code##0:wybe.int)
     foreign c {semipure,terminal} exit(exit_code##0:wybe.int)
@@ -156,7 +156,7 @@ LLVM code       : None
 
 module top-level code > public {impure} (0 calls)
 0: command_line.<0>
-()<{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}>:
+()<{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(1,(wybe.array.[|]<0>,fromList [NonAliasedParamCond 2 []]))]
@@ -181,7 +181,7 @@ module top-level code > public {impure} (0 calls)
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code##0:wybe.int)<{<<command_line.exit_code>>}; {<<command_line.exit_code>>}>:
+set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm store(~code##0:wybe.int, <<command_line.exit_code>>:wybe.int) @command_line:nn:nn
@@ -1032,7 +1032,7 @@ module top-level code > {terminal,inline,impure} (0 calls)
     foreign lpvm store(~%argv##0:wybe.array.raw_array(wybe.c_string), <<command_line.argv>>:wybe.array.raw_array(wybe.c_string))
     foreign c {impure} gc_init @memory_management:nn:nn
     foreign lpvm store(0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    command_line.<0><{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}> #2
+    command_line.<0><{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}> #2
     int_list_test.<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
     foreign lpvm load(<<command_line.exit_code>>:wybe.int, ?%exit_code##0:wybe.int)
     foreign c {semipure,terminal} exit(exit_code##0:wybe.int)
@@ -1104,7 +1104,7 @@ entry:
 
 module top-level code > public {impure} (0 calls)
 0: command_line.<0>
-()<{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}>:
+()<{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(1,(wybe.array.[|]<0>,fromList [NonAliasedParamCond 2 []]))]
@@ -1129,7 +1129,7 @@ module top-level code > public {impure} (0 calls)
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code##0:wybe.int)<{<<command_line.exit_code>>}; {<<command_line.exit_code>>}>:
+set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm store(~code##0:wybe.int, <<command_line.exit_code>>:wybe.int) @command_line:nn:nn

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -29,7 +29,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
     foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int) @position:nn:nn
     foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 900:wybe.int) @position:nn:nn
-    alias_cyclic.updateX<0>(tmp#0##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @alias_cyclic:nn:nn
+    alias_cyclic.updateX<0>(tmp#0##0:position.position, ?p2##0:position.position) #1 @alias_cyclic:nn:nn
     wybe.string.print_string<0>("p1(100,900):":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @io:nn:nn
     position.printPosition<0>(~tmp#0##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @alias_cyclic:nn:nn
     wybe.string.print_string<0>("p2(102,900):":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @io:nn:nn
@@ -38,7 +38,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
 
 updateX > public (2 calls)
 0: alias_cyclic.updateX<0>[410bae77d3]
-updateX(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+updateX(p1##0:position.position, ?p2##0:position.position)<{}; {}>:
   AliasPairs: [(p1##0,p2##0)]
   InterestingCallProperties: [InterestingUnaliased 0]
   MultiSpeczDepInfo: [(5,(alias_cyclic.updateY<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -48,7 +48,7 @@ updateX(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~p1##0:position.position, ?p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
-        alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @alias_cyclic:nn:nn
+        alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position) #5 @alias_cyclic:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_cyclic:nn:nn
@@ -60,7 +60,7 @@ updateX(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~p1##0:position.position, ?p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
-        alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @alias_cyclic:nn:nn
+        alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position) #5 @alias_cyclic:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_cyclic:nn:nn
@@ -69,7 +69,7 @@ updateX(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<
 
 updateY > public (1 calls)
 0: alias_cyclic.updateY<0>[410bae77d3]
-updateY(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+updateY(p1##0:position.position, ?p2##0:position.position)<{}; {}>:
   AliasPairs: [(p1##0,p2##0)]
   InterestingCallProperties: [InterestingUnaliased 0]
   MultiSpeczDepInfo: [(5,(alias_cyclic.updateX<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -79,7 +79,7 @@ updateY(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~p1##0:position.position, ?p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
-        alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @alias_cyclic:nn:nn
+        alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position) #5 @alias_cyclic:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_cyclic:nn:nn
@@ -91,7 +91,7 @@ updateY(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<
     0:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~p1##0:position.position, ?p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
-        alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @alias_cyclic:nn:nn
+        alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position) #5 @alias_cyclic:nn:nn
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_cyclic:nn:nn

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -22,7 +22,7 @@ module top-level code > public {inline,impure} (0 calls)
 
 backup > public {inline} (1 calls)
 0: alias_data.backup<0>
-backup(student1##0:student.student, ?student2##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+backup(student1##0:student.student, ?student2##0:student.student)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~student1##0:student.student, ?student2##0:student.student) @alias_data:nn:nn

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -21,7 +21,7 @@ module top-level code > public {impure} (0 calls)
     foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position) @position:nn:nn
     foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
     foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
-    alias_multifunc4.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @alias_multifunc4:nn:nn
+    alias_multifunc4.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position) #1 @alias_multifunc4:nn:nn
     wybe.string.print_string<0>("--- After calling replicate1:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #19 @io:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
@@ -52,7 +52,7 @@ module top-level code > public {impure} (0 calls)
 
 replicate1 > public (1 calls)
 0: alias_multifunc4.replicate1<0>
-replicate1(pa##0:position.position, ?pb##1:position.position, ?pc##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+replicate1(pa##0:position.position, ?pb##1:position.position, ?pc##0:position.position)<{}; {}>:
   AliasPairs: [(pa##0,pc##0)]
   InterestingCallProperties: []
     foreign llvm move(pa##0:position.position, ?pc##0:position.position) @alias_multifunc4:nn:nn

--- a/test-cases/final-dump/assert_error.exp
+++ b/test-cases/final-dump/assert_error.exp
@@ -9,9 +9,9 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-module top-level code > public {inline,impure} (0 calls)
+module top-level code > public {impure} (0 calls)
 0: assert_error.<0>
-()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.control.assert<0>(0:wybe.bool, c"assert_error:3:2":wybe.c_string) #1 @assert_error:nn:nn

--- a/test-cases/final-dump/bug228-okay.exp
+++ b/test-cases/final-dump/bug228-okay.exp
@@ -35,7 +35,7 @@ bar(?out1##0:wybe.int, ?out2##0:wybe.int)<{}; {}>:
 
 init_res > {inline} (1 calls)
 0: bug228-okay.init_res<0>
-init_res()<{<<bug228-okay.res>>}; {<<bug228-okay.res>>}>:
+init_res()<{}; {<<bug228-okay.res>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm store(2:wybe.int, <<bug228-okay.res>>:wybe.int) @bug228-okay:3:26

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -95,14 +95,14 @@ module top-level code > public {impure} (0 calls)
 
 gen#1 > {inline} (1 calls)
 0: higher_order_resources.gen#1<0>
-gen#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
+gen#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.list.length1<0>(~anon#1#1##0:wybe.list(T), 0:wybe.int, ?tmp#10##0:wybe.int) #2 @list:nn:nn
     higher_order_resources.take_max<0>(~tmp#10##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #1 @higher_order_resources:nn:nn
 gen#1 > {inline} (1 calls)
 1: higher_order_resources.gen#1<1>
-gen#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
+gen#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.list.length1<0>(~anon#1#1##0:wybe.list(T), 0:wybe.int, ?tmp#1##0:wybe.int) #1 @list:nn:nn
@@ -147,13 +147,13 @@ gen#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wy
 
 gen#3 > {inline} (1 calls)
 0: higher_order_resources.gen#3<0>
-gen#3(anon#3#1##0:wybe.int)<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
+gen#3(anon#3#1##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     higher_order_resources.take_max<0>(~anon#3#1##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #0 @higher_order_resources:nn:nn
 gen#3 > {inline} (1 calls)
 1: higher_order_resources.gen#3<1>
-gen#3(anon#3#1##0:wybe.int)<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
+gen#3(anon#3#1##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     higher_order_resources.take_max<0>(~anon#3#1##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #1 @higher_order_resources:nn:nn

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -20,7 +20,7 @@ AFTER EVERYTHING:
 
 module top-level code > public {impure} (0 calls)
 0: command_line.<0>
-()<{<<command_line.argc>>, <<command_line.argv>>, <<wybe.io.io>>}; {<<command_line.argc>>, <<command_line.arguments>>, <<command_line.argv>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}>:
+()<{<<command_line.argc>>, <<command_line.argv>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(1,(wybe.array.[|]<0>,fromList [NonAliasedParamCond 2 []]))]
@@ -45,7 +45,7 @@ module top-level code > public {impure} (0 calls)
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code##0:wybe.int)<{<<command_line.exit_code>>}; {<<command_line.exit_code>>}>:
+set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm store(~code##0:wybe.int, <<command_line.exit_code>>:wybe.int) @command_line:nn:nn
@@ -144,7 +144,7 @@ entry:
 
 module top-level code > public {impure} (0 calls)
 0: main_hello.<0>
-()<{<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}; {<<command_line.arguments>>, <<command_line.command>>, <<command_line.exit_code>>, <<wybe.io.io>>}>:
+()<{<<command_line.arguments>>, <<wybe.io.io>>}; {<<command_line.exit_code>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm store(42:wybe.int, <<command_line.exit_code>>:wybe.int) @command_line:nn:nn

--- a/test-cases/final-dump/multi_out.exp
+++ b/test-cases/final-dump/multi_out.exp
@@ -12,7 +12,7 @@ AFTER EVERYTHING:
 
 module top-level code > public {inline,impure} (0 calls)
 0: multi_out.<0>
-()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -30,7 +30,7 @@ module top-level code > public {inline,impure} (0 calls)
 
 update_both > {inline} (1 calls)
 0: person5.update_both<0>
-update_both(p1##0:person5.person, ?p1##1:person5.person, p2##0:person5.person, ?p2##1:person5.person)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+update_both(p1##0:person5.person, ?p1##1:person5.person, p2##0:person5.person, ?p2##1:person5.person)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm mutate(~p1##0:person5.person, ?p1##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Amy":wybe.string) @person5:nn:nn

--- a/test-cases/final-dump/purity_warning.exp
+++ b/test-cases/final-dump/purity_warning.exp
@@ -11,7 +11,7 @@ AFTER EVERYTHING:
 
 module top-level code > public {inline,impure} (0 calls)
 0: purity_warning.<0>
-()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 

--- a/test-cases/final-dump/resource_rollback.exp
+++ b/test-cases/final-dump/resource_rollback.exp
@@ -25,13 +25,13 @@ module top-level code > public {impure} (0 calls)
     case ~tmp#3##0:wybe.bool of
     0:
         foreign lpvm store(0:wybe.int, <<resource_rollback.res>>:wybe.int) @resource_rollback:nn:nn
-        resource_rollback.gen#1<0><{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}> #4
+        resource_rollback.gen#1<0><{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}> #4
 
     1:
         foreign c print_string(~s##0:wybe.c_string, ~tmp#7##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        resource_rollback.gen#1<0><{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}> #3
+        resource_rollback.gen#1<0><{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}> #3
 
 
 
@@ -46,7 +46,7 @@ foo(?s##0:wybe.c_string, ?#success##0:wybe.bool, %call_source_location##0:wybe.c
 
 gen#1 > (2 calls)
 0: resource_rollback.gen#1<0>
-gen#1()<{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}>:
+gen#1()<{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<resource_rollback.res>>:wybe.int, ?%res##0:wybe.int) @resource_rollback:nn:nn

--- a/test-cases/final-dump/resource_tmp_vars.exp
+++ b/test-cases/final-dump/resource_tmp_vars.exp
@@ -25,7 +25,7 @@ module top-level code > public {impure} (0 calls)
 
 gen#1 > {inline} (1 calls)
 0: resource_tmp_vars.gen#1<0>
-gen#1(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<resource_tmp_vars.counter>>, <<wybe.io.io>>}; {<<resource_tmp_vars.counter>>, <<wybe.io.io>>}>:
+gen#1(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<wybe.io.io>>}; {<<resource_tmp_vars.counter>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/stmt_nop.exp
+++ b/test-cases/final-dump/stmt_nop.exp
@@ -11,7 +11,7 @@ AFTER EVERYTHING:
 
 module top-level code > public {inline,impure} (0 calls)
 0: stmt_nop.<0>
-()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 

--- a/test-cases/final-dump/terminal_ok.exp
+++ b/test-cases/final-dump/terminal_ok.exp
@@ -11,7 +11,7 @@ AFTER EVERYTHING:
 
 module top-level code > public {inline,impure} (0 calls)
 0: terminal_ok.<0>
-()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     terminal_ok.exit_bool<0>(0:wybe.bool) #1 @terminal_ok:nn:nn

--- a/test-cases/final-dump/unbranch_bug.exp
+++ b/test-cases/final-dump/unbranch_bug.exp
@@ -11,38 +11,35 @@ AFTER EVERYTHING:
 
 module top-level code > public {inline,impure} (0 calls)
 0: unbranch_bug.<0>
-()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    unbranch_bug.gen#3<0>(0:wybe.list(4), 0:wybe.list(4))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
 
 
 gen#1 > {inline} (1 calls)
 0: unbranch_bug.gen#1<0>
-gen#1([tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+gen#1([tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)])<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
 gen#2 > {inline} (1 calls)
 0: unbranch_bug.gen#2<0>
-gen#2([tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+gen#2([tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)])<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
 gen#3 > (2 calls)
 0: unbranch_bug.gen#3<0>
-gen#3(tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(4))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+gen#3(tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(4))<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
+    foreign llvm icmp_ne(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
     case ~tmp#6##0:wybe.bool of
     0:
 
     1:
-        foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(4)) @list:nn:nn
-        unbranch_bug.gen#3<0>(~tmp#0##1:wybe.list(4), ~tmp#1##0:wybe.list(4))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
 
 
   LLVM code       :
@@ -61,7 +58,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"unbranch_bug.<0>"()    {
 entry:
-  tail call fastcc  void  @"unbranch_bug.gen#3<0>"(i64  0, i64  0)  
   ret void 
 }
 
@@ -83,11 +79,6 @@ entry:
   %"1#tmp#6##0" = icmp ne i64 %"tmp#0##0", 0 
   br i1 %"1#tmp#6##0", label %if.then, label %if.else 
 if.then:
-  %1 = add   i64 %"tmp#0##0", 8 
-  %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  tail call fastcc  void  @"unbranch_bug.gen#3<0>"(i64  %4, i64  %"tmp#1##0")  
   ret void 
 if.else:
   ret void 


### PR DESCRIPTION
This PR add the ability to change the interface of a proc and all calls to the proc have more restricted GlobalFlows if we can infer that some flow is unneeded.

For instance, we may have remove through optimisation all writes to a global in a proc. We can then safely remove the outwards flow of the global from the interface of the proc.