### PR TITLE
Correctly restore global variables when breaking inside a `use` block in a loop

### DIFF
--- a/test-cases/final-dump/break_in_loop_in_do.exp
+++ b/test-cases/final-dump/break_in_loop_in_do.exp
@@ -1,0 +1,94 @@
+======================================================================
+AFTER EVERYTHING:
+ Module break_in_loop_in_do
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : break_in_loop_in_do.<0>
+  imports         : use wybe
+  resources       : counter: fromList [(break_in_loop_in_do.counter,wybe.int = 10 @break_in_loop_in_do:nn:nn @break_in_loop_in_do:nn:nn)]
+  procs           : 
+
+module top-level code > public {impure} (0 calls)
+0: break_in_loop_in_do.<0>
+()<{<<wybe.io.io>>}; {<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm store(10:wybe.int, <<break_in_loop_in_do.counter>>:wybe.int) @break_in_loop_in_do:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(10:wybe.int, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+
+gen#1 > {inline} (2 calls)
+0: break_in_loop_in_do.gen#1<0>
+gen#1([counter##0:wybe.int])<{<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}; {<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm load(<<break_in_loop_in_do.counter>>:wybe.int, ?%counter##1:wybe.int) @break_in_loop_in_do:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(~counter##1:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+
+gen#2 > {inline} (1 calls)
+0: break_in_loop_in_do.gen#2<0>
+gen#2(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}; {<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm store(tmp#0##0:wybe.int, <<break_in_loop_in_do.counter>>:wybe.int) @break_in_loop_in_do:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+  LLVM code       :
+
+; ModuleID = 'break_in_loop_in_do'
+
+
+ 
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+@"resource#break_in_loop_in_do.counter" =    global i64 undef
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"break_in_loop_in_do.<0>"()    {
+entry:
+  store  i64 10, i64* @"resource#break_in_loop_in_do.counter" 
+  tail call ccc  void  @print_int(i64  10)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"break_in_loop_in_do.gen#1<0>"()    {
+entry:
+  %1 = load  i64, i64* @"resource#break_in_loop_in_do.counter" 
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"break_in_loop_in_do.gen#2<0>"(i64  %"tmp#0##0")    {
+entry:
+  store  i64 %"tmp#0##0", i64* @"resource#break_in_loop_in_do.counter" 
+  tail call ccc  void  @print_int(i64  %"tmp#0##0")  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}

--- a/test-cases/final-dump/break_in_loop_in_do.wybe
+++ b/test-cases/final-dump/break_in_loop_in_do.wybe
@@ -1,0 +1,10 @@
+resource counter:int = 10
+
+do {
+    use counter in {
+        ?counter = 1
+        while counter = 10
+    }
+}
+
+!println(counter)


### PR DESCRIPTION
Fixes for bug #263