### PR TITLE
Fix for bug #250

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -2048,9 +2048,8 @@ modecheckStmt m name defPos assigned detism tmpCount final
                     $ bindingVars assigned3
         impurity <- lift $ stmtsImpurity tstStmt'
         let stmts' = if impurity > Pure 
-                     -- if the test is non-pure, need to keep the cond around
-                     then [maybePlace (Cond (seqToStmt tstStmt') [] elsStmts'
-                             (Just condBindings) (Just bindings) res) pos]
+                     -- if the test is non-pure, need to keep the test around
+                     then Not (seqToStmt tstStmt') `maybePlace` pos:elsStmts'
                      -- otherwise, the cond must fail and wont bind anything
                      else elsStmts'
         return (stmts', assigned3, tmpCount3)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -2044,7 +2044,12 @@ modecheckStmt m name defPos assigned detism tmpCount final
       else if mustFail assigned1 -- is condition guaranteed to fail?
       then do
         logTyped $ "Assigned by failing conditional: " ++ show assigned3
-        return (tstStmt'++elsStmts', assigned3, tmpCount3)
+        bindings <- mapFromUnivSetM ultimateVarType Set.empty
+                    $ bindingVars assigned3
+        -- We still need to have a Cond here. The test may be non-pure
+        return ([maybePlace (Cond (seqToStmt tstStmt') [] elsStmts'
+                        (Just condBindings) (Just bindings) res) pos], 
+                assigned3, tmpCount3)
       else do
         let finalAssigned = assigned2 `joinState` assigned3
         logTyped $ "Assigned by conditional: " ++ show finalAssigned
@@ -2053,7 +2058,7 @@ modecheckStmt m name defPos assigned detism tmpCount final
         return
           ([maybePlace (Cond (seqToStmt tstStmt') thnStmts' elsStmts'
                         (Just condBindings) (Just bindings) res)
-            pos], finalAssigned,tmpCount)
+            pos], finalAssigned,tmpCount3)
 modecheckStmt m name defPos assigned detism tmpCount final
     stmt@(TestBool exp) pos = do
     logTyped $ "Mode checking test " ++ show exp

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -19,22 +19,22 @@ module top-level code > public {impure} (0 calls)
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(8,(caret.gen#1<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:position.position) @position:nn:nn
-    foreign lpvm mutate(~tmp#13##0:position.position, ?tmp#14##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
-    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:position.position) @position:nn:nn
-    foreign lpvm mutate(~tmp#17##0:position.position, ?tmp#18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
-    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int) @position:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:caret.region) @caret:nn:nn
-    foreign lpvm mutate(~tmp#21##0:caret.region, ?tmp#22##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:position.position) @caret:nn:nn
-    foreign lpvm mutate(~tmp#22##0:caret.region, ?tmp#23##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:position.position) @caret:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:position.position) @position:nn:nn
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @position:nn:nn
+    foreign lpvm mutate(~tmp#19##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int) @position:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:caret.region) @caret:nn:nn
+    foreign lpvm mutate(~tmp#22##0:caret.region, ?tmp#23##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:position.position) @caret:nn:nn
+    foreign lpvm mutate(~tmp#23##0:caret.region, ?tmp#24##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:position.position) @caret:nn:nn
     foreign lpvm access(~tmp#2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("ten = ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11 @io:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#30##0:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~tmp#30##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    caret.gen#1<0>[410bae77d3](~tmp#23##0:caret.region, _:caret.region, _:position.position, _:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#32##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#33##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    caret.gen#1<0>[410bae77d3](~tmp#24##0:caret.region, _:caret.region, _:position.position, _:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8
 
 
 expand_region > public (0 calls)
@@ -75,10 +75,10 @@ gen#1(reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##0:position.position]
     foreign lpvm {noalias} mutate(~tmp#6##0:position.position, ?tmp#6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int) @position:nn:nn
     foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("now ten = ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9 @io:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
     foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position) @caret:nn:nn
     foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
@@ -86,10 +86,10 @@ gen#1(reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##0:position.position]
     foreign lpvm {noalias} mutate(~tmp#6##0:position.position, ?tmp#6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int) @position:nn:nn
     foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
     wybe.string.print_string<0>("now ten = ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9 @io:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/failure_in_cond_test.exp
+++ b/test-cases/final-dump/failure_in_cond_test.exp
@@ -1,0 +1,59 @@
+======================================================================
+AFTER EVERYTHING:
+ Module failure_in_cond_test
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : failure_in_cond_test.<0>
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+module top-level code > public {inline,impure} (0 calls)
+0: failure_in_cond_test.<0>
+()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+
+foo > {inline} (3 calls)
+0: failure_in_cond_test.foo<0>
+foo(?i##1:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(1:wybe.int, ?i##1:wybe.int) @failure_in_cond_test:nn:nn
+    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+  LLVM code       :
+
+; ModuleID = 'failure_in_cond_test'
+
+
+ 
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"failure_in_cond_test.<0>"()    {
+entry:
+  tail call ccc  void  @print_int(i64  1)  
+  ret void 
+}
+
+
+define external fastcc  {i64, i1} @"failure_in_cond_test.foo<0>"()    {
+entry:
+  %1 = insertvalue {i64, i1} undef, i64 1, 0 
+  %2 = insertvalue {i64, i1} %1, i1 1, 1 
+  ret {i64, i1} %2 
+}

--- a/test-cases/final-dump/failure_in_cond_test.wybe
+++ b/test-cases/final-dump/failure_in_cond_test.wybe
@@ -1,0 +1,9 @@
+# test case for #250
+
+def {test} foo(?i) {
+    ?i = 0
+    if {fail :: pass | else :: pass}
+    ?i = 1
+}
+
+if { foo(?i) :: !print(i) }


### PR DESCRIPTION
This fixes issue #250 

In the case a condition is guaranteed to fail, we used to remove the cond, but this was erroneous in a `test` proc because the condition now causes failure of the whole proc. We also cannot remove the condition because it may have side-effects. Instead, we still generate the cond, but have nothing in the "then" branch. 

A relevant test case exists for this.