### PR TITLE
Refactor codegen; reuse some generated closure procedures

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -84,7 +84,7 @@ module AST (
   updateTypeModifiers,
   addParameters, addTypeRep, setTypeRep, addConstructor,
   getModuleImplementationField, getModuleImplementation,
-  getLoadedModule, ifCurrentModuleElse, getLoadingModule, updateLoadedModule, updateLoadedModuleM,
+  getLoadedModule, getLoadingModule, updateLoadedModule, updateLoadedModuleM,
   getLoadedModuleImpln, updateLoadedModuleImpln, updateLoadedModuleImplnM,
   getModule, getModuleInterface, updateModule, getSpecModule,
   updateModImplementation, updateModImplementationM,
@@ -504,17 +504,6 @@ getLoadedModule modspec = do
     maybeMod <- gets (Map.lookup modspec . modules)
     logAST $ if isNothing maybeMod then " got nothing!" else " worked"
     return maybeMod
-
--- | Perform an action if in the current module or a submodule, 
--- else perform another
-ifCurrentModuleElse :: ModSpec -> StateT s Compiler a -> StateT s Compiler a
-                    -> StateT s Compiler a
-ifCurrentModuleElse mod current other = do
-    thisMod <- lift $ getModuleSpec
-    fileMod <- lift $ getModule modRootModSpec
-    if thisMod == mod || maybe False (`List.isPrefixOf` mod) fileMod
-    then current
-    else other
 
 
 -- |Apply the given function to the specified module, if it has been loaded;

--- a/src/Blocks.hs
+++ b/src/Blocks.hs
@@ -18,7 +18,8 @@ import           BinaryFactory
 import           Codegen
 import           Resources
 import           Config                          (wordSize, wordSizeBytes)
-import           Util                            (maybeNth, zipWith3M_, (|||), (&&&))
+import           Util                            (maybeNth, zipWith3M_, lift2,
+                                                  (|||), (&&&))
 import           Snippets
 import           Control.Monad                   as M
 import           Control.Monad.Extra             (ifM)
@@ -60,7 +61,6 @@ import           System.FilePath
 data ProcDefBlock =
     ProcDefBlock { blockProto   :: PrimProto
                  , blockDef     :: LLVMAST.Definition
-                 , blockExterns :: [LLVMAST.Definition]
                  } deriving (Show, Eq)
 
 
@@ -73,57 +73,58 @@ data ProcDefBlock =
 -- procedures can the prototype checked (match and eliminate unneeded
 -- arguments in cgen.)
 blockTransformModule :: ModSpec -> Compiler ()
-blockTransformModule thisMod =
-    do reenterModule thisMod
-       logBlocks $ "*** Translating Module: " ++ showModSpec thisMod
-       modRec <- getModule id
-       modFile <- getSource
-       logWrapWith '-' $ show modRec
-       procs <- getModuleImplementationField (Map.elems . modProcs)
-       -- Collect all procedure prototypes in the module
-       let protos = List.map extractLPVMProto (concat procs)
-       --------------------------------------------------
-       -- Collect prototypes of imported modules
-       imports <- getModuleImplementationField (keys . modImports)
-       importProtos <- mapM getPrimProtos
-                         (List.filter (not . isStdLib) imports)
-       let allProtos = protos ++ concat importProtos
+blockTransformModule thisMod = do 
+    reenterModule thisMod
+    logBlocks $ "*** Translating Module: " ++ showModSpec thisMod
+    modRec <- getModule id
+    modFile <- getSource
+    logWrapWith '-' $ show modRec
+    procs <- getModuleImplementationField (Map.elems . modProcs)
+    -- Collect all procedure prototypes in the module
+    let protos = List.map extractLPVMProto (concat procs)
+    --------------------------------------------------
+    -- Collect prototypes of imported modules
+    imports <- getModuleImplementationField (keys . modImports)
+    importProtos <- mapM getPrimProtos
+                        (List.filter (not . isStdLib) imports)
+    let allProtos = protos ++ concat importProtos
 
-       logBlocks $ "Prototypes:\n\t"
-                         ++ intercalate "\n\t" (List.map show allProtos)
-       --------------------------------------------------
-       -- Listing all known types
-       knownTypesSet <- Map.elems <$>
-                         getModuleImplementationField modKnownTypes
-       let knownTypes = concatMap Set.toList knownTypesSet
-       trs <- mapM moduleLLVMType knownTypes
-       -- typeList :: [(TypeSpec, LLVMAST.Type)]
-       let typeList = zip knownTypes trs
-       -- log the assoc list typeList
-       logWrapWith '.' $ "Known Types:\n" ++ intercalate "\n" (
-           List.map (\(a,b) -> show a ++ ": " ++ show b) typeList)
+    logBlocks $ "Prototypes:\n\t"
+                ++ intercalate "\n\t" (List.map show allProtos)
+    --------------------------------------------------
+    -- Listing all known types
+    knownTypesSet <- Map.elems <$>
+                        getModuleImplementationField modKnownTypes
+    let knownTypes = concatMap Set.toList knownTypesSet
+    trs <- mapM moduleLLVMType knownTypes
+    -- typeList :: [(TypeSpec, LLVMAST.Type)]
+    let typeList = zip knownTypes trs
+    -- log the assoc list typeList
+    logWrapWith '.' $ "Known Types:\n" ++ intercalate "\n" (
+        List.map (\(a,b) -> show a ++ ": " ++ show b) typeList)
 
-       --------------------------------------------------
-       -- Name mangling
-       let mangledProcs = concat $ mangleProcs <$> procs
+    --------------------------------------------------
+    -- Name mangling
+    let mangledProcs = concat $ mangleProcs <$> procs
 
-       --------------------------------------------------
-       -- Translate
-       procBlocks <- evalTranslation 0 $
-         mapM (translateProc allProtos) mangledProcs
-       let procBlocks' = List.concat procBlocks
-       --------------------------------------------------
+    --------------------------------------------------
+    -- Translate
+    (procBlocks, txState) <- mapM translateProc mangledProcs
+                             `runStateT` emptyTranslation
+    
+    let procBlocks' = List.concat procBlocks
+    --------------------------------------------------
 
-       let resDefs = modResources $ trustFromJust "blockTransformModule"
-                                  $ modImplementation modRec
-       let ress = concat $ Map.keys <$> Map.elems resDefs
-       llmod <- newLLVMModule (showModSpec thisMod) modFile procBlocks' ress
-       updateImplementation (\imp -> imp { modLLVM = Just llmod })
-       logBlocks $ "*** Translated Module: " ++ showModSpec thisMod
-       modRec' <- getModule id
-       logWrapWith '-' $ show modRec'
-       reexitModule
-       logBlocks $ "*** Exiting Module " ++ showModSpec thisMod ++ " ***"
+    let resDefs = modResources $ trustFromJust "blockTransformModule"
+                                $ modImplementation modRec
+    let ress = concat $ Map.keys <$> Map.elems resDefs
+    llmod <- newLLVMModule (showModSpec thisMod) modFile procBlocks' txState ress
+    updateImplementation (\imp -> imp { modLLVM = Just llmod })
+    logBlocks $ "*** Translated Module: " ++ showModSpec thisMod
+    modRec' <- getModule id
+    logWrapWith '-' $ show modRec'
+    reexitModule
+    logBlocks $ "*** Exiting Module " ++ showModSpec thisMod ++ " ***"
 
 
 -- -- |Affix its id number to the end of each proc name
@@ -209,16 +210,14 @@ isStdLib (m:_) = m == "wybe"
 -- require some global variable/constant declarations which is represented as
 -- G.Global values in the neededGlobalVars field of LLVMCompstate. All in all,
 -- externs and globals go on the top of the module.
-translateProc :: [PrimProto] -> ProcDef -> Translation [ProcDefBlock]
-translateProc modProtos proc = do
-    count <- getCount
+translateProc :: ProcDef -> Translation [ProcDefBlock]
+translateProc proc = do
     let proto = procImplnProto $ procImpln proc
     let body = procImplnBody $ procImpln proc
     let isClosure = isClosureVariant $ procVariant proc
     let speczBodies = procImplnSpeczBodies $ procImpln proc
     -- translate the standard version
-    (block, count') <- lift $ _translateProcImpl modProtos proto
-                                isClosure body count
+    block <- _translateProcImpl proto isClosure body
     -- translate the specialized versions
     let speczBodies' = speczBodies
                         |> Map.toList
@@ -232,52 +231,36 @@ translateProc modProtos proc = do
     when (hasDuplicates (List.map fst speczBodies'))
             $ shouldnt $ "Specz version id conflicts"
                 ++ show (List.map fst speczBodies')
-    (blocks, count'') <-
-            foldlM (\(currBlocks, currCount) (id, currBody) -> do
+    blocks <- mapM (\(id, currBody) -> do
                     -- rename this version of proc
                     let pname = primProtoName proto ++ "[" ++ id ++ "]"
                     let proto' = proto {primProtoName = pname}
-                    -- codegen
-                    (currBlock, currCount') <-
-                            lift $ _translateProcImpl modProtos
-                                        proto' isClosure
-                                        currBody currCount
-                    return (currBlock:currBlocks, currCount')
-            ) ([], count') speczBodies'
-    let blocks' = block:blocks
-    putCount count''
-    return blocks'
+                    _translateProcImpl proto' isClosure currBody
+            ) speczBodies'
+    return $ block:blocks
 
 
 -- Helper for `translateProc`. Translate the given `ProcBody` 
 -- (A specialized version of a procedure).
-_translateProcImpl :: [PrimProto] -> PrimProto -> Bool -> ProcBody
-                   -> Word -> Compiler (ProcDefBlock, Word)
-_translateProcImpl modProtos proto isClosure body startCount = do
+_translateProcImpl :: PrimProto -> Bool -> ProcBody -> Translation ProcDefBlock
+_translateProcImpl proto isClosure body = do
     let (proto', body') = if isClosure then closeClosure proto body
-                                       else (proto,body)
-    modspec <- getModuleSpec
-    logBlocks $ "\n" ++ replicate 70 '=' ++ "\n"
-    logBlocks $ "In Module: " ++ showModSpec modspec
-                ++ ", creating definition of: "
-    logBlocks $ "proto: " ++ show proto'
-                ++ "body: " ++ show body'
-                ++ "\n" ++ replicate 50 '-' ++ "\n"
-    -- Codegen
-    codestate <- execCodegen startCount modProtos
-                    (doCodegenBody proto' body')
+                                       else (proto, body)
+    modspec <- lift getModuleSpec
+    lift $ do
+        logBlocks $ "\n" ++ replicate 70 '=' ++ "\n"
+        logBlocks $ "In Module: " ++ showModSpec modspec
+                    ++ ", creating definition of: "
+        logBlocks $ "proto: " ++ show proto'
+                    ++ "body: " ++ show body'
+                    ++ "\n" ++ replicate 50 '-' ++ "\n"
+    codestate <- doCodegenBody proto' body' 
+                    `execStateT` emptyCodegen
     let pname = primProtoName proto
-    logBlocks $ show $ externs codestate
-    exs <- mapM declareExtern $ externs codestate
-    let globals = List.map LLVMAST.GlobalDefinition
-                    (Map.elems (globalVars codestate) 
-                     ++ Map.elems (resources codestate))
     let body' = createBlocks codestate
-    lldef <- makeGlobalDefinition pname proto' body'
-    logBlocks $ show lldef
-    let block = ProcDefBlock proto lldef (exs ++ globals)
-    let endCount = Codegen.count codestate
-    return (block, endCount)
+    lldef <- lift $ makeGlobalDefinition pname proto' body'
+    lift $ logBlocks $ show lldef
+    return $ ProcDefBlock proto lldef
 
 -- | Updates a PrimProto and ProcBody as though the Free Params are accessed
 -- via the closure environment 
@@ -374,7 +357,7 @@ doCodegenBody proto body = do
     entry <- addBlock entryBlockName
     -- Start with creation of blocks and adding instructions to it
     setBlock entry
-    params <- lift $ protoRealParams proto
+    params <- lift2 $ protoRealParams proto
     let (ins,outs) = List.partition ((== FlowIn) . primParamFlow) params
     mapM_ assignParam ins
     mapM_ preassignOutput outs
@@ -385,7 +368,7 @@ doCodegenBody proto body = do
 -- param's name on the symbol table. Don't assign if phantom.
 assignParam :: PrimParam -> Codegen ()
 assignParam p@PrimParam{primParamType=ty} = do
-    trep <- lift $ typeRep ty
+    trep <- typeRep' ty
     logCodegen $ "Maybe generating parameter " ++ show p
                  ++ " (" ++ show trep ++ ")"
     unless (repIsPhantom trep || paramInfoUnneeded (primParamInfo p))
@@ -401,7 +384,7 @@ preassignOutput :: PrimParam -> Codegen ()
 preassignOutput p = do
     let ty = primParamType p
     let nm = show (primParamName p)
-    trep <- lift $ typeRep ty
+    trep <- typeRep' ty
     let llty = repLLVMType trep
     assign nm (cons $ C.Undef llty) trep
 
@@ -413,7 +396,7 @@ preassignOutput p = do
 -- structure, pack the operands into it and return it.
 buildOutputOp :: [PrimParam] -> Codegen (Maybe Operand)
 buildOutputOp params = do
-    outParams <- lift $ filterM isOutputParam params
+    outParams <- lift2 $ filterM isOutputParam params
     logCodegen $ "OutParams: " ++ show outParams
     outputs <- mapM (liftM2 castVar primParamName primParamType) outParams
     logCodegen $ "Built outputs from symbol table: " ++ show outputs
@@ -522,7 +505,7 @@ cgen prim@(PrimCall callSiteID pspec args _) = do
     -- Find the prototype of the pspec being called
     -- and match it's parameters with the args here
     -- and remove the unneeded ones.
-    proto <- lift $ getProcPrimProto pspec
+    proto <- lift2 $ getProcPrimProto pspec
     logCodegen $ "Proto = " ++ show proto
     args' <- prepareArgs proto args
     logCodegen $ "Prepared args = " ++ show args'
@@ -533,7 +516,7 @@ cgen prim@(PrimCall callSiteID pspec args _) = do
     let (inArgs,outArgs) = partitionArgs args'
     logCodegen $ "In args = " ++ show inArgs
 
-    outTy <- lift $ primReturnType outArgs
+    outTy <- lift2 $ primReturnType outArgs
 
     inops <- mapM cgenArg inArgs
     logCodegen $ "Translated inputs = " ++ show inops
@@ -546,7 +529,7 @@ cgen prim@(PrimCall callSiteID pspec args _) = do
     addInstruction ins outArgs
 
 cgen prim@(PrimHigher cId (ArgProcRef pspec closed _) args) = do
-    pspec' <- fromMaybe pspec <$> lift (maybeGetClosureOf pspec)
+    pspec' <- fromMaybe pspec <$> lift2 (maybeGetClosureOf pspec)
     logCodegen $ "Compiling " ++ show prim
               ++ " as first order call to " ++ show pspec'
               ++ " closed over " ++ show closed
@@ -560,7 +543,7 @@ cgen prim@(PrimHigher callSiteId fn@ArgVar{} args) = do
     let (inArgs, outArgs) = partitionArgs $ setArgType AnyType <$> args
     inOps@(env:_) <- mapM cgenArg $ fn:inArgs
     logCodegen $ "In args = " ++ show inOps
-    fnPtrTy <- lift $ llvmClosureType (argType fn)
+    fnPtrTy <- llvmClosureType (argType fn)
     let addrPtrTy = ptr_t address_t
     envPtr <- inttoptr env addrPtrTy
     eltPtr <- doLoad address_t envPtr
@@ -596,8 +579,7 @@ cgen prim@(PrimForeign lang name flags args) = do
     let (inArgs,outArgs) = partitionArgs args'
     let nm = LLVMAST.Name $ toSBString name
     inops <- mapM cgenArg inArgs
-    -- alignedOps <- mapM makeCIntOp inops
-    outty <- lift $ primReturnType outArgs
+    outty <- lift2 $ primReturnType outArgs
     -- XXX this ignores lang and just uses C calling conventions for all calls
     let ins =
           callC
@@ -633,8 +615,8 @@ cgenLLVMUnop :: ProcName -> [Ident] -> [PrimArg] -> Codegen ()
 cgenLLVMUnop "move" flags args =
     case partitionArgs args of
       ([input],[output]) -> do
-           inRep <- lift $ typeRep $ argType input
-           outRep <- lift $ typeRep $ argType output
+           inRep <- typeRep' $ argType input
+           outRep <- typeRep' $ argType output
            (outTy, outNm) <- openPrimArg output
            inop <- cgenArg input
            assign outNm inop outRep
@@ -645,24 +627,13 @@ cgenLLVMUnop name flags args =
     case (Map.lookup name llvmMapUnop,partitionArgs args) of
         (Just (f,_,_),([inArg],[outArg])) -> do
             inOp <- cgenArg inArg
-            outRep <- lift $ typeRep $ argType outArg
+            outRep <- typeRep' $ argType outArg
             addInstruction (f inOp (repLLVMType outRep)) [outArg]
         (Just _,(inArgs,outArgs)) ->
             shouldnt $ "unary LLVM Instruction " ++ name ++ " with "
                         ++ show (length inArgs) ++ " input(s) and "
                         ++ show (length outArgs) ++ " output(s)"
         (Nothing,_) -> shouldnt $ "Unknown unary LLVM Instruction " ++ name
-
-
--- | Look inside the Prototype list stored in the CodegenState monad and
--- find a matching ProcSpec.
--- XXX This one is not used.
-findProto :: ProcSpec -> Codegen (Maybe PrimProto)
-findProto (ProcSpec _ nm i _) = do
-    allProtos <- gets Codegen.modProtos
-    let procNm = nm
-    let matchingProtos = List.filter ((== nm) . primProtoName) allProtos
-    return $ maybeNth i matchingProtos
 
 
 -- | Match PrimArgs with the paramaters in the given prototype. If a PrimArg's
@@ -680,13 +651,13 @@ prepareArgs' (ArgUnneeded _ _:as) (p:ps)
     | paramNeeded p = shouldnt $ "unneeded arg for needed param " ++ show p
     | otherwise     = prepareArgs' as ps
 prepareArgs' (a:as) (p@PrimParam{primParamType=ty}:ps) = do
-    real <- lift $ paramIsReal p
+    real <- lift2 $ paramIsReal p
     rest <- prepareArgs' as ps
     return $ if real then setArgType ty a:rest else rest
 
 
 filterPhantomArgs :: [PrimArg] -> Codegen [PrimArg]
-filterPhantomArgs = filterM ((not <$>) . lift . argIsPhantom)
+filterPhantomArgs = filterM ((not <$>) . lift2 . argIsPhantom)
 
 
 -- |Return the integer constant from an argument; error if it's not one
@@ -703,7 +674,7 @@ cgenLPVM "alloc" _ args@[sizeArg,addrArg] = do
           let (inputs,outputs) = partitionArgs args
           case inputs of
             [input] -> do
-                outRep <- lift $ typeRep $ argType addrArg
+                outRep <- typeRep' $ argType addrArg
                 let outTy = repLLVMType outRep
                 op <- gcAllocate sizeArg outTy
                 assign (pullName addrArg) op outRep
@@ -716,7 +687,7 @@ cgenLPVM "access" _ args@[addrArg,offsetArg,_,_,val] = do
                  ++ " " ++ show val
           baseAddr <- cgenArg addrArg
           finalAddr <- offsetAddr baseAddr iadd offsetArg
-          outRep <- lift $ typeRep $ argType val
+          outRep <- typeRep' $ argType val
           let outTy = repLLVMType outRep
           logCodegen $ "outTy = " ++ show outTy
           op <- gcAccess finalAddr outTy
@@ -733,7 +704,7 @@ cgenLPVM "mutate" flags
                        ++ " " ++ show startOffsetArg
                        ++ " " ++ show valArg
           -- First copy the structure
-          outRep <- lift $ typeRep $ argType addrArg
+          outRep <- typeRep' $ argType addrArg
           let outTy = repLLVMType outRep
           allocAddr <- gcAllocate sizeArg outTy
           outAddr <- offsetAddr allocAddr iadd startOffsetArg
@@ -757,7 +728,7 @@ cgenLPVM "mutate" _
                        ++ " " ++ show valArg
           baseAddr <- cgenArg addrArg
           gcMutate baseAddr offsetArg valArg
-          outRep <- lift $ typeRep $ argType addrArg
+          outRep <- typeRep' $ argType addrArg
           assign (pullName outArg) baseAddr Address
 
 cgenLPVM "mutate" _ [_, _, _, destructiveArg, _, _, _] =
@@ -767,8 +738,8 @@ cgenLPVM "mutate" _ [_, _, _, destructiveArg, _, _, _] =
 cgenLPVM "cast" _ args@[inArg,outArg] =
     case partitionArgs args of
         ([inArg],[outArg]) -> do
-            inRep <- lift $ typeRep $ argType inArg
-            outRep <- lift $ typeRep $ argType outArg
+            inRep <- typeRep' $ argType inArg
+            outRep <- typeRep' $ argType outArg
             let inTy = repLLVMType inRep
             let outTy = repLLVMType outRep
 
@@ -799,7 +770,7 @@ cgenLPVM "store" _ args = do
     case partitionArgs args of
         ([input, global@(ArgGlobal (GlobalResource res) ty)], []) -> do
             logCodegen $ "lpvm store " ++ show input ++ " " ++ show global
-            ty' <- lift $ llvmType ty
+            ty' <- llvmType' ty
             global <- getGlobalResource res ty'
             op <- cgenArg input
             store global op
@@ -812,8 +783,8 @@ cgenLPVM "load" _ args = do
         ([input@(ArgGlobal (GlobalResource res) ty)],
          [output@(ArgVar nm _ _ _ _)]) -> do
             logCodegen $ "lpvm load " ++ show input ++ " " ++ show output
-            ty' <- lift $ llvmType ty
-            trep <- lift $ typeRep ty
+            ty' <- llvmType' ty
+            trep <- typeRep' ty
             global <- getGlobalResource res ty'
             op' <- doLoad ty' global
             assign (show nm) op' trep
@@ -931,15 +902,15 @@ constantType _            = shouldnt "Cannot determine constant type."
 addInstruction :: Instruction -> [PrimArg] -> Codegen ()
 addInstruction ins outArgs = do
     logCodegen $ "addInstruction " ++ show outArgs ++ " = " ++ show ins
-    outTy <- lift $ primReturnType outArgs
+    outTy <- lift2 $ primReturnType outArgs
     logCodegen $ "outTy = " ++ show outTy
     case outArgs of
         [] -> case outTy of
             VoidType -> voidInstr ins
             _        -> shouldnt "empty outArgs cant assign values"
         [outArg] -> do
-            outRep <- lift $ typeRep $ argType outArg
-            outTy <- lift $ llvmType $ argType outArg
+            outRep <- typeRep' $ argType outArg
+            outTy <- llvmType' $ argType outArg
             logCodegen $ "outRep = " ++ show outRep
             let outName = pullName outArg
             outop <- namedInstr outTy outName ins
@@ -947,8 +918,8 @@ addInstruction ins outArgs = do
         _ -> do
             outOp <- instr outTy ins
             let outTySpecs = argType <$> outArgs
-            outTys <- lift $ mapM llvmType outTySpecs
-            treps <- lift $ mapM typeRep outTySpecs
+            outTys <- mapM llvmType' outTySpecs
+            treps <- mapM typeRep' outTySpecs
             fields <- structUnPack outOp outTys
             let outNames = List.map pullName outArgs
             zipWith3M_ assign outNames fields treps
@@ -1007,7 +978,7 @@ argIntVal _              = Nothing
 -- | Open a PrimArg into it's inferred type and string name.
 openPrimArg :: PrimArg -> Codegen (Type, String)
 openPrimArg ArgVar{argVarName=nm,argVarType=ty} = do
-    lltype <- lift $ llvmType ty
+    lltype <- llvmType' ty
     return (lltype, show nm)
 openPrimArg a = shouldnt $ "Can't Open!: "
                 ++ argDescription a
@@ -1019,12 +990,12 @@ openPrimArg a = shouldnt $ "Can't Open!: "
 -- * Constants are generated with cgenArgConst, then wrapped in `cons`
 cgenArg :: PrimArg -> Codegen LLVMAST.Operand
 cgenArg arg = do
-    opds <- gets operands
+    opds <- gets (stOpds . symtab)
     case Map.lookup arg opds of
         Just opd -> return opd
         Nothing -> do
             opd <- cgenArg' arg
-            modify $ \s -> s{operands=Map.insert arg opd opds}
+            addOperand arg opd
             return opd
 
 
@@ -1062,23 +1033,23 @@ cgenArg' arg = do
 --                  is to comply with the stdlib string implementation
 cgenArgConst :: PrimArg -> Codegen C.Constant
 cgenArgConst arg = do
-    opds <- gets operands
+    opds <- gets (stOpds . symtab)
     case Map.lookup arg opds of
         Just (ConstantOperand constant) -> return constant
         Just other -> shouldnt $ "cgenArgConst with " ++ show other
         Nothing -> do
             opd <- cgenArgConst' arg
-            modify $ \s -> s{operands=Map.insert arg (ConstantOperand opd) opds}
+            addOperand arg $ ConstantOperand opd
             return opd
 
 cgenArgConst' :: PrimArg -> Codegen C.Constant
 cgenArgConst' (ArgInt val ty) = do
-    toTy <- lift $ llvmType ty
+    toTy <- llvmType' ty
     case toTy of
         IntegerType bs -> return $ C.Int bs val
         _ -> consCast (C.Int (fromIntegral wordSize) val) address_t toTy
 cgenArgConst' (ArgFloat val ty) = do
-    toTy <- lift $ llvmType ty
+    toTy <- llvmType' ty
     case toTy of
         FloatingPointType DoubleFP -> return $ C.Float $ F.Double val
         _ -> consCast (C.Float $ F.Double val) float_t toTy
@@ -1098,12 +1069,12 @@ cgenArgConst' (ArgString s CString _) = do
     consCast strElem conPtrTy address_t
 cgenArgConst' (ArgChar c ty) = do
     let val = integerOrd c
-    toTy <- lift $ llvmType ty
+    toTy <- llvmType' ty
     case toTy of
         IntegerType bs -> return $ C.Int bs val
         _ -> consCast (C.Int (fromIntegral wordSize) val) address_t toTy
 cgenArgConst' (ArgUndef ty) = do
-    llty <- lift $ llvmType ty
+    llty <- llvmType' ty
     return $ C.Undef llty
 cgenArgConst' (ArgProcRef ps args ty) = do
     fnRef <- cgenFuncRef ps
@@ -1124,23 +1095,23 @@ cgenFuncRef ps = do
     let fName = LLVMAST.Name $ fromString $ show ps
     psType <- HigherOrderType defaultProcModifiers . (primParamTypeFlow <$>)
           <$> primActualParams ps
-    psTy <- lift $ llvmFuncType psType
+    psTy <- llvmFuncType psType
     logCodegen $ "  with type " ++ show psType
     let conFn = C.GlobalReference psTy fName
     return $ C.PtrToInt conFn address_t
 
 castVar :: PrimVarName -> TypeSpec -> Codegen Operand
 castVar nm ty = do
-    toTyRep <- lift $ typeRep ty
-    toTy <- lift $ llvmType ty
-    lift $ logBlocks $ "Coercing var " ++ show nm ++ " to " ++ show ty
+    toTyRep <- typeRep' ty
+    toTy <- llvmType' ty
+    lift2 $ logBlocks $ "Coercing var " ++ show nm ++ " to " ++ show ty
     (varOp,rep) <- getVar (show nm)
     let fromTy = repLLVMType rep
     doCast varOp fromTy toTy
 
 
 primActualParams :: ProcSpec -> Codegen [PrimParam]
-primActualParams pspec = lift $ do
+primActualParams pspec = lift2 $ do
     primParams <- protoRealParams . procImplnProto . procImpln 
               =<< getProcDef pspec
     let nonFreeParams = List.filter ((/= Free) . primParamFlowType) primParams
@@ -1150,7 +1121,7 @@ primActualParams pspec = lift $ do
 
 
 neededFreeArgs :: ProcSpec -> [PrimArg] -> Codegen [PrimArg]
-neededFreeArgs pspec args = lift $ do
+neededFreeArgs pspec args = lift2 $ do
     params <- List.filter ((==Free) . primParamFlowType) . primProtoParams
               . procImplnProto . procImpln <$> getProcDef pspec
     List.map snd <$> filterM (paramIsReal . fst) (zip params args)
@@ -1159,9 +1130,10 @@ neededFreeArgs pspec args = lift $ do
 addExternProcRef :: ProcSpec -> Codegen ()
 addExternProcRef ps@(ProcSpec mod _ _ _) = do
     args <- (primParamToArg <$>) <$> primActualParams ps
-    ifCurrentModuleElse mod
-        (return ())
-        (addExtern $ PrimCall 0 ps args univGlobalFlows)
+    thisMod <- lift2 getModuleSpec
+    fileMod <- lift2 $ getModule modRootModSpec
+    unless (thisMod == mod || maybe False (`List.isPrefixOf` mod) fileMod)
+        $ addExtern $ PrimCall 0 ps args univGlobalFlows
 
 
 addStringConstant :: String -> Codegen (LLVMAST.Type, C.Constant)
@@ -1271,19 +1243,22 @@ llvmMapUnop =
 llvmType :: TypeSpec -> Compiler LLVMAST.Type
 llvmType ty = repLLVMType <$> typeRep ty
 
-llvmFuncType :: TypeSpec -> Compiler LLVMAST.Type
+llvmType' :: TypeSpec -> Codegen LLVMAST.Type
+llvmType' = lift2 . llvmType
+
+llvmFuncType :: TypeSpec -> Codegen LLVMAST.Type
 llvmFuncType ty = do
-    tyRep <- typeRep ty
+    tyRep <- typeRep' ty
     case tyRep of
         Func ins outs -> do
             let inTys = repLLVMType <$> ins
             let outTys = repLLVMType <$> outs
-            outTy <- primReturnLLVMType outTys
+            outTy <- lift2 $ primReturnLLVMType outTys
             return $ ptr_t $ FunctionType outTy inTys False
         _ -> shouldnt $ "llvmFuncType of " ++ show ty
 
 
-llvmClosureType :: TypeSpec -> Compiler LLVMAST.Type
+llvmClosureType :: TypeSpec -> Codegen LLVMAST.Type
 llvmClosureType (HigherOrderType mods@ProcModifiers{modifierDetism=detism} tys)
     = llvmFuncType
         $ HigherOrderType mods{modifierDetism=Det}
@@ -1301,6 +1276,9 @@ typeRep ty =
             ++ show ty
             ++ ")"
     in fromMaybe err <$> lookupTypeRepresentation ty
+
+typeRep' :: TypeSpec -> Codegen TypeRepresentation
+typeRep' = lift2 . typeRep
 
 
 -- |The LLVM type of the specified module spec; error if it's not a type.
@@ -1342,14 +1320,16 @@ defaultLLVMType = repLLVMType defaultTypeRepresentation
 -- | Initialize and fill a new LLVMAST.Module with the translated
 -- global definitions (extern declarations and defined functions)
 -- of LPVM procedures in a module.
-newLLVMModule :: String -> String -> [ProcDefBlock] -> [ResourceSpec]
-              -> Compiler LLVMAST.Module
-newLLVMModule name fname blocks ress = do
+newLLVMModule :: String -> String -> [ProcDefBlock] -> TranslationState 
+              -> [ResourceSpec] -> Compiler LLVMAST.Module
+newLLVMModule name fname blocks (TranslationState _ consts vars exts) ress = do
     let defs = List.map blockDef blocks
-        exs  = concatMap blockExterns blocks
-    resExs <- catMaybes <$> mapM globalResourceExtern ress
-    let exs' = uniqueExterns (exs ++ resExs) ++ [mallocExtern]
-                                             ++ intrinsicExterns
+        varDefs = LLVMAST.GlobalDefinition <$> Map.elems vars
+        constDefs = LLVMAST.GlobalDefinition <$> Map.elems consts 
+    resDefs <- catMaybes <$> mapM globalResourceExtern ress
+    extDefs <- mapM declareExtern exts
+    let exs' = uniqueExterns (resDefs ++ varDefs ++ constDefs) 
+            ++ uniqueExterns (extDefs ++ [mallocExtern] ++ intrinsicExterns)
     return $ modWithDefinitions name fname $ exs' ++ defs
 
 
@@ -1365,14 +1345,12 @@ globalResourceExtern res = do
         _ -> shouldnt $ "globalResourceExtern " ++ show res
 
 
-
-
 -- | Filter out non-unique externs
 uniqueExterns :: [LLVMAST.Definition] -> [LLVMAST.Definition]
 uniqueExterns exs = List.nubBy sameDef exs
   where
     sameDef (LLVMAST.GlobalDefinition g1) (LLVMAST.GlobalDefinition g2)
-      = (G.name g1) == (G.name g2)
+      = G.name g1 == G.name g2
     sameDef _ _ = False
 
 
@@ -1531,7 +1509,7 @@ callWybeMalloc size = do
     let outTy = ptr_t (int_c 8)
     let fnName = LLVMAST.Name $ toSBString "wybe_malloc"
     sizeOp <- cgenArg size
-    sizeTy <- lift $ llvmType $ argType size
+    sizeTy <- llvmType' $ argType size
     logCodegen $ "callWybeMalloc casting size " ++ show sizeOp
                  ++ " to " ++ show int_t
     inops <- (:[]) <$> doCast sizeOp sizeTy int_t
@@ -1613,7 +1591,7 @@ gcMutate baseAddr offsetArg valArg = do
     logCodegen $ "gcMutate " ++ show baseAddr ++ " " ++ show offsetArg
                  ++ " " ++ show valArg
     finalAddr <- offsetAddr baseAddr iadd offsetArg
-    valTy <- lift $ llvmType $ argType valArg
+    valTy <- llvmType' $ argType valArg
     let ptrTy = ptr_t valTy
     ptr' <- inttoptr finalAddr ptrTy
     logCodegen $ "inttoptr " ++ show finalAddr ++ " " ++ show ptrTy
@@ -1656,4 +1634,4 @@ logWrapWith ch s = do
 
 
 logCodegen :: String -> Codegen ()
-logCodegen s = lift $ logBlocks s
+logCodegen s = lift2 $ logBlocks s

--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -9,15 +9,16 @@
 {-# LANGUAGE OverloadedStrings          #-}
 
 module Codegen (
-  Codegen(..), CodegenState(..), BlockState(..), Translation,
-  emptyModule, evalCodegen, addExtern, addGlobalConstant, getGlobalResource,
-  execCodegen, emptyCodegen, evalTranslation, getCount, putCount,
+  Codegen(..), CodegenState(..), BlockState(..), 
+  Translation(..), TranslationState(..), SymbolTable(..),
+  emptyModule, addExtern, addGlobalConstant, getGlobalResource,
+  emptyCodegen, emptyTranslation,
   -- * Blocks
   createBlocks, setBlock, addBlock, entryBlockName,
   callWybe, callC, externf, ret, globalDefine, externalC, externalWybe,
   phi, br, cbr, getBlock, retNothing, fresh,
   -- * Symbol storage
-  alloca, store, local, assign, load, getVar, localVar, preservingSymtab,
+  alloca, store, local, assign, addOperand, load, getVar, localVar, preservingSymtab,
   makeGlobalResourceVariable,
   operandType, doAlloca, doLoad, 
   bitcast, cbitcast, inttoptr, cinttoptr, ptrtoint, cptrtoint,
@@ -65,15 +66,16 @@ import qualified LLVM.AST.CallingConvention      as CC
 import qualified LLVM.AST.Constant               as C
 import qualified LLVM.AST.FloatingPointPredicate as FP
 import qualified LLVM.AST.IntegerPredicate       as IP
-
-import           AST                             hiding (Stmt(..))
 import           LLVM.Context
 import           LLVM.Module
+import           LLVM.AST.Linkage (Linkage(External))
+
+import           Util                            (lift2)
+import           AST                             hiding (Stmt(..))
 import           Options                         (LogSelection (Blocks,Codegen))
 import           Config                          (wordSize, functionDefSection)
 import           Unsafe.Coerce
 import           Debug.Trace
-import LLVM.AST.Linkage (Linkage(ExternWeak, External))
 
 ----------------------------------------------------------------------------
 -- Types                                                                  --
@@ -142,20 +144,10 @@ data CodegenState
         currentBlock :: Name     -- ^ Name of the active block to append to
       , blocks       :: Map.Map Name BlockState 
                                  -- ^ Blocks for function
-      , symtab       :: Map.Map String (Operand,TypeRepresentation) 
-                                 -- ^ Local symbol table of a function
       , blockCount   :: Int      -- ^ Incrementing count of basic blocks
-      , count        :: Word     -- ^ Count for temporary operands
+      , symtab       :: SymbolTable
+                                 -- ^ Local symbol table of a function
       , names        :: Names    -- ^ Name supply
-      , externs      :: [Prim]   -- ^ Primitives which need to be declared
-      , globalVars   :: Map.Map (C.Constant, Type) Global 
-                                 -- ^ Needed global variables/constants
-      , resources    :: Map.Map ResourceSpec Global
-                                 -- ^ Needed global variables for resources
-      , operands     :: Map.Map PrimArg Operand
-                                 -- ^ Previously generated operands
-      , modProtos    :: [PrimProto]
-                                 -- ^ Module procedures prototypes
       } deriving Show
 
 -- | 'BlockState' will generate the code for basic blocks inside of
@@ -171,45 +163,57 @@ data BlockState
       } deriving Show
 
 
+-- | SymbolTable state.
+-- Stores assignments and generated operands
+data SymbolTable 
+     = SymbolTable {
+         stVars :: Map.Map String (Operand,TypeRepresentation) 
+         
+                      -- ^ Assigned names
+       , stOpds :: Map.Map PrimArg Operand
+                      -- ^ Previously generated operands
+       } deriving Show
+
+
 -- | The 'Codegen' state monad will hold the state of the code generator
 -- That is, a map of block names to their 'BlockState' representation
 -- newtype Codegen a = Codegen { runCodegen :: StateT CodegenState Compiler a }
 --     deriving (Functor, Applicative, Monad, MonadState CodegenState)
 
-type Codegen = StateT CodegenState Compiler
+type Codegen = StateT CodegenState Translation
 
-execCodegen :: Word -> [PrimProto] -> Codegen a -> Compiler CodegenState
-execCodegen startCount protos codegen 
-    = execStateT codegen (emptyCodegen startCount protos)
+-- | TranslationState
+-- Stores data required across tranlating an LPVM module into an LLVm module
+data TranslationState 
+    = TranslationState {
+        txCount   :: Word -- ^ Count of used virtual registers 
+      , txConsts  :: Map.Map (C.Constant, Type) Global 
+                          -- ^ Needed global constants
+      , txVars    :: Map.Map GlobalInfo Global
+                          -- ^ Needed global variables
+      , txExterns :: [Prim]
+                          -- ^ Primitives which need to be declared
+      } deriving Show
 
-evalCodegen :: [PrimProto] -> Codegen t -> Compiler t
-evalCodegen protos codegen = evalStateT codegen (emptyCodegen 0 protos)
 
-type Translation = StateT Word Compiler
+type Translation = StateT TranslationState Compiler
 
-evalTranslation :: Word -> Translation a -> Compiler a
-evalTranslation = flip evalStateT
+emptyTranslation :: TranslationState
+emptyTranslation = TranslationState 0 Map.empty Map.empty []
 
-getCount :: Translation Word
-getCount = get
-
-putCount :: Word -> Translation ()
-putCount = put
 
 -- | Gets a new incremental word suffix for a temporary local operands
-fresh :: Codegen Word
+fresh :: Translation Word
 fresh = do
-  ix <- gets count
-  modify $ \s -> s { count = 1 + ix }
-  return (ix + 1)
+    count <- gets txCount
+    modify $ \s -> s { txCount=count + 1 }
+    return $ count + 1
 
 
 -- | Update the list of externs which will be needed. The 'Prim' will be
 -- converted to an extern declaration later.
 addExtern :: Prim -> Codegen ()
-addExtern p = do 
-  ex <- gets externs
-  modify $ \s -> s { externs = p : ex }
+addExtern prim = lift $ modify $ \s -> s { txExterns=prim:txExterns s}
 
 
 -- | Creates a Global value for a constant, given the type and appends it
@@ -218,28 +222,29 @@ addExtern p = do
 -- for reference.
 addGlobalConstant :: LLVMAST.Type -> C.Constant -> Codegen Name
 addGlobalConstant ty con = do 
-    modName <- lift $ fmap showModSpec getModuleSpec
-    globs <- gets globalVars
-    case Map.lookup (con, ty) globs of
+    modName <- lift2 $ showModSpec <$> getModuleSpec
+    consts <- lift $ gets txConsts
+    case Map.lookup (con, ty) consts of
         Just global -> return $ name global
-        Nothing -> do
+        Nothing -> lift $ do
             n <- fresh
             let ref = Name $ fromString $ modName ++ "." ++ show n
             let gvar = globalVariableDefaults { name = ref
                                               , isConstant = True
                                               , G.type' = ty
                                               , initializer = Just con }
-            modify $ \s -> s { globalVars = Map.insert (con, ty) gvar globs }
+            modify $ \s -> s {txConsts=Map.insert (con, ty) gvar $ txConsts s}
             return ref
 
 
 getGlobalResource :: ResourceSpec -> Type -> Codegen Operand
 getGlobalResource spec@(ResourceSpec mod nm) ty = do
-    ress <- gets resources
-    nm <- case Map.lookup spec ress of
+    vars <- lift $ gets txVars
+    let info = GlobalResource spec
+    nm <- case Map.lookup info vars of
             Nothing -> do
-                global <- lift $ makeGlobalResourceVariable spec ty
-                modify $ \s -> s { resources = Map.insert spec global ress }
+                global <- lift2 $ makeGlobalResourceVariable spec ty
+                lift $ modify $ \s -> s {txVars=Map.insert info global vars}
                 return $ G.name global
             Just ref -> return $ G.name ref
     return $ ConstantOperand $ C.GlobalReference (ptr_t ty) nm
@@ -328,20 +333,14 @@ emptyBlock :: Int -> BlockState
 emptyBlock i = BlockState i [] Nothing
 
 -- | Initialize an empty CodegenState for a new Definition.
-emptyCodegen :: Word -> [PrimProto] -> CodegenState
-emptyCodegen startCount protos =
-  CodegenState
-    (Name $ fromString entryBlockName)
-    Map.empty
-    Map.empty
-    1
-    startCount
-    Map.empty
-    []
-    Map.empty
-    Map.empty
-    Map.empty
-    protos
+emptyCodegen :: CodegenState
+emptyCodegen = CodegenState{ currentBlock=Name $ fromString entryBlockName
+                           , blocks=Map.empty
+                           , blockCount=1
+                           , symtab=SymbolTable Map.empty Map.empty
+                           , names=Map.empty
+                           }
+    
 
 -- | 'addBlock' creates and adds a new block to the current blocks
 addBlock :: String -> Codegen Name
@@ -395,10 +394,10 @@ createBlocks m = map makeBlock $ sortBlocks $ Map.toList (blocks m)
 
 -- | Convert our BlockState to the LLVM BasicBlock Type.
 makeBlock :: (Name, BlockState) -> BasicBlock
-makeBlock (l, (BlockState _ s t)) = BasicBlock l s (maketerm t)
+makeBlock (l, BlockState _ s t) = BasicBlock l s (maketerm t)
   where
     maketerm (Just x) = x
-    maketerm Nothing  = error $ "Block has no terminator: " ++ (show l)
+    maketerm Nothing  = error $ "Block has no terminator: " ++ show l
 
 -- | Sort the blocks on their ids. Blocks do get out of order since any block
 -- can be brought to be the 'currentBlock'.
@@ -446,7 +445,8 @@ globalVar t s = C.GlobalReference t $ LLVMAST.Name $ fromString s
 assign :: String -> Operand -> TypeRepresentation -> Codegen ()
 assign var op trep = do
     logCodegen $ "SYMTAB: " ++ var ++ " <- " ++ show op ++ ":" ++ show trep
-    modify $ \s -> s { symtab = Map.insert var (op,trep) $ symtab s }
+    st <- gets symtab
+    modify $ \s -> s { symtab=st{stVars=Map.insert var (op,trep) $ stVars st} }
 
 
 -- | Find and return the local operand by its given name from the symbol
@@ -455,7 +455,7 @@ assign var op trep = do
 getVar :: String -> Codegen (Operand,TypeRepresentation)
 getVar var = do
     let err = shouldnt $ "Local variable not in scope: " ++ show var
-    lcls <- gets symtab
+    lcls <- gets (stVars . symtab)
     return $ fromMaybe err $ Map.lookup var lcls
 
 
@@ -465,11 +465,15 @@ getVar var = do
 -- apply an another branch.
 preservingSymtab :: Codegen a -> Codegen a
 preservingSymtab code = do
-    CodegenState{symtab=oldSymtab, operands=oldOperands} <- get
+    oldSymtab <- gets symtab
     result <- code
-    modify $ \s -> s { symtab=oldSymtab, operands=oldOperands }
+    modify $ \s -> s { symtab=oldSymtab }
     return result
 
+addOperand :: PrimArg -> Operand -> Codegen ()
+addOperand arg opd = do  
+    st <- gets symtab
+    modify $ \s -> s { symtab=st{stOpds=Map.insert arg opd $ stOpds st} }
 
 
 -- | Look inside an operand and determine it's type.
@@ -511,7 +515,7 @@ namedInstr ty nm ins = do
 -- BasicBlock. The temp name is generated using a fresh word counter.
 instr :: Type -> Instruction -> Codegen Operand
 instr ty ins = do
-    ref <- UnName <$> fresh
+    ref <- UnName <$> lift fresh
     addInstr $ ref := ins
     return $ local ty ref
 
@@ -745,4 +749,4 @@ phi ty incoming = instr ty $ Phi ty incoming []
 
 
 logCodegen :: String -> Codegen ()
-logCodegen s = lift $ logMsg Codegen s
+logCodegen s = lift2 $ logMsg Codegen s

--- a/src/Expansion.hs
+++ b/src/Expansion.hs
@@ -232,7 +232,7 @@ expandPrim (PrimCall id pspec args gFlows) pos = do
         logExpansion "  Cannot inline:  already inlining"
         addInstr call' pos
     else do
-        def <- lift $ lift $ getProcDef pspec
+        def <- lift2 $ getProcDef pspec
         case procImpln def of
             ProcDefSrc _ -> shouldnt $ "uncompiled proc: " ++ show pspec
             ProcDefPrim{procImplnProto = proto, procImplnBody = body} ->
@@ -257,7 +257,7 @@ expandPrim call@(PrimHigher id fn args) pos = do
         ArgProcRef pspec closed _ -> do
             pspec' <- fromMaybe pspec <$> lift (lift $ maybeGetClosureOf pspec)
             logExpansion $ "  As first order call to " ++ show pspec'
-            gFlows <- lift $ lift $ getProcGlobalFlows pspec
+            gFlows <- lift2 $ getProcGlobalFlows pspec
             expandPrim (PrimCall id pspec' (closed ++ args) gFlows) pos
         _ -> do
             args' <- mapM expandArg args
@@ -370,4 +370,4 @@ addInputAssign _ _ = return ()
 
 -- |Log a message, if we are logging inlining and code expansion activity.
 logExpansion :: String -> Expander ()
-logExpansion s = lift $ lift $ logMsg Expansion s
+logExpansion s = lift2 $ logMsg Expansion s

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -14,13 +14,14 @@ module Util (sameLength, maybeNth, insertAt,
              removeFromDS, connectedItemsInDS,
              mapDS, filterDS, dsToTransitivePairs,
              intersectMapIdentity, orElse,
-             apply2way, (&&&), (|||), zipWith3M, zipWith3M_,
+             apply2way, (&&&), (|||), zipWith3M, zipWith3M_, lift2,
              useLocalCacheFileIfPossible, createLocalCacheFile
              ) where
 
 
 import           Config ( localCacheLibDir )
 import           Control.Monad ( when, unless )
+import           Control.Monad.Trans.Class
 import           Crypto.Hash ( hashWith, hashlazy, SHA1(..), Digest )
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy  as BL
@@ -269,6 +270,11 @@ zipWith3M f (a:as) (b:bs) (c:cs) = do
 -- |zipWithM_ version for 3 lists.
 zipWith3M_ :: Monad m => (a -> b -> c -> m d) -> [a] -> [b] -> [c] -> m ()
 zipWith3M_ f as bs cs = zipWith3M f as bs cs >> return ()
+
+
+-- | lift2 applies lift twice
+lift2 :: (MonadTrans t1, MonadTrans t2, Monad m, Monad (t2 m)) => m a -> t1 (t2 m) a
+lift2 act = lift $ lift act
 
 
 ----------------------------------------------------------------

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -125,21 +125,6 @@ set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
  
 
 
-declare external ccc  void @error_exit(i64, i64)    
-
-
-declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
-
-
-@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
-
-
-@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
 @"resource#command_line.argc" =    global i64 undef
 
 
@@ -153,6 +138,21 @@ declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)
 
 
 @"resource#command_line.exit_code" =    global i64 undef
+
+
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
+
+
+@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
+
+
+declare external ccc  void @error_exit(i64, i64)    
+
+
+declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -695,6 +695,15 @@ module top-level code > {terminal,inline,impure} (0 calls)
  
 
 
+@"resource#command_line.argc" = external   global i64 
+
+
+@"resource#command_line.argv" = external   global i64 
+
+
+@"resource#command_line.exit_code" = external   global i64 
+
+
 declare external ccc  void @exit(i64)    
 
 
@@ -705,15 +714,6 @@ declare external fastcc  void @"command_line.<0>"()
 
 
 declare external ccc  void @gc_init()    
-
-
-@"resource#command_line.argc" = external   global i64 
-
-
-@"resource#command_line.argv" = external   global i64 
-
-
-@"resource#command_line.exit_code" = external   global i64 
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -792,21 +792,6 @@ set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
  
 
 
-declare external ccc  void @error_exit(i64, i64)    
-
-
-declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
-
-
-@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
-
-
-@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
 @"resource#command_line.argc" =    global i64 undef
 
 
@@ -820,6 +805,21 @@ declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)
 
 
 @"resource#command_line.exit_code" =    global i64 undef
+
+
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
+
+
+@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
+
+
+declare external ccc  void @error_exit(i64, i64)    
+
+
+declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -1281,6 +1281,36 @@ print_info(d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
+@drone.178 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.177 to i64) }
+
+
+@drone.183 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.182 to i64) }
+
+
+@drone.193 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.192 to i64) }
+
+
+@drone.202 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.201 to i64) }
+
+
+@drone.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.1 to i64) }
+
+
+@drone.177 =    constant [?? x i8] c"(\00"
+
+
+@drone.192 =    constant [?? x i8] c") #\00"
+
+
+@drone.1 =    constant [?? x i8] c"** malloc count: \00"
+
+
+@drone.182 =    constant [?? x i8] c", \00"
+
+
+@drone.201 =    constant [?? x i8] c"invalid action!\00"
+
+
 declare external ccc  void @putchar(i8)    
 
 
@@ -1290,88 +1320,10 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-declare external ccc  i64 @malloc_count()    
-
-
 declare external ccc  i8 @read_char()    
 
 
-@drone.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.1 to i64) }
-
-
-@drone.1 =    constant [?? x i8] c"** malloc count: \00"
-
-
-@drone.158 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.157 to i64) }
-
-
-@drone.157 =    constant [?? x i8] c"** malloc count: \00"
-
-
-@drone.180 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.179 to i64) }
-
-
-@drone.185 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.184 to i64) }
-
-
-@drone.195 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.194 to i64) }
-
-
-@drone.204 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.203 to i64) }
-
-
-@drone.179 =    constant [?? x i8] c"(\00"
-
-
-@drone.194 =    constant [?? x i8] c") #\00"
-
-
-@drone.184 =    constant [?? x i8] c", \00"
-
-
-@drone.203 =    constant [?? x i8] c"invalid action!\00"
-
-
-@drone.206 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.205 to i64) }
-
-
-@drone.211 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.210 to i64) }
-
-
-@drone.221 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.220 to i64) }
-
-
-@drone.230 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.229 to i64) }
-
-
-@drone.205 =    constant [?? x i8] c"(\00"
-
-
-@drone.220 =    constant [?? x i8] c") #\00"
-
-
-@drone.210 =    constant [?? x i8] c", \00"
-
-
-@drone.229 =    constant [?? x i8] c"invalid action!\00"
-
-
-@drone.232 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.231 to i64) }
-
-
-@drone.237 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.236 to i64) }
-
-
-@drone.247 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.246 to i64) }
-
-
-@drone.231 =    constant [?? x i8] c"(\00"
-
-
-@drone.246 =    constant [?? x i8] c") #\00"
-
-
-@drone.236 =    constant [?? x i8] c", \00"
+declare external ccc  i64 @malloc_count()    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -1685,7 +1637,7 @@ entry:
 define external fastcc  void @"drone.gen#1<0>"()    {
 entry:
   %"1#mc##0" = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.158, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#mc##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -1696,23 +1648,23 @@ define external fastcc  i64 @"drone.gen#2<0>"(i64  %"d##0", i1  %"success##0")  
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
-  %159 = add   i64 %"d##0", 24 
-  %160 = inttoptr i64 %159 to i64* 
-  %161 = getelementptr  i64, i64* %160, i64 0 
-  %162 = load  i64, i64* %161 
-  %"2#tmp#14##0" = add   i64 %162, 1 
-  %163 = trunc i64 32 to i32  
-  %164 = tail call ccc  i8*  @wybe_malloc(i32  %163)  
-  %165 = ptrtoint i8* %164 to i64 
-  %166 = inttoptr i64 %165 to i8* 
-  %167 = inttoptr i64 %"d##0" to i8* 
-  %168 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %166, i8*  %167, i32  %168, i1  0)  
-  %169 = add   i64 %165, 24 
-  %170 = inttoptr i64 %169 to i64* 
-  %171 = getelementptr  i64, i64* %170, i64 0 
-  store  i64 %"2#tmp#14##0", i64* %171 
-  ret i64 %165 
+  %157 = add   i64 %"d##0", 24 
+  %158 = inttoptr i64 %157 to i64* 
+  %159 = getelementptr  i64, i64* %158, i64 0 
+  %160 = load  i64, i64* %159 
+  %"2#tmp#14##0" = add   i64 %160, 1 
+  %161 = trunc i64 32 to i32  
+  %162 = tail call ccc  i8*  @wybe_malloc(i32  %161)  
+  %163 = ptrtoint i8* %162 to i64 
+  %164 = inttoptr i64 %163 to i8* 
+  %165 = inttoptr i64 %"d##0" to i8* 
+  %166 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %164, i8*  %165, i32  %166, i1  0)  
+  %167 = add   i64 %163, 24 
+  %168 = inttoptr i64 %167 to i64* 
+  %169 = getelementptr  i64, i64* %168, i64 0 
+  store  i64 %"2#tmp#14##0", i64* %169 
+  ret i64 %163 
 if.else:
   ret i64 %"d##0" 
 }
@@ -1722,15 +1674,15 @@ define external fastcc  i64 @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  %"su
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
-  %172 = add   i64 %"d##0", 24 
-  %173 = inttoptr i64 %172 to i64* 
-  %174 = getelementptr  i64, i64* %173, i64 0 
-  %175 = load  i64, i64* %174 
-  %"2#tmp#14##0" = add   i64 %175, 1 
-  %176 = add   i64 %"d##0", 24 
-  %177 = inttoptr i64 %176 to i64* 
-  %178 = getelementptr  i64, i64* %177, i64 0 
-  store  i64 %"2#tmp#14##0", i64* %178 
+  %170 = add   i64 %"d##0", 24 
+  %171 = inttoptr i64 %170 to i64* 
+  %172 = getelementptr  i64, i64* %171, i64 0 
+  %173 = load  i64, i64* %172 
+  %"2#tmp#14##0" = add   i64 %173, 1 
+  %174 = add   i64 %"d##0", 24 
+  %175 = inttoptr i64 %174 to i64* 
+  %176 = getelementptr  i64, i64* %175, i64 0 
+  store  i64 %"2#tmp#14##0", i64* %176 
   ret i64 %"d##0" 
 if.else:
   ret i64 %"d##0" 
@@ -1776,45 +1728,45 @@ if.else:
   tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.then1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.180, i32 0, i32 0) to i64))  
-  %181 = inttoptr i64 %"d##0" to i64* 
-  %182 = getelementptr  i64, i64* %181, i64 0 
-  %183 = load  i64, i64* %182 
-  tail call ccc  void  @print_int(i64  %183)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.185, i32 0, i32 0) to i64))  
-  %186 = add   i64 %"d##0", 8 
-  %187 = inttoptr i64 %186 to i64* 
-  %188 = getelementptr  i64, i64* %187, i64 0 
-  %189 = load  i64, i64* %188 
-  tail call ccc  void  @print_int(i64  %189)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.185, i32 0, i32 0) to i64))  
-  %190 = add   i64 %"d##0", 16 
-  %191 = inttoptr i64 %190 to i64* 
-  %192 = getelementptr  i64, i64* %191, i64 0 
-  %193 = load  i64, i64* %192 
-  tail call ccc  void  @print_int(i64  %193)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.195, i32 0, i32 0) to i64))  
-  %196 = add   i64 %"d##0", 24 
-  %197 = inttoptr i64 %196 to i64* 
-  %198 = getelementptr  i64, i64* %197, i64 0 
-  %199 = load  i64, i64* %198 
-  tail call ccc  void  @print_int(i64  %199)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.178, i32 0, i32 0) to i64))  
+  %179 = inttoptr i64 %"d##0" to i64* 
+  %180 = getelementptr  i64, i64* %179, i64 0 
+  %181 = load  i64, i64* %180 
+  tail call ccc  void  @print_int(i64  %181)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.183, i32 0, i32 0) to i64))  
+  %184 = add   i64 %"d##0", 8 
+  %185 = inttoptr i64 %184 to i64* 
+  %186 = getelementptr  i64, i64* %185, i64 0 
+  %187 = load  i64, i64* %186 
+  tail call ccc  void  @print_int(i64  %187)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.183, i32 0, i32 0) to i64))  
+  %188 = add   i64 %"d##0", 16 
+  %189 = inttoptr i64 %188 to i64* 
+  %190 = getelementptr  i64, i64* %189, i64 0 
+  %191 = load  i64, i64* %190 
+  tail call ccc  void  @print_int(i64  %191)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.193, i32 0, i32 0) to i64))  
+  %194 = add   i64 %"d##0", 24 
+  %195 = inttoptr i64 %194 to i64* 
+  %196 = getelementptr  i64, i64* %195, i64 0 
+  %197 = load  i64, i64* %196 
+  tail call ccc  void  @print_int(i64  %197)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.else1:
-  %200 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
-  %201 = extractvalue {i64, i1} %200, 0 
-  %202 = extractvalue {i64, i1} %200, 1 
-  %"5#tmp#5##0" = icmp eq i1 %202, 0 
+  %198 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
+  %199 = extractvalue {i64, i1} %198, 0 
+  %200 = extractvalue {i64, i1} %198, 1 
+  %"5#tmp#5##0" = icmp eq i1 %200, 0 
   br i1 %"5#tmp#5##0", label %if.then2, label %if.else2 
 if.then2:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.204, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.202, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %201)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %199)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %201)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %199)  
   ret void 
 }
 
@@ -1832,74 +1784,74 @@ if.else:
   tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.then1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.206, i32 0, i32 0) to i64))  
-  %207 = inttoptr i64 %"d##0" to i64* 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.178, i32 0, i32 0) to i64))  
+  %203 = inttoptr i64 %"d##0" to i64* 
+  %204 = getelementptr  i64, i64* %203, i64 0 
+  %205 = load  i64, i64* %204 
+  tail call ccc  void  @print_int(i64  %205)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.183, i32 0, i32 0) to i64))  
+  %206 = add   i64 %"d##0", 8 
+  %207 = inttoptr i64 %206 to i64* 
   %208 = getelementptr  i64, i64* %207, i64 0 
   %209 = load  i64, i64* %208 
   tail call ccc  void  @print_int(i64  %209)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.211, i32 0, i32 0) to i64))  
-  %212 = add   i64 %"d##0", 8 
-  %213 = inttoptr i64 %212 to i64* 
-  %214 = getelementptr  i64, i64* %213, i64 0 
-  %215 = load  i64, i64* %214 
-  tail call ccc  void  @print_int(i64  %215)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.211, i32 0, i32 0) to i64))  
-  %216 = add   i64 %"d##0", 16 
-  %217 = inttoptr i64 %216 to i64* 
-  %218 = getelementptr  i64, i64* %217, i64 0 
-  %219 = load  i64, i64* %218 
-  tail call ccc  void  @print_int(i64  %219)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.221, i32 0, i32 0) to i64))  
-  %222 = add   i64 %"d##0", 24 
-  %223 = inttoptr i64 %222 to i64* 
-  %224 = getelementptr  i64, i64* %223, i64 0 
-  %225 = load  i64, i64* %224 
-  tail call ccc  void  @print_int(i64  %225)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.183, i32 0, i32 0) to i64))  
+  %210 = add   i64 %"d##0", 16 
+  %211 = inttoptr i64 %210 to i64* 
+  %212 = getelementptr  i64, i64* %211, i64 0 
+  %213 = load  i64, i64* %212 
+  tail call ccc  void  @print_int(i64  %213)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.193, i32 0, i32 0) to i64))  
+  %214 = add   i64 %"d##0", 24 
+  %215 = inttoptr i64 %214 to i64* 
+  %216 = getelementptr  i64, i64* %215, i64 0 
+  %217 = load  i64, i64* %216 
+  tail call ccc  void  @print_int(i64  %217)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.else1:
-  %226 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
-  %227 = extractvalue {i64, i1} %226, 0 
-  %228 = extractvalue {i64, i1} %226, 1 
-  %"5#tmp#5##0" = icmp eq i1 %228, 0 
+  %218 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
+  %219 = extractvalue {i64, i1} %218, 0 
+  %220 = extractvalue {i64, i1} %218, 1 
+  %"5#tmp#5##0" = icmp eq i1 %220, 0 
   br i1 %"5#tmp#5##0", label %if.then2, label %if.else2 
 if.then2:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.230, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.202, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %227)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %219)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %227)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %219)  
   ret void 
 }
 
 
 define external fastcc  void @"drone.print_info<0>"(i64  %"d##0")    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.232, i32 0, i32 0) to i64))  
-  %233 = inttoptr i64 %"d##0" to i64* 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.178, i32 0, i32 0) to i64))  
+  %221 = inttoptr i64 %"d##0" to i64* 
+  %222 = getelementptr  i64, i64* %221, i64 0 
+  %223 = load  i64, i64* %222 
+  tail call ccc  void  @print_int(i64  %223)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.183, i32 0, i32 0) to i64))  
+  %224 = add   i64 %"d##0", 8 
+  %225 = inttoptr i64 %224 to i64* 
+  %226 = getelementptr  i64, i64* %225, i64 0 
+  %227 = load  i64, i64* %226 
+  tail call ccc  void  @print_int(i64  %227)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.183, i32 0, i32 0) to i64))  
+  %228 = add   i64 %"d##0", 16 
+  %229 = inttoptr i64 %228 to i64* 
+  %230 = getelementptr  i64, i64* %229, i64 0 
+  %231 = load  i64, i64* %230 
+  tail call ccc  void  @print_int(i64  %231)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.193, i32 0, i32 0) to i64))  
+  %232 = add   i64 %"d##0", 24 
+  %233 = inttoptr i64 %232 to i64* 
   %234 = getelementptr  i64, i64* %233, i64 0 
   %235 = load  i64, i64* %234 
   tail call ccc  void  @print_int(i64  %235)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.237, i32 0, i32 0) to i64))  
-  %238 = add   i64 %"d##0", 8 
-  %239 = inttoptr i64 %238 to i64* 
-  %240 = getelementptr  i64, i64* %239, i64 0 
-  %241 = load  i64, i64* %240 
-  tail call ccc  void  @print_int(i64  %241)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.237, i32 0, i32 0) to i64))  
-  %242 = add   i64 %"d##0", 16 
-  %243 = inttoptr i64 %242 to i64* 
-  %244 = getelementptr  i64, i64* %243, i64 0 
-  %245 = load  i64, i64* %244 
-  tail call ccc  void  @print_int(i64  %245)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.247, i32 0, i32 0) to i64))  
-  %248 = add   i64 %"d##0", 24 
-  %249 = inttoptr i64 %248 to i64* 
-  %250 = getelementptr  i64, i64* %249, i64 0 
-  %251 = load  i64, i64* %250 
-  tail call ccc  void  @print_int(i64  %251)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -131,13 +131,13 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
 @command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
 
 
 @"resource#command_line.argc" =    global i64 undef
@@ -798,13 +798,13 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
 @command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
 
 
 @"resource#command_line.argc" =    global i64 undef
@@ -1296,106 +1296,82 @@ declare external ccc  i64 @malloc_count()
 declare external ccc  i8 @read_char()    
 
 
-@drone.4 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.3 to i64) }
-
-
-@drone.3 =    constant [?? x i8] c"** malloc count: \00"
-
-
 @drone.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.1 to i64) }
 
 
 @drone.1 =    constant [?? x i8] c"** malloc count: \00"
 
 
-@drone.160 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.159 to i64) }
+@drone.158 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.157 to i64) }
 
 
-@drone.159 =    constant [?? x i8] c"** malloc count: \00"
+@drone.157 =    constant [?? x i8] c"** malloc count: \00"
 
 
-@drone.208 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.207 to i64) }
+@drone.180 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.179 to i64) }
 
 
-@drone.207 =    constant [?? x i8] c"invalid action!\00"
+@drone.185 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.184 to i64) }
 
 
-@drone.199 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.198 to i64) }
+@drone.195 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.194 to i64) }
 
 
-@drone.198 =    constant [?? x i8] c") #\00"
+@drone.204 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.203 to i64) }
 
 
-@drone.193 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.192 to i64) }
+@drone.179 =    constant [?? x i8] c"(\00"
 
 
-@drone.192 =    constant [?? x i8] c", \00"
+@drone.194 =    constant [?? x i8] c") #\00"
 
 
-@drone.187 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.186 to i64) }
+@drone.184 =    constant [?? x i8] c", \00"
 
 
-@drone.186 =    constant [?? x i8] c", \00"
+@drone.203 =    constant [?? x i8] c"invalid action!\00"
 
 
-@drone.182 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.181 to i64) }
+@drone.206 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.205 to i64) }
 
 
-@drone.181 =    constant [?? x i8] c"(\00"
+@drone.211 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.210 to i64) }
 
 
-@drone.236 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.235 to i64) }
+@drone.221 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.220 to i64) }
 
 
-@drone.235 =    constant [?? x i8] c"invalid action!\00"
+@drone.230 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.229 to i64) }
 
 
-@drone.227 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.226 to i64) }
+@drone.205 =    constant [?? x i8] c"(\00"
 
 
-@drone.226 =    constant [?? x i8] c") #\00"
+@drone.220 =    constant [?? x i8] c") #\00"
 
 
-@drone.221 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.220 to i64) }
+@drone.210 =    constant [?? x i8] c", \00"
 
 
-@drone.220 =    constant [?? x i8] c", \00"
+@drone.229 =    constant [?? x i8] c"invalid action!\00"
 
 
-@drone.215 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.214 to i64) }
+@drone.232 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.231 to i64) }
 
 
-@drone.214 =    constant [?? x i8] c", \00"
+@drone.237 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.236 to i64) }
 
 
-@drone.210 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.209 to i64) }
+@drone.247 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.246 to i64) }
 
 
-@drone.209 =    constant [?? x i8] c"(\00"
+@drone.231 =    constant [?? x i8] c"(\00"
 
 
-@drone.255 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.254 to i64) }
+@drone.246 =    constant [?? x i8] c") #\00"
 
 
-@drone.254 =    constant [?? x i8] c") #\00"
-
-
-@drone.249 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.248 to i64) }
-
-
-@drone.248 =    constant [?? x i8] c", \00"
-
-
-@drone.243 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.242 to i64) }
-
-
-@drone.242 =    constant [?? x i8] c", \00"
-
-
-@drone.238 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.237 to i64) }
-
-
-@drone.237 =    constant [?? x i8] c"(\00"
+@drone.236 =    constant [?? x i8] c", \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -1419,7 +1395,7 @@ if.then:
   ret void 
 if.else:
   %"3#tmp#10##0" = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.4, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"3#tmp#10##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -1431,147 +1407,147 @@ entry:
   %"1#tmp#21##0" = icmp eq i8 %"action##0", 110 
   br i1 %"1#tmp#21##0", label %if.then, label %if.else 
 if.then:
-  %5 = add   i64 %"d##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  %8 = load  i64, i64* %7 
-  %"2#tmp#1##0" = sub   i64 %8, 1 
-  %9 = trunc i64 32 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
-  %12 = inttoptr i64 %11 to i8* 
-  %13 = inttoptr i64 %"d##0" to i8* 
-  %14 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
-  %15 = add   i64 %11, 8 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  store  i64 %"2#tmp#1##0", i64* %17 
-  %"2#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %11, i1  1)  
-  %18 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
-  %19 = insertvalue {i64, i1} %18, i1 1, 1 
-  ret {i64, i1} %19 
+  %3 = add   i64 %"d##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = getelementptr  i64, i64* %4, i64 0 
+  %6 = load  i64, i64* %5 
+  %"2#tmp#1##0" = sub   i64 %6, 1 
+  %7 = trunc i64 32 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i8* 
+  %11 = inttoptr i64 %"d##0" to i8* 
+  %12 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %10, i8*  %11, i32  %12, i1  0)  
+  %13 = add   i64 %9, 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = getelementptr  i64, i64* %14, i64 0 
+  store  i64 %"2#tmp#1##0", i64* %15 
+  %"2#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %9, i1  1)  
+  %16 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
+  %17 = insertvalue {i64, i1} %16, i1 1, 1 
+  ret {i64, i1} %17 
 if.else:
   %"3#tmp#20##0" = icmp eq i8 %"action##0", 115 
   br i1 %"3#tmp#20##0", label %if.then1, label %if.else1 
 if.then1:
-  %20 = add   i64 %"d##0", 8 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %"4#tmp#3##0" = add   i64 %23, 1 
-  %24 = trunc i64 32 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i8* 
-  %28 = inttoptr i64 %"d##0" to i8* 
-  %29 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %27, i8*  %28, i32  %29, i1  0)  
-  %30 = add   i64 %26, 8 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 %"4#tmp#3##0", i64* %32 
-  %"4#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %26, i1  1)  
-  %33 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
-  %34 = insertvalue {i64, i1} %33, i1 1, 1 
-  ret {i64, i1} %34 
+  %18 = add   i64 %"d##0", 8 
+  %19 = inttoptr i64 %18 to i64* 
+  %20 = getelementptr  i64, i64* %19, i64 0 
+  %21 = load  i64, i64* %20 
+  %"4#tmp#3##0" = add   i64 %21, 1 
+  %22 = trunc i64 32 to i32  
+  %23 = tail call ccc  i8*  @wybe_malloc(i32  %22)  
+  %24 = ptrtoint i8* %23 to i64 
+  %25 = inttoptr i64 %24 to i8* 
+  %26 = inttoptr i64 %"d##0" to i8* 
+  %27 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %25, i8*  %26, i32  %27, i1  0)  
+  %28 = add   i64 %24, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  %30 = getelementptr  i64, i64* %29, i64 0 
+  store  i64 %"4#tmp#3##0", i64* %30 
+  %"4#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %24, i1  1)  
+  %31 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
+  %32 = insertvalue {i64, i1} %31, i1 1, 1 
+  ret {i64, i1} %32 
 if.else1:
   %"5#tmp#19##0" = icmp eq i8 %"action##0", 119 
   br i1 %"5#tmp#19##0", label %if.then2, label %if.else2 
 if.then2:
-  %35 = inttoptr i64 %"d##0" to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %"6#tmp#5##0" = sub   i64 %37, 1 
-  %38 = trunc i64 32 to i32  
-  %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
-  %40 = ptrtoint i8* %39 to i64 
-  %41 = inttoptr i64 %40 to i8* 
-  %42 = inttoptr i64 %"d##0" to i8* 
-  %43 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %41, i8*  %42, i32  %43, i1  0)  
-  %44 = inttoptr i64 %40 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 %"6#tmp#5##0", i64* %45 
-  %"6#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %40, i1  1)  
-  %46 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
-  %47 = insertvalue {i64, i1} %46, i1 1, 1 
-  ret {i64, i1} %47 
+  %33 = inttoptr i64 %"d##0" to i64* 
+  %34 = getelementptr  i64, i64* %33, i64 0 
+  %35 = load  i64, i64* %34 
+  %"6#tmp#5##0" = sub   i64 %35, 1 
+  %36 = trunc i64 32 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i8* 
+  %40 = inttoptr i64 %"d##0" to i8* 
+  %41 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %39, i8*  %40, i32  %41, i1  0)  
+  %42 = inttoptr i64 %38 to i64* 
+  %43 = getelementptr  i64, i64* %42, i64 0 
+  store  i64 %"6#tmp#5##0", i64* %43 
+  %"6#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %38, i1  1)  
+  %44 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
+  %45 = insertvalue {i64, i1} %44, i1 1, 1 
+  ret {i64, i1} %45 
 if.else2:
   %"7#tmp#18##0" = icmp eq i8 %"action##0", 101 
   br i1 %"7#tmp#18##0", label %if.then3, label %if.else3 
 if.then3:
-  %48 = inttoptr i64 %"d##0" to i64* 
-  %49 = getelementptr  i64, i64* %48, i64 0 
-  %50 = load  i64, i64* %49 
-  %"8#tmp#7##0" = add   i64 %50, 1 
-  %51 = trunc i64 32 to i32  
-  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
-  %53 = ptrtoint i8* %52 to i64 
-  %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"d##0" to i8* 
-  %56 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i1  0)  
-  %57 = inttoptr i64 %53 to i64* 
-  %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"8#tmp#7##0", i64* %58 
-  %"8#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %53, i1  1)  
-  %59 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
-  %60 = insertvalue {i64, i1} %59, i1 1, 1 
-  ret {i64, i1} %60 
+  %46 = inttoptr i64 %"d##0" to i64* 
+  %47 = getelementptr  i64, i64* %46, i64 0 
+  %48 = load  i64, i64* %47 
+  %"8#tmp#7##0" = add   i64 %48, 1 
+  %49 = trunc i64 32 to i32  
+  %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
+  %51 = ptrtoint i8* %50 to i64 
+  %52 = inttoptr i64 %51 to i8* 
+  %53 = inttoptr i64 %"d##0" to i8* 
+  %54 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %52, i8*  %53, i32  %54, i1  0)  
+  %55 = inttoptr i64 %51 to i64* 
+  %56 = getelementptr  i64, i64* %55, i64 0 
+  store  i64 %"8#tmp#7##0", i64* %56 
+  %"8#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %51, i1  1)  
+  %57 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
+  %58 = insertvalue {i64, i1} %57, i1 1, 1 
+  ret {i64, i1} %58 
 if.else3:
   %"9#tmp#17##0" = icmp eq i8 %"action##0", 117 
   br i1 %"9#tmp#17##0", label %if.then4, label %if.else4 
 if.then4:
-  %61 = add   i64 %"d##0", 16 
-  %62 = inttoptr i64 %61 to i64* 
-  %63 = getelementptr  i64, i64* %62, i64 0 
-  %64 = load  i64, i64* %63 
-  %"10#tmp#9##0" = add   i64 %64, 1 
-  %65 = trunc i64 32 to i32  
-  %66 = tail call ccc  i8*  @wybe_malloc(i32  %65)  
-  %67 = ptrtoint i8* %66 to i64 
-  %68 = inttoptr i64 %67 to i8* 
-  %69 = inttoptr i64 %"d##0" to i8* 
-  %70 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %68, i8*  %69, i32  %70, i1  0)  
-  %71 = add   i64 %67, 16 
-  %72 = inttoptr i64 %71 to i64* 
-  %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %"10#tmp#9##0", i64* %73 
-  %"10#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %67, i1  1)  
-  %74 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
-  %75 = insertvalue {i64, i1} %74, i1 1, 1 
-  ret {i64, i1} %75 
+  %59 = add   i64 %"d##0", 16 
+  %60 = inttoptr i64 %59 to i64* 
+  %61 = getelementptr  i64, i64* %60, i64 0 
+  %62 = load  i64, i64* %61 
+  %"10#tmp#9##0" = add   i64 %62, 1 
+  %63 = trunc i64 32 to i32  
+  %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
+  %65 = ptrtoint i8* %64 to i64 
+  %66 = inttoptr i64 %65 to i8* 
+  %67 = inttoptr i64 %"d##0" to i8* 
+  %68 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i1  0)  
+  %69 = add   i64 %65, 16 
+  %70 = inttoptr i64 %69 to i64* 
+  %71 = getelementptr  i64, i64* %70, i64 0 
+  store  i64 %"10#tmp#9##0", i64* %71 
+  %"10#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %65, i1  1)  
+  %72 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
+  %73 = insertvalue {i64, i1} %72, i1 1, 1 
+  ret {i64, i1} %73 
 if.else4:
   %"11#tmp#16##0" = icmp eq i8 %"action##0", 100 
   br i1 %"11#tmp#16##0", label %if.then5, label %if.else5 
 if.then5:
-  %76 = add   i64 %"d##0", 16 
-  %77 = inttoptr i64 %76 to i64* 
-  %78 = getelementptr  i64, i64* %77, i64 0 
-  %79 = load  i64, i64* %78 
-  %"12#tmp#11##0" = sub   i64 %79, 1 
-  %80 = trunc i64 32 to i32  
-  %81 = tail call ccc  i8*  @wybe_malloc(i32  %80)  
-  %82 = ptrtoint i8* %81 to i64 
-  %83 = inttoptr i64 %82 to i8* 
-  %84 = inttoptr i64 %"d##0" to i8* 
-  %85 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %83, i8*  %84, i32  %85, i1  0)  
-  %86 = add   i64 %82, 16 
-  %87 = inttoptr i64 %86 to i64* 
-  %88 = getelementptr  i64, i64* %87, i64 0 
-  store  i64 %"12#tmp#11##0", i64* %88 
-  %"12#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %82, i1  1)  
-  %89 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
-  %90 = insertvalue {i64, i1} %89, i1 1, 1 
-  ret {i64, i1} %90 
+  %74 = add   i64 %"d##0", 16 
+  %75 = inttoptr i64 %74 to i64* 
+  %76 = getelementptr  i64, i64* %75, i64 0 
+  %77 = load  i64, i64* %76 
+  %"12#tmp#11##0" = sub   i64 %77, 1 
+  %78 = trunc i64 32 to i32  
+  %79 = tail call ccc  i8*  @wybe_malloc(i32  %78)  
+  %80 = ptrtoint i8* %79 to i64 
+  %81 = inttoptr i64 %80 to i8* 
+  %82 = inttoptr i64 %"d##0" to i8* 
+  %83 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %81, i8*  %82, i32  %83, i1  0)  
+  %84 = add   i64 %80, 16 
+  %85 = inttoptr i64 %84 to i64* 
+  %86 = getelementptr  i64, i64* %85, i64 0 
+  store  i64 %"12#tmp#11##0", i64* %86 
+  %"12#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %80, i1  1)  
+  %87 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
+  %88 = insertvalue {i64, i1} %87, i1 1, 1 
+  ret {i64, i1} %88 
 if.else5:
   %"13#d##2" = tail call fastcc  i64  @"drone.gen#2<0>"(i64  %"d##0", i1  0)  
-  %91 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
-  %92 = insertvalue {i64, i1} %91, i1 0, 1 
-  ret {i64, i1} %92 
+  %89 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
+  %90 = insertvalue {i64, i1} %89, i1 0, 1 
+  ret {i64, i1} %90 
 }
 
 
@@ -1580,136 +1556,136 @@ entry:
   %"1#tmp#21##0" = icmp eq i8 %"action##0", 110 
   br i1 %"1#tmp#21##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"d##0", 8 
-  %94 = inttoptr i64 %93 to i64* 
-  %95 = getelementptr  i64, i64* %94, i64 0 
-  %96 = load  i64, i64* %95 
-  %"2#tmp#1##0" = sub   i64 %96, 1 
-  %97 = add   i64 %"d##0", 8 
-  %98 = inttoptr i64 %97 to i64* 
-  %99 = getelementptr  i64, i64* %98, i64 0 
-  store  i64 %"2#tmp#1##0", i64* %99 
+  %91 = add   i64 %"d##0", 8 
+  %92 = inttoptr i64 %91 to i64* 
+  %93 = getelementptr  i64, i64* %92, i64 0 
+  %94 = load  i64, i64* %93 
+  %"2#tmp#1##0" = sub   i64 %94, 1 
+  %95 = add   i64 %"d##0", 8 
+  %96 = inttoptr i64 %95 to i64* 
+  %97 = getelementptr  i64, i64* %96, i64 0 
+  store  i64 %"2#tmp#1##0", i64* %97 
   %"2#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %100 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
-  %101 = insertvalue {i64, i1} %100, i1 1, 1 
-  ret {i64, i1} %101 
+  %98 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
+  %99 = insertvalue {i64, i1} %98, i1 1, 1 
+  ret {i64, i1} %99 
 if.else:
   %"3#tmp#20##0" = icmp eq i8 %"action##0", 115 
   br i1 %"3#tmp#20##0", label %if.then1, label %if.else1 
 if.then1:
-  %102 = add   i64 %"d##0", 8 
-  %103 = inttoptr i64 %102 to i64* 
-  %104 = getelementptr  i64, i64* %103, i64 0 
-  %105 = load  i64, i64* %104 
-  %"4#tmp#3##0" = add   i64 %105, 1 
-  %106 = add   i64 %"d##0", 8 
-  %107 = inttoptr i64 %106 to i64* 
-  %108 = getelementptr  i64, i64* %107, i64 0 
-  store  i64 %"4#tmp#3##0", i64* %108 
+  %100 = add   i64 %"d##0", 8 
+  %101 = inttoptr i64 %100 to i64* 
+  %102 = getelementptr  i64, i64* %101, i64 0 
+  %103 = load  i64, i64* %102 
+  %"4#tmp#3##0" = add   i64 %103, 1 
+  %104 = add   i64 %"d##0", 8 
+  %105 = inttoptr i64 %104 to i64* 
+  %106 = getelementptr  i64, i64* %105, i64 0 
+  store  i64 %"4#tmp#3##0", i64* %106 
   %"4#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %109 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
-  %110 = insertvalue {i64, i1} %109, i1 1, 1 
-  ret {i64, i1} %110 
+  %107 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
+  %108 = insertvalue {i64, i1} %107, i1 1, 1 
+  ret {i64, i1} %108 
 if.else1:
   %"5#tmp#19##0" = icmp eq i8 %"action##0", 119 
   br i1 %"5#tmp#19##0", label %if.then2, label %if.else2 
 if.then2:
-  %111 = inttoptr i64 %"d##0" to i64* 
-  %112 = getelementptr  i64, i64* %111, i64 0 
-  %113 = load  i64, i64* %112 
-  %"6#tmp#5##0" = sub   i64 %113, 1 
-  %114 = inttoptr i64 %"d##0" to i64* 
-  %115 = getelementptr  i64, i64* %114, i64 0 
-  store  i64 %"6#tmp#5##0", i64* %115 
+  %109 = inttoptr i64 %"d##0" to i64* 
+  %110 = getelementptr  i64, i64* %109, i64 0 
+  %111 = load  i64, i64* %110 
+  %"6#tmp#5##0" = sub   i64 %111, 1 
+  %112 = inttoptr i64 %"d##0" to i64* 
+  %113 = getelementptr  i64, i64* %112, i64 0 
+  store  i64 %"6#tmp#5##0", i64* %113 
   %"6#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %116 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
-  %117 = insertvalue {i64, i1} %116, i1 1, 1 
-  ret {i64, i1} %117 
+  %114 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
+  %115 = insertvalue {i64, i1} %114, i1 1, 1 
+  ret {i64, i1} %115 
 if.else2:
   %"7#tmp#18##0" = icmp eq i8 %"action##0", 101 
   br i1 %"7#tmp#18##0", label %if.then3, label %if.else3 
 if.then3:
-  %118 = inttoptr i64 %"d##0" to i64* 
-  %119 = getelementptr  i64, i64* %118, i64 0 
-  %120 = load  i64, i64* %119 
-  %"8#tmp#7##0" = add   i64 %120, 1 
-  %121 = inttoptr i64 %"d##0" to i64* 
-  %122 = getelementptr  i64, i64* %121, i64 0 
-  store  i64 %"8#tmp#7##0", i64* %122 
+  %116 = inttoptr i64 %"d##0" to i64* 
+  %117 = getelementptr  i64, i64* %116, i64 0 
+  %118 = load  i64, i64* %117 
+  %"8#tmp#7##0" = add   i64 %118, 1 
+  %119 = inttoptr i64 %"d##0" to i64* 
+  %120 = getelementptr  i64, i64* %119, i64 0 
+  store  i64 %"8#tmp#7##0", i64* %120 
   %"8#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %123 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
-  %124 = insertvalue {i64, i1} %123, i1 1, 1 
-  ret {i64, i1} %124 
+  %121 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
+  %122 = insertvalue {i64, i1} %121, i1 1, 1 
+  ret {i64, i1} %122 
 if.else3:
   %"9#tmp#17##0" = icmp eq i8 %"action##0", 117 
   br i1 %"9#tmp#17##0", label %if.then4, label %if.else4 
 if.then4:
-  %125 = add   i64 %"d##0", 16 
-  %126 = inttoptr i64 %125 to i64* 
-  %127 = getelementptr  i64, i64* %126, i64 0 
-  %128 = load  i64, i64* %127 
-  %"10#tmp#9##0" = add   i64 %128, 1 
-  %129 = add   i64 %"d##0", 16 
-  %130 = inttoptr i64 %129 to i64* 
-  %131 = getelementptr  i64, i64* %130, i64 0 
-  store  i64 %"10#tmp#9##0", i64* %131 
+  %123 = add   i64 %"d##0", 16 
+  %124 = inttoptr i64 %123 to i64* 
+  %125 = getelementptr  i64, i64* %124, i64 0 
+  %126 = load  i64, i64* %125 
+  %"10#tmp#9##0" = add   i64 %126, 1 
+  %127 = add   i64 %"d##0", 16 
+  %128 = inttoptr i64 %127 to i64* 
+  %129 = getelementptr  i64, i64* %128, i64 0 
+  store  i64 %"10#tmp#9##0", i64* %129 
   %"10#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %132 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
-  %133 = insertvalue {i64, i1} %132, i1 1, 1 
-  ret {i64, i1} %133 
+  %130 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
+  %131 = insertvalue {i64, i1} %130, i1 1, 1 
+  ret {i64, i1} %131 
 if.else4:
   %"11#tmp#16##0" = icmp eq i8 %"action##0", 100 
   br i1 %"11#tmp#16##0", label %if.then5, label %if.else5 
 if.then5:
-  %134 = add   i64 %"d##0", 16 
-  %135 = inttoptr i64 %134 to i64* 
-  %136 = getelementptr  i64, i64* %135, i64 0 
-  %137 = load  i64, i64* %136 
-  %"12#tmp#11##0" = sub   i64 %137, 1 
-  %138 = add   i64 %"d##0", 16 
-  %139 = inttoptr i64 %138 to i64* 
-  %140 = getelementptr  i64, i64* %139, i64 0 
-  store  i64 %"12#tmp#11##0", i64* %140 
+  %132 = add   i64 %"d##0", 16 
+  %133 = inttoptr i64 %132 to i64* 
+  %134 = getelementptr  i64, i64* %133, i64 0 
+  %135 = load  i64, i64* %134 
+  %"12#tmp#11##0" = sub   i64 %135, 1 
+  %136 = add   i64 %"d##0", 16 
+  %137 = inttoptr i64 %136 to i64* 
+  %138 = getelementptr  i64, i64* %137, i64 0 
+  store  i64 %"12#tmp#11##0", i64* %138 
   %"12#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %141 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
-  %142 = insertvalue {i64, i1} %141, i1 1, 1 
-  ret {i64, i1} %142 
+  %139 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
+  %140 = insertvalue {i64, i1} %139, i1 1, 1 
+  ret {i64, i1} %140 
 if.else5:
   %"13#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  0)  
-  %143 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
-  %144 = insertvalue {i64, i1} %143, i1 0, 1 
-  ret {i64, i1} %144 
+  %141 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
+  %142 = insertvalue {i64, i1} %141, i1 0, 1 
+  ret {i64, i1} %142 
 }
 
 
 define external fastcc  i64 @"drone.drone_init<0>"()    {
 entry:
-  %145 = trunc i64 32 to i32  
-  %146 = tail call ccc  i8*  @wybe_malloc(i32  %145)  
-  %147 = ptrtoint i8* %146 to i64 
-  %148 = inttoptr i64 %147 to i64* 
-  %149 = getelementptr  i64, i64* %148, i64 0 
-  store  i64 0, i64* %149 
-  %150 = add   i64 %147, 8 
-  %151 = inttoptr i64 %150 to i64* 
-  %152 = getelementptr  i64, i64* %151, i64 0 
-  store  i64 0, i64* %152 
-  %153 = add   i64 %147, 16 
-  %154 = inttoptr i64 %153 to i64* 
-  %155 = getelementptr  i64, i64* %154, i64 0 
-  store  i64 0, i64* %155 
-  %156 = add   i64 %147, 24 
-  %157 = inttoptr i64 %156 to i64* 
-  %158 = getelementptr  i64, i64* %157, i64 0 
-  store  i64 0, i64* %158 
-  ret i64 %147 
+  %143 = trunc i64 32 to i32  
+  %144 = tail call ccc  i8*  @wybe_malloc(i32  %143)  
+  %145 = ptrtoint i8* %144 to i64 
+  %146 = inttoptr i64 %145 to i64* 
+  %147 = getelementptr  i64, i64* %146, i64 0 
+  store  i64 0, i64* %147 
+  %148 = add   i64 %145, 8 
+  %149 = inttoptr i64 %148 to i64* 
+  %150 = getelementptr  i64, i64* %149, i64 0 
+  store  i64 0, i64* %150 
+  %151 = add   i64 %145, 16 
+  %152 = inttoptr i64 %151 to i64* 
+  %153 = getelementptr  i64, i64* %152, i64 0 
+  store  i64 0, i64* %153 
+  %154 = add   i64 %145, 24 
+  %155 = inttoptr i64 %154 to i64* 
+  %156 = getelementptr  i64, i64* %155, i64 0 
+  store  i64 0, i64* %156 
+  ret i64 %145 
 }
 
 
 define external fastcc  void @"drone.gen#1<0>"()    {
 entry:
   %"1#mc##0" = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.160, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.158, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#mc##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -1720,23 +1696,23 @@ define external fastcc  i64 @"drone.gen#2<0>"(i64  %"d##0", i1  %"success##0")  
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
-  %161 = add   i64 %"d##0", 24 
-  %162 = inttoptr i64 %161 to i64* 
-  %163 = getelementptr  i64, i64* %162, i64 0 
-  %164 = load  i64, i64* %163 
-  %"2#tmp#14##0" = add   i64 %164, 1 
-  %165 = trunc i64 32 to i32  
-  %166 = tail call ccc  i8*  @wybe_malloc(i32  %165)  
-  %167 = ptrtoint i8* %166 to i64 
-  %168 = inttoptr i64 %167 to i8* 
-  %169 = inttoptr i64 %"d##0" to i8* 
-  %170 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %168, i8*  %169, i32  %170, i1  0)  
-  %171 = add   i64 %167, 24 
-  %172 = inttoptr i64 %171 to i64* 
-  %173 = getelementptr  i64, i64* %172, i64 0 
-  store  i64 %"2#tmp#14##0", i64* %173 
-  ret i64 %167 
+  %159 = add   i64 %"d##0", 24 
+  %160 = inttoptr i64 %159 to i64* 
+  %161 = getelementptr  i64, i64* %160, i64 0 
+  %162 = load  i64, i64* %161 
+  %"2#tmp#14##0" = add   i64 %162, 1 
+  %163 = trunc i64 32 to i32  
+  %164 = tail call ccc  i8*  @wybe_malloc(i32  %163)  
+  %165 = ptrtoint i8* %164 to i64 
+  %166 = inttoptr i64 %165 to i8* 
+  %167 = inttoptr i64 %"d##0" to i8* 
+  %168 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %166, i8*  %167, i32  %168, i1  0)  
+  %169 = add   i64 %165, 24 
+  %170 = inttoptr i64 %169 to i64* 
+  %171 = getelementptr  i64, i64* %170, i64 0 
+  store  i64 %"2#tmp#14##0", i64* %171 
+  ret i64 %165 
 if.else:
   ret i64 %"d##0" 
 }
@@ -1746,15 +1722,15 @@ define external fastcc  i64 @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  %"su
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
-  %174 = add   i64 %"d##0", 24 
-  %175 = inttoptr i64 %174 to i64* 
-  %176 = getelementptr  i64, i64* %175, i64 0 
-  %177 = load  i64, i64* %176 
-  %"2#tmp#14##0" = add   i64 %177, 1 
-  %178 = add   i64 %"d##0", 24 
-  %179 = inttoptr i64 %178 to i64* 
-  %180 = getelementptr  i64, i64* %179, i64 0 
-  store  i64 %"2#tmp#14##0", i64* %180 
+  %172 = add   i64 %"d##0", 24 
+  %173 = inttoptr i64 %172 to i64* 
+  %174 = getelementptr  i64, i64* %173, i64 0 
+  %175 = load  i64, i64* %174 
+  %"2#tmp#14##0" = add   i64 %175, 1 
+  %176 = add   i64 %"d##0", 24 
+  %177 = inttoptr i64 %176 to i64* 
+  %178 = getelementptr  i64, i64* %177, i64 0 
+  store  i64 %"2#tmp#14##0", i64* %178 
   ret i64 %"d##0" 
 if.else:
   ret i64 %"d##0" 
@@ -1800,45 +1776,45 @@ if.else:
   tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.then1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.182, i32 0, i32 0) to i64))  
-  %183 = inttoptr i64 %"d##0" to i64* 
-  %184 = getelementptr  i64, i64* %183, i64 0 
-  %185 = load  i64, i64* %184 
-  tail call ccc  void  @print_int(i64  %185)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.187, i32 0, i32 0) to i64))  
-  %188 = add   i64 %"d##0", 8 
-  %189 = inttoptr i64 %188 to i64* 
-  %190 = getelementptr  i64, i64* %189, i64 0 
-  %191 = load  i64, i64* %190 
-  tail call ccc  void  @print_int(i64  %191)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.193, i32 0, i32 0) to i64))  
-  %194 = add   i64 %"d##0", 16 
-  %195 = inttoptr i64 %194 to i64* 
-  %196 = getelementptr  i64, i64* %195, i64 0 
-  %197 = load  i64, i64* %196 
-  tail call ccc  void  @print_int(i64  %197)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.199, i32 0, i32 0) to i64))  
-  %200 = add   i64 %"d##0", 24 
-  %201 = inttoptr i64 %200 to i64* 
-  %202 = getelementptr  i64, i64* %201, i64 0 
-  %203 = load  i64, i64* %202 
-  tail call ccc  void  @print_int(i64  %203)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.180, i32 0, i32 0) to i64))  
+  %181 = inttoptr i64 %"d##0" to i64* 
+  %182 = getelementptr  i64, i64* %181, i64 0 
+  %183 = load  i64, i64* %182 
+  tail call ccc  void  @print_int(i64  %183)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.185, i32 0, i32 0) to i64))  
+  %186 = add   i64 %"d##0", 8 
+  %187 = inttoptr i64 %186 to i64* 
+  %188 = getelementptr  i64, i64* %187, i64 0 
+  %189 = load  i64, i64* %188 
+  tail call ccc  void  @print_int(i64  %189)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.185, i32 0, i32 0) to i64))  
+  %190 = add   i64 %"d##0", 16 
+  %191 = inttoptr i64 %190 to i64* 
+  %192 = getelementptr  i64, i64* %191, i64 0 
+  %193 = load  i64, i64* %192 
+  tail call ccc  void  @print_int(i64  %193)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.195, i32 0, i32 0) to i64))  
+  %196 = add   i64 %"d##0", 24 
+  %197 = inttoptr i64 %196 to i64* 
+  %198 = getelementptr  i64, i64* %197, i64 0 
+  %199 = load  i64, i64* %198 
+  tail call ccc  void  @print_int(i64  %199)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.else1:
-  %204 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
-  %205 = extractvalue {i64, i1} %204, 0 
-  %206 = extractvalue {i64, i1} %204, 1 
-  %"5#tmp#5##0" = icmp eq i1 %206, 0 
+  %200 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
+  %201 = extractvalue {i64, i1} %200, 0 
+  %202 = extractvalue {i64, i1} %200, 1 
+  %"5#tmp#5##0" = icmp eq i1 %202, 0 
   br i1 %"5#tmp#5##0", label %if.then2, label %if.else2 
 if.then2:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.208, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.204, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %205)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %201)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %205)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %201)  
   ret void 
 }
 
@@ -1856,74 +1832,74 @@ if.else:
   tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.then1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.210, i32 0, i32 0) to i64))  
-  %211 = inttoptr i64 %"d##0" to i64* 
-  %212 = getelementptr  i64, i64* %211, i64 0 
-  %213 = load  i64, i64* %212 
-  tail call ccc  void  @print_int(i64  %213)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.215, i32 0, i32 0) to i64))  
-  %216 = add   i64 %"d##0", 8 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.206, i32 0, i32 0) to i64))  
+  %207 = inttoptr i64 %"d##0" to i64* 
+  %208 = getelementptr  i64, i64* %207, i64 0 
+  %209 = load  i64, i64* %208 
+  tail call ccc  void  @print_int(i64  %209)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.211, i32 0, i32 0) to i64))  
+  %212 = add   i64 %"d##0", 8 
+  %213 = inttoptr i64 %212 to i64* 
+  %214 = getelementptr  i64, i64* %213, i64 0 
+  %215 = load  i64, i64* %214 
+  tail call ccc  void  @print_int(i64  %215)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.211, i32 0, i32 0) to i64))  
+  %216 = add   i64 %"d##0", 16 
   %217 = inttoptr i64 %216 to i64* 
   %218 = getelementptr  i64, i64* %217, i64 0 
   %219 = load  i64, i64* %218 
   tail call ccc  void  @print_int(i64  %219)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.221, i32 0, i32 0) to i64))  
-  %222 = add   i64 %"d##0", 16 
+  %222 = add   i64 %"d##0", 24 
   %223 = inttoptr i64 %222 to i64* 
   %224 = getelementptr  i64, i64* %223, i64 0 
   %225 = load  i64, i64* %224 
   tail call ccc  void  @print_int(i64  %225)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.227, i32 0, i32 0) to i64))  
-  %228 = add   i64 %"d##0", 24 
-  %229 = inttoptr i64 %228 to i64* 
-  %230 = getelementptr  i64, i64* %229, i64 0 
-  %231 = load  i64, i64* %230 
-  tail call ccc  void  @print_int(i64  %231)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.else1:
-  %232 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
-  %233 = extractvalue {i64, i1} %232, 0 
-  %234 = extractvalue {i64, i1} %232, 1 
-  %"5#tmp#5##0" = icmp eq i1 %234, 0 
+  %226 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
+  %227 = extractvalue {i64, i1} %226, 0 
+  %228 = extractvalue {i64, i1} %226, 1 
+  %"5#tmp#5##0" = icmp eq i1 %228, 0 
   br i1 %"5#tmp#5##0", label %if.then2, label %if.else2 
 if.then2:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.236, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.230, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %233)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %227)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %233)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %227)  
   ret void 
 }
 
 
 define external fastcc  void @"drone.print_info<0>"(i64  %"d##0")    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.238, i32 0, i32 0) to i64))  
-  %239 = inttoptr i64 %"d##0" to i64* 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.232, i32 0, i32 0) to i64))  
+  %233 = inttoptr i64 %"d##0" to i64* 
+  %234 = getelementptr  i64, i64* %233, i64 0 
+  %235 = load  i64, i64* %234 
+  tail call ccc  void  @print_int(i64  %235)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.237, i32 0, i32 0) to i64))  
+  %238 = add   i64 %"d##0", 8 
+  %239 = inttoptr i64 %238 to i64* 
   %240 = getelementptr  i64, i64* %239, i64 0 
   %241 = load  i64, i64* %240 
   tail call ccc  void  @print_int(i64  %241)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.243, i32 0, i32 0) to i64))  
-  %244 = add   i64 %"d##0", 8 
-  %245 = inttoptr i64 %244 to i64* 
-  %246 = getelementptr  i64, i64* %245, i64 0 
-  %247 = load  i64, i64* %246 
-  tail call ccc  void  @print_int(i64  %247)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.249, i32 0, i32 0) to i64))  
-  %250 = add   i64 %"d##0", 16 
-  %251 = inttoptr i64 %250 to i64* 
-  %252 = getelementptr  i64, i64* %251, i64 0 
-  %253 = load  i64, i64* %252 
-  tail call ccc  void  @print_int(i64  %253)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.255, i32 0, i32 0) to i64))  
-  %256 = add   i64 %"d##0", 24 
-  %257 = inttoptr i64 %256 to i64* 
-  %258 = getelementptr  i64, i64* %257, i64 0 
-  %259 = load  i64, i64* %258 
-  tail call ccc  void  @print_int(i64  %259)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.237, i32 0, i32 0) to i64))  
+  %242 = add   i64 %"d##0", 16 
+  %243 = inttoptr i64 %242 to i64* 
+  %244 = getelementptr  i64, i64* %243, i64 0 
+  %245 = load  i64, i64* %244 
+  tail call ccc  void  @print_int(i64  %245)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.247, i32 0, i32 0) to i64))  
+  %248 = add   i64 %"d##0", 24 
+  %249 = inttoptr i64 %248 to i64* 
+  %250 = getelementptr  i64, i64* %249, i64 0 
+  %251 = load  i64, i64* %250 
+  tail call ccc  void  @print_int(i64  %251)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -194,21 +194,6 @@ set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
  
 
 
-declare external ccc  void @error_exit(i64, i64)    
-
-
-declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
-
-
-@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
-
-
-@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
 @"resource#command_line.argc" =    global i64 undef
 
 
@@ -222,6 +207,21 @@ declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)
 
 
 @"resource#command_line.exit_code" =    global i64 undef
+
+
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
+
+
+@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
+
+
+declare external ccc  void @error_exit(i64, i64)    
+
+
+declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -1045,6 +1045,15 @@ module top-level code > {terminal,inline,impure} (0 calls)
  
 
 
+@"resource#command_line.argc" = external   global i64 
+
+
+@"resource#command_line.argv" = external   global i64 
+
+
+@"resource#command_line.exit_code" = external   global i64 
+
+
 declare external ccc  void @exit(i64)    
 
 
@@ -1055,15 +1064,6 @@ declare external fastcc  void @"command_line.<0>"()
 
 
 declare external ccc  void @gc_init()    
-
-
-@"resource#command_line.argc" = external   global i64 
-
-
-@"resource#command_line.argv" = external   global i64 
-
-
-@"resource#command_line.exit_code" = external   global i64 
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -1142,21 +1142,6 @@ set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
  
 
 
-declare external ccc  void @error_exit(i64, i64)    
-
-
-declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
-
-
-@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
-
-
-@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
 @"resource#command_line.argc" =    global i64 undef
 
 
@@ -1170,6 +1155,21 @@ declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)
 
 
 @"resource#command_line.exit_code" =    global i64 undef
+
+
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
+
+
+@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
+
+
+declare external ccc  void @error_exit(i64, i64)    
+
+
+declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -3009,22 +3009,7 @@ test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  i64 @malloc_count()    
-
-
-declare external fastcc  void @"int_list.print<0>"(i64)    
-
-
-declare external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64, i64, i64, i64, i64)    
+@int_list_test.18 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.17 to i64) }
 
 
 @int_list_test.2 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @int_list_test.1 to i64) }
@@ -3060,6 +3045,9 @@ declare external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64, i64, i64, i64
 @int_list_test.15 =    constant [?? x i8] c" ** malloc count of test(non-aliased): \00"
 
 
+@int_list_test.17 =    constant [?? x i8] c"-\00"
+
+
 @int_list_test.3 =    constant [?? x i8] c"--------------------\00"
 
 
@@ -3073,6 +3061,15 @@ declare external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64, i64, i64, i64
 
 
 @int_list_test.1 =    constant [?? x i8] c"x y z:\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"int_list.print<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external fastcc  i64 @"int_list.sort<0>[410bae77d3]"(i64)    
@@ -3090,28 +3087,25 @@ declare external fastcc  i64 @"int_list.insert<0>[410bae77d3]"(i64, i64, i64)
 declare external fastcc  i64 @"int_list.extend<0>[410bae77d3]"(i64, i64)    
 
 
-declare external fastcc  i64 @"int_list.append<0>"(i64, i64)    
-
-
-declare external fastcc  i64 @"int_list.reverse_helper<0>"(i64, i64)    
-
-
-@int_list_test.18 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.17 to i64) }
-
-
-@int_list_test.17 =    constant [?? x i8] c"-\00"
-
-
 declare external fastcc  i64 @"int_list.append<0>[410bae77d3]"(i64, i64)    
 
 
 declare external fastcc  i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64, i64)    
 
 
-@int_list_test.20 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.19 to i64) }
+declare external fastcc  i64 @"int_list.append<0>"(i64, i64)    
 
 
-@int_list_test.19 =    constant [?? x i8] c"-\00"
+declare external fastcc  i64 @"int_list.reverse_helper<0>"(i64, i64)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  i64 @malloc_count()    
+
+
+declare external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -3217,7 +3211,7 @@ entry:
   %"1#x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"x##0", i64  0)  
   %"1#z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"z##0", i64  0)  
   %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.append<0>[410bae77d3]"(i64  %"y##0", i64  99)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#x##1")  
   tail call ccc  void  @putchar(i8  10)  
@@ -3227,19 +3221,19 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#x##1", i64  %"1#tmp#0##0")  
   %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#tmp#1##0", i64  %"1#z##1")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1#tmp#2##0", i64  4, i64  78)  
   %"1#tmp#4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1#tmp#3##0", i64  20)  
   %"1#tmp#5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1#tmp#4##0", i64  2)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1#tmp#5##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#l##5")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -200,13 +200,13 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
 @command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
 
 
 @"resource#command_line.argc" =    global i64 undef
@@ -1148,13 +1148,13 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
 @command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
 
 
 @"resource#command_line.argc" =    global i64 undef
@@ -3027,67 +3027,49 @@ declare external fastcc  void @"int_list.print<0>"(i64)
 declare external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64, i64, i64, i64, i64)    
 
 
-@int_list_test.22 =    constant {i64, i64} { i64 39, i64 ptrtoint ([?? x i8]* @int_list_test.21 to i64) }
-
-
-@int_list_test.21 =    constant [?? x i8] c" ** malloc count of test(non-aliased): \00"
-
-
-@int_list_test.20 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @int_list_test.19 to i64) }
-
-
-@int_list_test.19 =    constant [?? x i8] c" ** malloc count of test(aliased): \00"
-
-
-@int_list_test.18 =    constant {i64, i64} { i64 36, i64 ptrtoint ([?? x i8]* @int_list_test.17 to i64) }
-
-
-@int_list_test.17 =    constant [?? x i8] c" ** malloc count of building lists: \00"
-
-
-@int_list_test.16 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.15 to i64) }
-
-
-@int_list_test.15 =    constant [?? x i8] c"--------------------\00"
-
-
-@int_list_test.14 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @int_list_test.13 to i64) }
-
-
-@int_list_test.13 =    constant [?? x i8] c"tests without alias\00"
-
-
-@int_list_test.12 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.11 to i64) }
-
-
-@int_list_test.11 =    constant [?? x i8] c"--------------------\00"
-
-
-@int_list_test.10 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.9 to i64) }
-
-
-@int_list_test.9 =    constant [?? x i8] c"--------------------\00"
+@int_list_test.2 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @int_list_test.1 to i64) }
 
 
 @int_list_test.8 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @int_list_test.7 to i64) }
 
 
-@int_list_test.7 =    constant [?? x i8] c"original x y z:\00"
-
-
 @int_list_test.6 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @int_list_test.5 to i64) }
 
 
-@int_list_test.5 =    constant [?? x i8] c"tests with alias\00"
+@int_list_test.10 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @int_list_test.9 to i64) }
 
 
 @int_list_test.4 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.3 to i64) }
 
 
+@int_list_test.14 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @int_list_test.13 to i64) }
+
+
+@int_list_test.12 =    constant {i64, i64} { i64 36, i64 ptrtoint ([?? x i8]* @int_list_test.11 to i64) }
+
+
+@int_list_test.16 =    constant {i64, i64} { i64 39, i64 ptrtoint ([?? x i8]* @int_list_test.15 to i64) }
+
+
+@int_list_test.11 =    constant [?? x i8] c" ** malloc count of building lists: \00"
+
+
+@int_list_test.13 =    constant [?? x i8] c" ** malloc count of test(aliased): \00"
+
+
+@int_list_test.15 =    constant [?? x i8] c" ** malloc count of test(non-aliased): \00"
+
+
 @int_list_test.3 =    constant [?? x i8] c"--------------------\00"
 
 
-@int_list_test.2 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @int_list_test.1 to i64) }
+@int_list_test.7 =    constant [?? x i8] c"original x y z:\00"
+
+
+@int_list_test.5 =    constant [?? x i8] c"tests with alias\00"
+
+
+@int_list_test.9 =    constant [?? x i8] c"tests without alias\00"
 
 
 @int_list_test.1 =    constant [?? x i8] c"x y z:\00"
@@ -3114,28 +3096,10 @@ declare external fastcc  i64 @"int_list.append<0>"(i64, i64)
 declare external fastcc  i64 @"int_list.reverse_helper<0>"(i64, i64)    
 
 
-@int_list_test.30 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.29 to i64) }
+@int_list_test.18 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.17 to i64) }
 
 
-@int_list_test.29 =    constant [?? x i8] c"-\00"
-
-
-@int_list_test.28 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.27 to i64) }
-
-
-@int_list_test.27 =    constant [?? x i8] c"-\00"
-
-
-@int_list_test.26 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.25 to i64) }
-
-
-@int_list_test.25 =    constant [?? x i8] c"-\00"
-
-
-@int_list_test.24 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.23 to i64) }
-
-
-@int_list_test.23 =    constant [?? x i8] c"-\00"
+@int_list_test.17 =    constant [?? x i8] c"-\00"
 
 
 declare external fastcc  i64 @"int_list.append<0>[410bae77d3]"(i64, i64)    
@@ -3144,28 +3108,10 @@ declare external fastcc  i64 @"int_list.append<0>[410bae77d3]"(i64, i64)
 declare external fastcc  i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64, i64)    
 
 
-@int_list_test.38 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.37 to i64) }
+@int_list_test.20 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.19 to i64) }
 
 
-@int_list_test.37 =    constant [?? x i8] c"-\00"
-
-
-@int_list_test.36 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.35 to i64) }
-
-
-@int_list_test.35 =    constant [?? x i8] c"-\00"
-
-
-@int_list_test.34 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.33 to i64) }
-
-
-@int_list_test.33 =    constant [?? x i8] c"-\00"
-
-
-@int_list_test.32 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.31 to i64) }
-
-
-@int_list_test.31 =    constant [?? x i8] c"-\00"
+@int_list_test.19 =    constant [?? x i8] c"-\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -3206,25 +3152,25 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.4, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.4, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.10, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.12, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.14, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#mc1##2" = tail call ccc  i64  @malloc_count()  
   tail call fastcc  void  @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"1#tmp#0##0", i64  %"1#tmp#1##0", i64  %"1#tmp#2##0")  
   %"1#mc2##2" = tail call ccc  i64  @malloc_count()  
   %"1#tmp#5##0" = sub   i64 %"1#mc2##2", %"1#mc1##2" 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.16, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.12, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#tmp#3##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.14, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#tmp#4##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.22, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.16, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -3236,7 +3182,7 @@ entry:
   %"1#x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"x##0", i64  0)  
   %"1#z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"z##0", i64  0)  
   %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.append<0>"(i64  %"y##0", i64  99)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.24, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#x##1")  
   tail call ccc  void  @putchar(i8  10)  
@@ -3246,19 +3192,19 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#x##1", i64  %"1#tmp#0##0")  
   %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#tmp#1##0", i64  %"1#z##1")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.26, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1#tmp#2##0", i64  4, i64  78)  
   %"1#tmp#4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1#tmp#3##0", i64  20)  
   %"1#tmp#5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1#tmp#4##0", i64  2)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.28, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1#tmp#5##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.30, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#l##5")  
   tail call ccc  void  @putchar(i8  10)  
@@ -3271,7 +3217,7 @@ entry:
   %"1#x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"x##0", i64  0)  
   %"1#z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"z##0", i64  0)  
   %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.append<0>[410bae77d3]"(i64  %"y##0", i64  99)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.32, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#x##1")  
   tail call ccc  void  @putchar(i8  10)  
@@ -3281,19 +3227,19 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#x##1", i64  %"1#tmp#0##0")  
   %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#tmp#1##0", i64  %"1#z##1")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.34, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1#tmp#2##0", i64  4, i64  78)  
   %"1#tmp#4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1#tmp#3##0", i64  20)  
   %"1#tmp#5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1#tmp#4##0", i64  2)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.36, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1#tmp#5##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.38, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#l##5")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/aaa.exp
+++ b/test-cases/final-dump/aaa.exp
@@ -29,16 +29,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @aaa.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @aaa.1 to i64) }
 
 
 @aaa.1 =    constant [?? x i8] c"AAA: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -82,16 +82,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @bbb.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @bbb.1 to i64) }
 
 
 @bbb.1 =    constant [?? x i8] c"BBB: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -135,16 +135,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @ccc.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @ccc.1 to i64) }
 
 
 @ccc.1 =    constant [?? x i8] c"CCC: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -187,16 +187,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @ddd.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @ddd.1 to i64) }
 
 
 @ddd.1 =    constant [?? x i8] c"DDD: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -158,19 +158,19 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias1.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.5 to i64) }
-
-
-@alias1.5 =    constant [?? x i8] c"-------------- Calling baz: \00"
+@alias1.2 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.1 to i64) }
 
 
 @alias1.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.3 to i64) }
 
 
+@alias1.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.5 to i64) }
+
+
 @alias1.3 =    constant [?? x i8] c"-------------- Calling bar: \00"
 
 
-@alias1.2 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.1 to i64) }
+@alias1.5 =    constant [?? x i8] c"-------------- Calling baz: \00"
 
 
 @alias1.1 =    constant [?? x i8] c"-------------- Calling foo: \00"
@@ -179,16 +179,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
-@alias1.34 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.33 to i64) }
+@alias1.16 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.15 to i64) }
 
 
-@alias1.33 =    constant [?? x i8] c"expect p2(555,102):\00"
+@alias1.18 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.17 to i64) }
+
+
+@alias1.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.19 to i64) }
 
 
 @alias1.32 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.31 to i64) }
-
-
-@alias1.31 =    constant [?? x i8] c"expect p1(101,102):\00"
 
 
 @alias1.30 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.29 to i64) }
@@ -197,115 +197,91 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 @alias1.29 =    constant [?? x i8] c"--- Inside bar, after calling x(!p2, 555): \00"
 
 
-@alias1.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.19 to i64) }
-
-
-@alias1.19 =    constant [?? x i8] c"expect p2(101,102):\00"
-
-
-@alias1.18 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.17 to i64) }
+@alias1.15 =    constant [?? x i8] c"--- Inside bar: \00"
 
 
 @alias1.17 =    constant [?? x i8] c"expect p1(101,102):\00"
 
 
-@alias1.16 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.15 to i64) }
+@alias1.19 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
-@alias1.15 =    constant [?? x i8] c"--- Inside bar: \00"
+@alias1.31 =    constant [?? x i8] c"expect p2(555,102):\00"
 
 
-@alias1.78 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.77 to i64) }
+@alias1.42 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.41 to i64) }
 
 
-@alias1.77 =    constant [?? x i8] c"expect p3(33333333,102):\00"
-
-
-@alias1.76 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.75 to i64) }
-
-
-@alias1.75 =    constant [?? x i8] c"expect p2(101,102):\00"
-
-
-@alias1.74 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.73 to i64) }
-
-
-@alias1.73 =    constant [?? x i8] c"expect p1(555,102):\00"
-
-
-@alias1.72 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.71 to i64) }
-
-
-@alias1.71 =    constant [?? x i8] c"--- Inside baz, after calling x(!p1, 555): \00"
-
-
-@alias1.62 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.61 to i64) }
-
-
-@alias1.61 =    constant [?? x i8] c"expect p3(33333333,102):\00"
-
-
-@alias1.48 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.47 to i64) }
-
-
-@alias1.47 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias1.44 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.43 to i64) }
 
 
 @alias1.46 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.45 to i64) }
 
 
-@alias1.45 =    constant [?? x i8] c"expect p1(101,102):\00"
+@alias1.72 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.71 to i64) }
 
 
-@alias1.44 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.43 to i64) }
+@alias1.60 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.59 to i64) }
 
 
-@alias1.43 =    constant [?? x i8] c"--- Inside baz: \00"
+@alias1.70 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.69 to i64) }
 
 
-@alias1.106 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.105 to i64) }
+@alias1.69 =    constant [?? x i8] c"--- Inside baz, after calling x(!p1, 555): \00"
 
 
-@alias1.105 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias1.41 =    constant [?? x i8] c"--- Inside baz: \00"
 
 
-@alias1.104 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.103 to i64) }
+@alias1.43 =    constant [?? x i8] c"expect p1(101,102):\00"
 
 
-@alias1.103 =    constant [?? x i8] c"expect p1(555,102):\00"
+@alias1.71 =    constant [?? x i8] c"expect p1(555,102):\00"
 
 
-@alias1.102 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.101 to i64) }
+@alias1.45 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
-@alias1.101 =    constant [?? x i8] c"--- Inside foo, after calling x(!p1, 555): \00"
+@alias1.59 =    constant [?? x i8] c"expect p3(33333333,102):\00"
 
 
-@alias1.92 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.91 to i64) }
+@alias1.82 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.81 to i64) }
 
 
-@alias1.91 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias1.84 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.83 to i64) }
 
 
-@alias1.90 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.89 to i64) }
+@alias1.86 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.85 to i64) }
 
 
-@alias1.89 =    constant [?? x i8] c"expect p1(101,102):\00"
+@alias1.98 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.97 to i64) }
 
 
-@alias1.88 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.87 to i64) }
+@alias1.96 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.95 to i64) }
 
 
-@alias1.87 =    constant [?? x i8] c"--- Inside foo: \00"
+@alias1.95 =    constant [?? x i8] c"--- Inside foo, after calling x(!p1, 555): \00"
+
+
+@alias1.81 =    constant [?? x i8] c"--- Inside foo: \00"
+
+
+@alias1.83 =    constant [?? x i8] c"expect p1(101,102):\00"
+
+
+@alias1.97 =    constant [?? x i8] c"expect p1(555,102):\00"
+
+
+@alias1.85 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
 declare external ccc  void @print_int(i64)    
 
 
-@alias1.116 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias1.115 to i64) }
+@alias1.108 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias1.107 to i64) }
 
 
-@alias1.115 =    constant [?? x i8] c"random print\00"
+@alias1.107 =    constant [?? x i8] c"random print\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -360,9 +336,9 @@ entry:
   store  i64 555, i64* %28 
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.32, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.18, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.34, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.32, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %23)  
   ret void 
 }
@@ -370,95 +346,95 @@ entry:
 
 define external fastcc  void @"alias1.baz<0>"()    {
 entry:
-  %35 = trunc i64 16 to i32  
-  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
-  %37 = ptrtoint i8* %36 to i64 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 101, i64* %39 
-  %40 = add   i64 %37, 8 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 102, i64* %42 
-  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %37)  
+  %33 = trunc i64 16 to i32  
+  %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
+  %35 = ptrtoint i8* %34 to i64 
+  %36 = inttoptr i64 %35 to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  store  i64 101, i64* %37 
+  %38 = add   i64 %35, 8 
+  %39 = inttoptr i64 %38 to i64* 
+  %40 = getelementptr  i64, i64* %39, i64 0 
+  store  i64 102, i64* %40 
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %35)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.42, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.44, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %35)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.46, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.48, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %49 = add   i64 %"1#p2##0", 8 
-  %50 = inttoptr i64 %49 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  %52 = load  i64, i64* %51 
-  %53 = trunc i64 16 to i32  
-  %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
-  %55 = ptrtoint i8* %54 to i64 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 33333333, i64* %57 
-  %58 = add   i64 %55, 8 
-  %59 = inttoptr i64 %58 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %52, i64* %60 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.62, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
-  %63 = trunc i64 16 to i32  
-  %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
-  %65 = ptrtoint i8* %64 to i64 
-  %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %37 to i8* 
-  %68 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i1  0)  
-  %69 = inttoptr i64 %65 to i64* 
-  %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 555, i64* %70 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.72, i32 0, i32 0) to i64))  
+  %47 = add   i64 %"1#p2##0", 8 
+  %48 = inttoptr i64 %47 to i64* 
+  %49 = getelementptr  i64, i64* %48, i64 0 
+  %50 = load  i64, i64* %49 
+  %51 = trunc i64 16 to i32  
+  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
+  %53 = ptrtoint i8* %52 to i64 
+  %54 = inttoptr i64 %53 to i64* 
+  %55 = getelementptr  i64, i64* %54, i64 0 
+  store  i64 33333333, i64* %55 
+  %56 = add   i64 %53, 8 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = getelementptr  i64, i64* %57, i64 0 
+  store  i64 %50, i64* %58 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.60, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %53)  
+  %61 = trunc i64 16 to i32  
+  %62 = tail call ccc  i8*  @wybe_malloc(i32  %61)  
+  %63 = ptrtoint i8* %62 to i64 
+  %64 = inttoptr i64 %63 to i8* 
+  %65 = inttoptr i64 %35 to i8* 
+  %66 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %64, i8*  %65, i32  %66, i1  0)  
+  %67 = inttoptr i64 %63 to i64* 
+  %68 = getelementptr  i64, i64* %67, i64 0 
+  store  i64 555, i64* %68 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.70, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.74, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %65)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.76, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.72, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %63)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.46, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.78, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.60, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %53)  
   ret void 
 }
 
 
 define external fastcc  void @"alias1.foo<0>"()    {
 entry:
-  %79 = trunc i64 16 to i32  
-  %80 = tail call ccc  i8*  @wybe_malloc(i32  %79)  
-  %81 = ptrtoint i8* %80 to i64 
-  %82 = inttoptr i64 %81 to i64* 
-  %83 = getelementptr  i64, i64* %82, i64 0 
-  store  i64 101, i64* %83 
-  %84 = add   i64 %81, 8 
-  %85 = inttoptr i64 %84 to i64* 
-  %86 = getelementptr  i64, i64* %85, i64 0 
-  store  i64 102, i64* %86 
-  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %81)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.88, i32 0, i32 0) to i64))  
+  %73 = trunc i64 16 to i32  
+  %74 = tail call ccc  i8*  @wybe_malloc(i32  %73)  
+  %75 = ptrtoint i8* %74 to i64 
+  %76 = inttoptr i64 %75 to i64* 
+  %77 = getelementptr  i64, i64* %76, i64 0 
+  store  i64 101, i64* %77 
+  %78 = add   i64 %75, 8 
+  %79 = inttoptr i64 %78 to i64* 
+  %80 = getelementptr  i64, i64* %79, i64 0 
+  store  i64 102, i64* %80 
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %75)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.82, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.90, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %81)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.92, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.84, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %75)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.86, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %93 = trunc i64 16 to i32  
-  %94 = tail call ccc  i8*  @wybe_malloc(i32  %93)  
-  %95 = ptrtoint i8* %94 to i64 
-  %96 = inttoptr i64 %95 to i8* 
-  %97 = inttoptr i64 %81 to i8* 
-  %98 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %96, i8*  %97, i32  %98, i1  0)  
-  %99 = inttoptr i64 %95 to i64* 
-  %100 = getelementptr  i64, i64* %99, i64 0 
-  store  i64 555, i64* %100 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.102, i32 0, i32 0) to i64))  
+  %87 = trunc i64 16 to i32  
+  %88 = tail call ccc  i8*  @wybe_malloc(i32  %87)  
+  %89 = ptrtoint i8* %88 to i64 
+  %90 = inttoptr i64 %89 to i8* 
+  %91 = inttoptr i64 %75 to i8* 
+  %92 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %90, i8*  %91, i32  %92, i1  0)  
+  %93 = inttoptr i64 %89 to i64* 
+  %94 = getelementptr  i64, i64* %93, i64 0 
+  store  i64 555, i64* %94 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.96, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.104, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %95)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.106, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.98, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %89)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.86, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -466,21 +442,21 @@ entry:
 
 define external fastcc  i64 @"alias1.replicate<0>"(i64  %"p1##0")    {
 entry:
-  %107 = trunc i64 16 to i32  
-  %108 = tail call ccc  i8*  @wybe_malloc(i32  %107)  
-  %109 = ptrtoint i8* %108 to i64 
-  %110 = inttoptr i64 %109 to i64* 
-  %111 = getelementptr  i64, i64* %110, i64 0 
-  store  i64 0, i64* %111 
-  %112 = add   i64 %109, 8 
-  %113 = inttoptr i64 %112 to i64* 
-  %114 = getelementptr  i64, i64* %113, i64 0 
-  store  i64 0, i64* %114 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.116, i32 0, i32 0) to i64))  
-  %117 = inttoptr i64 %109 to i64* 
-  %118 = getelementptr  i64, i64* %117, i64 0 
-  %119 = load  i64, i64* %118 
-  tail call ccc  void  @print_int(i64  %119)  
+  %99 = trunc i64 16 to i32  
+  %100 = tail call ccc  i8*  @wybe_malloc(i32  %99)  
+  %101 = ptrtoint i8* %100 to i64 
+  %102 = inttoptr i64 %101 to i64* 
+  %103 = getelementptr  i64, i64* %102, i64 0 
+  store  i64 0, i64* %103 
+  %104 = add   i64 %101, 8 
+  %105 = inttoptr i64 %104 to i64* 
+  %106 = getelementptr  i64, i64* %105, i64 0 
+  store  i64 0, i64* %106 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.108, i32 0, i32 0) to i64))  
+  %109 = inttoptr i64 %101 to i64* 
+  %110 = getelementptr  i64, i64* %109, i64 0 
+  %111 = load  i64, i64* %110 
+  tail call ccc  void  @print_int(i64  %111)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -544,19 +520,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -152,34 +152,16 @@ replicate(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@alias1.2 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.1 to i64) }
-
-
-@alias1.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.3 to i64) }
-
-
-@alias1.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.5 to i64) }
-
-
-@alias1.3 =    constant [?? x i8] c"-------------- Calling bar: \00"
-
-
-@alias1.5 =    constant [?? x i8] c"-------------- Calling baz: \00"
-
-
-@alias1.1 =    constant [?? x i8] c"-------------- Calling foo: \00"
-
-
-declare external fastcc  void @"position.printPosition<0>"(i64)    
+@alias1.98 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias1.97 to i64) }
 
 
 @alias1.16 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.15 to i64) }
+
+
+@alias1.42 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.41 to i64) }
+
+
+@alias1.78 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.77 to i64) }
 
 
 @alias1.18 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.17 to i64) }
@@ -191,7 +173,28 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 @alias1.32 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.31 to i64) }
 
 
+@alias1.68 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.67 to i64) }
+
+
+@alias1.56 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.55 to i64) }
+
+
+@alias1.2 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.1 to i64) }
+
+
+@alias1.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.3 to i64) }
+
+
+@alias1.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.5 to i64) }
+
+
 @alias1.30 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.29 to i64) }
+
+
+@alias1.66 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.65 to i64) }
+
+
+@alias1.88 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.87 to i64) }
 
 
 @alias1.29 =    constant [?? x i8] c"--- Inside bar, after calling x(!p2, 555): \00"
@@ -200,7 +203,31 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 @alias1.15 =    constant [?? x i8] c"--- Inside bar: \00"
 
 
+@alias1.65 =    constant [?? x i8] c"--- Inside baz, after calling x(!p1, 555): \00"
+
+
+@alias1.41 =    constant [?? x i8] c"--- Inside baz: \00"
+
+
+@alias1.87 =    constant [?? x i8] c"--- Inside foo, after calling x(!p1, 555): \00"
+
+
+@alias1.77 =    constant [?? x i8] c"--- Inside foo: \00"
+
+
+@alias1.3 =    constant [?? x i8] c"-------------- Calling bar: \00"
+
+
+@alias1.5 =    constant [?? x i8] c"-------------- Calling baz: \00"
+
+
+@alias1.1 =    constant [?? x i8] c"-------------- Calling foo: \00"
+
+
 @alias1.17 =    constant [?? x i8] c"expect p1(101,102):\00"
+
+
+@alias1.67 =    constant [?? x i8] c"expect p1(555,102):\00"
 
 
 @alias1.19 =    constant [?? x i8] c"expect p2(101,102):\00"
@@ -209,79 +236,22 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 @alias1.31 =    constant [?? x i8] c"expect p2(555,102):\00"
 
 
-@alias1.42 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.41 to i64) }
+@alias1.55 =    constant [?? x i8] c"expect p3(33333333,102):\00"
 
 
-@alias1.44 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.43 to i64) }
+@alias1.97 =    constant [?? x i8] c"random print\00"
 
 
-@alias1.46 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.45 to i64) }
-
-
-@alias1.72 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.71 to i64) }
-
-
-@alias1.60 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.59 to i64) }
-
-
-@alias1.70 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.69 to i64) }
-
-
-@alias1.69 =    constant [?? x i8] c"--- Inside baz, after calling x(!p1, 555): \00"
-
-
-@alias1.41 =    constant [?? x i8] c"--- Inside baz: \00"
-
-
-@alias1.43 =    constant [?? x i8] c"expect p1(101,102):\00"
-
-
-@alias1.71 =    constant [?? x i8] c"expect p1(555,102):\00"
-
-
-@alias1.45 =    constant [?? x i8] c"expect p2(101,102):\00"
-
-
-@alias1.59 =    constant [?? x i8] c"expect p3(33333333,102):\00"
-
-
-@alias1.82 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.81 to i64) }
-
-
-@alias1.84 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.83 to i64) }
-
-
-@alias1.86 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.85 to i64) }
-
-
-@alias1.98 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.97 to i64) }
-
-
-@alias1.96 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.95 to i64) }
-
-
-@alias1.95 =    constant [?? x i8] c"--- Inside foo, after calling x(!p1, 555): \00"
-
-
-@alias1.81 =    constant [?? x i8] c"--- Inside foo: \00"
-
-
-@alias1.83 =    constant [?? x i8] c"expect p1(101,102):\00"
-
-
-@alias1.97 =    constant [?? x i8] c"expect p1(555,102):\00"
-
-
-@alias1.85 =    constant [?? x i8] c"expect p2(101,102):\00"
+declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  void @print_int(i64)    
 
 
-@alias1.108 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias1.107 to i64) }
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias1.107 =    constant [?? x i8] c"random print\00"
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -359,82 +329,82 @@ entry:
   %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %35)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.42, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.44, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.18, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %35)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %47 = add   i64 %"1#p2##0", 8 
-  %48 = inttoptr i64 %47 to i64* 
-  %49 = getelementptr  i64, i64* %48, i64 0 
-  %50 = load  i64, i64* %49 
-  %51 = trunc i64 16 to i32  
-  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
-  %53 = ptrtoint i8* %52 to i64 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 33333333, i64* %55 
-  %56 = add   i64 %53, 8 
-  %57 = inttoptr i64 %56 to i64* 
-  %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %50, i64* %58 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.60, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %53)  
-  %61 = trunc i64 16 to i32  
-  %62 = tail call ccc  i8*  @wybe_malloc(i32  %61)  
-  %63 = ptrtoint i8* %62 to i64 
-  %64 = inttoptr i64 %63 to i8* 
-  %65 = inttoptr i64 %35 to i8* 
-  %66 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %64, i8*  %65, i32  %66, i1  0)  
-  %67 = inttoptr i64 %63 to i64* 
-  %68 = getelementptr  i64, i64* %67, i64 0 
-  store  i64 555, i64* %68 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.70, i32 0, i32 0) to i64))  
+  %43 = add   i64 %"1#p2##0", 8 
+  %44 = inttoptr i64 %43 to i64* 
+  %45 = getelementptr  i64, i64* %44, i64 0 
+  %46 = load  i64, i64* %45 
+  %47 = trunc i64 16 to i32  
+  %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
+  %49 = ptrtoint i8* %48 to i64 
+  %50 = inttoptr i64 %49 to i64* 
+  %51 = getelementptr  i64, i64* %50, i64 0 
+  store  i64 33333333, i64* %51 
+  %52 = add   i64 %49, 8 
+  %53 = inttoptr i64 %52 to i64* 
+  %54 = getelementptr  i64, i64* %53, i64 0 
+  store  i64 %46, i64* %54 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.56, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %49)  
+  %57 = trunc i64 16 to i32  
+  %58 = tail call ccc  i8*  @wybe_malloc(i32  %57)  
+  %59 = ptrtoint i8* %58 to i64 
+  %60 = inttoptr i64 %59 to i8* 
+  %61 = inttoptr i64 %35 to i8* 
+  %62 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %60, i8*  %61, i32  %62, i1  0)  
+  %63 = inttoptr i64 %59 to i64* 
+  %64 = getelementptr  i64, i64* %63, i64 0 
+  store  i64 555, i64* %64 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.66, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.72, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %63)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.68, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %59)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.60, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %53)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.56, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %49)  
   ret void 
 }
 
 
 define external fastcc  void @"alias1.foo<0>"()    {
 entry:
-  %73 = trunc i64 16 to i32  
-  %74 = tail call ccc  i8*  @wybe_malloc(i32  %73)  
-  %75 = ptrtoint i8* %74 to i64 
-  %76 = inttoptr i64 %75 to i64* 
-  %77 = getelementptr  i64, i64* %76, i64 0 
-  store  i64 101, i64* %77 
-  %78 = add   i64 %75, 8 
-  %79 = inttoptr i64 %78 to i64* 
-  %80 = getelementptr  i64, i64* %79, i64 0 
-  store  i64 102, i64* %80 
-  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %75)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.82, i32 0, i32 0) to i64))  
+  %69 = trunc i64 16 to i32  
+  %70 = tail call ccc  i8*  @wybe_malloc(i32  %69)  
+  %71 = ptrtoint i8* %70 to i64 
+  %72 = inttoptr i64 %71 to i64* 
+  %73 = getelementptr  i64, i64* %72, i64 0 
+  store  i64 101, i64* %73 
+  %74 = add   i64 %71, 8 
+  %75 = inttoptr i64 %74 to i64* 
+  %76 = getelementptr  i64, i64* %75, i64 0 
+  store  i64 102, i64* %76 
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %71)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.78, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.84, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %75)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.86, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.18, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %71)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %87 = trunc i64 16 to i32  
-  %88 = tail call ccc  i8*  @wybe_malloc(i32  %87)  
-  %89 = ptrtoint i8* %88 to i64 
-  %90 = inttoptr i64 %89 to i8* 
-  %91 = inttoptr i64 %75 to i8* 
-  %92 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %90, i8*  %91, i32  %92, i1  0)  
-  %93 = inttoptr i64 %89 to i64* 
-  %94 = getelementptr  i64, i64* %93, i64 0 
-  store  i64 555, i64* %94 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.96, i32 0, i32 0) to i64))  
+  %79 = trunc i64 16 to i32  
+  %80 = tail call ccc  i8*  @wybe_malloc(i32  %79)  
+  %81 = ptrtoint i8* %80 to i64 
+  %82 = inttoptr i64 %81 to i8* 
+  %83 = inttoptr i64 %71 to i8* 
+  %84 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %82, i8*  %83, i32  %84, i1  0)  
+  %85 = inttoptr i64 %81 to i64* 
+  %86 = getelementptr  i64, i64* %85, i64 0 
+  store  i64 555, i64* %86 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.88, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.98, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %89)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.86, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.68, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %81)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -442,21 +412,21 @@ entry:
 
 define external fastcc  i64 @"alias1.replicate<0>"(i64  %"p1##0")    {
 entry:
-  %99 = trunc i64 16 to i32  
-  %100 = tail call ccc  i8*  @wybe_malloc(i32  %99)  
-  %101 = ptrtoint i8* %100 to i64 
-  %102 = inttoptr i64 %101 to i64* 
-  %103 = getelementptr  i64, i64* %102, i64 0 
-  store  i64 0, i64* %103 
-  %104 = add   i64 %101, 8 
-  %105 = inttoptr i64 %104 to i64* 
-  %106 = getelementptr  i64, i64* %105, i64 0 
-  store  i64 0, i64* %106 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.108, i32 0, i32 0) to i64))  
-  %109 = inttoptr i64 %101 to i64* 
-  %110 = getelementptr  i64, i64* %109, i64 0 
-  %111 = load  i64, i64* %110 
-  tail call ccc  void  @print_int(i64  %111)  
+  %89 = trunc i64 16 to i32  
+  %90 = tail call ccc  i8*  @wybe_malloc(i32  %89)  
+  %91 = ptrtoint i8* %90 to i64 
+  %92 = inttoptr i64 %91 to i64* 
+  %93 = getelementptr  i64, i64* %92, i64 0 
+  store  i64 0, i64* %93 
+  %94 = add   i64 %91, 8 
+  %95 = inttoptr i64 %94 to i64* 
+  %96 = getelementptr  i64, i64* %95, i64 0 
+  store  i64 0, i64* %96 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.98, i32 0, i32 0) to i64))  
+  %99 = inttoptr i64 %91 to i64* 
+  %100 = getelementptr  i64, i64* %99, i64 0 
+  %101 = load  i64, i64* %100 
+  tail call ccc  void  @print_int(i64  %101)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -508,15 +478,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -533,6 +494,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -74,31 +74,10 @@ pcopy(p1##0:position.position, ?p2##2:position.position)<{<<wybe.io.io>>}; {<<wy
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
 @alias2.2 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias2.1 to i64) }
 
 
 @alias2.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias2.13 to i64) }
-
-
-@alias2.12 =    constant {i64, i64} { i64 25, i64 ptrtoint ([?? x i8]* @alias2.11 to i64) }
-
-
-@alias2.11 =    constant [?? x i8] c"--- After calling pcopy: \00"
-
-
-@alias2.1 =    constant [?? x i8] c"copy a position\00"
-
-
-@alias2.13 =    constant [?? x i8] c"expect r(0,20):\00"
 
 
 @alias2.58 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias2.57 to i64) }
@@ -107,10 +86,31 @@ declare external ccc  void @putchar(i8)
 @alias2.56 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias2.55 to i64) }
 
 
+@alias2.12 =    constant {i64, i64} { i64 25, i64 ptrtoint ([?? x i8]* @alias2.11 to i64) }
+
+
+@alias2.11 =    constant [?? x i8] c"--- After calling pcopy: \00"
+
+
 @alias2.55 =    constant [?? x i8] c"--- Inside pcopy: \00"
 
 
+@alias2.1 =    constant [?? x i8] c"copy a position\00"
+
+
 @alias2.57 =    constant [?? x i8] c"expect p2(0,20):\00"
+
+
+@alias2.13 =    constant [?? x i8] c"expect r(0,20):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -252,15 +252,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -277,6 +268,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -83,10 +83,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
+@alias2.2 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias2.1 to i64) }
+
+
 @alias2.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias2.13 to i64) }
-
-
-@alias2.13 =    constant [?? x i8] c"expect r(0,20):\00"
 
 
 @alias2.12 =    constant {i64, i64} { i64 25, i64 ptrtoint ([?? x i8]* @alias2.11 to i64) }
@@ -95,22 +95,22 @@ declare external ccc  void @putchar(i8)
 @alias2.11 =    constant [?? x i8] c"--- After calling pcopy: \00"
 
 
-@alias2.2 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias2.1 to i64) }
-
-
 @alias2.1 =    constant [?? x i8] c"copy a position\00"
 
 
+@alias2.13 =    constant [?? x i8] c"expect r(0,20):\00"
+
+
 @alias2.58 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias2.57 to i64) }
-
-
-@alias2.57 =    constant [?? x i8] c"expect p2(0,20):\00"
 
 
 @alias2.56 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias2.55 to i64) }
 
 
 @alias2.55 =    constant [?? x i8] c"--- Inside pcopy: \00"
+
+
+@alias2.57 =    constant [?? x i8] c"expect p2(0,20):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -264,19 +264,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -83,64 +83,52 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias3.22 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.21 to i64) }
-
-
-@alias3.21 =    constant [?? x i8] c"expect p2(2,2):\00"
-
-
-@alias3.20 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias3.19 to i64) }
-
-
-@alias3.19 =    constant [?? x i8] c"expect p1(555,1):\00"
-
-
-@alias3.18 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias3.17 to i64) }
-
-
-@alias3.17 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
+@alias3.12 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.11 to i64) }
 
 
 @alias3.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.13 to i64) }
 
 
-@alias3.13 =    constant [?? x i8] c"expect p2(2,2):\00"
-
-
-@alias3.12 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.11 to i64) }
-
-
-@alias3.11 =    constant [?? x i8] c"expect p1(1,1):\00"
+@alias3.20 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias3.19 to i64) }
 
 
 @alias3.10 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias3.9 to i64) }
 
 
+@alias3.18 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias3.17 to i64) }
+
+
 @alias3.9 =    constant [?? x i8] c"--- After calling replicate1: \00"
 
 
-@alias3.41 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.40 to i64) }
+@alias3.17 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
 
 
-@alias3.40 =    constant [?? x i8] c"expect p2(2,2):\00"
+@alias3.11 =    constant [?? x i8] c"expect p1(1,1):\00"
 
 
-@alias3.39 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.38 to i64) }
+@alias3.19 =    constant [?? x i8] c"expect p1(555,1):\00"
 
 
-@alias3.38 =    constant [?? x i8] c"expect p1(1,1):\00"
+@alias3.13 =    constant [?? x i8] c"expect p2(2,2):\00"
 
 
-@alias3.26 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.25 to i64) }
+@alias3.24 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.23 to i64) }
 
 
-@alias3.25 =    constant [?? x i8] c"expect p1(1,1):\00"
+@alias3.37 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.36 to i64) }
 
 
-@alias3.24 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias3.23 to i64) }
+@alias3.22 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias3.21 to i64) }
 
 
-@alias3.23 =    constant [?? x i8] c"--- Inside replicate1: \00"
+@alias3.21 =    constant [?? x i8] c"--- Inside replicate1: \00"
+
+
+@alias3.23 =    constant [?? x i8] c"expect p1(1,1):\00"
+
+
+@alias3.36 =    constant [?? x i8] c"expect p2(2,2):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -182,7 +170,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.22, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.14, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -190,29 +178,29 @@ entry:
 
 define external fastcc  i64 @"alias3.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.24, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.22, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.26, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.24, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
-  %27 = trunc i64 16 to i32  
-  %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
-  %29 = ptrtoint i8* %28 to i64 
-  %30 = inttoptr i64 %29 to i8* 
-  %31 = inttoptr i64 %"p1##0" to i8* 
-  %32 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i1  0)  
-  %33 = inttoptr i64 %29 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  store  i64 2, i64* %34 
-  %35 = add   i64 %29, 8 
-  %36 = inttoptr i64 %35 to i64* 
-  %37 = getelementptr  i64, i64* %36, i64 0 
-  store  i64 2, i64* %37 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.39, i32 0, i32 0) to i64))  
+  %25 = trunc i64 16 to i32  
+  %26 = tail call ccc  i8*  @wybe_malloc(i32  %25)  
+  %27 = ptrtoint i8* %26 to i64 
+  %28 = inttoptr i64 %27 to i8* 
+  %29 = inttoptr i64 %"p1##0" to i8* 
+  %30 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %28, i8*  %29, i32  %30, i1  0)  
+  %31 = inttoptr i64 %27 to i64* 
+  %32 = getelementptr  i64, i64* %31, i64 0 
+  store  i64 2, i64* %32 
+  %33 = add   i64 %27, 8 
+  %34 = inttoptr i64 %33 to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  store  i64 2, i64* %35 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.24, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.41, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %29)  
-  ret i64 %29 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.37, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %27)  
+  ret i64 %27 
 }
 --------------------------------------------------
  Module position
@@ -274,19 +262,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -74,15 +74,6 @@ replicate1(p1##0:position.position, ?p2##2:position.position)<{<<wybe.io.io>>}; 
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
 @alias3.12 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.11 to i64) }
 
 
@@ -90,6 +81,9 @@ declare external ccc  void @putchar(i8)
 
 
 @alias3.20 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias3.19 to i64) }
+
+
+@alias3.22 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias3.21 to i64) }
 
 
 @alias3.10 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias3.9 to i64) }
@@ -104,6 +98,9 @@ declare external ccc  void @putchar(i8)
 @alias3.17 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
 
 
+@alias3.21 =    constant [?? x i8] c"--- Inside replicate1: \00"
+
+
 @alias3.11 =    constant [?? x i8] c"expect p1(1,1):\00"
 
 
@@ -113,22 +110,13 @@ declare external ccc  void @putchar(i8)
 @alias3.13 =    constant [?? x i8] c"expect p2(2,2):\00"
 
 
-@alias3.24 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.23 to i64) }
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
-@alias3.37 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.36 to i64) }
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias3.22 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias3.21 to i64) }
-
-
-@alias3.21 =    constant [?? x i8] c"--- Inside replicate1: \00"
-
-
-@alias3.23 =    constant [?? x i8] c"expect p1(1,1):\00"
-
-
-@alias3.36 =    constant [?? x i8] c"expect p2(2,2):\00"
+declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -180,27 +168,27 @@ define external fastcc  i64 @"alias3.replicate1<0>"(i64  %"p1##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.22, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.24, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.12, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
-  %25 = trunc i64 16 to i32  
-  %26 = tail call ccc  i8*  @wybe_malloc(i32  %25)  
-  %27 = ptrtoint i8* %26 to i64 
-  %28 = inttoptr i64 %27 to i8* 
-  %29 = inttoptr i64 %"p1##0" to i8* 
-  %30 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %28, i8*  %29, i32  %30, i1  0)  
-  %31 = inttoptr i64 %27 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 2, i64* %32 
-  %33 = add   i64 %27, 8 
-  %34 = inttoptr i64 %33 to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  store  i64 2, i64* %35 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.24, i32 0, i32 0) to i64))  
+  %23 = trunc i64 16 to i32  
+  %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
+  %25 = ptrtoint i8* %24 to i64 
+  %26 = inttoptr i64 %25 to i8* 
+  %27 = inttoptr i64 %"p1##0" to i8* 
+  %28 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %26, i8*  %27, i32  %28, i1  0)  
+  %29 = inttoptr i64 %25 to i64* 
+  %30 = getelementptr  i64, i64* %29, i64 0 
+  store  i64 2, i64* %30 
+  %31 = add   i64 %25, 8 
+  %32 = inttoptr i64 %31 to i64* 
+  %33 = getelementptr  i64, i64* %32, i64 0 
+  store  i64 2, i64* %33 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.12, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.37, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %27)  
-  ret i64 %27 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.14, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %25)  
+  ret i64 %25 
 }
 --------------------------------------------------
  Module position
@@ -250,15 +238,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -275,6 +254,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -84,49 +84,43 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias4.22 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.21 to i64) }
-
-
-@alias4.21 =    constant [?? x i8] c"expect p2(100,200):\00"
-
-
-@alias4.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.19 to i64) }
-
-
-@alias4.19 =    constant [?? x i8] c"expect p1(555,100):\00"
-
-
-@alias4.18 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias4.17 to i64) }
-
-
-@alias4.17 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
+@alias4.12 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.11 to i64) }
 
 
 @alias4.14 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.13 to i64) }
 
 
-@alias4.13 =    constant [?? x i8] c"expect p2(100,200):\00"
-
-
-@alias4.12 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.11 to i64) }
-
-
-@alias4.11 =    constant [?? x i8] c"expect p1(100,100):\00"
+@alias4.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.19 to i64) }
 
 
 @alias4.10 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias4.9 to i64) }
 
 
+@alias4.18 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias4.17 to i64) }
+
+
 @alias4.9 =    constant [?? x i8] c"--- After calling replicate1: \00"
+
+
+@alias4.17 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
+
+
+@alias4.11 =    constant [?? x i8] c"expect p1(100,100):\00"
+
+
+@alias4.19 =    constant [?? x i8] c"expect p1(555,100):\00"
+
+
+@alias4.13 =    constant [?? x i8] c"expect p2(100,200):\00"
 
 
 declare external ccc  void @print_int(i64)    
 
 
-@alias4.32 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias4.31 to i64) }
+@alias4.30 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias4.29 to i64) }
 
 
-@alias4.31 =    constant [?? x i8] c"random replicate1\00"
+@alias4.29 =    constant [?? x i8] c"random replicate1\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -168,7 +162,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.22, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.14, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -176,34 +170,34 @@ entry:
 
 define external fastcc  i64 @"alias4.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %23 = trunc i64 16 to i32  
-  %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
-  %25 = ptrtoint i8* %24 to i64 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  store  i64 0, i64* %27 
-  %28 = add   i64 %25, 8 
-  %29 = inttoptr i64 %28 to i64* 
-  %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 0, i64* %30 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.32, i32 0, i32 0) to i64))  
+  %21 = trunc i64 16 to i32  
+  %22 = tail call ccc  i8*  @wybe_malloc(i32  %21)  
+  %23 = ptrtoint i8* %22 to i64 
+  %24 = inttoptr i64 %23 to i64* 
+  %25 = getelementptr  i64, i64* %24, i64 0 
+  store  i64 0, i64* %25 
+  %26 = add   i64 %23, 8 
+  %27 = inttoptr i64 %26 to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  store  i64 0, i64* %28 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %33 = inttoptr i64 %25 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  %35 = load  i64, i64* %34 
-  tail call ccc  void  @print_int(i64  %35)  
+  %31 = inttoptr i64 %23 to i64* 
+  %32 = getelementptr  i64, i64* %31, i64 0 
+  %33 = load  i64, i64* %32 
+  tail call ccc  void  @print_int(i64  %33)  
   tail call ccc  void  @putchar(i8  10)  
-  %36 = inttoptr i64 %"p1##0" to i64* 
-  %37 = getelementptr  i64, i64* %36, i64 0 
-  %38 = load  i64, i64* %37 
-  %39 = inttoptr i64 %25 to i64* 
-  %40 = getelementptr  i64, i64* %39, i64 0 
-  store  i64 %38, i64* %40 
-  %41 = add   i64 %25, 8 
-  %42 = inttoptr i64 %41 to i64* 
-  %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 200, i64* %43 
-  ret i64 %25 
+  %34 = inttoptr i64 %"p1##0" to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  %36 = load  i64, i64* %35 
+  %37 = inttoptr i64 %23 to i64* 
+  %38 = getelementptr  i64, i64* %37, i64 0 
+  store  i64 %36, i64* %38 
+  %39 = add   i64 %23, 8 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  store  i64 200, i64* %41 
+  ret i64 %23 
 }
 --------------------------------------------------
  Module position
@@ -265,19 +259,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -75,13 +75,7 @@ replicate1(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; 
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
+@alias4.30 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias4.29 to i64) }
 
 
 @alias4.12 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.11 to i64) }
@@ -114,13 +108,19 @@ declare external ccc  void @putchar(i8)
 @alias4.13 =    constant [?? x i8] c"expect p2(100,200):\00"
 
 
+@alias4.29 =    constant [?? x i8] c"random replicate1\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
 declare external ccc  void @print_int(i64)    
 
 
-@alias4.30 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias4.29 to i64) }
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias4.29 =    constant [?? x i8] c"random replicate1\00"
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -247,15 +247,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -272,6 +263,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias5.exp
+++ b/test-cases/final-dump/alias5.exp
@@ -80,28 +80,28 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias5.14 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.13 to i64) }
-
-
-@alias5.13 =    constant [?? x i8] c"expect p4=45000: \00"
-
-
 @alias5.12 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.11 to i64) }
-
-
-@alias5.11 =    constant [?? x i8] c"expect p3=100: \00"
-
-
-@alias5.10 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.9 to i64) }
-
-
-@alias5.9 =    constant [?? x i8] c"expect p2=100: \00"
 
 
 @alias5.8 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.7 to i64) }
 
 
+@alias5.10 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.9 to i64) }
+
+
+@alias5.14 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.13 to i64) }
+
+
 @alias5.7 =    constant [?? x i8] c"expect p1=111: \00"
+
+
+@alias5.9 =    constant [?? x i8] c"expect p2=100: \00"
+
+
+@alias5.11 =    constant [?? x i8] c"expect p3=100: \00"
+
+
+@alias5.13 =    constant [?? x i8] c"expect p4=45000: \00"
 
 
 @alias5.16 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.15 to i64) }

--- a/test-cases/final-dump/alias5.exp
+++ b/test-cases/final-dump/alias5.exp
@@ -71,15 +71,6 @@ replicate1(v1##0:wybe.int, ?v2##0:wybe.int, v3##0:wybe.int, ?v4##1:wybe.int)<{<<
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @alias5.12 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.11 to i64) }
 
 
@@ -90,6 +81,9 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @alias5.14 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.13 to i64) }
+
+
+@alias5.16 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.15 to i64) }
 
 
 @alias5.7 =    constant [?? x i8] c"expect p1=111: \00"
@@ -104,10 +98,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias5.13 =    constant [?? x i8] c"expect p4=45000: \00"
 
 
-@alias5.16 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.15 to i64) }
-
-
 @alias5.15 =    constant [?? x i8] c"random replicate1\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -114,13 +114,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias_cyclic.12 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias_cyclic.11 to i64) }
 
 
-@alias_cyclic.11 =    constant [?? x i8] c"p2(102,900):\00"
-
-
 @alias_cyclic.10 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias_cyclic.9 to i64) }
 
 
 @alias_cyclic.9 =    constant [?? x i8] c"p1(100,900):\00"
+
+
+@alias_cyclic.11 =    constant [?? x i8] c"p2(102,900):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -309,19 +309,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -105,12 +105,6 @@ updateY(p1##0:position.position, ?p2##0:position.position)<{}; {}>:
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @alias_cyclic.12 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias_cyclic.11 to i64) }
 
 
@@ -121,6 +115,12 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @alias_cyclic.11 =    constant [?? x i8] c"p2(102,900):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -297,15 +297,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -322,6 +313,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -58,15 +58,6 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external fastcc  void @"student.printStudent<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @alias_data.20 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @alias_data.19 to i64) }
 
 
@@ -83,6 +74,15 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @alias_data.21 =    constant [?? x i8] c"student2\00"
+
+
+declare external fastcc  void @"student.printStudent<0>"(i64)    
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -212,21 +212,6 @@ printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-@student.10 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @student.9 to i64) }
-
-
-@student.9 =    constant [?? x i8] c"Declarative Programming\00"
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @student.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.19 to i64) }
 
 
@@ -236,6 +221,12 @@ declare external ccc  void @print_int(i64)
 @student.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.33 to i64) }
 
 
+@student.10 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @student.9 to i64) }
+
+
+@student.9 =    constant [?? x i8] c"Declarative Programming\00"
+
+
 @student.28 =    constant [?? x i8] c"course code: \00"
 
 
@@ -243,6 +234,15 @@ declare external ccc  void @print_int(i64)
 
 
 @student.19 =    constant [?? x i8] c"student id: \00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -67,22 +67,22 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias_data.22 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @alias_data.21 to i64) }
-
-
-@alias_data.21 =    constant [?? x i8] c"student2\00"
-
-
 @alias_data.20 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @alias_data.19 to i64) }
 
 
-@alias_data.19 =    constant [?? x i8] c"student1\00"
+@alias_data.22 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @alias_data.21 to i64) }
 
 
 @alias_data.10 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @alias_data.9 to i64) }
 
 
 @alias_data.9 =    constant [?? x i8] c"intro to cs\00"
+
+
+@alias_data.19 =    constant [?? x i8] c"student1\00"
+
+
+@alias_data.21 =    constant [?? x i8] c"student2\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -227,19 +227,19 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@student.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.33 to i64) }
-
-
-@student.33 =    constant [?? x i8] c"course name: \00"
+@student.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.19 to i64) }
 
 
 @student.29 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.28 to i64) }
 
 
+@student.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.33 to i64) }
+
+
 @student.28 =    constant [?? x i8] c"course code: \00"
 
 
-@student.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.19 to i64) }
+@student.33 =    constant [?? x i8] c"course name: \00"
 
 
 @student.19 =    constant [?? x i8] c"student id: \00"

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -75,13 +75,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias_des.36 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_des.35 to i64) }
 
 
-@alias_des.35 =    constant [?? x i8] c"expect p2(101,103):\00"
-
-
 @alias_des.34 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_des.33 to i64) }
 
 
 @alias_des.33 =    constant [?? x i8] c"expect p1(10000,102):\00"
+
+
+@alias_des.35 =    constant [?? x i8] c"expect p2(101,103):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -212,19 +212,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -60,10 +60,10 @@ replicate(?p2##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
+@alias_des.36 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_des.35 to i64) }
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+@alias_des.34 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_des.33 to i64) }
 
 
 @alias_des.4 =    constant {i64, i64} { i64 47, i64 ptrtoint ([?? x i8]* @alias_des.3 to i64) }
@@ -72,16 +72,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias_des.3 =    constant [?? x i8] c"--- after x(!p2, 20000) - expect p2(20000,103):\00"
 
 
-@alias_des.36 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_des.35 to i64) }
-
-
-@alias_des.34 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_des.33 to i64) }
-
-
 @alias_des.33 =    constant [?? x i8] c"expect p1(10000,102):\00"
 
 
 @alias_des.35 =    constant [?? x i8] c"expect p2(101,103):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -200,15 +200,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -225,6 +216,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -127,19 +127,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -30,16 +30,16 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @alias_des2.12 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @alias_des2.11 to i64) }
 
 
 @alias_des2.11 =    constant [?? x i8] c"expect pos(200,100):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -115,15 +115,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -140,6 +131,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -92,15 +92,6 @@ simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?#result##0:mytree.tree)<{}; {
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
-
-
 @alias_fork1.24 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork1.23 to i64) }
 
 
@@ -111,6 +102,15 @@ declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)
 
 
 @alias_fork1.25 =    constant [?? x i8] c"}\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -317,13 +317,16 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
 
 
 @mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
+
+
+@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
+
+
+@mytree.16 =    constant [?? x i8] c", \00"
 
 
 @mytree.1 =    constant [?? x i8] c"{\00"
@@ -335,10 +338,7 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
-
-
-@mytree.16 =    constant [?? x i8] c", \00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -101,16 +101,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
 
 
-@alias_fork1.26 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork1.25 to i64) }
-
-
-@alias_fork1.25 =    constant [?? x i8] c"}\00"
-
-
 @alias_fork1.24 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork1.23 to i64) }
 
 
+@alias_fork1.26 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork1.25 to i64) }
+
+
 @alias_fork1.23 =    constant [?? x i8] c"{\00"
+
+
+@alias_fork1.25 =    constant [?? x i8] c"}\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -320,16 +320,16 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
-
-
-@mytree.3 =    constant [?? x i8] c"}\00"
-
-
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
 
 
+@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
+
+
 @mytree.1 =    constant [?? x i8] c"{\00"
+
+
+@mytree.3 =    constant [?? x i8] c"}\00"
 
 
 declare external ccc  void @print_int(i64)    

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -91,15 +91,6 @@ simpleMerge(tl##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
-
-
 @alias_fork2.19 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.18 to i64) }
 
 
@@ -109,7 +100,13 @@ declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)
 @alias_fork2.17 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.16 to i64) }
 
 
+@alias_fork2.35 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_fork2.34 to i64) }
+
+
 @alias_fork2.13 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.12 to i64) }
+
+
+@alias_fork2.37 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.36 to i64) }
 
 
 @alias_fork2.18 =    constant [?? x i8] c"\00"
@@ -118,40 +115,25 @@ declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)
 @alias_fork2.12 =    constant [?? x i8] c"expect t -  1 200:\00"
 
 
+@alias_fork2.36 =    constant [?? x i8] c"expect t1 - 1 200:\00"
+
+
+@alias_fork2.34 =    constant [?? x i8] c"expect t1 - 1000:\00"
+
+
 @alias_fork2.14 =    constant [?? x i8] c"{\00"
 
 
 @alias_fork2.16 =    constant [?? x i8] c"}\00"
 
 
-@alias_fork2.41 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.40 to i64) }
+declare external ccc  void @putchar(i8)    
 
 
-@alias_fork2.37 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.36 to i64) }
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias_fork2.39 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.38 to i64) }
-
-
-@alias_fork2.35 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_fork2.34 to i64) }
-
-
-@alias_fork2.43 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.42 to i64) }
-
-
-@alias_fork2.40 =    constant [?? x i8] c"\00"
-
-
-@alias_fork2.42 =    constant [?? x i8] c"expect t1 - 1 200:\00"
-
-
-@alias_fork2.34 =    constant [?? x i8] c"expect t1 - 1000:\00"
-
-
-@alias_fork2.36 =    constant [?? x i8] c"{\00"
-
-
-@alias_fork2.38 =    constant [?? x i8] c"}\00"
+declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -215,15 +197,15 @@ define external fastcc  void @"alias_fork2.gen#1<0>"(i64  %"t##0", i64  %"t1##0"
 entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.35, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %"1#tmp#9##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t1##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.37, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.39, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.41, i32 0, i32 0) to i64))  
+  %"1#tmp#9##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t1##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.15, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.17, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.19, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.43, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.37, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %"1#tmp#17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.37, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.39, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.41, i32 0, i32 0) to i64))  
+  %"1#tmp#17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.15, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.17, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.19, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -231,21 +213,21 @@ entry:
 
 define external fastcc  i64 @"alias_fork2.simpleMerge<0>"(i64  %"tl##0")    {
 entry:
-  %44 = trunc i64 24 to i32  
-  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
-  %46 = ptrtoint i8* %45 to i64 
+  %38 = trunc i64 24 to i32  
+  %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
+  %40 = ptrtoint i8* %39 to i64 
+  %41 = inttoptr i64 %40 to i64* 
+  %42 = getelementptr  i64, i64* %41, i64 0 
+  store  i64 %"tl##0", i64* %42 
+  %43 = add   i64 %40, 8 
+  %44 = inttoptr i64 %43 to i64* 
+  %45 = getelementptr  i64, i64* %44, i64 0 
+  store  i64 200, i64* %45 
+  %46 = add   i64 %40, 16 
   %47 = inttoptr i64 %46 to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 %"tl##0", i64* %48 
-  %49 = add   i64 %46, 8 
-  %50 = inttoptr i64 %49 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 200, i64* %51 
-  %52 = add   i64 %46, 16 
-  %53 = inttoptr i64 %52 to i64* 
-  %54 = getelementptr  i64, i64* %53, i64 0 
-  store  i64 0, i64* %54 
-  ret i64 %46 
+  store  i64 0, i64* %48 
+  ret i64 %40 
 }
 --------------------------------------------------
  Module mytree
@@ -310,13 +292,16 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
 
 
 @mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
+
+
+@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
+
+
+@mytree.16 =    constant [?? x i8] c", \00"
 
 
 @mytree.1 =    constant [?? x i8] c"{\00"
@@ -328,10 +313,7 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
-
-
-@mytree.16 =    constant [?? x i8] c", \00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -103,73 +103,55 @@ declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)
 @alias_fork2.19 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.18 to i64) }
 
 
-@alias_fork2.18 =    constant [?? x i8] c"\00"
+@alias_fork2.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.14 to i64) }
 
 
 @alias_fork2.17 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.16 to i64) }
 
 
-@alias_fork2.16 =    constant [?? x i8] c"}\00"
-
-
-@alias_fork2.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.14 to i64) }
-
-
-@alias_fork2.14 =    constant [?? x i8] c"{\00"
-
-
 @alias_fork2.13 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.12 to i64) }
+
+
+@alias_fork2.18 =    constant [?? x i8] c"\00"
 
 
 @alias_fork2.12 =    constant [?? x i8] c"expect t -  1 200:\00"
 
 
-@alias_fork2.49 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.48 to i64) }
+@alias_fork2.14 =    constant [?? x i8] c"{\00"
 
 
-@alias_fork2.48 =    constant [?? x i8] c"\00"
-
-
-@alias_fork2.47 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.46 to i64) }
-
-
-@alias_fork2.46 =    constant [?? x i8] c"}\00"
-
-
-@alias_fork2.45 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.44 to i64) }
-
-
-@alias_fork2.44 =    constant [?? x i8] c"{\00"
-
-
-@alias_fork2.43 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.42 to i64) }
-
-
-@alias_fork2.42 =    constant [?? x i8] c"expect t1 - 1 200:\00"
+@alias_fork2.16 =    constant [?? x i8] c"}\00"
 
 
 @alias_fork2.41 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.40 to i64) }
 
 
-@alias_fork2.40 =    constant [?? x i8] c"\00"
+@alias_fork2.37 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.36 to i64) }
 
 
 @alias_fork2.39 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.38 to i64) }
 
 
-@alias_fork2.38 =    constant [?? x i8] c"}\00"
+@alias_fork2.35 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_fork2.34 to i64) }
 
 
-@alias_fork2.37 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.36 to i64) }
+@alias_fork2.43 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.42 to i64) }
+
+
+@alias_fork2.40 =    constant [?? x i8] c"\00"
+
+
+@alias_fork2.42 =    constant [?? x i8] c"expect t1 - 1 200:\00"
+
+
+@alias_fork2.34 =    constant [?? x i8] c"expect t1 - 1000:\00"
 
 
 @alias_fork2.36 =    constant [?? x i8] c"{\00"
 
 
-@alias_fork2.35 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_fork2.34 to i64) }
-
-
-@alias_fork2.34 =    constant [?? x i8] c"expect t1 - 1000:\00"
+@alias_fork2.38 =    constant [?? x i8] c"}\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -239,9 +221,9 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.43, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %"1#tmp#17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.45, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.47, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.49, i32 0, i32 0) to i64))  
+  %"1#tmp#17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.37, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.39, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.41, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -249,21 +231,21 @@ entry:
 
 define external fastcc  i64 @"alias_fork2.simpleMerge<0>"(i64  %"tl##0")    {
 entry:
-  %50 = trunc i64 24 to i32  
-  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
-  %52 = ptrtoint i8* %51 to i64 
+  %44 = trunc i64 24 to i32  
+  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
+  %46 = ptrtoint i8* %45 to i64 
+  %47 = inttoptr i64 %46 to i64* 
+  %48 = getelementptr  i64, i64* %47, i64 0 
+  store  i64 %"tl##0", i64* %48 
+  %49 = add   i64 %46, 8 
+  %50 = inttoptr i64 %49 to i64* 
+  %51 = getelementptr  i64, i64* %50, i64 0 
+  store  i64 200, i64* %51 
+  %52 = add   i64 %46, 16 
   %53 = inttoptr i64 %52 to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
-  store  i64 %"tl##0", i64* %54 
-  %55 = add   i64 %52, 8 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 200, i64* %57 
-  %58 = add   i64 %52, 16 
-  %59 = inttoptr i64 %58 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 0, i64* %60 
-  ret i64 %52 
+  store  i64 0, i64* %54 
+  ret i64 %46 
 }
 --------------------------------------------------
  Module mytree
@@ -331,16 +313,16 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
-
-
-@mytree.3 =    constant [?? x i8] c"}\00"
-
-
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
 
 
+@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
+
+
 @mytree.1 =    constant [?? x i8] c"{\00"
+
+
+@mytree.3 =    constant [?? x i8] c"}\00"
 
 
 declare external ccc  void @print_int(i64)    

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -74,25 +74,25 @@ declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)
 @alias_fork3.30 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork3.29 to i64) }
 
 
-@alias_fork3.29 =    constant [?? x i8] c"\00"
+@alias_fork3.26 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork3.25 to i64) }
 
 
 @alias_fork3.28 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork3.27 to i64) }
 
 
-@alias_fork3.27 =    constant [?? x i8] c"}\00"
+@alias_fork3.24 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_fork3.23 to i64) }
 
 
-@alias_fork3.26 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork3.25 to i64) }
+@alias_fork3.29 =    constant [?? x i8] c"\00"
+
+
+@alias_fork3.23 =    constant [?? x i8] c"expect t - 100:\00"
 
 
 @alias_fork3.25 =    constant [?? x i8] c"{\00"
 
 
-@alias_fork3.24 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_fork3.23 to i64) }
-
-
-@alias_fork3.23 =    constant [?? x i8] c"expect t - 100:\00"
+@alias_fork3.27 =    constant [?? x i8] c"}\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -234,16 +234,16 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
-
-
-@mytree.3 =    constant [?? x i8] c"}\00"
-
-
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
 
 
+@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
+
+
 @mytree.1 =    constant [?? x i8] c"{\00"
+
+
+@mytree.3 =    constant [?? x i8] c"}\00"
 
 
 declare external ccc  void @print_int(i64)    

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -62,15 +62,6 @@ simpleSlice(tr##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
-
-
 @alias_fork3.30 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork3.29 to i64) }
 
 
@@ -93,6 +84,15 @@ declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)
 
 
 @alias_fork3.27 =    constant [?? x i8] c"}\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -231,13 +231,16 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
 
 
 @mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
+
+
+@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
+
+
+@mytree.16 =    constant [?? x i8] c", \00"
 
 
 @mytree.1 =    constant [?? x i8] c"{\00"
@@ -249,10 +252,7 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
-
-
-@mytree.16 =    constant [?? x i8] c", \00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -35,15 +35,6 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64)    
-
-
 @alias_m.13 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.12 to i64) }
 
 
@@ -60,6 +51,15 @@ declare external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64)
 
 
 @alias_m.16 =    constant [?? x i8] c"expect p3(3,3)\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -269,6 +269,12 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)
  
 
 
+@alias_mfoo.13 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.12 to i64) }
+
+
+@alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
+
+
 declare external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64)    
 
 
@@ -276,18 +282,6 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 
 
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@alias_mfoo.13 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.12 to i64) }
-
-
-@alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
-
-
-@alias_mfoo.46 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.45 to i64) }
-
-
-@alias_mfoo.45 =    constant [?? x i8] c"p3:\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -366,30 +360,30 @@ if.then:
   %43 = inttoptr i64 %42 to i64* 
   %44 = getelementptr  i64, i64* %43, i64 0 
   store  i64 3, i64* %44 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
-  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %48 = insertvalue {i64, i64} %47, i64 %39, 1 
-  ret {i64, i64} %48 
+  %45 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %46 = insertvalue {i64, i64} %45, i64 %39, 1 
+  ret {i64, i64} %46 
 if.else:
   %"3#tmp#3##0" = add   i64 %36, 1 
-  %49 = inttoptr i64 %"p1##0" to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %50 
+  %47 = inttoptr i64 %"p1##0" to i64* 
+  %48 = getelementptr  i64, i64* %47, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %48 
   %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %51 = trunc i64 16 to i32  
-  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
-  %53 = ptrtoint i8* %52 to i64 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 2, i64* %55 
-  %56 = add   i64 %53, 8 
-  %57 = inttoptr i64 %56 to i64* 
-  %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 2, i64* %58 
-  %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
-  ret {i64, i64} %60 
+  %49 = trunc i64 16 to i32  
+  %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
+  %51 = ptrtoint i8* %50 to i64 
+  %52 = inttoptr i64 %51 to i64* 
+  %53 = getelementptr  i64, i64* %52, i64 0 
+  store  i64 2, i64* %53 
+  %54 = add   i64 %51, 8 
+  %55 = inttoptr i64 %54 to i64* 
+  %56 = getelementptr  i64, i64* %55, i64 0 
+  store  i64 2, i64* %56 
+  %57 = insertvalue {i64, i64} undef, i64 %51, 0 
+  %58 = insertvalue {i64, i64} %57, i64 %"3#p3##0", 1 
+  ret {i64, i64} %58 
 }
 --------------------------------------------------
  Module position
@@ -439,15 +433,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -464,6 +449,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -44,22 +44,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64)    
 
 
-@alias_m.17 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.16 to i64) }
-
-
-@alias_m.16 =    constant [?? x i8] c"expect p3(3,3)\00"
+@alias_m.13 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.12 to i64) }
 
 
 @alias_m.15 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.14 to i64) }
 
 
-@alias_m.14 =    constant [?? x i8] c"expect p2(2,2)\00"
-
-
-@alias_m.13 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.12 to i64) }
+@alias_m.17 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.16 to i64) }
 
 
 @alias_m.12 =    constant [?? x i8] c"expect p1(2,2)\00"
+
+
+@alias_m.14 =    constant [?? x i8] c"expect p2(2,2)\00"
+
+
+@alias_m.16 =    constant [?? x i8] c"expect p3(3,3)\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -451,19 +451,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -177,6 +177,12 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)
  
 
 
+@alias_mfoo.13 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.12 to i64) }
+
+
+@alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
+
+
 declare external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64)    
 
 
@@ -184,18 +190,6 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 
 
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@alias_mfoo.13 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.12 to i64) }
-
-
-@alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
-
-
-@alias_mfoo.46 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.45 to i64) }
-
-
-@alias_mfoo.45 =    constant [?? x i8] c"p3:\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -274,30 +268,30 @@ if.then:
   %43 = inttoptr i64 %42 to i64* 
   %44 = getelementptr  i64, i64* %43, i64 0 
   store  i64 3, i64* %44 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
-  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %48 = insertvalue {i64, i64} %47, i64 %39, 1 
-  ret {i64, i64} %48 
+  %45 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %46 = insertvalue {i64, i64} %45, i64 %39, 1 
+  ret {i64, i64} %46 
 if.else:
   %"3#tmp#3##0" = add   i64 %36, 1 
-  %49 = inttoptr i64 %"p1##0" to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %50 
+  %47 = inttoptr i64 %"p1##0" to i64* 
+  %48 = getelementptr  i64, i64* %47, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %48 
   %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %51 = trunc i64 16 to i32  
-  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
-  %53 = ptrtoint i8* %52 to i64 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 2, i64* %55 
-  %56 = add   i64 %53, 8 
-  %57 = inttoptr i64 %56 to i64* 
-  %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 2, i64* %58 
-  %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
-  ret {i64, i64} %60 
+  %49 = trunc i64 16 to i32  
+  %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
+  %51 = ptrtoint i8* %50 to i64 
+  %52 = inttoptr i64 %51 to i64* 
+  %53 = getelementptr  i64, i64* %52, i64 0 
+  store  i64 2, i64* %53 
+  %54 = add   i64 %51, 8 
+  %55 = inttoptr i64 %54 to i64* 
+  %56 = getelementptr  i64, i64* %55, i64 0 
+  store  i64 2, i64* %56 
+  %57 = insertvalue {i64, i64} undef, i64 %51, 0 
+  %58 = insertvalue {i64, i64} %57, i64 %"3#p3##0", 1 
+  ret {i64, i64} %58 
 }
 --------------------------------------------------
  Module position
@@ -347,15 +341,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -372,6 +357,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -359,19 +359,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -177,6 +177,12 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)
  
 
 
+@alias_mfoo.13 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.12 to i64) }
+
+
+@alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
+
+
 declare external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64)    
 
 
@@ -184,18 +190,6 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 
 
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@alias_mfoo.13 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.12 to i64) }
-
-
-@alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
-
-
-@alias_mfoo.46 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.45 to i64) }
-
-
-@alias_mfoo.45 =    constant [?? x i8] c"p3:\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -274,30 +268,30 @@ if.then:
   %43 = inttoptr i64 %42 to i64* 
   %44 = getelementptr  i64, i64* %43, i64 0 
   store  i64 3, i64* %44 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
-  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %48 = insertvalue {i64, i64} %47, i64 %39, 1 
-  ret {i64, i64} %48 
+  %45 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %46 = insertvalue {i64, i64} %45, i64 %39, 1 
+  ret {i64, i64} %46 
 if.else:
   %"3#tmp#3##0" = add   i64 %36, 1 
-  %49 = inttoptr i64 %"p1##0" to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %50 
+  %47 = inttoptr i64 %"p1##0" to i64* 
+  %48 = getelementptr  i64, i64* %47, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %48 
   %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %51 = trunc i64 16 to i32  
-  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
-  %53 = ptrtoint i8* %52 to i64 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 2, i64* %55 
-  %56 = add   i64 %53, 8 
-  %57 = inttoptr i64 %56 to i64* 
-  %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 2, i64* %58 
-  %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
-  ret {i64, i64} %60 
+  %49 = trunc i64 16 to i32  
+  %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
+  %51 = ptrtoint i8* %50 to i64 
+  %52 = inttoptr i64 %51 to i64* 
+  %53 = getelementptr  i64, i64* %52, i64 0 
+  store  i64 2, i64* %53 
+  %54 = add   i64 %51, 8 
+  %55 = inttoptr i64 %54 to i64* 
+  %56 = getelementptr  i64, i64* %55, i64 0 
+  store  i64 2, i64* %56 
+  %57 = insertvalue {i64, i64} undef, i64 %51, 0 
+  %58 = insertvalue {i64, i64} %57, i64 %"3#p3##0", 1 
+  ret {i64, i64} %58 
 }
 --------------------------------------------------
  Module position
@@ -347,15 +341,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -372,6 +357,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -359,19 +359,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -160,19 +160,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -41,22 +41,22 @@ foo(pa##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @alias_mod_param.10 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_mod_param.9 to i64) }
-
-
-@alias_mod_param.9 =    constant [?? x i8] c"expect p1(10,10):\00"
 
 
 @alias_mod_param.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_mod_param.19 to i64) }
 
 
+@alias_mod_param.9 =    constant [?? x i8] c"expect p1(10,10):\00"
+
+
 @alias_mod_param.19 =    constant [?? x i8] c"expect pa(1111,10):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -148,15 +148,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -173,6 +164,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -104,67 +104,55 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc.35 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.34 to i64) }
-
-
-@alias_multifunc.34 =    constant [?? x i8] c"expect p3(101,102):\00"
-
-
-@alias_multifunc.33 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.32 to i64) }
-
-
-@alias_multifunc.32 =    constant [?? x i8] c"expect p2(101,102):\00"
-
-
-@alias_multifunc.31 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.30 to i64) }
-
-
-@alias_multifunc.30 =    constant [?? x i8] c"expect p1(555,102):\00"
-
-
-@alias_multifunc.29 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_multifunc.28 to i64) }
-
-
-@alias_multifunc.28 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
-
-
-@alias_multifunc.19 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.18 to i64) }
-
-
-@alias_multifunc.18 =    constant [?? x i8] c"expect p3(101,102):\00"
+@alias_multifunc.15 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.14 to i64) }
 
 
 @alias_multifunc.17 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.16 to i64) }
 
 
-@alias_multifunc.16 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias_multifunc.19 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.18 to i64) }
 
 
-@alias_multifunc.15 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.14 to i64) }
-
-
-@alias_multifunc.14 =    constant [?? x i8] c"expect p1(101,102):\00"
+@alias_multifunc.31 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.30 to i64) }
 
 
 @alias_multifunc.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc.12 to i64) }
 
 
+@alias_multifunc.29 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_multifunc.28 to i64) }
+
+
 @alias_multifunc.12 =    constant [?? x i8] c"--- After calling replicate1: \00"
+
+
+@alias_multifunc.28 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
+
+
+@alias_multifunc.14 =    constant [?? x i8] c"expect p1(101,102):\00"
+
+
+@alias_multifunc.30 =    constant [?? x i8] c"expect p1(555,102):\00"
+
+
+@alias_multifunc.16 =    constant [?? x i8] c"expect p2(101,102):\00"
+
+
+@alias_multifunc.18 =    constant [?? x i8] c"expect p3(101,102):\00"
 
 
 declare external ccc  void @print_int(i64)    
 
 
-@alias_multifunc.45 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.44 to i64) }
+@alias_multifunc.41 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.40 to i64) }
 
 
-@alias_multifunc.44 =    constant [?? x i8] c"random replicate1 \00"
+@alias_multifunc.40 =    constant [?? x i8] c"random replicate1 \00"
 
 
-@alias_multifunc.60 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.59 to i64) }
+@alias_multifunc.56 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.55 to i64) }
 
 
-@alias_multifunc.59 =    constant [?? x i8] c"random replicate2 \00"
+@alias_multifunc.55 =    constant [?? x i8] c"random replicate2 \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -217,9 +205,9 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.31, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %22)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.33, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.17, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.35, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.19, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }
@@ -227,46 +215,46 @@ entry:
 
 define external fastcc  {i64, i64} @"alias_multifunc.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %36 = trunc i64 16 to i32  
-  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
-  %38 = ptrtoint i8* %37 to i64 
-  %39 = inttoptr i64 %38 to i64* 
-  %40 = getelementptr  i64, i64* %39, i64 0 
-  store  i64 0, i64* %40 
-  %41 = add   i64 %38, 8 
-  %42 = inttoptr i64 %41 to i64* 
+  %32 = trunc i64 16 to i32  
+  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
+  %34 = ptrtoint i8* %33 to i64 
+  %35 = inttoptr i64 %34 to i64* 
+  %36 = getelementptr  i64, i64* %35, i64 0 
+  store  i64 0, i64* %36 
+  %37 = add   i64 %34, 8 
+  %38 = inttoptr i64 %37 to i64* 
+  %39 = getelementptr  i64, i64* %38, i64 0 
+  store  i64 0, i64* %39 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.41, i32 0, i32 0) to i64))  
+  %42 = inttoptr i64 %34 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 0, i64* %43 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.45, i32 0, i32 0) to i64))  
-  %46 = inttoptr i64 %38 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  %48 = load  i64, i64* %47 
-  tail call ccc  void  @print_int(i64  %48)  
+  %44 = load  i64, i64* %43 
+  tail call ccc  void  @print_int(i64  %44)  
   tail call ccc  void  @putchar(i8  10)  
   %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc.replicate2<0>"(i64  %"p1##0")  
-  %49 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %50 = insertvalue {i64, i64} %49, i64 %"1#p3##0", 1 
-  ret {i64, i64} %50 
+  %45 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %46 = insertvalue {i64, i64} %45, i64 %"1#p3##0", 1 
+  ret {i64, i64} %46 
 }
 
 
 define external fastcc  i64 @"alias_multifunc.replicate2<0>"(i64  %"p1##0")    {
 entry:
-  %51 = trunc i64 16 to i32  
-  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
-  %53 = ptrtoint i8* %52 to i64 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 0, i64* %55 
-  %56 = add   i64 %53, 8 
-  %57 = inttoptr i64 %56 to i64* 
+  %47 = trunc i64 16 to i32  
+  %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
+  %49 = ptrtoint i8* %48 to i64 
+  %50 = inttoptr i64 %49 to i64* 
+  %51 = getelementptr  i64, i64* %50, i64 0 
+  store  i64 0, i64* %51 
+  %52 = add   i64 %49, 8 
+  %53 = inttoptr i64 %52 to i64* 
+  %54 = getelementptr  i64, i64* %53, i64 0 
+  store  i64 0, i64* %54 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.56, i32 0, i32 0) to i64))  
+  %57 = inttoptr i64 %49 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 0, i64* %58 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.60, i32 0, i32 0) to i64))  
-  %61 = inttoptr i64 %53 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  %63 = load  i64, i64* %62 
-  tail call ccc  void  @print_int(i64  %63)  
+  %59 = load  i64, i64* %58 
+  tail call ccc  void  @print_int(i64  %59)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -330,19 +318,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -95,13 +95,10 @@ replicate2(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; 
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
+@alias_multifunc.41 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.40 to i64) }
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
+@alias_multifunc.56 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.55 to i64) }
 
 
 @alias_multifunc.15 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.14 to i64) }
@@ -140,19 +137,22 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc.18 =    constant [?? x i8] c"expect p3(101,102):\00"
 
 
-declare external ccc  void @print_int(i64)    
-
-
-@alias_multifunc.41 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.40 to i64) }
-
-
 @alias_multifunc.40 =    constant [?? x i8] c"random replicate1 \00"
 
 
-@alias_multifunc.56 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.55 to i64) }
-
-
 @alias_multifunc.55 =    constant [?? x i8] c"random replicate2 \00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -306,15 +306,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -331,6 +322,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -92,67 +92,61 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc1.39 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.38 to i64) }
-
-
-@alias_multifunc1.38 =    constant [?? x i8] c"expect p3(10,10):\00"
-
-
-@alias_multifunc1.37 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.36 to i64) }
-
-
-@alias_multifunc1.36 =    constant [?? x i8] c"expect p1(11,10):\00"
-
-
-@alias_multifunc1.35 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc1.34 to i64) }
-
-
-@alias_multifunc1.34 =    constant [?? x i8] c"--- After calling x(!p1, 11): \00"
-
-
-@alias_multifunc1.25 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc1.24 to i64) }
-
-
-@alias_multifunc1.24 =    constant [?? x i8] c"expect p2(2222222,10):\00"
-
-
-@alias_multifunc1.23 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @alias_multifunc1.22 to i64) }
-
-
-@alias_multifunc1.22 =    constant [?? x i8] c"--- After calling x(!p2, 2222222): \00"
-
-
-@alias_multifunc1.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.18 to i64) }
-
-
-@alias_multifunc1.18 =    constant [?? x i8] c"expect p3(10,10):\00"
+@alias_multifunc1.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.14 to i64) }
 
 
 @alias_multifunc1.17 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.16 to i64) }
 
 
-@alias_multifunc1.16 =    constant [?? x i8] c"expect p2(22,10):\00"
+@alias_multifunc1.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.18 to i64) }
 
 
-@alias_multifunc1.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.14 to i64) }
+@alias_multifunc1.37 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.36 to i64) }
 
 
-@alias_multifunc1.14 =    constant [?? x i8] c"expect p1(10,10):\00"
+@alias_multifunc1.25 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc1.24 to i64) }
 
 
 @alias_multifunc1.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc1.12 to i64) }
 
 
+@alias_multifunc1.35 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc1.34 to i64) }
+
+
+@alias_multifunc1.23 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @alias_multifunc1.22 to i64) }
+
+
 @alias_multifunc1.12 =    constant [?? x i8] c"--- After calling replicate1: \00"
+
+
+@alias_multifunc1.34 =    constant [?? x i8] c"--- After calling x(!p1, 11): \00"
+
+
+@alias_multifunc1.22 =    constant [?? x i8] c"--- After calling x(!p2, 2222222): \00"
+
+
+@alias_multifunc1.14 =    constant [?? x i8] c"expect p1(10,10):\00"
+
+
+@alias_multifunc1.36 =    constant [?? x i8] c"expect p1(11,10):\00"
+
+
+@alias_multifunc1.16 =    constant [?? x i8] c"expect p2(22,10):\00"
+
+
+@alias_multifunc1.24 =    constant [?? x i8] c"expect p2(2222222,10):\00"
+
+
+@alias_multifunc1.18 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
 declare external ccc  void @print_int(i64)    
 
 
-@alias_multifunc1.59 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @alias_multifunc1.58 to i64) }
+@alias_multifunc1.57 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @alias_multifunc1.56 to i64) }
 
 
-@alias_multifunc1.58 =    constant [?? x i8] c"some noise...\00"
+@alias_multifunc1.56 =    constant [?? x i8] c"some noise...\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -205,7 +199,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.37, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %28)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.39, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.19, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }
@@ -215,39 +209,39 @@ define external fastcc  {i64, i64} @"alias_multifunc1.replicate1<0>"(i64  %"p1##
 entry:
   %"1#p2##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"p1##0")  
   %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"1#p2##0")  
-  %40 = trunc i64 16 to i32  
-  %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
-  %42 = ptrtoint i8* %41 to i64 
-  %43 = inttoptr i64 %42 to i8* 
-  %44 = inttoptr i64 %"1#p2##0" to i8* 
-  %45 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %43, i8*  %44, i32  %45, i1  0)  
-  %46 = inttoptr i64 %42 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 22, i64* %47 
-  %48 = insertvalue {i64, i64} undef, i64 %42, 0 
-  %49 = insertvalue {i64, i64} %48, i64 %"1#p3##0", 1 
-  ret {i64, i64} %49 
+  %38 = trunc i64 16 to i32  
+  %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
+  %40 = ptrtoint i8* %39 to i64 
+  %41 = inttoptr i64 %40 to i8* 
+  %42 = inttoptr i64 %"1#p2##0" to i8* 
+  %43 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %41, i8*  %42, i32  %43, i1  0)  
+  %44 = inttoptr i64 %40 to i64* 
+  %45 = getelementptr  i64, i64* %44, i64 0 
+  store  i64 22, i64* %45 
+  %46 = insertvalue {i64, i64} undef, i64 %40, 0 
+  %47 = insertvalue {i64, i64} %46, i64 %"1#p3##0", 1 
+  ret {i64, i64} %47 
 }
 
 
 define external fastcc  i64 @"alias_multifunc1.replicate2<0>"(i64  %"p1##0")    {
 entry:
-  %50 = trunc i64 16 to i32  
-  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
-  %52 = ptrtoint i8* %51 to i64 
-  %53 = inttoptr i64 %52 to i64* 
-  %54 = getelementptr  i64, i64* %53, i64 0 
-  store  i64 0, i64* %54 
-  %55 = add   i64 %52, 8 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 0, i64* %57 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.59, i32 0, i32 0) to i64))  
-  %60 = inttoptr i64 %52 to i64* 
-  %61 = getelementptr  i64, i64* %60, i64 0 
-  %62 = load  i64, i64* %61 
-  tail call ccc  void  @print_int(i64  %62)  
+  %48 = trunc i64 16 to i32  
+  %49 = tail call ccc  i8*  @wybe_malloc(i32  %48)  
+  %50 = ptrtoint i8* %49 to i64 
+  %51 = inttoptr i64 %50 to i64* 
+  %52 = getelementptr  i64, i64* %51, i64 0 
+  store  i64 0, i64* %52 
+  %53 = add   i64 %50, 8 
+  %54 = inttoptr i64 %53 to i64* 
+  %55 = getelementptr  i64, i64* %54, i64 0 
+  store  i64 0, i64* %55 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.57, i32 0, i32 0) to i64))  
+  %58 = inttoptr i64 %50 to i64* 
+  %59 = getelementptr  i64, i64* %58, i64 0 
+  %60 = load  i64, i64* %59 
+  tail call ccc  void  @print_int(i64  %60)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -311,19 +305,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -83,13 +83,7 @@ replicate2(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; 
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
+@alias_multifunc1.57 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @alias_multifunc1.56 to i64) }
 
 
 @alias_multifunc1.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.14 to i64) }
@@ -140,13 +134,19 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc1.18 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
+@alias_multifunc1.56 =    constant [?? x i8] c"some noise...\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
 declare external ccc  void @print_int(i64)    
 
 
-@alias_multifunc1.57 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @alias_multifunc1.56 to i64) }
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias_multifunc1.56 =    constant [?? x i8] c"some noise...\00"
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -293,15 +293,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -318,6 +309,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -87,61 +87,49 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc2.35 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.34 to i64) }
-
-
-@alias_multifunc2.34 =    constant [?? x i8] c"expect p3(10,10):\00"
-
-
-@alias_multifunc2.33 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.32 to i64) }
-
-
-@alias_multifunc2.32 =    constant [?? x i8] c"expect p2(22,10):\00"
-
-
-@alias_multifunc2.31 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.30 to i64) }
-
-
-@alias_multifunc2.30 =    constant [?? x i8] c"expect p1(11,10):\00"
-
-
-@alias_multifunc2.29 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc2.28 to i64) }
-
-
-@alias_multifunc2.28 =    constant [?? x i8] c"--- After calling x(!p1, 11): \00"
-
-
-@alias_multifunc2.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.18 to i64) }
-
-
-@alias_multifunc2.18 =    constant [?? x i8] c"expect p3(10,10):\00"
+@alias_multifunc2.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.14 to i64) }
 
 
 @alias_multifunc2.17 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.16 to i64) }
 
 
-@alias_multifunc2.16 =    constant [?? x i8] c"expect p2(22,10):\00"
+@alias_multifunc2.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.18 to i64) }
 
 
-@alias_multifunc2.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.14 to i64) }
-
-
-@alias_multifunc2.14 =    constant [?? x i8] c"expect p1(10,10):\00"
+@alias_multifunc2.31 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.30 to i64) }
 
 
 @alias_multifunc2.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc2.12 to i64) }
 
 
+@alias_multifunc2.29 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc2.28 to i64) }
+
+
 @alias_multifunc2.12 =    constant [?? x i8] c"--- After calling replicate1: \00"
+
+
+@alias_multifunc2.28 =    constant [?? x i8] c"--- After calling x(!p1, 11): \00"
+
+
+@alias_multifunc2.14 =    constant [?? x i8] c"expect p1(10,10):\00"
+
+
+@alias_multifunc2.30 =    constant [?? x i8] c"expect p1(11,10):\00"
+
+
+@alias_multifunc2.16 =    constant [?? x i8] c"expect p2(22,10):\00"
+
+
+@alias_multifunc2.18 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
 declare external ccc  void @print_int(i64)    
 
 
-@alias_multifunc2.55 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc2.54 to i64) }
+@alias_multifunc2.51 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc2.50 to i64) }
 
 
-@alias_multifunc2.54 =    constant [?? x i8] c"random replicate2 \00"
+@alias_multifunc2.50 =    constant [?? x i8] c"random replicate2 \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -187,9 +175,9 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.31, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %22)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.33, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.17, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.35, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.19, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }
@@ -199,39 +187,39 @@ define external fastcc  {i64, i64} @"alias_multifunc2.replicate1<0>"(i64  %"p1##
 entry:
   %"1#p2##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"p1##0")  
   %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"1#p2##0")  
-  %36 = trunc i64 16 to i32  
-  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
-  %38 = ptrtoint i8* %37 to i64 
-  %39 = inttoptr i64 %38 to i8* 
-  %40 = inttoptr i64 %"1#p2##0" to i8* 
-  %41 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %39, i8*  %40, i32  %41, i1  0)  
-  %42 = inttoptr i64 %38 to i64* 
-  %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 22, i64* %43 
-  %44 = insertvalue {i64, i64} undef, i64 %38, 0 
-  %45 = insertvalue {i64, i64} %44, i64 %"1#p3##0", 1 
-  ret {i64, i64} %45 
+  %32 = trunc i64 16 to i32  
+  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
+  %34 = ptrtoint i8* %33 to i64 
+  %35 = inttoptr i64 %34 to i8* 
+  %36 = inttoptr i64 %"1#p2##0" to i8* 
+  %37 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %35, i8*  %36, i32  %37, i1  0)  
+  %38 = inttoptr i64 %34 to i64* 
+  %39 = getelementptr  i64, i64* %38, i64 0 
+  store  i64 22, i64* %39 
+  %40 = insertvalue {i64, i64} undef, i64 %34, 0 
+  %41 = insertvalue {i64, i64} %40, i64 %"1#p3##0", 1 
+  ret {i64, i64} %41 
 }
 
 
 define external fastcc  i64 @"alias_multifunc2.replicate2<0>"(i64  %"p1##0")    {
 entry:
-  %46 = trunc i64 16 to i32  
-  %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
-  %48 = ptrtoint i8* %47 to i64 
-  %49 = inttoptr i64 %48 to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 0, i64* %50 
-  %51 = add   i64 %48, 8 
-  %52 = inttoptr i64 %51 to i64* 
+  %42 = trunc i64 16 to i32  
+  %43 = tail call ccc  i8*  @wybe_malloc(i32  %42)  
+  %44 = ptrtoint i8* %43 to i64 
+  %45 = inttoptr i64 %44 to i64* 
+  %46 = getelementptr  i64, i64* %45, i64 0 
+  store  i64 0, i64* %46 
+  %47 = add   i64 %44, 8 
+  %48 = inttoptr i64 %47 to i64* 
+  %49 = getelementptr  i64, i64* %48, i64 0 
+  store  i64 0, i64* %49 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.51, i32 0, i32 0) to i64))  
+  %52 = inttoptr i64 %44 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
-  store  i64 0, i64* %53 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.55, i32 0, i32 0) to i64))  
-  %56 = inttoptr i64 %48 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  %58 = load  i64, i64* %57 
-  tail call ccc  void  @print_int(i64  %58)  
+  %54 = load  i64, i64* %53 
+  tail call ccc  void  @print_int(i64  %54)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -295,19 +283,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -78,15 +78,6 @@ replicate2(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; 
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
 @alias_multifunc2.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.14 to i64) }
 
 
@@ -97,6 +88,9 @@ declare external ccc  void @putchar(i8)
 
 
 @alias_multifunc2.31 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.30 to i64) }
+
+
+@alias_multifunc2.51 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc2.50 to i64) }
 
 
 @alias_multifunc2.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc2.12 to i64) }
@@ -123,13 +117,19 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc2.18 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
+@alias_multifunc2.50 =    constant [?? x i8] c"random replicate2 \00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
 declare external ccc  void @print_int(i64)    
 
 
-@alias_multifunc2.51 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc2.50 to i64) }
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias_multifunc2.50 =    constant [?? x i8] c"random replicate2 \00"
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -271,15 +271,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -296,6 +287,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -72,58 +72,52 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc3.28 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.27 to i64) }
-
-
-@alias_multifunc3.27 =    constant [?? x i8] c"expect p2(10,10):\00"
-
-
-@alias_multifunc3.26 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc3.25 to i64) }
-
-
-@alias_multifunc3.25 =    constant [?? x i8] c"expect p1(999,10):\00"
-
-
-@alias_multifunc3.24 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc3.23 to i64) }
-
-
-@alias_multifunc3.23 =    constant [?? x i8] c"--- After called x(!p1, 999):\00"
+@alias_multifunc3.12 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.11 to i64) }
 
 
 @alias_multifunc3.14 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.13 to i64) }
 
 
-@alias_multifunc3.13 =    constant [?? x i8] c"expect p2(10,10):\00"
+@alias_multifunc3.26 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc3.25 to i64) }
 
 
-@alias_multifunc3.12 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.11 to i64) }
-
-
-@alias_multifunc3.11 =    constant [?? x i8] c"expect p1(10,10):\00"
+@alias_multifunc3.24 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc3.23 to i64) }
 
 
 @alias_multifunc3.10 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc3.9 to i64) }
 
 
+@alias_multifunc3.23 =    constant [?? x i8] c"--- After called x(!p1, 999):\00"
+
+
 @alias_multifunc3.9 =    constant [?? x i8] c"--- After calling replicate1:\00"
 
 
-@alias_multifunc3.42 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.41 to i64) }
+@alias_multifunc3.11 =    constant [?? x i8] c"expect p1(10,10):\00"
 
 
-@alias_multifunc3.41 =    constant [?? x i8] c"expect pb(10,10):\00"
+@alias_multifunc3.25 =    constant [?? x i8] c"expect p1(999,10):\00"
 
 
-@alias_multifunc3.40 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc3.39 to i64) }
+@alias_multifunc3.13 =    constant [?? x i8] c"expect p2(10,10):\00"
 
 
-@alias_multifunc3.39 =    constant [?? x i8] c"expect pa(1111,10):\00"
+@alias_multifunc3.40 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.39 to i64) }
 
 
-@alias_multifunc3.38 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc3.37 to i64) }
+@alias_multifunc3.38 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc3.37 to i64) }
 
 
-@alias_multifunc3.37 =    constant [?? x i8] c"--- Inside replicate1:\00"
+@alias_multifunc3.36 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc3.35 to i64) }
+
+
+@alias_multifunc3.35 =    constant [?? x i8] c"--- Inside replicate1:\00"
+
+
+@alias_multifunc3.37 =    constant [?? x i8] c"expect pa(1111,10):\00"
+
+
+@alias_multifunc3.39 =    constant [?? x i8] c"expect pb(10,10):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -165,7 +159,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.26, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %17)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.28, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.14, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -173,21 +167,21 @@ entry:
 
 define external fastcc  i64 @"alias_multifunc3.replicate1<0>"(i64  %"pa##0")    {
 entry:
-  %29 = trunc i64 16 to i32  
-  %30 = tail call ccc  i8*  @wybe_malloc(i32  %29)  
-  %31 = ptrtoint i8* %30 to i64 
-  %32 = inttoptr i64 %31 to i8* 
-  %33 = inttoptr i64 %"pa##0" to i8* 
-  %34 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %32, i8*  %33, i32  %34, i1  0)  
-  %35 = inttoptr i64 %31 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 1111, i64* %36 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.38, i32 0, i32 0) to i64))  
+  %27 = trunc i64 16 to i32  
+  %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
+  %29 = ptrtoint i8* %28 to i64 
+  %30 = inttoptr i64 %29 to i8* 
+  %31 = inttoptr i64 %"pa##0" to i8* 
+  %32 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i1  0)  
+  %33 = inttoptr i64 %29 to i64* 
+  %34 = getelementptr  i64, i64* %33, i64 0 
+  store  i64 1111, i64* %34 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.36, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.38, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %29)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.40, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %31)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.42, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"pa##0")  
   ret i64 %"pa##0" 
 }
@@ -251,19 +245,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -63,22 +63,22 @@ replicate1(pa##0:position.position, ?pb##0:position.position)<{<<wybe.io.io>>}; 
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
 @alias_multifunc3.12 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.11 to i64) }
 
 
 @alias_multifunc3.14 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.13 to i64) }
 
 
+@alias_multifunc3.40 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.39 to i64) }
+
+
 @alias_multifunc3.26 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc3.25 to i64) }
+
+
+@alias_multifunc3.38 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc3.37 to i64) }
+
+
+@alias_multifunc3.36 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc3.35 to i64) }
 
 
 @alias_multifunc3.24 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc3.23 to i64) }
@@ -93,6 +93,9 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc3.9 =    constant [?? x i8] c"--- After calling replicate1:\00"
 
 
+@alias_multifunc3.35 =    constant [?? x i8] c"--- Inside replicate1:\00"
+
+
 @alias_multifunc3.11 =    constant [?? x i8] c"expect p1(10,10):\00"
 
 
@@ -102,22 +105,19 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc3.13 =    constant [?? x i8] c"expect p2(10,10):\00"
 
 
-@alias_multifunc3.40 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.39 to i64) }
-
-
-@alias_multifunc3.38 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc3.37 to i64) }
-
-
-@alias_multifunc3.36 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc3.35 to i64) }
-
-
-@alias_multifunc3.35 =    constant [?? x i8] c"--- Inside replicate1:\00"
-
-
 @alias_multifunc3.37 =    constant [?? x i8] c"expect pa(1111,10):\00"
 
 
 @alias_multifunc3.39 =    constant [?? x i8] c"expect pb(10,10):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -233,15 +233,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -258,6 +249,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -109,58 +109,58 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc4.32 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias_multifunc4.31 to i64) }
-
-
-@alias_multifunc4.31 =    constant [?? x i8] c"expect p7(1111111111,99999):\00"
-
-
-@alias_multifunc4.30 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_multifunc4.29 to i64) }
-
-
-@alias_multifunc4.29 =    constant [?? x i8] c"expect p6(99999,99999):\00"
-
-
-@alias_multifunc4.28 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.27 to i64) }
-
-
-@alias_multifunc4.27 =    constant [?? x i8] c"--- After calling replicate22:\00"
-
-
-@alias_multifunc4.23 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_multifunc4.22 to i64) }
-
-
-@alias_multifunc4.22 =    constant [?? x i8] c"expect p4(99999,99999):\00"
-
-
-@alias_multifunc4.21 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.20 to i64) }
-
-
-@alias_multifunc4.20 =    constant [?? x i8] c"--- After calling replicate21:\00"
-
-
-@alias_multifunc4.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.18 to i64) }
-
-
-@alias_multifunc4.18 =    constant [?? x i8] c"expect p3(10,10):\00"
+@alias_multifunc4.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.14 to i64) }
 
 
 @alias_multifunc4.17 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.16 to i64) }
 
 
-@alias_multifunc4.16 =    constant [?? x i8] c"expect p2(99,10):\00"
+@alias_multifunc4.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.18 to i64) }
 
 
-@alias_multifunc4.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.14 to i64) }
+@alias_multifunc4.23 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_multifunc4.22 to i64) }
 
 
-@alias_multifunc4.14 =    constant [?? x i8] c"expect p1(10,10):\00"
+@alias_multifunc4.30 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_multifunc4.29 to i64) }
+
+
+@alias_multifunc4.32 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias_multifunc4.31 to i64) }
 
 
 @alias_multifunc4.13 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc4.12 to i64) }
 
 
+@alias_multifunc4.21 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.20 to i64) }
+
+
+@alias_multifunc4.28 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.27 to i64) }
+
+
 @alias_multifunc4.12 =    constant [?? x i8] c"--- After calling replicate1:\00"
+
+
+@alias_multifunc4.20 =    constant [?? x i8] c"--- After calling replicate21:\00"
+
+
+@alias_multifunc4.27 =    constant [?? x i8] c"--- After calling replicate22:\00"
+
+
+@alias_multifunc4.14 =    constant [?? x i8] c"expect p1(10,10):\00"
+
+
+@alias_multifunc4.16 =    constant [?? x i8] c"expect p2(99,10):\00"
+
+
+@alias_multifunc4.18 =    constant [?? x i8] c"expect p3(10,10):\00"
+
+
+@alias_multifunc4.22 =    constant [?? x i8] c"expect p4(99999,99999):\00"
+
+
+@alias_multifunc4.29 =    constant [?? x i8] c"expect p6(99999,99999):\00"
+
+
+@alias_multifunc4.31 =    constant [?? x i8] c"expect p7(1111111111,99999):\00"
 
 
 @alias_multifunc4.71 =    constant {i64, i64} { i64 53, i64 ptrtoint ([?? x i8]* @alias_multifunc4.70 to i64) }
@@ -169,13 +169,13 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc4.70 =    constant [?? x i8] c"--- Inside replicate21, expect pc(1111111111,99999): \00"
 
 
+@alias_multifunc4.81 =    constant {i64, i64} { i64 47, i64 ptrtoint ([?? x i8]* @alias_multifunc4.80 to i64) }
+
+
 @alias_multifunc4.91 =    constant {i64, i64} { i64 86, i64 ptrtoint ([?? x i8]* @alias_multifunc4.90 to i64) }
 
 
 @alias_multifunc4.90 =    constant [?? x i8] c"--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): \00"
-
-
-@alias_multifunc4.81 =    constant {i64, i64} { i64 47, i64 ptrtoint ([?? x i8]* @alias_multifunc4.80 to i64) }
 
 
 @alias_multifunc4.80 =    constant [?? x i8] c"--- Inside replicate22, expect pc(99999,99999):\00"
@@ -377,19 +377,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -100,15 +100,6 @@ replicate22(?pb##0:position.position, ?pc##1:position.position)<{<<wybe.io.io>>}
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
 @alias_multifunc4.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.14 to i64) }
 
 
@@ -136,6 +127,15 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc4.28 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.27 to i64) }
 
 
+@alias_multifunc4.81 =    constant {i64, i64} { i64 47, i64 ptrtoint ([?? x i8]* @alias_multifunc4.80 to i64) }
+
+
+@alias_multifunc4.71 =    constant {i64, i64} { i64 53, i64 ptrtoint ([?? x i8]* @alias_multifunc4.70 to i64) }
+
+
+@alias_multifunc4.91 =    constant {i64, i64} { i64 86, i64 ptrtoint ([?? x i8]* @alias_multifunc4.90 to i64) }
+
+
 @alias_multifunc4.12 =    constant [?? x i8] c"--- After calling replicate1:\00"
 
 
@@ -143,6 +143,15 @@ declare external ccc  void @putchar(i8)
 
 
 @alias_multifunc4.27 =    constant [?? x i8] c"--- After calling replicate22:\00"
+
+
+@alias_multifunc4.70 =    constant [?? x i8] c"--- Inside replicate21, expect pc(1111111111,99999): \00"
+
+
+@alias_multifunc4.90 =    constant [?? x i8] c"--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): \00"
+
+
+@alias_multifunc4.80 =    constant [?? x i8] c"--- Inside replicate22, expect pc(99999,99999):\00"
 
 
 @alias_multifunc4.14 =    constant [?? x i8] c"expect p1(10,10):\00"
@@ -163,22 +172,13 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc4.31 =    constant [?? x i8] c"expect p7(1111111111,99999):\00"
 
 
-@alias_multifunc4.71 =    constant {i64, i64} { i64 53, i64 ptrtoint ([?? x i8]* @alias_multifunc4.70 to i64) }
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
-@alias_multifunc4.70 =    constant [?? x i8] c"--- Inside replicate21, expect pc(1111111111,99999): \00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias_multifunc4.81 =    constant {i64, i64} { i64 47, i64 ptrtoint ([?? x i8]* @alias_multifunc4.80 to i64) }
-
-
-@alias_multifunc4.91 =    constant {i64, i64} { i64 86, i64 ptrtoint ([?? x i8]* @alias_multifunc4.90 to i64) }
-
-
-@alias_multifunc4.90 =    constant [?? x i8] c"--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): \00"
-
-
-@alias_multifunc4.80 =    constant [?? x i8] c"--- Inside replicate22, expect pc(99999,99999):\00"
+declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -365,15 +365,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -390,6 +381,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -79,15 +79,6 @@ if_test(a##0:position.position, b##0:position.position, ?r##0:position.position)
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
 @alias_recursion1.30 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_recursion1.29 to i64) }
 
 
@@ -140,6 +131,15 @@ declare external ccc  void @putchar(i8)
 
 
 @alias_recursion1.27 =    constant [?? x i8] c"expect r(-200,-201):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -268,15 +268,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -293,6 +284,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -88,46 +88,28 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_recursion1.46 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @alias_recursion1.45 to i64) }
+@alias_recursion1.30 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_recursion1.29 to i64) }
 
 
-@alias_recursion1.45 =    constant [?? x i8] c"expect r still (-200,-201):\00"
+@alias_recursion1.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_recursion1.19 to i64) }
 
 
-@alias_recursion1.44 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.43 to i64) }
+@alias_recursion1.28 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @alias_recursion1.27 to i64) }
 
 
-@alias_recursion1.43 =    constant [?? x i8] c"expect pa(-1000,101):\00"
+@alias_recursion1.22 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.21 to i64) }
 
 
-@alias_recursion1.34 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_recursion1.33 to i64) }
+@alias_recursion1.40 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.39 to i64) }
 
 
-@alias_recursion1.33 =    constant [?? x i8] c"--- modify pa^x: \00"
+@alias_recursion1.18 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_recursion1.17 to i64) }
 
 
-@alias_recursion1.32 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @alias_recursion1.31 to i64) }
+@alias_recursion1.42 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @alias_recursion1.41 to i64) }
 
 
-@alias_recursion1.31 =    constant [?? x i8] c"expect r(-200,-201):\00"
-
-
-@alias_recursion1.30 =    constant {i64, i64} { i64 38, i64 ptrtoint ([?? x i8]* @alias_recursion1.29 to i64) }
-
-
-@alias_recursion1.29 =    constant [?? x i8] c"--- expected result to be same as pb: \00"
-
-
-@alias_recursion1.28 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.27 to i64) }
-
-
-@alias_recursion1.27 =    constant [?? x i8] c"expect pb(-200,-201):\00"
-
-
-@alias_recursion1.26 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_recursion1.25 to i64) }
-
-
-@alias_recursion1.25 =    constant [?? x i8] c"expect pa(100,101):\00"
+@alias_recursion1.26 =    constant {i64, i64} { i64 38, i64 ptrtoint ([?? x i8]* @alias_recursion1.25 to i64) }
 
 
 @alias_recursion1.24 =    constant {i64, i64} { i64 57, i64 ptrtoint ([?? x i8]* @alias_recursion1.23 to i64) }
@@ -136,22 +118,28 @@ declare external ccc  void @putchar(i8)
 @alias_recursion1.23 =    constant [?? x i8] c"--- after calling if_test, pa and pb should be the same: \00"
 
 
-@alias_recursion1.22 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.21 to i64) }
+@alias_recursion1.17 =    constant [?? x i8] c"--- before proc call: \00"
 
 
-@alias_recursion1.21 =    constant [?? x i8] c"expect pb(-200,-201):\00"
+@alias_recursion1.25 =    constant [?? x i8] c"--- expected result to be same as pb: \00"
 
 
-@alias_recursion1.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_recursion1.19 to i64) }
+@alias_recursion1.29 =    constant [?? x i8] c"--- modify pa^x: \00"
+
+
+@alias_recursion1.39 =    constant [?? x i8] c"expect pa(-1000,101):\00"
 
 
 @alias_recursion1.19 =    constant [?? x i8] c"expect pa(100,101):\00"
 
 
-@alias_recursion1.18 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_recursion1.17 to i64) }
+@alias_recursion1.21 =    constant [?? x i8] c"expect pb(-200,-201):\00"
 
 
-@alias_recursion1.17 =    constant [?? x i8] c"--- before proc call: \00"
+@alias_recursion1.41 =    constant [?? x i8] c"expect r still (-200,-201):\00"
+
+
+@alias_recursion1.27 =    constant [?? x i8] c"expect r(-200,-201):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -191,29 +179,29 @@ entry:
   %"1#r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %3, i64  %11)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.26, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.28, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.22, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.26, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.28, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.32, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.34, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  %35 = trunc i64 16 to i32  
-  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
-  %37 = ptrtoint i8* %36 to i64 
-  %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %3 to i8* 
-  %40 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i1  0)  
-  %41 = inttoptr i64 %37 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 -1000, i64* %42 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.44, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.46, i32 0, i32 0) to i64))  
+  %31 = trunc i64 16 to i32  
+  %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
+  %33 = ptrtoint i8* %32 to i64 
+  %34 = inttoptr i64 %33 to i8* 
+  %35 = inttoptr i64 %3 to i8* 
+  %36 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i1  0)  
+  %37 = inttoptr i64 %33 to i64* 
+  %38 = getelementptr  i64, i64* %37, i64 0 
+  store  i64 -1000, i64* %38 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.40, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %33)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.42, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
   ret void 
 }
@@ -221,10 +209,10 @@ entry:
 
 define external fastcc  i64 @"alias_recursion1.if_test<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
-  %47 = inttoptr i64 %"a##0" to i64* 
-  %48 = getelementptr  i64, i64* %47, i64 0 
-  %49 = load  i64, i64* %48 
-  %"1#tmp#1##0" = icmp sgt i64 %49, 0 
+  %43 = inttoptr i64 %"a##0" to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  %45 = load  i64, i64* %44 
+  %"1#tmp#1##0" = icmp sgt i64 %45, 0 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %"b##0", i64  %"a##0")  
@@ -292,19 +280,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -120,15 +120,6 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
 @alias_scc_proc.15 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.14 to i64) }
 
 
@@ -141,7 +132,13 @@ declare external ccc  void @putchar(i8)
 @alias_scc_proc.13 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_scc_proc.12 to i64) }
 
 
+@alias_scc_proc.58 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_scc_proc.57 to i64) }
+
+
 @alias_scc_proc.12 =    constant [?? x i8] c"--- After calling foo: \00"
+
+
+@alias_scc_proc.57 =    constant [?? x i8] c"--- Inside foo: expect p3(3,3):\00"
 
 
 @alias_scc_proc.14 =    constant [?? x i8] c"expect p1(2,2):\00"
@@ -153,16 +150,13 @@ declare external ccc  void @putchar(i8)
 @alias_scc_proc.18 =    constant [?? x i8] c"expect p3(3,3):\00"
 
 
-@alias_scc_proc.58 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_scc_proc.57 to i64) }
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
-@alias_scc_proc.57 =    constant [?? x i8] c"--- Inside foo: expect p3(3,3):\00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias_scc_proc.91 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_scc_proc.90 to i64) }
-
-
-@alias_scc_proc.90 =    constant [?? x i8] c"--- Inside foo: expect p3(3,3):\00"
+declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -321,30 +315,30 @@ if.then:
   %88 = inttoptr i64 %87 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
   store  i64 3, i64* %89 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.91, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.58, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %84)  
-  %92 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %93 = insertvalue {i64, i64} %92, i64 %84, 1 
-  ret {i64, i64} %93 
+  %90 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %91 = insertvalue {i64, i64} %90, i64 %84, 1 
+  ret {i64, i64} %91 
 if.else:
   %"3#tmp#3##0" = add   i64 %81, 1 
-  %94 = inttoptr i64 %"p1##0" to i64* 
-  %95 = getelementptr  i64, i64* %94, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %95 
+  %92 = inttoptr i64 %"p1##0" to i64* 
+  %93 = getelementptr  i64, i64* %92, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %93 
   %"3#p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %96 = trunc i64 16 to i32  
-  %97 = tail call ccc  i8*  @wybe_malloc(i32  %96)  
-  %98 = ptrtoint i8* %97 to i64 
-  %99 = inttoptr i64 %98 to i64* 
-  %100 = getelementptr  i64, i64* %99, i64 0 
-  store  i64 2, i64* %100 
-  %101 = add   i64 %98, 8 
-  %102 = inttoptr i64 %101 to i64* 
-  %103 = getelementptr  i64, i64* %102, i64 0 
-  store  i64 2, i64* %103 
-  %104 = insertvalue {i64, i64} undef, i64 %98, 0 
-  %105 = insertvalue {i64, i64} %104, i64 %"3#p3##0", 1 
-  ret {i64, i64} %105 
+  %94 = trunc i64 16 to i32  
+  %95 = tail call ccc  i8*  @wybe_malloc(i32  %94)  
+  %96 = ptrtoint i8* %95 to i64 
+  %97 = inttoptr i64 %96 to i64* 
+  %98 = getelementptr  i64, i64* %97, i64 0 
+  store  i64 2, i64* %98 
+  %99 = add   i64 %96, 8 
+  %100 = inttoptr i64 %99 to i64* 
+  %101 = getelementptr  i64, i64* %100, i64 0 
+  store  i64 2, i64* %101 
+  %102 = insertvalue {i64, i64} undef, i64 %96, 0 
+  %103 = insertvalue {i64, i64} %102, i64 %"3#p3##0", 1 
+  ret {i64, i64} %103 
 }
 --------------------------------------------------
  Module position
@@ -394,15 +388,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -419,6 +404,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -129,28 +129,28 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_scc_proc.19 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.18 to i64) }
-
-
-@alias_scc_proc.18 =    constant [?? x i8] c"expect p3(3,3):\00"
+@alias_scc_proc.15 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.14 to i64) }
 
 
 @alias_scc_proc.17 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.16 to i64) }
 
 
-@alias_scc_proc.16 =    constant [?? x i8] c"expect p2(2,2):\00"
-
-
-@alias_scc_proc.15 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.14 to i64) }
-
-
-@alias_scc_proc.14 =    constant [?? x i8] c"expect p1(2,2):\00"
+@alias_scc_proc.19 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.18 to i64) }
 
 
 @alias_scc_proc.13 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_scc_proc.12 to i64) }
 
 
 @alias_scc_proc.12 =    constant [?? x i8] c"--- After calling foo: \00"
+
+
+@alias_scc_proc.14 =    constant [?? x i8] c"expect p1(2,2):\00"
+
+
+@alias_scc_proc.16 =    constant [?? x i8] c"expect p2(2,2):\00"
+
+
+@alias_scc_proc.18 =    constant [?? x i8] c"expect p3(3,3):\00"
 
 
 @alias_scc_proc.58 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_scc_proc.57 to i64) }
@@ -406,19 +406,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -375,34 +375,34 @@ i(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:wybe
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@anon_field.18 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @anon_field.17 to i64) }
-
-
-@anon_field.17 =    constant [?? x i8] c"uh oh\00"
+@anon_field.172 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @anon_field.171 to i64) }
 
 
 @anon_field.148 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @anon_field.147 to i64) }
 
 
-@anon_field.147 =    constant [?? x i8] c"good\00"
-
-
-@anon_field.172 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @anon_field.171 to i64) }
-
-
-@anon_field.171 =    constant [?? x i8] c"bad\00"
+@anon_field.18 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @anon_field.17 to i64) }
 
 
 @anon_field.183 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @anon_field.182 to i64) }
 
 
+@anon_field.171 =    constant [?? x i8] c"bad\00"
+
+
+@anon_field.147 =    constant [?? x i8] c"good\00"
+
+
 @anon_field.182 =    constant [?? x i8] c"maybe\00"
+
+
+@anon_field.17 =    constant [?? x i8] c"uh oh\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/anon_field_variable.exp
+++ b/test-cases/final-dump/anon_field_variable.exp
@@ -131,16 +131,16 @@ foo(?foo#1##0:T, #result##0:anon_field_variable(T), ?#success##0:wybe.bool)<{}; 
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @anon_field_variable.7 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @anon_field_variable.6 to i64) }
 
 
 @anon_field_variable.6 =    constant [?? x i8] c"foo\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/assert_error.exp
+++ b/test-cases/final-dump/assert_error.exp
@@ -31,13 +31,13 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  void @"wybe.control.assert<0>"(i1, i64)    
 
 
-@assert_error.3 =    constant [?? x i8] c"we should never get here\00"
+@assert_error.1 =    constant [?? x i8] c"assert_error:3:2\00"
 
 
 @assert_error.2 =    constant [?? x i8] c"assert_error:5:2\00"
 
 
-@assert_error.1 =    constant [?? x i8] c"assert_error:3:2\00"
+@assert_error.3 =    constant [?? x i8] c"we should never get here\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/assert_error.exp
+++ b/test-cases/final-dump/assert_error.exp
@@ -25,12 +25,6 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external ccc  void @error_exit(i64, i64)    
-
-
-declare external fastcc  void @"wybe.control.assert<0>"(i1, i64)    
-
-
 @assert_error.1 =    constant [?? x i8] c"assert_error:3:2\00"
 
 
@@ -38,6 +32,12 @@ declare external fastcc  void @"wybe.control.assert<0>"(i1, i64)
 
 
 @assert_error.3 =    constant [?? x i8] c"we should never get here\00"
+
+
+declare external ccc  void @error_exit(i64, i64)    
+
+
+declare external fastcc  void @"wybe.control.assert<0>"(i1, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/bar.exp
+++ b/test-cases/final-dump/bar.exp
@@ -114,16 +114,16 @@ toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @numbers.2 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @numbers.1 to i64) }
 
 
 @numbers.1 =    constant [?? x i8] c"Numbers has been initialised.\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/bbb.exp
+++ b/test-cases/final-dump/bbb.exp
@@ -28,16 +28,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @bbb.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @bbb.1 to i64) }
 
 
 @bbb.1 =    constant [?? x i8] c"BBB: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -80,16 +80,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @ddd.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @ddd.1 to i64) }
 
 
 @ddd.1 =    constant [?? x i8] c"DDD: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/block_comment.exp
+++ b/test-cases/final-dump/block_comment.exp
@@ -46,22 +46,16 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@block_comment.6 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @block_comment.5 to i64) }
-
-
-@block_comment.5 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
+@block_comment.2 =    constant {i64, i64} { i64 41, i64 ptrtoint ([?? x i8]* @block_comment.1 to i64) }
 
 
 @block_comment.4 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @block_comment.3 to i64) }
 
 
-@block_comment.3 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
-
-
-@block_comment.2 =    constant {i64, i64} { i64 41, i64 ptrtoint ([?? x i8]* @block_comment.1 to i64) }
-
-
 @block_comment.1 =    constant [?? x i8] c"print(x:string) creates a newline already\00"
+
+
+@block_comment.3 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -75,7 +69,7 @@ entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.2, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.6, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @putchar(i8  99)  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/block_comment.exp
+++ b/test-cases/final-dump/block_comment.exp
@@ -37,15 +37,6 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external ccc  void @print_int(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @block_comment.2 =    constant {i64, i64} { i64 41, i64 ptrtoint ([?? x i8]* @block_comment.1 to i64) }
 
 
@@ -56,6 +47,15 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @block_comment.3 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/break_in_loop_in_do.exp
+++ b/test-cases/final-dump/break_in_loop_in_do.exp
@@ -52,13 +52,13 @@ gen#2(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<break_in_loop_in_do.counter>>, 
  
 
 
+@"resource#break_in_loop_in_do.counter" =    global i64 undef
+
+
 declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  void @print_int(i64)    
-
-
-@"resource#break_in_loop_in_do.counter" =    global i64 undef
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/bug214.exp
+++ b/test-cases/final-dump/bug214.exp
@@ -269,18 +269,6 @@ submarine(?sub_pos##0:bug214.position, ?aim##0:wybe.int, #result##0:bug214)<{}; 
  
 
 
-declare external fastcc  i1 @"wybe.int.=<0>"(i64, i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @bug214.43 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @bug214.42 to i64) }
 
 
@@ -293,6 +281,9 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @bug214.51 =    constant [?? x i8] c"Part 2: \00"
 
 
+declare external fastcc  i1 @"wybe.int.=<0>"(i64, i64)    
+
+
 declare external ccc  i64 @read_line()    
 
 
@@ -300,6 +291,15 @@ declare external ccc  i64 @read_int()
 
 
 declare external fastcc  i64 @"wybe.string.string<0>"(i64)    
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -811,9 +811,6 @@ up(?#result##0:bug214.direction)<{}; {}>:
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
-
-
 @bug214.direction.10 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @bug214.direction.9 to i64) }
 
 
@@ -830,6 +827,9 @@ declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)
 
 
 @bug214.direction.9 =    constant [?? x i8] c"up\00"
+
+
+declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -1038,12 +1038,6 @@ y(#rec##0:bug214.position, ?#rec##1:bug214.position, #field##0:wybe.int)<{}; {}>
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @bug214.position.41 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @bug214.position.40 to i64) }
 
 
@@ -1060,6 +1054,12 @@ declare external ccc  void @print_int(i64)
 
 
 @bug214.position.45 =    constant [?? x i8] c",\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/bug214.exp
+++ b/test-cases/final-dump/bug214.exp
@@ -281,16 +281,16 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@bug214.52 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @bug214.51 to i64) }
-
-
-@bug214.51 =    constant [?? x i8] c"Part 2: \00"
-
-
 @bug214.43 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @bug214.42 to i64) }
 
 
+@bug214.52 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @bug214.51 to i64) }
+
+
 @bug214.42 =    constant [?? x i8] c"Part 1: \00"
+
+
+@bug214.51 =    constant [?? x i8] c"Part 2: \00"
 
 
 declare external ccc  i64 @read_line()    
@@ -817,19 +817,19 @@ declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)
 @bug214.direction.10 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @bug214.direction.9 to i64) }
 
 
-@bug214.direction.9 =    constant [?? x i8] c"up\00"
-
-
 @bug214.direction.6 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @bug214.direction.5 to i64) }
-
-
-@bug214.direction.5 =    constant [?? x i8] c"down\00"
 
 
 @bug214.direction.2 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @bug214.direction.1 to i64) }
 
 
+@bug214.direction.5 =    constant [?? x i8] c"down\00"
+
+
 @bug214.direction.1 =    constant [?? x i8] c"forward\00"
+
+
+@bug214.direction.9 =    constant [?? x i8] c"up\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -1044,22 +1044,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@bug214.position.52 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @bug214.position.51 to i64) }
-
-
-@bug214.position.51 =    constant [?? x i8] c")\00"
+@bug214.position.41 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @bug214.position.40 to i64) }
 
 
 @bug214.position.46 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @bug214.position.45 to i64) }
 
 
-@bug214.position.45 =    constant [?? x i8] c",\00"
-
-
-@bug214.position.41 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @bug214.position.40 to i64) }
+@bug214.position.52 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @bug214.position.51 to i64) }
 
 
 @bug214.position.40 =    constant [?? x i8] c"(\00"
+
+
+@bug214.position.51 =    constant [?? x i8] c")\00"
+
+
+@bug214.position.45 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/bug228-okay.exp
+++ b/test-cases/final-dump/bug228-okay.exp
@@ -48,13 +48,13 @@ init_res()<{}; {<<bug228-okay.res>>}>:
  
 
 
+@"resource#bug228-okay.res" =    global i64 undef
+
+
 declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  void @print_int(i64)    
-
-
-@"resource#bug228-okay.res" =    global i64 undef
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -84,7 +84,10 @@ foo(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  i64 @read_int()    
+@call_site_id.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.1 to i64) }
+
+
+@call_site_id.1 =    constant [?? x i8] c" \00"
 
 
 declare external ccc  void @putchar(i8)    
@@ -96,10 +99,7 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@call_site_id.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.1 to i64) }
-
-
-@call_site_id.1 =    constant [?? x i8] c" \00"
+declare external ccc  i64 @read_int()    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -96,42 +96,6 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@call_site_id.14 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.13 to i64) }
-
-
-@call_site_id.13 =    constant [?? x i8] c" \00"
-
-
-@call_site_id.12 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.11 to i64) }
-
-
-@call_site_id.11 =    constant [?? x i8] c" \00"
-
-
-@call_site_id.10 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.9 to i64) }
-
-
-@call_site_id.9 =    constant [?? x i8] c" \00"
-
-
-@call_site_id.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.7 to i64) }
-
-
-@call_site_id.7 =    constant [?? x i8] c" \00"
-
-
-@call_site_id.6 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.5 to i64) }
-
-
-@call_site_id.5 =    constant [?? x i8] c" \00"
-
-
-@call_site_id.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.3 to i64) }
-
-
-@call_site_id.3 =    constant [?? x i8] c" \00"
-
-
 @call_site_id.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.1 to i64) }
 
 
@@ -186,12 +150,12 @@ entry:
 define external fastcc  void @"call_site_id.foo<0>"(i64  %"x##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.4, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.6, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.8, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.10, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.12, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.14, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64))  
   %"1#tmp#1##0" = mul   i64 %"x##0", 5 
   %"1#tmp#0##0" = add   i64 %"1#tmp#1##0", 10 
   tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -99,6 +99,18 @@ gen#1(reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##0:position.position]
  
 
 
+@caret.29 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @caret.28 to i64) }
+
+
+@caret.145 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @caret.144 to i64) }
+
+
+@caret.144 =    constant [?? x i8] c"now ten = \00"
+
+
+@caret.28 =    constant [?? x i8] c"ten = \00"
+
+
 declare external ccc  void @putchar(i8)    
 
 
@@ -108,28 +120,10 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@caret.29 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @caret.28 to i64) }
-
-
-@caret.28 =    constant [?? x i8] c"ten = \00"
-
-
 declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)    
 
 
 declare external fastcc  i64 @"wybe.int.min<0>"(i64, i64)    
-
-
-@caret.145 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @caret.144 to i64) }
-
-
-@caret.144 =    constant [?? x i8] c"now ten = \00"
-
-
-@caret.159 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @caret.158 to i64) }
-
-
-@caret.158 =    constant [?? x i8] c"now ten = \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -349,7 +343,7 @@ entry:
   %155 = inttoptr i64 %149 to i64* 
   %156 = getelementptr  i64, i64* %155, i64 0 
   %157 = load  i64, i64* %156 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.159, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.145, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %157)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -777,15 +771,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -802,6 +787,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -789,19 +789,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/ccc.exp
+++ b/test-cases/final-dump/ccc.exp
@@ -28,16 +28,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @ccc.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @ccc.1 to i64) }
 
 
 @ccc.1 =    constant [?? x i8] c"CCC: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -80,16 +80,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @ddd.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @ddd.1 to i64) }
 
 
 @ddd.1 =    constant [?? x i8] c"DDD: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/char-escape.exp
+++ b/test-cases/final-dump/char-escape.exp
@@ -61,82 +61,82 @@ test(ch##0:wybe.char, code##0:wybe.int, name##0:wybe.string)<{<<wybe.io.io>>}; {
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
+@char-escape.20 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @char-escape.19 to i64) }
+
+
+@char-escape.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @char-escape.1 to i64) }
+
+
+@char-escape.4 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @char-escape.3 to i64) }
+
+
+@char-escape.8 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @char-escape.7 to i64) }
+
+
+@char-escape.12 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @char-escape.11 to i64) }
+
+
+@char-escape.10 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @char-escape.9 to i64) }
+
+
+@char-escape.6 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @char-escape.5 to i64) }
+
+
+@char-escape.18 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @char-escape.17 to i64) }
+
+
+@char-escape.16 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @char-escape.15 to i64) }
+
+
+@char-escape.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @char-escape.13 to i64) }
+
+
 @char-escape.22 =    constant {i64, i64} { i64 36, i64 ptrtoint ([?? x i8]* @char-escape.21 to i64) }
 
 
 @char-escape.21 =    constant [?? x i8] c"\07string with hex character escapes!\0a\00"
 
 
-@char-escape.20 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @char-escape.19 to i64) }
-
-
-@char-escape.19 =    constant [?? x i8] c"hex\00"
-
-
-@char-escape.18 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @char-escape.17 to i64) }
-
-
-@char-escape.17 =    constant [?? x i8] c"vertical tab\00"
-
-
-@char-escape.16 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @char-escape.15 to i64) }
-
-
-@char-escape.15 =    constant [?? x i8] c"horizontal tab\00"
-
-
-@char-escape.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @char-escape.13 to i64) }
-
-
-@char-escape.13 =    constant [?? x i8] c"carriage return\00"
-
-
-@char-escape.12 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @char-escape.11 to i64) }
-
-
-@char-escape.11 =    constant [?? x i8] c"newline\00"
-
-
-@char-escape.10 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @char-escape.9 to i64) }
-
-
-@char-escape.9 =    constant [?? x i8] c"formfeed\00"
-
-
-@char-escape.8 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @char-escape.7 to i64) }
-
-
-@char-escape.7 =    constant [?? x i8] c"escape\00"
-
-
-@char-escape.6 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @char-escape.5 to i64) }
-
-
 @char-escape.5 =    constant [?? x i8] c"backspace\00"
-
-
-@char-escape.4 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @char-escape.3 to i64) }
 
 
 @char-escape.3 =    constant [?? x i8] c"bell\00"
 
 
-@char-escape.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @char-escape.1 to i64) }
+@char-escape.13 =    constant [?? x i8] c"carriage return\00"
+
+
+@char-escape.7 =    constant [?? x i8] c"escape\00"
+
+
+@char-escape.9 =    constant [?? x i8] c"formfeed\00"
+
+
+@char-escape.19 =    constant [?? x i8] c"hex\00"
+
+
+@char-escape.15 =    constant [?? x i8] c"horizontal tab\00"
+
+
+@char-escape.11 =    constant [?? x i8] c"newline\00"
 
 
 @char-escape.1 =    constant [?? x i8] c"null\00"
 
 
+@char-escape.17 =    constant [?? x i8] c"vertical tab\00"
+
+
 declare external ccc  void @putchar(i8)    
+
+
+@char-escape.25 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @char-escape.24 to i64) }
 
 
 @char-escape.27 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @char-escape.26 to i64) }
 
 
 @char-escape.26 =    constant [?? x i8] c" char escapes don't work\00"
-
-
-@char-escape.25 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @char-escape.24 to i64) }
 
 
 @char-escape.24 =    constant [?? x i8] c" char escapes work\00"

--- a/test-cases/final-dump/char-escape.exp
+++ b/test-cases/final-dump/char-escape.exp
@@ -58,9 +58,6 @@ test(ch##0:wybe.char, code##0:wybe.int, name##0:wybe.string)<{<<wybe.io.io>>}; {
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @char-escape.20 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @char-escape.19 to i64) }
 
 
@@ -91,10 +88,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @char-escape.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @char-escape.13 to i64) }
 
 
+@char-escape.25 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @char-escape.24 to i64) }
+
+
+@char-escape.27 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @char-escape.26 to i64) }
+
+
 @char-escape.22 =    constant {i64, i64} { i64 36, i64 ptrtoint ([?? x i8]* @char-escape.21 to i64) }
 
 
 @char-escape.21 =    constant [?? x i8] c"\07string with hex character escapes!\0a\00"
+
+
+@char-escape.26 =    constant [?? x i8] c" char escapes don't work\00"
+
+
+@char-escape.24 =    constant [?? x i8] c" char escapes work\00"
 
 
 @char-escape.5 =    constant [?? x i8] c"backspace\00"
@@ -130,16 +139,7 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@char-escape.25 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @char-escape.24 to i64) }
-
-
-@char-escape.27 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @char-escape.26 to i64) }
-
-
-@char-escape.26 =    constant [?? x i8] c" char escapes don't work\00"
-
-
-@char-escape.24 =    constant [?? x i8] c" char escapes work\00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/compute.exp
+++ b/test-cases/final-dump/compute.exp
@@ -171,16 +171,16 @@ factorial(n##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @math.utils.2 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @math.utils.1 to i64) }
 
 
 @math.utils.1 =    constant [?? x i8] c"Utils has been initialised.\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -69,16 +69,16 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@coordinate.22 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @coordinate.21 to i64) }
-
-
-@coordinate.21 =    constant [?? x i8] c"expect crd2^z=1000: \00"
-
-
 @coordinate.16 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @coordinate.15 to i64) }
 
 
+@coordinate.22 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @coordinate.21 to i64) }
+
+
 @coordinate.15 =    constant [?? x i8] c"expect crd1^z=8000: \00"
+
+
+@coordinate.21 =    constant [?? x i8] c"expect crd2^z=1000: \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -60,15 +60,6 @@ fcopy(crd1##0:coordinate.Coordinate, ?#result##0:coordinate.Coordinate)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @coordinate.16 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @coordinate.15 to i64) }
 
 
@@ -79,6 +70,15 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @coordinate.21 =    constant [?? x i8] c"expect crd2^z=1000: \00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/ddd.exp
+++ b/test-cases/final-dump/ddd.exp
@@ -27,16 +27,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @ddd.2 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @ddd.1 to i64) }
 
 
 @ddd.1 =    constant [?? x i8] c"DDD: Init\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -317,76 +317,58 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@dead_cell_size.102 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.101 to i64) }
-
-
-@dead_cell_size.101 =    constant [?? x i8] c")\00"
-
-
-@dead_cell_size.100 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.99 to i64) }
-
-
-@dead_cell_size.99 =    constant [?? x i8] c"td(\00"
-
-
-@dead_cell_size.94 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.93 to i64) }
-
-
-@dead_cell_size.93 =    constant [?? x i8] c")\00"
-
-
-@dead_cell_size.92 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.91 to i64) }
-
-
-@dead_cell_size.91 =    constant [?? x i8] c",\00"
+@dead_cell_size.74 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.73 to i64) }
 
 
 @dead_cell_size.90 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.89 to i64) }
 
 
-@dead_cell_size.89 =    constant [?? x i8] c",\00"
-
-
-@dead_cell_size.88 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.87 to i64) }
-
-
-@dead_cell_size.87 =    constant [?? x i8] c"tc(\00"
-
-
-@dead_cell_size.74 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.73 to i64) }
-
-
-@dead_cell_size.73 =    constant [?? x i8] c")\00"
+@dead_cell_size.67 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @dead_cell_size.66 to i64) }
 
 
 @dead_cell_size.72 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.71 to i64) }
 
 
-@dead_cell_size.71 =    constant [?? x i8] c"tb(\00"
+@dead_cell_size.88 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.87 to i64) }
 
 
-@dead_cell_size.67 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @dead_cell_size.66 to i64) }
+@dead_cell_size.96 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.95 to i64) }
+
+
+@dead_cell_size.73 =    constant [?? x i8] c")\00"
+
+
+@dead_cell_size.89 =    constant [?? x i8] c",\00"
 
 
 @dead_cell_size.66 =    constant [?? x i8] c"ta\00"
 
 
-@dead_cell_size.111 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.110 to i64) }
+@dead_cell_size.71 =    constant [?? x i8] c"tb(\00"
 
 
-@dead_cell_size.110 =    constant [?? x i8] c")\00"
+@dead_cell_size.87 =    constant [?? x i8] c"tc(\00"
 
 
-@dead_cell_size.109 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @dead_cell_size.108 to i64) }
+@dead_cell_size.95 =    constant [?? x i8] c"td(\00"
 
 
-@dead_cell_size.108 =    constant [?? x i8] c"t2b(\00"
+@dead_cell_size.105 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.104 to i64) }
 
 
-@dead_cell_size.104 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.103 to i64) }
+@dead_cell_size.98 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.97 to i64) }
 
 
-@dead_cell_size.103 =    constant [?? x i8] c"t2a\00"
+@dead_cell_size.103 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @dead_cell_size.102 to i64) }
+
+
+@dead_cell_size.104 =    constant [?? x i8] c")\00"
+
+
+@dead_cell_size.97 =    constant [?? x i8] c"t2a\00"
+
+
+@dead_cell_size.102 =    constant [?? x i8] c"t2b(\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -619,22 +601,22 @@ if.then3:
   tail call ccc  void  @print_int(i64  %78)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.90, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %82)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.92, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.90, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %86)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.94, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.74, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
   %"9#tmp#16##0" = icmp eq i64 %"4#tmp#7##0", 2 
   br i1 %"9#tmp#16##0", label %if.then4, label %if.else4 
 if.then4:
-  %95 = add   i64 %"x##0", -2 
-  %96 = inttoptr i64 %95 to i64* 
-  %97 = getelementptr  i64, i64* %96, i64 0 
-  %98 = load  i64, i64* %97 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.100, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %98)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.102, i32 0, i32 0) to i64))  
+  %91 = add   i64 %"x##0", -2 
+  %92 = inttoptr i64 %91 to i64* 
+  %93 = getelementptr  i64, i64* %92, i64 0 
+  %94 = load  i64, i64* %93 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.96, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %94)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.74, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else4:
@@ -648,19 +630,19 @@ entry:
   %"1#tmp#2##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  0, i64  %"x##0")  
   br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.104, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.98, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
   %"3#tmp#4##0" = icmp ne i64 %"x##0", 0 
   br i1 %"3#tmp#4##0", label %if.then1, label %if.else1 
 if.then1:
-  %105 = inttoptr i64 %"x##0" to i64* 
-  %106 = getelementptr  i64, i64* %105, i64 0 
-  %107 = load  i64, i64* %106 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.109, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %107)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.111, i32 0, i32 0) to i64))  
+  %99 = inttoptr i64 %"x##0" to i64* 
+  %100 = getelementptr  i64, i64* %99, i64 0 
+  %101 = load  i64, i64* %100 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.103, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %101)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.105, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -308,15 +308,6 @@ print_t2(x##0:dead_cell_size.t2)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @dead_cell_size.74 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.73 to i64) }
 
 
@@ -335,10 +326,22 @@ declare external ccc  void @print_int(i64)
 @dead_cell_size.96 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.95 to i64) }
 
 
+@dead_cell_size.98 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.97 to i64) }
+
+
+@dead_cell_size.103 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @dead_cell_size.102 to i64) }
+
+
 @dead_cell_size.73 =    constant [?? x i8] c")\00"
 
 
 @dead_cell_size.89 =    constant [?? x i8] c",\00"
+
+
+@dead_cell_size.97 =    constant [?? x i8] c"t2a\00"
+
+
+@dead_cell_size.102 =    constant [?? x i8] c"t2b(\00"
 
 
 @dead_cell_size.66 =    constant [?? x i8] c"ta\00"
@@ -353,22 +356,13 @@ declare external ccc  void @print_int(i64)
 @dead_cell_size.95 =    constant [?? x i8] c"td(\00"
 
 
-@dead_cell_size.105 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.104 to i64) }
+declare external ccc  void @putchar(i8)    
 
 
-@dead_cell_size.98 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.97 to i64) }
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@dead_cell_size.103 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @dead_cell_size.102 to i64) }
-
-
-@dead_cell_size.104 =    constant [?? x i8] c")\00"
-
-
-@dead_cell_size.97 =    constant [?? x i8] c"t2a\00"
-
-
-@dead_cell_size.102 =    constant [?? x i8] c"t2b(\00"
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -642,7 +636,7 @@ if.then1:
   %101 = load  i64, i64* %100 
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.103, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %101)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.105, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.74, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:

--- a/test-cases/final-dump/disjunctive-cond.exp
+++ b/test-cases/final-dump/disjunctive-cond.exp
@@ -136,16 +136,7 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @disjunctive-cond.1 =    constant [?? x i8] c"all good\00"
 
 
-@disjunctive-cond.8 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.7 to i64) }
-
-
-@disjunctive-cond.7 =    constant [?? x i8] c"no good\00"
-
-
-@disjunctive-cond.6 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @disjunctive-cond.5 to i64) }
-
-
-@disjunctive-cond.5 =    constant [?? x i8] c"also good\00"
+@disjunctive-cond.6 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.5 to i64) }
 
 
 @disjunctive-cond.4 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @disjunctive-cond.3 to i64) }
@@ -154,34 +145,31 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @disjunctive-cond.3 =    constant [?? x i8] c"also good\00"
 
 
-@disjunctive-cond.12 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @disjunctive-cond.11 to i64) }
+@disjunctive-cond.5 =    constant [?? x i8] c"no good\00"
 
 
-@disjunctive-cond.11 =    constant [?? x i8] c"more good\00"
+@disjunctive-cond.8 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.7 to i64) }
 
 
-@disjunctive-cond.10 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.9 to i64) }
+@disjunctive-cond.10 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @disjunctive-cond.9 to i64) }
 
 
-@disjunctive-cond.9 =    constant [?? x i8] c"no good\00"
+@disjunctive-cond.9 =    constant [?? x i8] c"more good\00"
 
 
-@disjunctive-cond.18 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @disjunctive-cond.17 to i64) }
+@disjunctive-cond.7 =    constant [?? x i8] c"no good\00"
 
 
-@disjunctive-cond.17 =    constant [?? x i8] c"still good\00"
+@disjunctive-cond.12 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.11 to i64) }
 
 
-@disjunctive-cond.16 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @disjunctive-cond.15 to i64) }
+@disjunctive-cond.14 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @disjunctive-cond.13 to i64) }
 
 
-@disjunctive-cond.15 =    constant [?? x i8] c"still good\00"
+@disjunctive-cond.11 =    constant [?? x i8] c"no good\00"
 
 
-@disjunctive-cond.14 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.13 to i64) }
-
-
-@disjunctive-cond.13 =    constant [?? x i8] c"no good\00"
+@disjunctive-cond.13 =    constant [?? x i8] c"still good\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -210,12 +198,12 @@ if.then:
 if.else:
   br i1 %"b##0", label %if.then1, label %if.else1 
 if.then1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.6, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"disjunctive-cond.gen#2<0>"(i1  0, i1  1)  
   ret void 
 if.else1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.8, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"disjunctive-cond.gen#2<0>"(i1  0, i1  0)  
   ret void 
@@ -231,12 +219,12 @@ if.else:
   %"3#tmp#2##0" = xor i1 %"b##0", 1 
   br i1 %"3#tmp#2##0", label %if.then2, label %if.else2 
 if.then1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.10, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"disjunctive-cond.gen#3<0>"(i1  1, i1  1)  
   ret void 
 if.else1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.12, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"disjunctive-cond.gen#3<0>"(i1  1, i1  0)  
   ret void 
@@ -255,15 +243,15 @@ entry:
 if.then:
   br i1 %"b##0", label %if.then1, label %if.else1 
 if.else:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.18, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-if.then1:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.14, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
+if.then1:
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.12, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
 if.else1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.16, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.14, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/disjunctive-cond.exp
+++ b/test-cases/final-dump/disjunctive-cond.exp
@@ -124,52 +124,40 @@ gen#3(a##0:wybe.bool, b##0:wybe.bool, [tmp#0##0:wybe.bool], [tmp#1##0:wybe.bool]
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+@disjunctive-cond.6 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.5 to i64) }
 
 
 @disjunctive-cond.2 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @disjunctive-cond.1 to i64) }
 
 
-@disjunctive-cond.1 =    constant [?? x i8] c"all good\00"
-
-
-@disjunctive-cond.6 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.5 to i64) }
-
-
 @disjunctive-cond.4 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @disjunctive-cond.3 to i64) }
+
+
+@disjunctive-cond.8 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @disjunctive-cond.7 to i64) }
+
+
+@disjunctive-cond.10 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @disjunctive-cond.9 to i64) }
+
+
+@disjunctive-cond.1 =    constant [?? x i8] c"all good\00"
 
 
 @disjunctive-cond.3 =    constant [?? x i8] c"also good\00"
 
 
+@disjunctive-cond.7 =    constant [?? x i8] c"more good\00"
+
+
 @disjunctive-cond.5 =    constant [?? x i8] c"no good\00"
 
 
-@disjunctive-cond.8 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.7 to i64) }
+@disjunctive-cond.9 =    constant [?? x i8] c"still good\00"
 
 
-@disjunctive-cond.10 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @disjunctive-cond.9 to i64) }
+declare external ccc  void @putchar(i8)    
 
 
-@disjunctive-cond.9 =    constant [?? x i8] c"more good\00"
-
-
-@disjunctive-cond.7 =    constant [?? x i8] c"no good\00"
-
-
-@disjunctive-cond.12 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @disjunctive-cond.11 to i64) }
-
-
-@disjunctive-cond.14 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @disjunctive-cond.13 to i64) }
-
-
-@disjunctive-cond.11 =    constant [?? x i8] c"no good\00"
-
-
-@disjunctive-cond.13 =    constant [?? x i8] c"still good\00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -219,12 +207,12 @@ if.else:
   %"3#tmp#2##0" = xor i1 %"b##0", 1 
   br i1 %"3#tmp#2##0", label %if.then2, label %if.else2 
 if.then1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.8, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"disjunctive-cond.gen#3<0>"(i1  1, i1  1)  
   ret void 
 if.else1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.10, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"disjunctive-cond.gen#3<0>"(i1  1, i1  0)  
   ret void 
@@ -243,15 +231,15 @@ entry:
 if.then:
   br i1 %"b##0", label %if.then1, label %if.else1 
 if.else:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.14, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.then1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.12, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.14, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -50,16 +50,16 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@early_error.4 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @early_error.3 to i64) }
-
-
-@early_error.3 =    constant [?? x i8] c"should print this error message\00"
-
-
 @early_error.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @early_error.1 to i64) }
 
 
+@early_error.4 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @early_error.3 to i64) }
+
+
 @early_error.1 =    constant [?? x i8] c"should print this\00"
+
+
+@early_error.3 =    constant [?? x i8] c"should print this error message\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -38,18 +38,6 @@ my_error(msg##0:wybe.string)<{}; {}>:
  
 
 
-declare external ccc  void @exit(i64)    
-
-
-declare external ccc  void @puts(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @early_error.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @early_error.1 to i64) }
 
 
@@ -60,6 +48,18 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @early_error.3 =    constant [?? x i8] c"should print this error message\00"
+
+
+declare external ccc  void @exit(i64)    
+
+
+declare external ccc  void @puts(i64)    
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/early_exit.exp
+++ b/test-cases/final-dump/early_exit.exp
@@ -28,6 +28,12 @@ module top-level code > public {impure} (0 calls)
  
 
 
+@early_exit.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @early_exit.1 to i64) }
+
+
+@early_exit.1 =    constant [?? x i8] c"should print this\00"
+
+
 declare external ccc  void @exit(i64)    
 
 
@@ -35,12 +41,6 @@ declare external ccc  void @putchar(i8)
 
 
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@early_exit.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @early_exit.1 to i64) }
-
-
-@early_exit.1 =    constant [?? x i8] c"should print this\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/early_exit2.exp
+++ b/test-cases/final-dump/early_exit2.exp
@@ -36,6 +36,12 @@ my_exit(code##0:wybe.int)<{}; {}>:
  
 
 
+@early_exit2.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @early_exit2.1 to i64) }
+
+
+@early_exit2.1 =    constant [?? x i8] c"should print this\00"
+
+
 declare external ccc  void @exit(i64)    
 
 
@@ -43,12 +49,6 @@ declare external ccc  void @putchar(i8)
 
 
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@early_exit2.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @early_exit2.1 to i64) }
-
-
-@early_exit2.1 =    constant [?? x i8] c"should print this\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/eof_comment.exp
+++ b/test-cases/final-dump/eof_comment.exp
@@ -27,16 +27,16 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @eof_comment.2 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @eof_comment.1 to i64) }
 
 
 @eof_comment.1 =    constant [?? x i8] c"Wominjeka!\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -42,7 +42,10 @@ if_test(x##0:wybe.int, ?#result##0:wybe.string)<{}; {}>:
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+@exp_if.4 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @exp_if.3 to i64) }
+
+
+@exp_if.6 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @exp_if.5 to i64) }
 
 
 @exp_if.2 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @exp_if.1 to i64) }
@@ -51,16 +54,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @exp_if.1 =    constant [?? x i8] c"expect larger: \00"
 
 
-@exp_if.4 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @exp_if.3 to i64) }
-
-
-@exp_if.6 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @exp_if.5 to i64) }
-
-
 @exp_if.3 =    constant [?? x i8] c"larger\00"
 
 
 @exp_if.5 =    constant [?? x i8] c"smaller\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -51,16 +51,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @exp_if.1 =    constant [?? x i8] c"expect larger: \00"
 
 
-@exp_if.6 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @exp_if.5 to i64) }
-
-
-@exp_if.5 =    constant [?? x i8] c"smaller\00"
-
-
 @exp_if.4 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @exp_if.3 to i64) }
 
 
+@exp_if.6 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @exp_if.5 to i64) }
+
+
 @exp_if.3 =    constant [?? x i8] c"larger\00"
+
+
+@exp_if.5 =    constant [?? x i8] c"smaller\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/exp_print.exp
+++ b/test-cases/final-dump/exp_print.exp
@@ -37,15 +37,6 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external ccc  void @print_int(i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @exp_print.2 =    constant {i64, i64} { i64 41, i64 ptrtoint ([?? x i8]* @exp_print.1 to i64) }
 
 
@@ -56,6 +47,15 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @exp_print.3 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/exp_print.exp
+++ b/test-cases/final-dump/exp_print.exp
@@ -46,22 +46,16 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@exp_print.6 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @exp_print.5 to i64) }
-
-
-@exp_print.5 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
+@exp_print.2 =    constant {i64, i64} { i64 41, i64 ptrtoint ([?? x i8]* @exp_print.1 to i64) }
 
 
 @exp_print.4 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @exp_print.3 to i64) }
 
 
-@exp_print.3 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
-
-
-@exp_print.2 =    constant {i64, i64} { i64 41, i64 ptrtoint ([?? x i8]* @exp_print.1 to i64) }
-
-
 @exp_print.1 =    constant [?? x i8] c"print(x:string) creates a newline already\00"
+
+
+@exp_print.3 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -75,7 +69,7 @@ entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.2, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.6, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @putchar(i8  99)  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/exp_simple.exp
+++ b/test-cases/final-dump/exp_simple.exp
@@ -47,6 +47,12 @@ foreign_add(?#result##0:wybe.int)<{}; {}>:
  
 
 
+@exp_simple.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @exp_simple.1 to i64) }
+
+
+@exp_simple.1 =    constant [?? x i8] c"hello\00"
+
+
 declare external ccc  void @print_int(i64)    
 
 
@@ -57,12 +63,6 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 declare external ccc  void @print_float(double)    
-
-
-@exp_simple.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @exp_simple.1 to i64) }
-
-
-@exp_simple.1 =    constant [?? x i8] c"hello\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -614,6 +614,12 @@ reverse1(lst##0:generic_list(T), suffix##0:generic_list(T), ?#result##0:generic_
  
 
 
+@generic_use.68 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @generic_use.67 to i64) }
+
+
+@generic_use.67 =    constant [?? x i8] c", \00"
+
+
 declare external ccc  void @putchar(i8)    
 
 
@@ -621,12 +627,6 @@ declare external ccc  void @print_int(i64)
 
 
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@generic_use.68 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @generic_use.67 to i64) }
-
-
-@generic_use.67 =    constant [?? x i8] c", \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -148,22 +148,22 @@ declare external ccc  void @print_int(i64)
 declare external ccc  void @print_float(double)    
 
 
-@higher_order_refs.10 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#6<0>" to i64)]
-
-
-@higher_order_refs.9 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#5<0>" to i64)]
-
-
-@higher_order_refs.7 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#4<0>" to i64)]
-
-
-@higher_order_refs.5 =    constant [2 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#3<1>" to i64), i64 bitcast (double 5.000000e-1 to i64)]
+@higher_order_refs.1 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#1<1>" to i64)]
 
 
 @higher_order_refs.3 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#2<1>" to i64)]
 
 
-@higher_order_refs.1 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#1<1>" to i64)]
+@higher_order_refs.5 =    constant [2 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#3<1>" to i64), i64 bitcast (double 5.000000e-1 to i64)]
+
+
+@higher_order_refs.7 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#4<0>" to i64)]
+
+
+@higher_order_refs.9 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#5<0>" to i64)]
+
+
+@higher_order_refs.10 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#6<0>" to i64)]
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -139,15 +139,6 @@ id(i##0:K, ?#result##0:K)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external ccc  void @print_float(double)    
-
-
 @higher_order_refs.1 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#1<1>" to i64)]
 
 
@@ -164,6 +155,15 @@ declare external ccc  void @print_float(double)
 
 
 @higher_order_refs.10 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#6<0>" to i64)]
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  void @print_float(double)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -210,9 +210,6 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@higher_order_resources.158 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#2<1>" to i64)]
-
-
 @higher_order_resources.61 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @higher_order_resources.60 to i64) }
 
 
@@ -220,6 +217,9 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @higher_order_resources.58 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#1<1>" to i64)]
+
+
+@higher_order_resources.158 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#2<1>" to i64)]
 
 
 @"resource#higher_order_resources.maximum" =    global i64 undef

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -201,13 +201,10 @@ take_max(i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_re
  
 
 
-declare external ccc  void @putchar(i8)    
+@"resource#higher_order_resources.maximum" =    global i64 undef
 
 
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+@higher_order_resources.163 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_resources.162 to i64) }
 
 
 @higher_order_resources.61 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @higher_order_resources.60 to i64) }
@@ -216,37 +213,31 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @higher_order_resources.60 =    constant [?? x i8] c"*****\00"
 
 
+@higher_order_resources.162 =    constant [?? x i8] c"> \00"
+
+
 @higher_order_resources.58 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#1<1>" to i64)]
 
 
 @higher_order_resources.158 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#2<1>" to i64)]
 
 
-@"resource#higher_order_resources.maximum" =    global i64 undef
+@higher_order_resources.161 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#3<1>" to i64)]
+
+
+declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)    
 
 
 declare external fastcc  i64 @"wybe.list.length1<0>"(i64, i64)    
 
 
-@higher_order_resources.163 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_resources.162 to i64) }
+declare external ccc  void @putchar(i8)    
 
 
-@higher_order_resources.162 =    constant [?? x i8] c"> \00"
+declare external ccc  void @print_int(i64)    
 
 
-@higher_order_resources.161 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#3<1>" to i64)]
-
-
-@higher_order_resources.168 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_resources.167 to i64) }
-
-
-@higher_order_resources.167 =    constant [?? x i8] c"> \00"
-
-
-@higher_order_resources.166 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#3<1>" to i64)]
-
-
-declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)    
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -501,10 +492,10 @@ define external fastcc  void @"higher_order_resources.gen#2<1>"(i64  %"#env##0",
 entry:
   %165 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
-  tail call fastcc  void  @"higher_order_resources.gen#4<0>"(i64  %"anon#2#1##0", i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.166, i32 0, i32 0) to i64), i64  %"anon#2#1##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.168, i32 0, i32 0) to i64))  
-  %169 = load  i64, i64* @"resource#higher_order_resources.maximum" 
-  tail call ccc  void  @print_int(i64  %169)  
+  tail call fastcc  void  @"higher_order_resources.gen#4<0>"(i64  %"anon#2#1##0", i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.161, i32 0, i32 0) to i64), i64  %"anon#2#1##0")  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.163, i32 0, i32 0) to i64))  
+  %166 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  tail call ccc  void  @print_int(i64  %166)  
   tail call ccc  void  @putchar(i8  10)  
   store  i64 %165, i64* @"resource#higher_order_resources.maximum" 
   %"1#tmp#6##0" = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#2#1##0", i64  0)  
@@ -532,18 +523,18 @@ entry:
   %"1#tmp#3##0" = icmp ne i64 %"tmp#0##0", 0 
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %170 = inttoptr i64 %"tmp#0##0" to i64* 
-  %171 = getelementptr  i64, i64* %170, i64 0 
-  %172 = load  i64, i64* %171 
-  %173 = add   i64 %"tmp#0##0", 8 
-  %174 = inttoptr i64 %173 to i64* 
-  %175 = getelementptr  i64, i64* %174, i64 0 
-  %176 = load  i64, i64* %175 
-  %177 = inttoptr i64 %"f##0" to i64* 
-  %178 = load  i64, i64* %177 
-  %179 = inttoptr i64 %178 to void (i64, i64)* 
-  tail call fastcc  void  %179(i64  %"f##0", i64  %172)  
-  tail call fastcc  void  @"higher_order_resources.gen#4<0>"(i64  %"as##0", i64  %"f##0", i64  %176)  
+  %167 = inttoptr i64 %"tmp#0##0" to i64* 
+  %168 = getelementptr  i64, i64* %167, i64 0 
+  %169 = load  i64, i64* %168 
+  %170 = add   i64 %"tmp#0##0", 8 
+  %171 = inttoptr i64 %170 to i64* 
+  %172 = getelementptr  i64, i64* %171, i64 0 
+  %173 = load  i64, i64* %172 
+  %174 = inttoptr i64 %"f##0" to i64* 
+  %175 = load  i64, i64* %174 
+  %176 = inttoptr i64 %175 to void (i64, i64)* 
+  tail call fastcc  void  %176(i64  %"f##0", i64  %169)  
+  tail call fastcc  void  @"higher_order_resources.gen#4<0>"(i64  %"as##0", i64  %"f##0", i64  %173)  
   ret void 
 if.else:
   ret void 
@@ -559,8 +550,8 @@ entry:
 
 define external fastcc  void @"higher_order_resources.take_max<0>"(i64  %"i##0")    {
 entry:
-  %180 = load  i64, i64* @"resource#higher_order_resources.maximum" 
-  %"1#tmp#0##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %"i##0", i64  %180)  
+  %177 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  %"1#tmp#0##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %"i##0", i64  %177)  
   store  i64 %"1#tmp#0##0", i64* @"resource#higher_order_resources.maximum" 
   ret void 
 }

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -214,70 +214,46 @@ gen#9(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@higher_order_tests.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.1 to i64) }
-
-
-@higher_order_tests.1 =    constant [?? x i8] c"*1\00"
-
-
-@higher_order_tests.3 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#1<1>" to i64)]
-
-
 @higher_order_tests.18 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.17 to i64) }
-
-
-@higher_order_tests.17 =    constant [?? x i8] c"1\00"
-
-
-@higher_order_tests.24 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.23 to i64) }
-
-
-@higher_order_tests.23 =    constant [?? x i8] c"*2\00"
 
 
 @higher_order_tests.30 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.29 to i64) }
 
 
-@higher_order_tests.29 =    constant [?? x i8] c"2\00"
+@higher_order_tests.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.1 to i64) }
 
 
-@higher_order_tests.34 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.33 to i64) }
+@higher_order_tests.24 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.23 to i64) }
 
 
 @higher_order_tests.32 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @higher_order_tests.31 to i64) }
 
 
-@higher_order_tests.33 =    constant [?? x i8] c"*1\00"
+@higher_order_tests.1 =    constant [?? x i8] c"*1\00"
+
+
+@higher_order_tests.23 =    constant [?? x i8] c"*2\00"
 
 
 @higher_order_tests.31 =    constant [?? x i8] c"------\00"
 
 
-@higher_order_tests.35 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#6<1>" to i64)]
+@higher_order_tests.17 =    constant [?? x i8] c"1\00"
 
 
-@higher_order_tests.42 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.41 to i64) }
+@higher_order_tests.29 =    constant [?? x i8] c"2\00"
 
 
-@higher_order_tests.41 =    constant [?? x i8] c"1\00"
+@higher_order_tests.3 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#1<1>" to i64)]
 
 
-@higher_order_tests.48 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.47 to i64) }
+@higher_order_tests.33 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#6<1>" to i64)]
 
 
-@higher_order_tests.47 =    constant [?? x i8] c"*2\00"
+declare external ccc  void @putchar(i8)    
 
 
-@higher_order_tests.54 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.53 to i64) }
-
-
-@higher_order_tests.53 =    constant [?? x i8] c"2\00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -400,12 +376,12 @@ entry:
   %"1#tmp#4##0" = tail call fastcc  i1  @"higher_order_tests.gen#6<0>"(i64  1)  
   br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.34, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.35, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.33, i32 0, i32 0) to i64))  
   ret void 
 if.else:
-  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.35, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.33, i32 0, i32 0) to i64))  
   ret void 
 }
 
@@ -420,21 +396,21 @@ entry:
 define external fastcc  i64 @"higher_order_tests.gen#6<1>"(i64  %"#env##0", i64  %"anon#2#1##0")    {
 entry:
   %"1##success##0" = icmp eq i64 %"anon#2#1##0", 1 
-  %36 = zext i1 %"1##success##0" to i64  
-  ret i64 %36 
+  %34 = zext i1 %"1##success##0" to i64  
+  ret i64 %34 
 }
 
 
 define external fastcc  void @"higher_order_tests.gen#7<0>"(i64  %"t##0")    {
 entry:
-  %37 = inttoptr i64 %"t##0" to i64* 
-  %38 = load  i64, i64* %37 
-  %39 = inttoptr i64 %38 to i64 (i64, i64)* 
-  %"1#tmp#3##0" = tail call fastcc  i64  %39(i64  %"t##0", i64  1)  
-  %40 = trunc i64 %"1#tmp#3##0" to i1  
-  br i1 %40, label %if.then, label %if.else 
+  %35 = inttoptr i64 %"t##0" to i64* 
+  %36 = load  i64, i64* %35 
+  %37 = inttoptr i64 %36 to i64 (i64, i64)* 
+  %"1#tmp#3##0" = tail call fastcc  i64  %37(i64  %"t##0", i64  1)  
+  %38 = trunc i64 %"1#tmp#3##0" to i1  
+  br i1 %38, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.42, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"higher_order_tests.gen#8<0>"(i64  %"t##0")  
   ret void 
@@ -446,14 +422,14 @@ if.else:
 
 define external fastcc  void @"higher_order_tests.gen#8<0>"(i64  %"t##0")    {
 entry:
-  %43 = inttoptr i64 %"t##0" to i64* 
-  %44 = load  i64, i64* %43 
-  %45 = inttoptr i64 %44 to i64 (i64, i64)* 
-  %"1#tmp#2##0" = tail call fastcc  i64  %45(i64  %"t##0", i64  2)  
-  %46 = trunc i64 %"1#tmp#2##0" to i1  
-  br i1 %46, label %if.then, label %if.else 
+  %39 = inttoptr i64 %"t##0" to i64* 
+  %40 = load  i64, i64* %39 
+  %41 = inttoptr i64 %40 to i64 (i64, i64)* 
+  %"1#tmp#2##0" = tail call fastcc  i64  %41(i64  %"t##0", i64  2)  
+  %42 = trunc i64 %"1#tmp#2##0" to i1  
+  br i1 %42, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.48, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"higher_order_tests.gen#9<0>"(i64  %"t##0")  
   ret void 
@@ -465,14 +441,14 @@ if.else:
 
 define external fastcc  void @"higher_order_tests.gen#9<0>"(i64  %"t##0")    {
 entry:
-  %49 = inttoptr i64 %"t##0" to i64* 
-  %50 = load  i64, i64* %49 
-  %51 = inttoptr i64 %50 to i64 (i64, i64)* 
-  %"1#tmp#1##0" = tail call fastcc  i64  %51(i64  %"t##0", i64  2)  
-  %52 = trunc i64 %"1#tmp#1##0" to i1  
-  br i1 %52, label %if.then, label %if.else 
+  %43 = inttoptr i64 %"t##0" to i64* 
+  %44 = load  i64, i64* %43 
+  %45 = inttoptr i64 %44 to i64 (i64, i64)* 
+  %"1#tmp#1##0" = tail call fastcc  i64  %45(i64  %"t##0", i64  2)  
+  %46 = trunc i64 %"1#tmp#1##0" to i1  
+  br i1 %46, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.54, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -220,70 +220,64 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@higher_order_tests.4 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#1<1>" to i64)]
-
-
-@higher_order_tests.3 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#1<1>" to i64)]
-
-
 @higher_order_tests.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.1 to i64) }
 
 
 @higher_order_tests.1 =    constant [?? x i8] c"*1\00"
 
 
-@higher_order_tests.19 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.18 to i64) }
+@higher_order_tests.3 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#1<1>" to i64)]
 
 
-@higher_order_tests.18 =    constant [?? x i8] c"1\00"
+@higher_order_tests.18 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.17 to i64) }
 
 
-@higher_order_tests.25 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.24 to i64) }
+@higher_order_tests.17 =    constant [?? x i8] c"1\00"
 
 
-@higher_order_tests.24 =    constant [?? x i8] c"*2\00"
+@higher_order_tests.24 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.23 to i64) }
 
 
-@higher_order_tests.31 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.30 to i64) }
+@higher_order_tests.23 =    constant [?? x i8] c"*2\00"
 
 
-@higher_order_tests.30 =    constant [?? x i8] c"2\00"
+@higher_order_tests.30 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.29 to i64) }
 
 
-@higher_order_tests.37 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#6<1>" to i64)]
+@higher_order_tests.29 =    constant [?? x i8] c"2\00"
 
 
-@higher_order_tests.36 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#6<1>" to i64)]
+@higher_order_tests.34 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.33 to i64) }
 
 
-@higher_order_tests.35 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.34 to i64) }
+@higher_order_tests.32 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @higher_order_tests.31 to i64) }
 
 
-@higher_order_tests.34 =    constant [?? x i8] c"*1\00"
+@higher_order_tests.33 =    constant [?? x i8] c"*1\00"
 
 
-@higher_order_tests.33 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @higher_order_tests.32 to i64) }
+@higher_order_tests.31 =    constant [?? x i8] c"------\00"
 
 
-@higher_order_tests.32 =    constant [?? x i8] c"------\00"
+@higher_order_tests.35 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#6<1>" to i64)]
 
 
-@higher_order_tests.44 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.43 to i64) }
+@higher_order_tests.42 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.41 to i64) }
 
 
-@higher_order_tests.43 =    constant [?? x i8] c"1\00"
+@higher_order_tests.41 =    constant [?? x i8] c"1\00"
 
 
-@higher_order_tests.50 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.49 to i64) }
+@higher_order_tests.48 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @higher_order_tests.47 to i64) }
 
 
-@higher_order_tests.49 =    constant [?? x i8] c"*2\00"
+@higher_order_tests.47 =    constant [?? x i8] c"*2\00"
 
 
-@higher_order_tests.56 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.55 to i64) }
+@higher_order_tests.54 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @higher_order_tests.53 to i64) }
 
 
-@higher_order_tests.55 =    constant [?? x i8] c"2\00"
+@higher_order_tests.53 =    constant [?? x i8] c"2\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -302,30 +296,30 @@ if.then:
   tail call fastcc  void  @"higher_order_tests.gen#2<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.3, i32 0, i32 0) to i64))  
   ret void 
 if.else:
-  tail call fastcc  void  @"higher_order_tests.gen#2<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.4, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"higher_order_tests.gen#2<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.3, i32 0, i32 0) to i64))  
   ret void 
 }
 
 
 define external fastcc  i1 @"higher_order_tests.do_test<0>"(i64  %"f##0", i64  %"i##0")    {
 entry:
-  %5 = inttoptr i64 %"f##0" to i64* 
-  %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %6 to i64 (i64, i64)* 
-  %"1##success##0" = tail call fastcc  i64  %7(i64  %"f##0", i64  %"i##0")  
-  %8 = trunc i64 %"1##success##0" to i1  
-  ret i1 %8 
+  %4 = inttoptr i64 %"f##0" to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = inttoptr i64 %5 to i64 (i64, i64)* 
+  %"1##success##0" = tail call fastcc  i64  %6(i64  %"f##0", i64  %"i##0")  
+  %7 = trunc i64 %"1##success##0" to i1  
+  ret i1 %7 
 }
 
 
 define external fastcc  i1 @"higher_order_tests.do_test2<0>"(i64  %"f##0", i64  %"i##0")    {
 entry:
-  %9 = inttoptr i64 %"f##0" to i64* 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %10 to i64 (i64, i64)* 
-  %"1##success##0" = tail call fastcc  i64  %11(i64  %"f##0", i64  %"i##0")  
-  %12 = trunc i64 %"1##success##0" to i1  
-  ret i1 %12 
+  %8 = inttoptr i64 %"f##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = inttoptr i64 %9 to i64 (i64, i64)* 
+  %"1##success##0" = tail call fastcc  i64  %10(i64  %"f##0", i64  %"i##0")  
+  %11 = trunc i64 %"1##success##0" to i1  
+  ret i1 %11 
 }
 
 
@@ -337,21 +331,21 @@ entry:
 
 define external fastcc  i64 @"higher_order_tests.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0")    {
 entry:
-  %13 = zext i1 1 to i64  
-  ret i64 %13 
+  %12 = zext i1 1 to i64  
+  ret i64 %12 
 }
 
 
 define external fastcc  void @"higher_order_tests.gen#2<0>"(i64  %"t##0")    {
 entry:
-  %14 = inttoptr i64 %"t##0" to i64* 
-  %15 = load  i64, i64* %14 
-  %16 = inttoptr i64 %15 to i64 (i64, i64)* 
-  %"1#tmp#7##0" = tail call fastcc  i64  %16(i64  %"t##0", i64  1)  
-  %17 = trunc i64 %"1#tmp#7##0" to i1  
-  br i1 %17, label %if.then, label %if.else 
+  %13 = inttoptr i64 %"t##0" to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %14 to i64 (i64, i64)* 
+  %"1#tmp#7##0" = tail call fastcc  i64  %15(i64  %"t##0", i64  1)  
+  %16 = trunc i64 %"1#tmp#7##0" to i1  
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.19, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"higher_order_tests.gen#3<0>"(i64  %"t##0")  
   ret void 
@@ -363,14 +357,14 @@ if.else:
 
 define external fastcc  void @"higher_order_tests.gen#3<0>"(i64  %"t##0")    {
 entry:
-  %20 = inttoptr i64 %"t##0" to i64* 
-  %21 = load  i64, i64* %20 
-  %22 = inttoptr i64 %21 to i64 (i64, i64)* 
-  %"1#tmp#6##0" = tail call fastcc  i64  %22(i64  %"t##0", i64  2)  
-  %23 = trunc i64 %"1#tmp#6##0" to i1  
-  br i1 %23, label %if.then, label %if.else 
+  %19 = inttoptr i64 %"t##0" to i64* 
+  %20 = load  i64, i64* %19 
+  %21 = inttoptr i64 %20 to i64 (i64, i64)* 
+  %"1#tmp#6##0" = tail call fastcc  i64  %21(i64  %"t##0", i64  2)  
+  %22 = trunc i64 %"1#tmp#6##0" to i1  
+  br i1 %22, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.25, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"higher_order_tests.gen#4<0>"(i64  %"t##0")  
   ret void 
@@ -382,14 +376,14 @@ if.else:
 
 define external fastcc  void @"higher_order_tests.gen#4<0>"(i64  %"t##0")    {
 entry:
-  %26 = inttoptr i64 %"t##0" to i64* 
-  %27 = load  i64, i64* %26 
-  %28 = inttoptr i64 %27 to i64 (i64, i64)* 
-  %"1#tmp#5##0" = tail call fastcc  i64  %28(i64  %"t##0", i64  2)  
-  %29 = trunc i64 %"1#tmp#5##0" to i1  
-  br i1 %29, label %if.then, label %if.else 
+  %25 = inttoptr i64 %"t##0" to i64* 
+  %26 = load  i64, i64* %25 
+  %27 = inttoptr i64 %26 to i64 (i64, i64)* 
+  %"1#tmp#5##0" = tail call fastcc  i64  %27(i64  %"t##0", i64  2)  
+  %28 = trunc i64 %"1#tmp#5##0" to i1  
+  br i1 %28, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.31, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"higher_order_tests.gen#5<0>"()  
   ret void 
@@ -401,17 +395,17 @@ if.else:
 
 define external fastcc  void @"higher_order_tests.gen#5<0>"()    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.33, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.32, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#4##0" = tail call fastcc  i1  @"higher_order_tests.gen#6<0>"(i64  1)  
   br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.35, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.36, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.35, i32 0, i32 0) to i64))  
   ret void 
 if.else:
-  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.37, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.35, i32 0, i32 0) to i64))  
   ret void 
 }
 
@@ -426,21 +420,21 @@ entry:
 define external fastcc  i64 @"higher_order_tests.gen#6<1>"(i64  %"#env##0", i64  %"anon#2#1##0")    {
 entry:
   %"1##success##0" = icmp eq i64 %"anon#2#1##0", 1 
-  %38 = zext i1 %"1##success##0" to i64  
-  ret i64 %38 
+  %36 = zext i1 %"1##success##0" to i64  
+  ret i64 %36 
 }
 
 
 define external fastcc  void @"higher_order_tests.gen#7<0>"(i64  %"t##0")    {
 entry:
-  %39 = inttoptr i64 %"t##0" to i64* 
-  %40 = load  i64, i64* %39 
-  %41 = inttoptr i64 %40 to i64 (i64, i64)* 
-  %"1#tmp#3##0" = tail call fastcc  i64  %41(i64  %"t##0", i64  1)  
-  %42 = trunc i64 %"1#tmp#3##0" to i1  
-  br i1 %42, label %if.then, label %if.else 
+  %37 = inttoptr i64 %"t##0" to i64* 
+  %38 = load  i64, i64* %37 
+  %39 = inttoptr i64 %38 to i64 (i64, i64)* 
+  %"1#tmp#3##0" = tail call fastcc  i64  %39(i64  %"t##0", i64  1)  
+  %40 = trunc i64 %"1#tmp#3##0" to i1  
+  br i1 %40, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.44, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.42, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"higher_order_tests.gen#8<0>"(i64  %"t##0")  
   ret void 
@@ -452,14 +446,14 @@ if.else:
 
 define external fastcc  void @"higher_order_tests.gen#8<0>"(i64  %"t##0")    {
 entry:
-  %45 = inttoptr i64 %"t##0" to i64* 
-  %46 = load  i64, i64* %45 
-  %47 = inttoptr i64 %46 to i64 (i64, i64)* 
-  %"1#tmp#2##0" = tail call fastcc  i64  %47(i64  %"t##0", i64  2)  
-  %48 = trunc i64 %"1#tmp#2##0" to i1  
-  br i1 %48, label %if.then, label %if.else 
+  %43 = inttoptr i64 %"t##0" to i64* 
+  %44 = load  i64, i64* %43 
+  %45 = inttoptr i64 %44 to i64 (i64, i64)* 
+  %"1#tmp#2##0" = tail call fastcc  i64  %45(i64  %"t##0", i64  2)  
+  %46 = trunc i64 %"1#tmp#2##0" to i1  
+  br i1 %46, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.50, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.48, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"higher_order_tests.gen#9<0>"(i64  %"t##0")  
   ret void 
@@ -471,14 +465,14 @@ if.else:
 
 define external fastcc  void @"higher_order_tests.gen#9<0>"(i64  %"t##0")    {
 entry:
-  %51 = inttoptr i64 %"t##0" to i64* 
-  %52 = load  i64, i64* %51 
-  %53 = inttoptr i64 %52 to i64 (i64, i64)* 
-  %"1#tmp#1##0" = tail call fastcc  i64  %53(i64  %"t##0", i64  2)  
-  %54 = trunc i64 %"1#tmp#1##0" to i1  
-  br i1 %54, label %if.then, label %if.else 
+  %49 = inttoptr i64 %"t##0" to i64* 
+  %50 = load  i64, i64* %49 
+  %51 = inttoptr i64 %50 to i64 (i64, i64)* 
+  %"1#tmp#1##0" = tail call fastcc  i64  %51(i64  %"t##0", i64  2)  
+  %52 = trunc i64 %"1#tmp#1##0" to i1  
+  br i1 %52, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.56, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.54, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:

--- a/test-cases/final-dump/hypot.exp
+++ b/test-cases/final-dump/hypot.exp
@@ -172,94 +172,94 @@ declare external ccc  double @llvm.exp.f64(double)
 declare external ccc  double @llvm.sqrt.f64(double)    
 
 
-@hypot.30 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @hypot.29 to i64) }
-
-
-@hypot.29 =    constant [?? x i8] c"iround(pi) = \00"
-
-
-@hypot.28 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @hypot.27 to i64) }
-
-
-@hypot.27 =    constant [?? x i8] c"round(pi) = \00"
-
-
-@hypot.26 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @hypot.25 to i64) }
-
-
-@hypot.25 =    constant [?? x i8] c"ceil(pi) = \00"
-
-
-@hypot.24 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @hypot.23 to i64) }
-
-
-@hypot.23 =    constant [?? x i8] c"floor(pi) = \00"
-
-
-@hypot.22 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @hypot.21 to i64) }
-
-
-@hypot.21 =    constant [?? x i8] c"base 2 log(e) = \00"
-
-
-@hypot.20 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @hypot.19 to i64) }
-
-
-@hypot.19 =    constant [?? x i8] c"common log(e) = \00"
-
-
-@hypot.18 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @hypot.17 to i64) }
-
-
-@hypot.17 =    constant [?? x i8] c"ln(e) = \00"
-
-
-@hypot.16 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @hypot.15 to i64) }
-
-
-@hypot.15 =    constant [?? x i8] c"cos(30 degrees) = \00"
-
-
-@hypot.14 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @hypot.13 to i64) }
-
-
-@hypot.13 =    constant [?? x i8] c"sin(30 degrees) = \00"
-
-
-@hypot.12 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @hypot.11 to i64) }
-
-
-@hypot.11 =    constant [?? x i8] c"cos(30) = \00"
-
-
-@hypot.10 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @hypot.9 to i64) }
-
-
-@hypot.9 =    constant [?? x i8] c"sin(30) = \00"
-
-
 @hypot.8 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @hypot.7 to i64) }
-
-
-@hypot.7 =    constant [?? x i8] c" = \00"
 
 
 @hypot.6 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @hypot.5 to i64) }
 
 
-@hypot.5 =    constant [?? x i8] c"e = \00"
+@hypot.18 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @hypot.17 to i64) }
+
+
+@hypot.12 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @hypot.11 to i64) }
 
 
 @hypot.4 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @hypot.3 to i64) }
 
 
-@hypot.3 =    constant [?? x i8] c"area(5) = \00"
+@hypot.10 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @hypot.9 to i64) }
+
+
+@hypot.26 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @hypot.25 to i64) }
+
+
+@hypot.24 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @hypot.23 to i64) }
+
+
+@hypot.28 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @hypot.27 to i64) }
 
 
 @hypot.2 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @hypot.1 to i64) }
 
 
+@hypot.30 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @hypot.29 to i64) }
+
+
+@hypot.20 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @hypot.19 to i64) }
+
+
+@hypot.22 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @hypot.21 to i64) }
+
+
+@hypot.14 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @hypot.13 to i64) }
+
+
+@hypot.16 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @hypot.15 to i64) }
+
+
+@hypot.7 =    constant [?? x i8] c" = \00"
+
+
+@hypot.3 =    constant [?? x i8] c"area(5) = \00"
+
+
+@hypot.21 =    constant [?? x i8] c"base 2 log(e) = \00"
+
+
+@hypot.25 =    constant [?? x i8] c"ceil(pi) = \00"
+
+
+@hypot.19 =    constant [?? x i8] c"common log(e) = \00"
+
+
+@hypot.15 =    constant [?? x i8] c"cos(30 degrees) = \00"
+
+
+@hypot.11 =    constant [?? x i8] c"cos(30) = \00"
+
+
+@hypot.5 =    constant [?? x i8] c"e = \00"
+
+
+@hypot.23 =    constant [?? x i8] c"floor(pi) = \00"
+
+
 @hypot.1 =    constant [?? x i8] c"hypot(3,4) = \00"
+
+
+@hypot.29 =    constant [?? x i8] c"iround(pi) = \00"
+
+
+@hypot.17 =    constant [?? x i8] c"ln(e) = \00"
+
+
+@hypot.27 =    constant [?? x i8] c"round(pi) = \00"
+
+
+@hypot.13 =    constant [?? x i8] c"sin(30 degrees) = \00"
+
+
+@hypot.9 =    constant [?? x i8] c"sin(30) = \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/hypot.exp
+++ b/test-cases/final-dump/hypot.exp
@@ -130,48 +130,6 @@ hypot(s1##0:wybe.float, s2##0:wybe.float, ?#result##0:wybe.float)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_float(double)    
-
-
-declare external ccc  double @llvm.round.f64(double)    
-
-
-declare external ccc  double @llvm.ceil.f64(double)    
-
-
-declare external ccc  double @llvm.floor.f64(double)    
-
-
-declare external ccc  double @llvm.log2.f64(double)    
-
-
-declare external ccc  double @llvm.log10.f64(double)    
-
-
-declare external ccc  double @llvm.log.f64(double)    
-
-
-declare external ccc  double @llvm.cos.f64(double)    
-
-
-declare external ccc  double @llvm.sin.f64(double)    
-
-
-declare external ccc  double @llvm.exp.f64(double)    
-
-
-declare external ccc  double @llvm.sqrt.f64(double)    
-
-
 @hypot.8 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @hypot.7 to i64) }
 
 
@@ -260,6 +218,48 @@ declare external ccc  double @llvm.sqrt.f64(double)
 
 
 @hypot.9 =    constant [?? x i8] c"sin(30) = \00"
+
+
+declare external ccc  double @llvm.sqrt.f64(double)    
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_float(double)    
+
+
+declare external ccc  double @llvm.round.f64(double)    
+
+
+declare external ccc  double @llvm.ceil.f64(double)    
+
+
+declare external ccc  double @llvm.floor.f64(double)    
+
+
+declare external ccc  double @llvm.log2.f64(double)    
+
+
+declare external ccc  double @llvm.log10.f64(double)    
+
+
+declare external ccc  double @llvm.log.f64(double)    
+
+
+declare external ccc  double @llvm.cos.f64(double)    
+
+
+declare external ccc  double @llvm.sin.f64(double)    
+
+
+declare external ccc  double @llvm.exp.f64(double)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -53,16 +53,16 @@ distance(p1##0:position.position, p2##0:position.position, ?#result##0:wybe.int)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 declare external ccc  i64 @isqrt(i64)    
 
 
 declare external ccc  i64 @ipow(i64, i64)    
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -172,15 +172,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -197,6 +188,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -184,19 +184,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/io_flow_ok.exp
+++ b/test-cases/final-dump/io_flow_ok.exp
@@ -74,40 +74,28 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@io_flow_ok.10 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @io_flow_ok.9 to i64) }
-
-
-@io_flow_ok.9 =    constant [?? x i8] c"hello world!\00"
-
-
-@io_flow_ok.8 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @io_flow_ok.7 to i64) }
-
-
-@io_flow_ok.7 =    constant [?? x i8] c"That's odd!\00"
-
-
-@io_flow_ok.6 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @io_flow_ok.5 to i64) }
-
-
-@io_flow_ok.5 =    constant [?? x i8] c"hello world!\00"
-
-
 @io_flow_ok.4 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @io_flow_ok.3 to i64) }
 
 
-@io_flow_ok.3 =    constant [?? x i8] c"OK\00"
+@io_flow_ok.6 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @io_flow_ok.5 to i64) }
 
 
 @io_flow_ok.2 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @io_flow_ok.1 to i64) }
 
 
+@io_flow_ok.3 =    constant [?? x i8] c"OK\00"
+
+
+@io_flow_ok.5 =    constant [?? x i8] c"That's odd!\00"
+
+
 @io_flow_ok.1 =    constant [?? x i8] c"hello world!\00"
 
 
-@io_flow_ok.12 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @io_flow_ok.11 to i64) }
+@io_flow_ok.8 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @io_flow_ok.7 to i64) }
 
 
-@io_flow_ok.11 =    constant [?? x i8] c"hello world!\00"
+@io_flow_ok.7 =    constant [?? x i8] c"hello world!\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -125,13 +113,13 @@ entry:
 if.then:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.6, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.8, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.10, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -139,7 +127,7 @@ if.else:
 
 define external fastcc  void @"io_flow_ok.aok<0>"()    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.12, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/io_flow_ok.exp
+++ b/test-cases/final-dump/io_flow_ok.exp
@@ -68,12 +68,6 @@ unknown(?#success##0:wybe.bool)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @io_flow_ok.4 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @io_flow_ok.3 to i64) }
 
 
@@ -92,10 +86,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @io_flow_ok.1 =    constant [?? x i8] c"hello world!\00"
 
 
-@io_flow_ok.8 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @io_flow_ok.7 to i64) }
+declare external ccc  void @putchar(i8)    
 
 
-@io_flow_ok.7 =    constant [?? x i8] c"hello world!\00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -127,7 +121,7 @@ if.else:
 
 define external fastcc  void @"io_flow_ok.aok<0>"()    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.8, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -119,15 +119,6 @@ gen#4(h##0:wybe.int, h2##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.int
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @list_loop.42 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @list_loop.41 to i64) }
 
 
@@ -140,16 +131,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @list_loop.39 =    constant [?? x i8] c"    \00"
 
 
-@list_loop.46 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @list_loop.45 to i64) }
+declare external ccc  void @putchar(i8)    
 
 
-@list_loop.44 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @list_loop.43 to i64) }
+declare external ccc  void @print_int(i64)    
 
 
-@list_loop.45 =    constant [?? x i8] c" \00"
-
-
-@list_loop.43 =    constant [?? x i8] c"    \00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -252,9 +240,9 @@ if.else:
 
 define external fastcc  void @"list_loop.gen#4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.44, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.40, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.42, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h2##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -131,10 +131,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @list_loop.42 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @list_loop.41 to i64) }
 
 
-@list_loop.41 =    constant [?? x i8] c" \00"
-
-
 @list_loop.40 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @list_loop.39 to i64) }
+
+
+@list_loop.41 =    constant [?? x i8] c" \00"
 
 
 @list_loop.39 =    constant [?? x i8] c"    \00"
@@ -143,10 +143,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @list_loop.46 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @list_loop.45 to i64) }
 
 
-@list_loop.45 =    constant [?? x i8] c" \00"
-
-
 @list_loop.44 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @list_loop.43 to i64) }
+
+
+@list_loop.45 =    constant [?? x i8] c" \00"
 
 
 @list_loop.43 =    constant [?? x i8] c"    \00"

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -84,6 +84,12 @@ print(lst##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
+@loop_bug.9 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @loop_bug.8 to i64) }
+
+
+@loop_bug.8 =    constant [?? x i8] c", \00"
+
+
 declare external ccc  void @putchar(i8)    
 
 
@@ -91,18 +97,6 @@ declare external ccc  void @print_int(i64)
 
 
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@loop_bug.9 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @loop_bug.8 to i64) }
-
-
-@loop_bug.8 =    constant [?? x i8] c", \00"
-
-
-@loop_bug.11 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @loop_bug.10 to i64) }
-
-
-@loop_bug.10 =    constant [?? x i8] c", \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -135,7 +129,7 @@ if.else:
 
 define external fastcc  void @"loop_bug.gen#2<0>"(i64  %"h##0", i64  %"lst##0", i64  %"t##0")    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.11, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
   tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %"t##0")  
   ret void 
@@ -148,15 +142,15 @@ entry:
   %"1#tmp#6##0" = icmp ne i64 %"lst##0", 0 
   br i1 %"1#tmp#6##0", label %if.then, label %if.else 
 if.then:
-  %12 = inttoptr i64 %"lst##0" to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  %15 = add   i64 %"lst##0", 8 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  %18 = load  i64, i64* %17 
-  tail call ccc  void  @print_int(i64  %14)  
-  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %18)  
+  %10 = inttoptr i64 %"lst##0" to i64* 
+  %11 = getelementptr  i64, i64* %10, i64 0 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"lst##0", 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = getelementptr  i64, i64* %14, i64 0 
+  %16 = load  i64, i64* %15 
+  tail call ccc  void  @print_int(i64  %12)  
+  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %16)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -64,13 +64,13 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
 @command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
 
 
 @"resource#command_line.argc" =    global i64 undef
@@ -177,13 +177,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
+@main_hello.2 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @main_hello.1 to i64) }
+
+
 @main_hello.8 =    constant {i64, i64} { i64 25, i64 ptrtoint ([?? x i8]* @main_hello.7 to i64) }
 
 
 @main_hello.7 =    constant [?? x i8] c" command line argument(s)\00"
-
-
-@main_hello.2 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @main_hello.1 to i64) }
 
 
 @main_hello.1 =    constant [?? x i8] c"hello, world!\00"

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -58,21 +58,6 @@ set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}>:
  
 
 
-declare external ccc  void @error_exit(i64, i64)    
-
-
-declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
-
-
-@command_line.11 =    constant [?? x i8] c"\00"
-
-
-@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
-
-
-@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
-
-
 @"resource#command_line.argc" =    global i64 undef
 
 
@@ -86,6 +71,21 @@ declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)
 
 
 @"resource#command_line.exit_code" =    global i64 undef
+
+
+@command_line.11 =    constant [?? x i8] c"\00"
+
+
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
+
+
+@command_line.16 =    constant [?? x i8] c"command_line:18:15\00"
+
+
+declare external ccc  void @error_exit(i64, i64)    
+
+
+declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>[785a827a1b]"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -168,13 +168,10 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
+@"resource#command_line.arguments" = external   global i64 
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
+@"resource#command_line.exit_code" = external   global i64 
 
 
 @main_hello.2 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @main_hello.1 to i64) }
@@ -189,10 +186,13 @@ declare external ccc  void @print_int(i64)
 @main_hello.1 =    constant [?? x i8] c"hello, world!\00"
 
 
-@"resource#command_line.arguments" = external   global i64 
+declare external ccc  void @putchar(i8)    
 
 
-@"resource#command_line.exit_code" = external   global i64 
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/main_hello2.exp
+++ b/test-cases/final-dump/main_hello2.exp
@@ -28,12 +28,6 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @main_hello2.4 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @main_hello2.3 to i64) }
 
 
@@ -44,6 +38,12 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @main_hello2.3 =    constant [?? x i8] c"world!\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/main_hello2.exp
+++ b/test-cases/final-dump/main_hello2.exp
@@ -37,13 +37,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @main_hello2.4 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @main_hello2.3 to i64) }
 
 
-@main_hello2.3 =    constant [?? x i8] c"world!\00"
-
-
 @main_hello2.2 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @main_hello2.1 to i64) }
 
 
 @main_hello2.1 =    constant [?? x i8] c"hello, \00"
+
+
+@main_hello2.3 =    constant [?? x i8] c"world!\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -139,10 +139,7 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
-@multi_specz.38 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.37 to i64) }
-
-
-@multi_specz.37 =    constant [?? x i8] c"=============\00"
+@multi_specz.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.33 to i64) }
 
 
 @multi_specz.36 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.35 to i64) }
@@ -151,28 +148,19 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 @multi_specz.35 =    constant [?? x i8] c"-------------\00"
 
 
-@multi_specz.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.33 to i64) }
-
-
 @multi_specz.33 =    constant [?? x i8] c"=============\00"
 
 
-@multi_specz.76 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.75 to i64) }
-
-
-@multi_specz.75 =    constant [?? x i8] c"=============\00"
-
-
-@multi_specz.74 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.73 to i64) }
-
-
-@multi_specz.73 =    constant [?? x i8] c"-------------\00"
+@multi_specz.70 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.69 to i64) }
 
 
 @multi_specz.72 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.71 to i64) }
 
 
-@multi_specz.71 =    constant [?? x i8] c"=============\00"
+@multi_specz.71 =    constant [?? x i8] c"-------------\00"
+
+
+@multi_specz.69 =    constant [?? x i8] c"=============\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -238,7 +226,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %19)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %27)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.38, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -246,56 +234,56 @@ entry:
 
 define external fastcc  void @"multi_specz.bar2<0>"()    {
 entry:
-  %39 = trunc i64 16 to i32  
-  %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
-  %41 = ptrtoint i8* %40 to i64 
-  %42 = inttoptr i64 %41 to i64* 
-  %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 0, i64* %43 
-  %44 = add   i64 %41, 8 
-  %45 = inttoptr i64 %44 to i64* 
-  %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 1, i64* %46 
-  %47 = trunc i64 16 to i32  
-  %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
-  %49 = ptrtoint i8* %48 to i64 
-  %50 = inttoptr i64 %49 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 0, i64* %51 
-  %52 = add   i64 %49, 8 
-  %53 = inttoptr i64 %52 to i64* 
-  %54 = getelementptr  i64, i64* %53, i64 0 
-  store  i64 2, i64* %54 
-  %55 = trunc i64 16 to i32  
-  %56 = tail call ccc  i8*  @wybe_malloc(i32  %55)  
-  %57 = ptrtoint i8* %56 to i64 
-  %58 = inttoptr i64 %57 to i64* 
-  %59 = getelementptr  i64, i64* %58, i64 0 
-  store  i64 0, i64* %59 
-  %60 = add   i64 %57, 8 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  store  i64 3, i64* %62 
-  %63 = trunc i64 16 to i32  
-  %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
-  %65 = ptrtoint i8* %64 to i64 
-  %66 = inttoptr i64 %65 to i64* 
-  %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 0, i64* %67 
-  %68 = add   i64 %65, 8 
-  %69 = inttoptr i64 %68 to i64* 
-  %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 4, i64* %70 
+  %37 = trunc i64 16 to i32  
+  %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
+  %39 = ptrtoint i8* %38 to i64 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  store  i64 0, i64* %41 
+  %42 = add   i64 %39, 8 
+  %43 = inttoptr i64 %42 to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  store  i64 1, i64* %44 
+  %45 = trunc i64 16 to i32  
+  %46 = tail call ccc  i8*  @wybe_malloc(i32  %45)  
+  %47 = ptrtoint i8* %46 to i64 
+  %48 = inttoptr i64 %47 to i64* 
+  %49 = getelementptr  i64, i64* %48, i64 0 
+  store  i64 0, i64* %49 
+  %50 = add   i64 %47, 8 
+  %51 = inttoptr i64 %50 to i64* 
+  %52 = getelementptr  i64, i64* %51, i64 0 
+  store  i64 2, i64* %52 
+  %53 = trunc i64 16 to i32  
+  %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
+  %55 = ptrtoint i8* %54 to i64 
+  %56 = inttoptr i64 %55 to i64* 
+  %57 = getelementptr  i64, i64* %56, i64 0 
+  store  i64 0, i64* %57 
+  %58 = add   i64 %55, 8 
+  %59 = inttoptr i64 %58 to i64* 
+  %60 = getelementptr  i64, i64* %59, i64 0 
+  store  i64 3, i64* %60 
+  %61 = trunc i64 16 to i32  
+  %62 = tail call ccc  i8*  @wybe_malloc(i32  %61)  
+  %63 = ptrtoint i8* %62 to i64 
+  %64 = inttoptr i64 %63 to i64* 
+  %65 = getelementptr  i64, i64* %64, i64 0 
+  store  i64 0, i64* %65 
+  %66 = add   i64 %63, 8 
+  %67 = inttoptr i64 %66 to i64* 
+  %68 = getelementptr  i64, i64* %67, i64 0 
+  store  i64 4, i64* %68 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.70, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"multi_specz.foo<0>"(i64  %39, i64  %47, i64  %55, i64  %63)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.72, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"multi_specz.foo<0>"(i64  %41, i64  %49, i64  %57, i64  %65)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.74, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %41)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %49)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %57)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %65)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.76, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %47)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %63)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.70, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -323,26 +311,26 @@ entry:
 
 define external fastcc  void @"multi_specz.modifyAndPrint<0>"(i64  %"pos##0", i64  %"v##0")    {
 entry:
-  %77 = trunc i64 16 to i32  
-  %78 = tail call ccc  i8*  @wybe_malloc(i32  %77)  
-  %79 = ptrtoint i8* %78 to i64 
-  %80 = inttoptr i64 %79 to i8* 
-  %81 = inttoptr i64 %"pos##0" to i8* 
-  %82 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %80, i8*  %81, i32  %82, i1  0)  
-  %83 = inttoptr i64 %79 to i64* 
-  %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"v##0", i64* %84 
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %79)  
+  %73 = trunc i64 16 to i32  
+  %74 = tail call ccc  i8*  @wybe_malloc(i32  %73)  
+  %75 = ptrtoint i8* %74 to i64 
+  %76 = inttoptr i64 %75 to i8* 
+  %77 = inttoptr i64 %"pos##0" to i8* 
+  %78 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %76, i8*  %77, i32  %78, i1  0)  
+  %79 = inttoptr i64 %75 to i64* 
+  %80 = getelementptr  i64, i64* %79, i64 0 
+  store  i64 %"v##0", i64* %80 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %75)  
   ret void 
 }
 
 
 define external fastcc  void @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"pos##0", i64  %"v##0")    {
 entry:
-  %85 = inttoptr i64 %"pos##0" to i64* 
-  %86 = getelementptr  i64, i64* %85, i64 0 
-  store  i64 %"v##0", i64* %86 
+  %81 = inttoptr i64 %"pos##0" to i64* 
+  %82 = getelementptr  i64, i64* %81, i64 0 
+  store  i64 %"v##0", i64* %82 
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"pos##0")  
   ret void 
 }
@@ -406,19 +394,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -130,15 +130,6 @@ modifyAndPrint(pos##0:position.position, v##0:wybe.int)<{<<wybe.io.io>>}; {<<wyb
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
 @multi_specz.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.33 to i64) }
 
 
@@ -151,16 +142,13 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 @multi_specz.33 =    constant [?? x i8] c"=============\00"
 
 
-@multi_specz.70 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.69 to i64) }
+declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
-@multi_specz.72 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.71 to i64) }
+declare external ccc  void @putchar(i8)    
 
 
-@multi_specz.71 =    constant [?? x i8] c"-------------\00"
-
-
-@multi_specz.69 =    constant [?? x i8] c"=============\00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -274,16 +262,16 @@ entry:
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   store  i64 4, i64* %68 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.70, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"multi_specz.foo<0>"(i64  %39, i64  %47, i64  %55, i64  %63)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.72, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.36, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %47)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %63)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.70, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -311,26 +299,26 @@ entry:
 
 define external fastcc  void @"multi_specz.modifyAndPrint<0>"(i64  %"pos##0", i64  %"v##0")    {
 entry:
-  %73 = trunc i64 16 to i32  
-  %74 = tail call ccc  i8*  @wybe_malloc(i32  %73)  
-  %75 = ptrtoint i8* %74 to i64 
-  %76 = inttoptr i64 %75 to i8* 
-  %77 = inttoptr i64 %"pos##0" to i8* 
-  %78 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %76, i8*  %77, i32  %78, i1  0)  
-  %79 = inttoptr i64 %75 to i64* 
-  %80 = getelementptr  i64, i64* %79, i64 0 
-  store  i64 %"v##0", i64* %80 
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %75)  
+  %69 = trunc i64 16 to i32  
+  %70 = tail call ccc  i8*  @wybe_malloc(i32  %69)  
+  %71 = ptrtoint i8* %70 to i64 
+  %72 = inttoptr i64 %71 to i8* 
+  %73 = inttoptr i64 %"pos##0" to i8* 
+  %74 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %72, i8*  %73, i32  %74, i1  0)  
+  %75 = inttoptr i64 %71 to i64* 
+  %76 = getelementptr  i64, i64* %75, i64 0 
+  store  i64 %"v##0", i64* %76 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %71)  
   ret void 
 }
 
 
 define external fastcc  void @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"pos##0", i64  %"v##0")    {
 entry:
-  %81 = inttoptr i64 %"pos##0" to i64* 
-  %82 = getelementptr  i64, i64* %81, i64 0 
-  store  i64 %"v##0", i64* %82 
+  %77 = inttoptr i64 %"pos##0" to i64* 
+  %78 = getelementptr  i64, i64* %77, i64 0 
+  store  i64 %"v##0", i64* %78 
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"pos##0")  
   ret void 
 }
@@ -382,15 +370,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -407,6 +386,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -73,19 +73,13 @@ declare external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64)
 declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64, i64, i64, i64, i64)    
 
 
-@multi_specz_cyclic_exe.38 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.37 to i64) }
-
-
-@multi_specz_cyclic_exe.37 =    constant [?? x i8] c"=============\00"
+@multi_specz_cyclic_exe.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.33 to i64) }
 
 
 @multi_specz_cyclic_exe.36 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.35 to i64) }
 
 
 @multi_specz_cyclic_exe.35 =    constant [?? x i8] c"-------------\00"
-
-
-@multi_specz_cyclic_exe.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.33 to i64) }
 
 
 @multi_specz_cyclic_exe.33 =    constant [?? x i8] c"=============\00"
@@ -153,7 +147,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %19)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %27)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.38, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -285,22 +279,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@multi_specz_cyclic_lib.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.22 to i64) }
-
-
-@multi_specz_cyclic_lib.22 =    constant [?? x i8] c")\00"
-
-
 @multi_specz_cyclic_lib.17 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.16 to i64) }
 
 
-@multi_specz_cyclic_lib.16 =    constant [?? x i8] c",\00"
+@multi_specz_cyclic_lib.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.22 to i64) }
 
 
 @multi_specz_cyclic_lib.12 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.11 to i64) }
 
 
 @multi_specz_cyclic_lib.11 =    constant [?? x i8] c" (\00"
+
+
+@multi_specz_cyclic_lib.22 =    constant [?? x i8] c")\00"
+
+
+@multi_specz_cyclic_lib.16 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -61,18 +61,6 @@ main()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64, i64, i64, i64, i64)    
-
-
 @multi_specz_cyclic_exe.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.33 to i64) }
 
 
@@ -83,6 +71,18 @@ declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64,
 
 
 @multi_specz_cyclic_exe.33 =    constant [?? x i8] c"=============\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -261,24 +261,6 @@ printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.
  
 
 
-declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)    
-
-
-declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64, i64, i64, i64, i64)    
-
-
-declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64, i64, i64, i64, i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @multi_specz_cyclic_lib.17 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.16 to i64) }
 
 
@@ -295,6 +277,24 @@ declare external ccc  void @print_int(i64)
 
 
 @multi_specz_cyclic_lib.16 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64, i64, i64, i64, i64)    
+
+
+declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64, i64, i64, i64, i64)    
+
+
+declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -320,23 +320,6 @@ if.else:
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
-entry:
-  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
-  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
-  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x3##0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x4##0", i64  444)  
-  ret void 
-if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
-  ret void 
-}
-
-
 define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
   %"1#tmp#0##0" = sub   i64 %"n##0", 1 
@@ -350,6 +333,23 @@ if.then:
   ret void 
 if.else:
   tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
+entry:
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x4##0", i64  444)  
+  ret void 
+if.else:
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }
 
@@ -714,19 +714,19 @@ foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
  
 
 
-declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64, i64, i64, i64, i64)    
+declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64, i64, i64, i64, i64)    
 
 
 declare external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64, i64)    
-
-
-declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64, i64, i64, i64, i64)    
 
 
 declare external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64, i64)    
 
 
 declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64, i64, i64, i64, i64)    
+
+
+declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -752,23 +752,6 @@ if.else:
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
-entry:
-  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
-  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
-  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x2##0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x3##0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
-  ret void 
-if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
-  ret void 
-}
-
-
 define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
   %"1#tmp#0##0" = sub   i64 %"n##0", 1 
@@ -782,5 +765,22 @@ if.then:
   ret void 
 if.else:
   tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
+entry:
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
+  ret void 
+if.else:
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -91,22 +91,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@multi_specz_cyclic_lib.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.20 to i64) }
-
-
-@multi_specz_cyclic_lib.20 =    constant [?? x i8] c")\00"
-
-
 @multi_specz_cyclic_lib.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.14 to i64) }
 
 
-@multi_specz_cyclic_lib.14 =    constant [?? x i8] c",\00"
+@multi_specz_cyclic_lib.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.20 to i64) }
 
 
 @multi_specz_cyclic_lib.10 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.9 to i64) }
 
 
 @multi_specz_cyclic_lib.9 =    constant [?? x i8] c" (\00"
+
+
+@multi_specz_cyclic_lib.20 =    constant [?? x i8] c")\00"
+
+
+@multi_specz_cyclic_lib.14 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -79,18 +79,6 @@ printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.
  
 
 
-declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @multi_specz_cyclic_lib.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.14 to i64) }
 
 
@@ -107,6 +95,18 @@ declare external ccc  void @print_int(i64)
 
 
 @multi_specz_cyclic_lib.14 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -91,22 +91,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@multi_specz_cyclic_lib.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.20 to i64) }
-
-
-@multi_specz_cyclic_lib.20 =    constant [?? x i8] c")\00"
-
-
 @multi_specz_cyclic_lib.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.14 to i64) }
 
 
-@multi_specz_cyclic_lib.14 =    constant [?? x i8] c",\00"
+@multi_specz_cyclic_lib.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.20 to i64) }
 
 
 @multi_specz_cyclic_lib.10 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.9 to i64) }
 
 
 @multi_specz_cyclic_lib.9 =    constant [?? x i8] c" (\00"
+
+
+@multi_specz_cyclic_lib.20 =    constant [?? x i8] c")\00"
+
+
+@multi_specz_cyclic_lib.14 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -79,18 +79,6 @@ printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.
  
 
 
-declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @multi_specz_cyclic_lib.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.14 to i64) }
 
 
@@ -107,6 +95,18 @@ declare external ccc  void @print_int(i64)
 
 
 @multi_specz_cyclic_lib.14 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -197,18 +197,6 @@ print_t(x##0:multictr2.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_float(double)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @multictr2.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.6 to i64) }
 
 
@@ -261,6 +249,18 @@ declare external ccc  void @print_int(i64)
 
 
 @multictr2.54 =    constant [?? x i8] c"c08(\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_float(double)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -209,112 +209,58 @@ declare external ccc  void @print_float(double)
 declare external ccc  void @print_int(i64)    
 
 
-@multictr2.75 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.74 to i64) }
+@multictr2.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.6 to i64) }
 
 
-@multictr2.74 =    constant [?? x i8] c")\00"
-
-
-@multictr2.73 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multictr2.72 to i64) }
-
-
-@multictr2.72 =    constant [?? x i8] c", \00"
-
-
-@multictr2.71 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multictr2.70 to i64) }
-
-
-@multictr2.70 =    constant [?? x i8] c", \00"
-
-
-@multictr2.69 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.68 to i64) }
-
-
-@multictr2.68 =    constant [?? x i8] c"c08(\00"
-
-
-@multictr2.55 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.54 to i64) }
-
-
-@multictr2.54 =    constant [?? x i8] c")\00"
-
-
-@multictr2.53 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.52 to i64) }
-
-
-@multictr2.52 =    constant [?? x i8] c"c07(\00"
-
-
-@multictr2.47 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.46 to i64) }
-
-
-@multictr2.46 =    constant [?? x i8] c")\00"
-
-
-@multictr2.45 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.44 to i64) }
-
-
-@multictr2.44 =    constant [?? x i8] c"c06(\00"
-
-
-@multictr2.39 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.38 to i64) }
-
-
-@multictr2.38 =    constant [?? x i8] c")\00"
-
-
-@multictr2.37 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.36 to i64) }
-
-
-@multictr2.36 =    constant [?? x i8] c"c05(\00"
-
-
-@multictr2.31 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.30 to i64) }
-
-
-@multictr2.30 =    constant [?? x i8] c")\00"
-
-
-@multictr2.29 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.28 to i64) }
-
-
-@multictr2.28 =    constant [?? x i8] c"c04(\00"
-
-
-@multictr2.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.22 to i64) }
-
-
-@multictr2.22 =    constant [?? x i8] c")\00"
-
-
-@multictr2.21 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.20 to i64) }
-
-
-@multictr2.20 =    constant [?? x i8] c"c03(\00"
-
-
-@multictr2.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.14 to i64) }
-
-
-@multictr2.14 =    constant [?? x i8] c")\00"
+@multictr2.57 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multictr2.56 to i64) }
 
 
 @multictr2.13 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.12 to i64) }
 
 
-@multictr2.12 =    constant [?? x i8] c"c03(\00"
+@multictr2.23 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.22 to i64) }
 
 
-@multictr2.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.6 to i64) }
+@multictr2.29 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.28 to i64) }
 
 
-@multictr2.6 =    constant [?? x i8] c")\00"
+@multictr2.35 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.34 to i64) }
 
 
 @multictr2.5 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.4 to i64) }
 
 
+@multictr2.41 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.40 to i64) }
+
+
+@multictr2.55 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.54 to i64) }
+
+
+@multictr2.6 =    constant [?? x i8] c")\00"
+
+
+@multictr2.56 =    constant [?? x i8] c", \00"
+
+
 @multictr2.4 =    constant [?? x i8] c"c01(\00"
+
+
+@multictr2.12 =    constant [?? x i8] c"c03(\00"
+
+
+@multictr2.22 =    constant [?? x i8] c"c04(\00"
+
+
+@multictr2.28 =    constant [?? x i8] c"c05(\00"
+
+
+@multictr2.34 =    constant [?? x i8] c"c06(\00"
+
+
+@multictr2.40 =    constant [?? x i8] c"c07(\00"
+
+
+@multictr2.54 =    constant [?? x i8] c"c08(\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -347,97 +293,97 @@ if.then1:
   %11 = load  i64, i64* %10 
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %11)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.15, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
   %"5#tmp#16##0" = icmp eq i64 %"1#tmp#9##0", 2 
   br i1 %"5#tmp#16##0", label %if.then2, label %if.else2 
 if.then2:
-  %16 = add   i64 %"x##0", -2 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.21, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %19)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.23, i32 0, i32 0) to i64))  
+  %14 = add   i64 %"x##0", -2 
+  %15 = inttoptr i64 %14 to i64* 
+  %16 = getelementptr  i64, i64* %15, i64 0 
+  %17 = load  i64, i64* %16 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.13, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
   %"7#tmp#19##0" = icmp eq i64 %"1#tmp#9##0", 3 
   br i1 %"7#tmp#19##0", label %if.then3, label %if.else3 
 if.then3:
-  %24 = add   i64 %"x##0", -3 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.29, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %27)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.31, i32 0, i32 0) to i64))  
+  %18 = add   i64 %"x##0", -3 
+  %19 = inttoptr i64 %18 to i64* 
+  %20 = getelementptr  i64, i64* %19, i64 0 
+  %21 = load  i64, i64* %20 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.23, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %21)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
   %"9#tmp#22##0" = icmp eq i64 %"1#tmp#9##0", 4 
   br i1 %"9#tmp#22##0", label %if.then4, label %if.else4 
 if.then4:
-  %32 = add   i64 %"x##0", -4 
-  %33 = inttoptr i64 %32 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  %35 = load  i64, i64* %34 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.37, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %35)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.39, i32 0, i32 0) to i64))  
+  %24 = add   i64 %"x##0", -4 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = getelementptr  i64, i64* %25, i64 0 
+  %27 = load  i64, i64* %26 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.29, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %27)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else4:
   %"11#tmp#25##0" = icmp eq i64 %"1#tmp#9##0", 5 
   br i1 %"11#tmp#25##0", label %if.then5, label %if.else5 
 if.then5:
-  %40 = add   i64 %"x##0", -5 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  %43 = load  i64, i64* %42 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.45, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %43)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.47, i32 0, i32 0) to i64))  
+  %30 = add   i64 %"x##0", -5 
+  %31 = inttoptr i64 %30 to i64* 
+  %32 = getelementptr  i64, i64* %31, i64 0 
+  %33 = load  i64, i64* %32 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.35, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %33)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else5:
   %"13#tmp#28##0" = icmp eq i64 %"1#tmp#9##0", 6 
   br i1 %"13#tmp#28##0", label %if.then6, label %if.else6 
 if.then6:
-  %48 = add   i64 %"x##0", -6 
-  %49 = inttoptr i64 %48 to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  %51 = load  i64, i64* %50 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.53, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %51)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.55, i32 0, i32 0) to i64))  
+  %36 = add   i64 %"x##0", -6 
+  %37 = inttoptr i64 %36 to i64* 
+  %38 = getelementptr  i64, i64* %37, i64 0 
+  %39 = load  i64, i64* %38 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.41, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %39)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else6:
   %"15#tmp#31##0" = icmp eq i64 %"1#tmp#9##0", 7 
   br i1 %"15#tmp#31##0", label %if.then7, label %if.else7 
 if.then7:
-  %56 = add   i64 %"x##0", -7 
-  %57 = inttoptr i64 %56 to i64* 
-  %58 = getelementptr  i64, i64* %57, i64 0 
-  %59 = load  i64, i64* %58 
-  %60 = add   i64 %"x##0", 1 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  %63 = load  i64, i64* %62 
-  %64 = add   i64 %"x##0", 9 
-  %65 = inttoptr i64 %64 to double* 
-  %66 = getelementptr  double, double* %65, i64 0 
-  %67 = load  double, double* %66 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.69, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %59)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.71, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %63)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.73, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_float(double  %67)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.75, i32 0, i32 0) to i64))  
+  %42 = add   i64 %"x##0", -7 
+  %43 = inttoptr i64 %42 to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  %45 = load  i64, i64* %44 
+  %46 = add   i64 %"x##0", 1 
+  %47 = inttoptr i64 %46 to i64* 
+  %48 = getelementptr  i64, i64* %47, i64 0 
+  %49 = load  i64, i64* %48 
+  %50 = add   i64 %"x##0", 9 
+  %51 = inttoptr i64 %50 to double* 
+  %52 = getelementptr  double, double* %51, i64 0 
+  %53 = load  double, double* %52 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.55, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %45)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.57, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %49)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.57, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_float(double  %53)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else7:

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -65,16 +65,16 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
-
-
-@mytree.3 =    constant [?? x i8] c"}\00"
-
-
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
 
 
+@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
+
+
 @mytree.1 =    constant [?? x i8] c"{\00"
+
+
+@mytree.3 =    constant [?? x i8] c"}\00"
 
 
 declare external ccc  void @print_int(i64)    

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -62,13 +62,16 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
 
 
 @mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
+
+
+@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
+
+
+@mytree.16 =    constant [?? x i8] c", \00"
 
 
 @mytree.1 =    constant [?? x i8] c"{\00"
@@ -80,10 +83,7 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
-
-
-@mytree.16 =    constant [?? x i8] c", \00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/nested_if.exp
+++ b/test-cases/final-dump/nested_if.exp
@@ -57,12 +57,6 @@ nested_if(i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @nested_if.6 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @nested_if.5 to i64) }
 
 
@@ -85,6 +79,12 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @nested_if.1 =    constant [?? x i8] c"zero\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/nested_if.exp
+++ b/test-cases/final-dump/nested_if.exp
@@ -63,16 +63,13 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@nested_if.8 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_if.7 to i64) }
-
-
-@nested_if.7 =    constant [?? x i8] c"other\00"
-
-
 @nested_if.6 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @nested_if.5 to i64) }
 
 
-@nested_if.5 =    constant [?? x i8] c"two\00"
+@nested_if.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @nested_if.1 to i64) }
+
+
+@nested_if.8 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_if.7 to i64) }
 
 
 @nested_if.4 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @nested_if.3 to i64) }
@@ -81,7 +78,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @nested_if.3 =    constant [?? x i8] c"one thousand and one\00"
 
 
-@nested_if.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @nested_if.1 to i64) }
+@nested_if.7 =    constant [?? x i8] c"other\00"
+
+
+@nested_if.5 =    constant [?? x i8] c"two\00"
 
 
 @nested_if.1 =    constant [?? x i8] c"zero\00"

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -66,25 +66,25 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
+@nested_loop.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.1 to i64) }
+
+
 @nested_loop.4 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.3 to i64) }
 
 
 @nested_loop.3 =    constant [?? x i8] c"Inner\00"
 
 
-@nested_loop.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.1 to i64) }
-
-
 @nested_loop.1 =    constant [?? x i8] c"Outer\00"
+
+
+@nested_loop.6 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.5 to i64) }
 
 
 @nested_loop.8 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.7 to i64) }
 
 
 @nested_loop.7 =    constant [?? x i8] c"Inner\00"
-
-
-@nested_loop.6 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.5 to i64) }
 
 
 @nested_loop.5 =    constant [?? x i8] c"Outer\00"

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -60,12 +60,6 @@ gen#2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @nested_loop.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.1 to i64) }
 
 
@@ -78,22 +72,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @nested_loop.1 =    constant [?? x i8] c"Outer\00"
 
 
-@nested_loop.6 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.5 to i64) }
+declare external ccc  void @putchar(i8)    
 
 
-@nested_loop.8 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.7 to i64) }
-
-
-@nested_loop.7 =    constant [?? x i8] c"Inner\00"
-
-
-@nested_loop.5 =    constant [?? x i8] c"Outer\00"
-
-
-@nested_loop.10 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.9 to i64) }
-
-
-@nested_loop.9 =    constant [?? x i8] c"Inner\00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -115,9 +97,9 @@ entry:
 
 define external fastcc  void @"nested_loop.gen#1<0>"()    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.6, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.8, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"nested_loop.gen#2<0>"()  
   ret void 
@@ -126,7 +108,7 @@ entry:
 
 define external fastcc  void @"nested_loop.gen#2<0>"()    {
 entry:
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.10, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"nested_loop.gen#2<0>"()  
   ret void 

--- a/test-cases/final-dump/numbers.exp
+++ b/test-cases/final-dump/numbers.exp
@@ -55,16 +55,16 @@ toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @numbers.2 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @numbers.1 to i64) }
 
 
 @numbers.1 =    constant [?? x i8] c"Numbers has been initialised.\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -34,13 +34,13 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @person1.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person1.1 to i64) }
 
 
 @person1.1 =    constant [?? x i8] c"Wang\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -38,12 +38,6 @@ module top-level code > public {inline,impure} (0 calls)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@person2.4 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person2.3 to i64) }
-
-
-@person2.3 =    constant [?? x i8] c"Smith\00"
-
-
 @person2.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person2.1 to i64) }
 
 
@@ -59,7 +53,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  void @"person2.<0>"()    {
 entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.2, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.4, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.2, i32 0, i32 0) to i64))  
   ret void 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -35,13 +35,13 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @person2.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person2.1 to i64) }
 
 
 @person2.1 =    constant [?? x i8] c"Smith\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -35,9 +35,6 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @person3.4 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person3.3 to i64) }
 
 
@@ -48,6 +45,9 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @person3.3 =    constant [?? x i8] c"Wang\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -41,13 +41,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @person3.4 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person3.3 to i64) }
 
 
-@person3.3 =    constant [?? x i8] c"Wang\00"
-
-
 @person3.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person3.1 to i64) }
 
 
 @person3.1 =    constant [?? x i8] c"Smith\00"
+
+
+@person3.3 =    constant [?? x i8] c"Wang\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -38,13 +38,13 @@ module top-level code > public {inline,impure} (0 calls)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
+@person4.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person4.1 to i64) }
+
+
 @person4.4 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person4.3 to i64) }
 
 
 @person4.3 =    constant [?? x i8] c"Smith\00"
-
-
-@person4.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person4.1 to i64) }
 
 
 @person4.1 =    constant [?? x i8] c"Wang\00"

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -35,9 +35,6 @@ module top-level code > public {inline,impure} (0 calls)
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @person4.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person4.1 to i64) }
 
 
@@ -48,6 +45,9 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @person4.1 =    constant [?? x i8] c"Wang\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -44,9 +44,6 @@ update_both(p1##0:person5.person, ?p1##1:person5.person, p2##0:person5.person, ?
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @person5.2 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.1 to i64) }
 
 
@@ -59,16 +56,7 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @person5.3 =    constant [?? x i8] c"Bob\00"
 
 
-@person5.14 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.13 to i64) }
-
-
-@person5.24 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.23 to i64) }
-
-
-@person5.13 =    constant [?? x i8] c"Amy\00"
-
-
-@person5.23 =    constant [?? x i8] c"Bob\00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -96,20 +84,20 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = inttoptr i64 %7 to i64* 
   %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.14, i32 0, i32 0) to i64), i64* %12 
-  %15 = trunc i64 16 to i32  
-  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
-  %17 = ptrtoint i8* %16 to i64 
-  %18 = inttoptr i64 %17 to i8* 
-  %19 = inttoptr i64 %"p2##0" to i8* 
-  %20 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %18, i8*  %19, i32  %20, i1  0)  
-  %21 = inttoptr i64 %17 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.24, i32 0, i32 0) to i64), i64* %22 
-  %25 = insertvalue {i64, i64} undef, i64 %7, 0 
-  %26 = insertvalue {i64, i64} %25, i64 %17, 1 
-  ret {i64, i64} %26 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.2, i32 0, i32 0) to i64), i64* %12 
+  %13 = trunc i64 16 to i32  
+  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
+  %15 = ptrtoint i8* %14 to i64 
+  %16 = inttoptr i64 %15 to i8* 
+  %17 = inttoptr i64 %"p2##0" to i8* 
+  %18 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %16, i8*  %17, i32  %18, i1  0)  
+  %19 = inttoptr i64 %15 to i64* 
+  %20 = getelementptr  i64, i64* %19, i64 0 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.4, i32 0, i32 0) to i64), i64* %20 
+  %21 = insertvalue {i64, i64} undef, i64 %7, 0 
+  %22 = insertvalue {i64, i64} %21, i64 %15, 1 
+  ret {i64, i64} %22 
 }
 --------------------------------------------------
  Module person5.person

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -47,28 +47,28 @@ update_both(p1##0:person5.person, ?p1##1:person5.person, p2##0:person5.person, ?
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@person5.4 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.3 to i64) }
-
-
-@person5.3 =    constant [?? x i8] c"Bob\00"
-
-
 @person5.2 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.1 to i64) }
+
+
+@person5.4 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.3 to i64) }
 
 
 @person5.1 =    constant [?? x i8] c"Amy\00"
 
 
-@person5.24 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.23 to i64) }
-
-
-@person5.23 =    constant [?? x i8] c"Bob\00"
+@person5.3 =    constant [?? x i8] c"Bob\00"
 
 
 @person5.14 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.13 to i64) }
 
 
+@person5.24 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.23 to i64) }
+
+
 @person5.13 =    constant [?? x i8] c"Amy\00"
+
+
+@person5.23 =    constant [?? x i8] c"Bob\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -47,15 +47,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -72,6 +63,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -59,19 +59,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -59,19 +59,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -47,15 +47,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -72,6 +63,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -379,16 +379,16 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @position1.13 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @position1.12 to i64) }
 
 
 @position1.12 =    constant [?? x i8] c"expect posA(111,112):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -59,19 +59,19 @@ declare external ccc  void @print_int(i64)
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.12 =    constant [?? x i8] c")\00"
-
-
 @position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
-
-
-@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
 
 
 @position.1 =    constant [?? x i8] c" (\00"
+
+
+@position.12 =    constant [?? x i8] c")\00"
+
+
+@position.6 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -392,10 +392,10 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
+@position2.18 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @position2.17 to i64) }
+
+
 @position2.25 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @position2.24 to i64) }
-
-
-@position2.24 =    constant [?? x i8] c"expect posB(333,222):\00"
 
 
 @position2.23 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @position2.22 to i64) }
@@ -404,10 +404,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @position2.22 =    constant [?? x i8] c"expect posA(111,20000):\00"
 
 
-@position2.18 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @position2.17 to i64) }
-
-
 @position2.17 =    constant [?? x i8] c"expect posA(111,222):\00"
+
+
+@position2.24 =    constant [?? x i8] c"expect posB(333,222):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -47,15 +47,6 @@ printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
@@ -72,6 +63,15 @@ declare external ccc  void @print_int(i64)
 
 
 @position.6 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -386,12 +386,6 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external fastcc  void @"position.printPosition<0>"(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @position2.18 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @position2.17 to i64) }
 
 
@@ -408,6 +402,12 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @position2.24 =    constant [?? x i8] c"expect posB(333,222):\00"
+
+
+declare external fastcc  void @"position.printPosition<0>"(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/proc_beer.exp
+++ b/test-cases/final-dump/proc_beer.exp
@@ -71,6 +71,12 @@ gen#2(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
+@proc_beer.2 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_beer.1 to i64) }
+
+
+@proc_beer.1 =    constant [?? x i8] c" bottles of beer on the wall\00"
+
+
 declare external ccc  void @putchar(i8)    
 
 
@@ -78,18 +84,6 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 declare external ccc  void @print_int(i64)    
-
-
-@proc_beer.2 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_beer.1 to i64) }
-
-
-@proc_beer.1 =    constant [?? x i8] c" bottles of beer on the wall\00"
-
-
-@proc_beer.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_beer.3 to i64) }
-
-
-@proc_beer.3 =    constant [?? x i8] c" bottles of beer on the wall\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -131,7 +125,7 @@ if.else:
 define external fastcc  void @"proc_beer.gen#2<0>"(i64  %"count##0")    {
 entry:
   tail call ccc  void  @print_int(i64  %"count##0")  
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.4, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#count##1" = sub   i64 %"count##0", 1 
   tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  %"1#count##1")  

--- a/test-cases/final-dump/proc_gcd.exp
+++ b/test-cases/final-dump/proc_gcd.exp
@@ -78,10 +78,10 @@ mod(x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.i
  
 
 
-declare external ccc  void @print_int(i64)    
-
-
 declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/proc_hello.exp
+++ b/test-cases/final-dump/proc_hello.exp
@@ -27,16 +27,16 @@ print2([x##0:wybe.int], [y##0:wybe.int])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @proc_hello.2 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @proc_hello.1 to i64) }
 
 
 @proc_hello.1 =    constant [?? x i8] c"hello, world\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -91,25 +91,10 @@ yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.i
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.io.print<5>"(i1)    
+@proc_yorn.4 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @proc_yorn.3 to i64) }
 
 
 @proc_yorn.2 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @proc_yorn.1 to i64) }
-
-
-@proc_yorn.1 =    constant [?? x i8] c"Well, yes or no?\00"
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  i8 @read_char()    
-
-
-@proc_yorn.4 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @proc_yorn.3 to i64) }
 
 
 @proc_yorn.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn.5 to i64) }
@@ -119,6 +104,21 @@ declare external ccc  i8 @read_char()
 
 
 @proc_yorn.5 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
+
+
+@proc_yorn.1 =    constant [?? x i8] c"Well, yes or no?\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  i8 @read_char()    
+
+
+declare external fastcc  void @"wybe.io.print<5>"(i1)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -109,16 +109,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  i8 @read_char()    
 
 
-@proc_yorn.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn.5 to i64) }
-
-
-@proc_yorn.5 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
-
-
 @proc_yorn.4 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @proc_yorn.3 to i64) }
 
 
+@proc_yorn.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn.5 to i64) }
+
+
 @proc_yorn.3 =    constant [?? x i8] c" (y/n) \00"
+
+
+@proc_yorn.5 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -50,15 +50,6 @@ yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.i
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  i8 @read_char()    
-
-
 @proc_yorn2.2 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @proc_yorn2.1 to i64) }
 
 
@@ -69,6 +60,15 @@ declare external ccc  i8 @read_char()
 
 
 @proc_yorn2.3 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  i8 @read_char()    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -59,16 +59,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  i8 @read_char()    
 
 
-@proc_yorn2.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn2.3 to i64) }
-
-
-@proc_yorn2.3 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
-
-
 @proc_yorn2.2 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @proc_yorn2.1 to i64) }
 
 
+@proc_yorn2.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn2.3 to i64) }
+
+
 @proc_yorn2.1 =    constant [?? x i8] c" (y/n) \00"
+
+
+@proc_yorn2.3 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/resource_rollback.exp
+++ b/test-cases/final-dump/resource_rollback.exp
@@ -66,22 +66,22 @@ gen#1()<{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; 
  
 
 
-declare external ccc  void @putchar(i8)    
+@"resource#resource_rollback.res" =    global i64 undef
 
 
-declare external ccc  void @print_string(i64)    
-
-
-declare external ccc  void @print_int(i64)    
+@"resource#resource_rollback.ser" =    global i64 undef
 
 
 @resource_rollback.1 =    constant [?? x i8] c"resource_rollback:15:7\00"
 
 
-@"resource#resource_rollback.res" =    global i64 undef
+declare external ccc  void @putchar(i8)    
 
 
-@"resource#resource_rollback.ser" =    global i64 undef
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  void @print_string(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/resource_tmp_vars.exp
+++ b/test-cases/final-dump/resource_tmp_vars.exp
@@ -44,13 +44,13 @@ gen#1(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<wybe.io.io>>}; {<<resource_tmp_
  
 
 
+@"resource#resource_tmp_vars.counter" =    global i64 undef
+
+
 declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  void @print_int(i64)    
-
-
-@"resource#resource_tmp_vars.counter" =    global i64 undef
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/specials.exp
+++ b/test-cases/final-dump/specials.exp
@@ -90,10 +90,10 @@ show_location(%call_source_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.
 declare external ccc  void @putchar(i8)    
 
 
-declare external ccc  void @print_int(i64)    
-
-
 declare external ccc  void @print_string(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/specials_one_module.exp
+++ b/test-cases/final-dump/specials_one_module.exp
@@ -92,6 +92,18 @@ show_location(%call_source_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.
  
 
 
+@specials_one_module.4 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @specials_one_module.3 to i64) }
+
+
+@specials_one_module.3 =    constant [?? x i8] c" (should be line 28)\00"
+
+
+@specials_one_module.1 =    constant [?? x i8] c"specials_one_module\00"
+
+
+@specials_one_module.2 =    constant [?? x i8] c"specials_one_module:29:2\00"
+
+
 declare external ccc  void @putchar(i8)    
 
 
@@ -101,19 +113,7 @@ declare external ccc  void @print_int(i64)
 declare external ccc  void @print_string(i64)    
 
 
-@specials_one_module.1 =    constant [?? x i8] c"specials_one_module\00"
-
-
-@specials_one_module.2 =    constant [?? x i8] c"specials_one_module:29:2\00"
-
-
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-@specials_one_module.4 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @specials_one_module.3 to i64) }
-
-
-@specials_one_module.3 =    constant [?? x i8] c" (should be line 28)\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/specials_one_module.exp
+++ b/test-cases/final-dump/specials_one_module.exp
@@ -101,10 +101,10 @@ declare external ccc  void @print_int(i64)
 declare external ccc  void @print_string(i64)    
 
 
-@specials_one_module.2 =    constant [?? x i8] c"specials_one_module:29:2\00"
-
-
 @specials_one_module.1 =    constant [?? x i8] c"specials_one_module\00"
+
+
+@specials_one_module.2 =    constant [?? x i8] c"specials_one_module:29:2\00"
 
 
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    

--- a/test-cases/final-dump/specials_use.exp
+++ b/test-cases/final-dump/specials_use.exp
@@ -196,16 +196,16 @@ declare external ccc  void @print_string(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@specials_use.4 =    constant [?? x i8] c"!ROOT!/final-dump/specials_use.wybe:8:2\00"
-
-
-@specials_use.3 =    constant [?? x i8] c"specials_use:7:2\00"
-
-
 @specials_use.2 =    constant [?? x i8] c"!ROOT!/final-dump/specials_use.wybe\00"
 
 
+@specials_use.4 =    constant [?? x i8] c"!ROOT!/final-dump/specials_use.wybe:8:2\00"
+
+
 @specials_use.1 =    constant [?? x i8] c"specials_use\00"
+
+
+@specials_use.3 =    constant [?? x i8] c"specials_use:7:2\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/specials_use.exp
+++ b/test-cases/final-dump/specials_use.exp
@@ -90,10 +90,10 @@ show_location(%call_source_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.
 declare external ccc  void @putchar(i8)    
 
 
-declare external ccc  void @print_int(i64)    
-
-
 declare external ccc  void @print_string(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -187,15 +187,6 @@ module top-level code > public {impure} (0 calls)
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_string(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @specials_use.2 =    constant [?? x i8] c"!ROOT!/final-dump/specials_use.wybe\00"
 
 
@@ -206,6 +197,15 @@ declare external ccc  void @print_int(i64)
 
 
 @specials_use.3 =    constant [?? x i8] c"specials_use:7:2\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_string(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -718,12 +718,6 @@ xrange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @stmt_for.16 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @stmt_for.15 to i64) }
 
 
@@ -802,7 +796,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @stmt_for.1 =    constant [?? x i8] c"single_generator:\00"
 
 
+declare external ccc  void @putchar(i8)    
+
+
 declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -724,79 +724,79 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@stmt_for.26 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @stmt_for.25 to i64) }
-
-
-@stmt_for.25 =    constant [?? x i8] c"\0ausing_irange_reverse\00"
-
-
-@stmt_for.24 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.23 to i64) }
-
-
-@stmt_for.23 =    constant [?? x i8] c"\0ausing_irange\00"
-
-
-@stmt_for.22 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @stmt_for.21 to i64) }
-
-
-@stmt_for.21 =    constant [?? x i8] c"\0ausing_xrange_reverse\00"
-
-
-@stmt_for.20 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.19 to i64) }
-
-
-@stmt_for.19 =    constant [?? x i8] c"\0ausing_xrange\00"
-
-
-@stmt_for.18 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.17 to i64) }
-
-
-@stmt_for.17 =    constant [?? x i8] c"\0ausing_unless\00"
-
-
 @stmt_for.16 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @stmt_for.15 to i64) }
-
-
-@stmt_for.15 =    constant [?? x i8] c"\0ausing_when\00"
-
-
-@stmt_for.14 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.13 to i64) }
-
-
-@stmt_for.13 =    constant [?? x i8] c"\0ausing_until\00"
-
-
-@stmt_for.12 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.11 to i64) }
-
-
-@stmt_for.11 =    constant [?? x i8] c"\0ausing_while\00"
 
 
 @stmt_for.10 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @stmt_for.9 to i64) }
 
 
-@stmt_for.9 =    constant [?? x i8] c"\0ausing_next\00"
+@stmt_for.12 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.11 to i64) }
+
+
+@stmt_for.14 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.13 to i64) }
 
 
 @stmt_for.8 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.7 to i64) }
 
 
-@stmt_for.7 =    constant [?? x i8] c"\0ausing_break\00"
+@stmt_for.18 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.17 to i64) }
 
 
-@stmt_for.6 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @stmt_for.5 to i64) }
+@stmt_for.20 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.19 to i64) }
 
 
-@stmt_for.5 =    constant [?? x i8] c"\0ashortest_generator_termination\00"
+@stmt_for.24 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.23 to i64) }
+
+
+@stmt_for.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @stmt_for.1 to i64) }
 
 
 @stmt_for.4 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @stmt_for.3 to i64) }
 
 
+@stmt_for.22 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @stmt_for.21 to i64) }
+
+
+@stmt_for.26 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @stmt_for.25 to i64) }
+
+
+@stmt_for.6 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @stmt_for.5 to i64) }
+
+
 @stmt_for.3 =    constant [?? x i8] c"\0amultiple_generator\00"
 
 
-@stmt_for.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @stmt_for.1 to i64) }
+@stmt_for.5 =    constant [?? x i8] c"\0ashortest_generator_termination\00"
+
+
+@stmt_for.7 =    constant [?? x i8] c"\0ausing_break\00"
+
+
+@stmt_for.23 =    constant [?? x i8] c"\0ausing_irange\00"
+
+
+@stmt_for.25 =    constant [?? x i8] c"\0ausing_irange_reverse\00"
+
+
+@stmt_for.9 =    constant [?? x i8] c"\0ausing_next\00"
+
+
+@stmt_for.17 =    constant [?? x i8] c"\0ausing_unless\00"
+
+
+@stmt_for.13 =    constant [?? x i8] c"\0ausing_until\00"
+
+
+@stmt_for.15 =    constant [?? x i8] c"\0ausing_when\00"
+
+
+@stmt_for.11 =    constant [?? x i8] c"\0ausing_while\00"
+
+
+@stmt_for.19 =    constant [?? x i8] c"\0ausing_xrange\00"
+
+
+@stmt_for.21 =    constant [?? x i8] c"\0ausing_xrange_reverse\00"
 
 
 @stmt_for.1 =    constant [?? x i8] c"single_generator:\00"

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -115,28 +115,28 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
+@stmt_if.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @stmt_if.12 to i64) }
+
+
 @stmt_if.15 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.14 to i64) }
 
 
 @stmt_if.14 =    constant [?? x i8] c"lookup fails when it should succeed\00"
 
 
-@stmt_if.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @stmt_if.12 to i64) }
-
-
 @stmt_if.12 =    constant [?? x i8] c"lookup succeeds when it should\00"
-
-
-@stmt_if.19 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.18 to i64) }
-
-
-@stmt_if.18 =    constant [?? x i8] c"lookup succeeds when it should fail\00"
 
 
 @stmt_if.17 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @stmt_if.16 to i64) }
 
 
+@stmt_if.19 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.18 to i64) }
+
+
 @stmt_if.16 =    constant [?? x i8] c"lookup fails when it should\00"
+
+
+@stmt_if.18 =    constant [?? x i8] c"lookup succeeds when it should fail\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -109,10 +109,7 @@ lookup(key##0:wybe.int, tree##0:stmt_if.tree, ?result##0:wybe.bool)<{}; {}>:
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+@stmt_if.17 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @stmt_if.16 to i64) }
 
 
 @stmt_if.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @stmt_if.12 to i64) }
@@ -121,22 +118,25 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @stmt_if.15 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.14 to i64) }
 
 
-@stmt_if.14 =    constant [?? x i8] c"lookup fails when it should succeed\00"
-
-
-@stmt_if.12 =    constant [?? x i8] c"lookup succeeds when it should\00"
-
-
-@stmt_if.17 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @stmt_if.16 to i64) }
-
-
 @stmt_if.19 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.18 to i64) }
 
 
 @stmt_if.16 =    constant [?? x i8] c"lookup fails when it should\00"
 
 
+@stmt_if.14 =    constant [?? x i8] c"lookup fails when it should succeed\00"
+
+
+@stmt_if.12 =    constant [?? x i8] c"lookup succeeds when it should\00"
+
+
 @stmt_if.18 =    constant [?? x i8] c"lookup succeeds when it should fail\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -95,13 +95,13 @@ lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?#result##0:wybe.bool)<{}; {}>:
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @stmt_if2.13 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @stmt_if2.12 to i64) }
 
 
 @stmt_if2.12 =    constant [?? x i8] c"found\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -208,142 +208,76 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)    
 
 
-@string.46 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.45 to i64) }
-
-
-@string.45 =    constant [?? x i8] c"abc\00"
-
-
-@string.44 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.43 to i64) }
-
-
-@string.43 =    constant [?? x i8] c"abc\00"
-
-
-@string.42 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.41 to i64) }
-
-
-@string.41 =    constant [?? x i8] c"abc\00"
-
-
-@string.40 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.39 to i64) }
-
-
-@string.39 =    constant [?? x i8] c"abc\00"
-
-
-@string.38 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @string.37 to i64) }
-
-
-@string.37 =    constant [?? x i8] c"abcdefgh\00"
-
-
-@string.36 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.35 to i64) }
-
-
-@string.35 =    constant [?? x i8] c"cd\00"
-
-
-@string.34 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.33 to i64) }
-
-
-@string.33 =    constant [?? x i8] c"ab\00"
-
-
-@string.32 =    constant {i64, i64} { i64 26, i64 ptrtoint ([?? x i8]* @string.31 to i64) }
-
-
-@string.31 =    constant [?? x i8] c"abcdefghijklmnopqrstuvwxyz\00"
-
-
-@string.30 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.29 to i64) }
-
-
-@string.29 =    constant [?? x i8] c"abc\00"
-
-
-@string.28 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.27 to i64) }
-
-
-@string.27 =    constant [?? x i8] c"abc\00"
-
-
-@string.26 =    constant [?? x i8] c"\0aTESTING INDEXING\00"
-
-
-@string.25 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @string.24 to i64) }
-
-
-@string.24 =    constant [?? x i8] c"abcdefghijkl\00"
-
-
-@string.23 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.22 to i64) }
-
-
-@string.22 =    constant [?? x i8] c"abc\00"
-
-
-@string.21 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.20 to i64) }
-
-
-@string.20 =    constant [?? x i8] c"abc\00"
-
-
-@string.19 =    constant [?? x i8] c"\0aTESTING LOOPS\00"
-
-
-@string.18 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.17 to i64) }
-
-
-@string.17 =    constant [?? x i8] c"abc\00"
-
-
-@string.16 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.15 to i64) }
-
-
-@string.15 =    constant [?? x i8] c"efg\00"
-
-
-@string.14 =    constant [?? x i8] c"\0aTESTING CONVERSION TO c_string\00"
-
-
-@string.13 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @string.12 to i64) }
-
-
-@string.12 =    constant [?? x i8] c"abcdefghi\00"
-
-
-@string.11 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.10 to i64) }
-
-
-@string.10 =    constant [?? x i8] c"abc\00"
-
-
-@string.9 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.8 to i64) }
-
-
-@string.8 =    constant [?? x i8] c"abc\00"
-
-
-@string.7 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.6 to i64) }
-
-
-@string.6 =    constant [?? x i8] c"abc\00"
+@string.3 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @string.2 to i64) }
 
 
 @string.5 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @string.4 to i64) }
 
 
-@string.4 =    constant [?? x i8] c"a\00"
+@string.20 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.19 to i64) }
 
 
-@string.3 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @string.2 to i64) }
+@string.22 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.21 to i64) }
+
+
+@string.12 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.11 to i64) }
+
+
+@string.7 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.6 to i64) }
+
+
+@string.24 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @string.23 to i64) }
+
+
+@string.9 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @string.8 to i64) }
+
+
+@string.15 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @string.14 to i64) }
+
+
+@string.18 =    constant {i64, i64} { i64 26, i64 ptrtoint ([?? x i8]* @string.17 to i64) }
 
 
 @string.2 =    constant [?? x i8] c"\00"
 
 
+@string.10 =    constant [?? x i8] c"\0aTESTING CONVERSION TO c_string\00"
+
+
+@string.16 =    constant [?? x i8] c"\0aTESTING INDEXING\00"
+
+
+@string.13 =    constant [?? x i8] c"\0aTESTING LOOPS\00"
+
+
 @string.1 =    constant [?? x i8] c"TESTING CONSTRUCTION\00"
+
+
+@string.4 =    constant [?? x i8] c"a\00"
+
+
+@string.19 =    constant [?? x i8] c"ab\00"
+
+
+@string.6 =    constant [?? x i8] c"abc\00"
+
+
+@string.23 =    constant [?? x i8] c"abcdefgh\00"
+
+
+@string.8 =    constant [?? x i8] c"abcdefghi\00"
+
+
+@string.14 =    constant [?? x i8] c"abcdefghijkl\00"
+
+
+@string.17 =    constant [?? x i8] c"abcdefghijklmnopqrstuvwxyz\00"
+
+
+@string.21 =    constant [?? x i8] c"cd\00"
+
+
+@string.11 =    constant [?? x i8] c"efg\00"
 
 
 declare external fastcc  {i8, i64, i1} @"wybe.string.[|]<0>"(i64)    
@@ -355,7 +289,7 @@ declare external fastcc  {i8, i64, i1} @"wybe.string.[|]<0>[785a827a1b]"(i64)
 declare external fastcc  {i8, i1} @"wybe.string.[]<0>"(i64, i64)    
 
 
-@string.58 =    constant [?? x i8] c"OUT OF RANGE\00"
+@string.36 =    constant [?? x i8] c"OUT OF RANGE\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -374,7 +308,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %"1#tmp#0##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.9, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.11, i32 0, i32 0) to i64))  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#107##0" = shl   i64 97, 2 
@@ -383,51 +317,51 @@ entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#1##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#6##0" = tail call fastcc  i64  @"wybe.range.construct<0>"(i64  1, i64  3, i64  100)  
-  %"1#tmp#2##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.13, i32 0, i32 0) to i64), i64  %"1#tmp#6##0")  
+  %"1#tmp#2##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.9, i32 0, i32 0) to i64), i64  %"1#tmp#6##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#7##0" = tail call fastcc  i64  @"wybe.range...<0>"(i64  1, i64  3)  
   %"1#tmp#4##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %"1#tmp#2##0", i64  %"1#tmp#7##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#4##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.14, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#71##0" = shl   i64 100, 2 
   %"1#tmp#72##0" = or i64 %"1#tmp#71##0", 1024 
   %"1#tmp#10##0" = or i64 %"1#tmp#72##0", 3 
   %"1#tmp#12##0" = tail call fastcc  i64  @"wybe.range...<0>"(i64  1, i64  2)  
-  %"1#tmp#11##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.16, i32 0, i32 0) to i64), i64  %"1#tmp#12##0")  
+  %"1#tmp#11##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.12, i32 0, i32 0) to i64), i64  %"1#tmp#12##0")  
   %"1#tmp#9##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  %"1#tmp#10##0", i64  %"1#tmp#11##0")  
-  %"1#tmp#8##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.18, i32 0, i32 0) to i64), i64  %"1#tmp#9##0")  
+  %"1#tmp#8##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  %"1#tmp#9##0")  
   %"1#r##0" = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  %"1#tmp#8##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#8##0")  
   tail call ccc  void  @putchar(i8  32)  
   tail call ccc  void  @print_string(i64  %"1#r##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.19, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"string.gen#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.21, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.23, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"string.gen#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64))  
   %"1#tmp#14##0" = tail call fastcc  i64  @"wybe.range.irange<0>"(i64  10, i64  -1, i64  1)  
-  %"1#tmp#13##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.25, i32 0, i32 0) to i64), i64  %"1#tmp#14##0")  
+  %"1#tmp#13##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.15, i32 0, i32 0) to i64), i64  %"1#tmp#14##0")  
   tail call fastcc  void  @"string.gen#1<0>"(i64  %"1#tmp#13##0", i64  %"1#tmp#13##0")  
-  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.26, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.16, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.28, i32 0, i32 0) to i64), i64  0)  
-  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.30, i32 0, i32 0) to i64), i64  1)  
-  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.32, i32 0, i32 0) to i64), i64  25)  
-  %"1#tmp#15##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.34, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.36, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  0)  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  1)  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.18, i32 0, i32 0) to i64), i64  25)  
+  %"1#tmp#15##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.20, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.22, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#15##0", i64  1)  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#15##0", i64  2)  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#1##0", i64  0)  
   %"1#tmp#19##0" = tail call fastcc  i64  @"wybe.range.construct<0>"(i64  0, i64  2, i64  10)  
-  %"1#tmp#18##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.38, i32 0, i32 0) to i64), i64  %"1#tmp#19##0")  
+  %"1#tmp#18##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.24, i32 0, i32 0) to i64), i64  %"1#tmp#19##0")  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#18##0", i64  0)  
-  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.40, i32 0, i32 0) to i64), i64  3)  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  3)  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#1##0", i64  3)  
-  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.42, i32 0, i32 0) to i64), i64  -3)  
-  %"1#tmp#21##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.44, i32 0, i32 0) to i64), i64  %"1#tmp#19##0")  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  -3)  
+  %"1#tmp#21##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  %"1#tmp#19##0")  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#21##0", i64  2)  
-  %"1#tmp#23##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.46, i32 0, i32 0) to i64), i64  %"1#tmp#1##0")  
+  %"1#tmp#23##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  %"1#tmp#1##0")  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#23##0", i64  2)  
   %"1#tmp#110##0" = shl   i64 98, 2 
   %"1#tmp#111##0" = or i64 %"1#tmp#110##0", 1024 
@@ -446,14 +380,14 @@ entry:
 
 define external fastcc  void @"string.gen#1<0>"(i64  %"s##0", i64  %"tmp#0##0")    {
 entry:
-  %47 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>"(i64  %"tmp#0##0")  
-  %48 = extractvalue {i8, i64, i1} %47, 0 
-  %49 = extractvalue {i8, i64, i1} %47, 1 
-  %50 = extractvalue {i8, i64, i1} %47, 2 
-  br i1 %50, label %if.then, label %if.else 
+  %25 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>"(i64  %"tmp#0##0")  
+  %26 = extractvalue {i8, i64, i1} %25, 0 
+  %27 = extractvalue {i8, i64, i1} %25, 1 
+  %28 = extractvalue {i8, i64, i1} %25, 2 
+  br i1 %28, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @putchar(i8  %48)  
-  tail call fastcc  void  @"string.gen#1<0>[6dacb8fd25]"(i64  %"s##0", i64  %49)  
+  tail call ccc  void  @putchar(i8  %26)  
+  tail call fastcc  void  @"string.gen#1<0>[6dacb8fd25]"(i64  %"s##0", i64  %27)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  10)  
@@ -463,14 +397,14 @@ if.else:
 
 define external fastcc  void @"string.gen#1<0>[6dacb8fd25]"(i64  %"s##0", i64  %"tmp#0##0")    {
 entry:
-  %51 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
-  %52 = extractvalue {i8, i64, i1} %51, 0 
-  %53 = extractvalue {i8, i64, i1} %51, 1 
-  %54 = extractvalue {i8, i64, i1} %51, 2 
-  br i1 %54, label %if.then, label %if.else 
+  %29 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
+  %30 = extractvalue {i8, i64, i1} %29, 0 
+  %31 = extractvalue {i8, i64, i1} %29, 1 
+  %32 = extractvalue {i8, i64, i1} %29, 2 
+  br i1 %32, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @putchar(i8  %52)  
-  tail call fastcc  void  @"string.gen#1<0>[6dacb8fd25]"(i64  %"s##0", i64  %53)  
+  tail call ccc  void  @putchar(i8  %30)  
+  tail call fastcc  void  @"string.gen#1<0>[6dacb8fd25]"(i64  %"s##0", i64  %31)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  10)  
@@ -487,16 +421,16 @@ entry:
 
 define external fastcc  void @"string.test_index<0>"(i64  %"s##0", i64  %"i##0")    {
 entry:
-  %55 = tail call fastcc  {i8, i1}  @"wybe.string.[]<0>"(i64  %"s##0", i64  %"i##0")  
-  %56 = extractvalue {i8, i1} %55, 0 
-  %57 = extractvalue {i8, i1} %55, 1 
-  br i1 %57, label %if.then, label %if.else 
+  %33 = tail call fastcc  {i8, i1}  @"wybe.string.[]<0>"(i64  %"s##0", i64  %"i##0")  
+  %34 = extractvalue {i8, i1} %33, 0 
+  %35 = extractvalue {i8, i1} %33, 1 
+  br i1 %35, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @putchar(i8  %56)  
+  tail call ccc  void  @putchar(i8  %34)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.58, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.36, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -181,33 +181,6 @@ test_index(s##0:wybe.string, i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external fastcc  i64 @"wybe.string.[]<1>"(i64, i64)    
-
-
-declare external fastcc  i64 @"wybe.range...<0>"(i64, i64)    
-
-
-declare external fastcc  i64 @"wybe.string.,,<0>"(i64, i64)    
-
-
-declare external fastcc  i64 @"wybe.range.construct<0>"(i64, i64, i64)    
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_string(i64)    
-
-
-declare external fastcc  i64 @"wybe.range.irange<0>"(i64, i64, i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)    
-
-
 @string.3 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @string.2 to i64) }
 
 
@@ -250,6 +223,9 @@ declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)
 @string.13 =    constant [?? x i8] c"\0aTESTING LOOPS\00"
 
 
+@string.36 =    constant [?? x i8] c"OUT OF RANGE\00"
+
+
 @string.1 =    constant [?? x i8] c"TESTING CONSTRUCTION\00"
 
 
@@ -280,16 +256,40 @@ declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)
 @string.11 =    constant [?? x i8] c"efg\00"
 
 
-declare external fastcc  {i8, i64, i1} @"wybe.string.[|]<0>"(i64)    
+declare external ccc  void @putchar(i8)    
 
 
-declare external fastcc  {i8, i64, i1} @"wybe.string.[|]<0>[785a827a1b]"(i64)    
+declare external ccc  void @print_string(i64)    
 
 
 declare external fastcc  {i8, i1} @"wybe.string.[]<0>"(i64, i64)    
 
 
-@string.36 =    constant [?? x i8] c"OUT OF RANGE\00"
+declare external fastcc  {i8, i64, i1} @"wybe.string.[|]<0>[785a827a1b]"(i64)    
+
+
+declare external fastcc  {i8, i64, i1} @"wybe.string.[|]<0>"(i64)    
+
+
+declare external fastcc  i64 @"wybe.string.[]<1>"(i64, i64)    
+
+
+declare external fastcc  i64 @"wybe.range...<0>"(i64, i64)    
+
+
+declare external fastcc  i64 @"wybe.string.,,<0>"(i64, i64)    
+
+
+declare external fastcc  i64 @"wybe.range.construct<0>"(i64, i64, i64)    
+
+
+declare external fastcc  i64 @"wybe.range.irange<0>"(i64, i64, i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -92,19 +92,19 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@student.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.33 to i64) }
-
-
-@student.33 =    constant [?? x i8] c"course name: \00"
+@student.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.19 to i64) }
 
 
 @student.29 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.28 to i64) }
 
 
+@student.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.33 to i64) }
+
+
 @student.28 =    constant [?? x i8] c"course code: \00"
 
 
-@student.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.19 to i64) }
+@student.33 =    constant [?? x i8] c"course name: \00"
 
 
 @student.19 =    constant [?? x i8] c"student id: \00"

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -77,21 +77,6 @@ printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-@student.10 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @student.9 to i64) }
-
-
-@student.9 =    constant [?? x i8] c"Declarative Programming\00"
-
-
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @student.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.19 to i64) }
 
 
@@ -101,6 +86,12 @@ declare external ccc  void @print_int(i64)
 @student.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.33 to i64) }
 
 
+@student.10 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @student.9 to i64) }
+
+
+@student.9 =    constant [?? x i8] c"Declarative Programming\00"
+
+
 @student.28 =    constant [?? x i8] c"course code: \00"
 
 
@@ -108,6 +99,15 @@ declare external ccc  void @print_int(i64)
 
 
 @student.19 =    constant [?? x i8] c"student id: \00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/submodule.exp
+++ b/test-cases/final-dump/submodule.exp
@@ -59,7 +59,7 @@ semi_hidden()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+@submodule.privatetest.4 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @submodule.privatetest.3 to i64) }
 
 
 @submodule.privatetest.2 =    constant {i64, i64} { i64 32, i64 ptrtoint ([?? x i8]* @submodule.privatetest.1 to i64) }
@@ -68,10 +68,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @submodule.privatetest.1 =    constant [?? x i8] c"private proc in a private module\00"
 
 
-@submodule.privatetest.4 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @submodule.privatetest.3 to i64) }
-
-
 @submodule.privatetest.3 =    constant [?? x i8] c"public proc in a private module\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -126,7 +126,7 @@ visible()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
  
 
 
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+@submodule.publictest.4 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @submodule.publictest.3 to i64) }
 
 
 @submodule.publictest.2 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @submodule.publictest.1 to i64) }
@@ -135,10 +135,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @submodule.publictest.1 =    constant [?? x i8] c"private proc in a public module\00"
 
 
-@submodule.publictest.4 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @submodule.publictest.3 to i64) }
-
-
 @submodule.publictest.3 =    constant [?? x i8] c"public proc in a public module\00"
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -132,19 +132,19 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@test_loop.25 =    constant {i64, i64} { i64 39, i64 ptrtoint ([?? x i8]* @test_loop.24 to i64) }
-
-
-@test_loop.24 =    constant [?? x i8] c"Couldn't find even number divisible by \00"
-
-
 @test_loop.23 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @test_loop.22 to i64) }
+
+
+@test_loop.21 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @test_loop.20 to i64) }
+
+
+@test_loop.25 =    constant {i64, i64} { i64 39, i64 ptrtoint ([?? x i8]* @test_loop.24 to i64) }
 
 
 @test_loop.22 =    constant [?? x i8] c" is \00"
 
 
-@test_loop.21 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @test_loop.20 to i64) }
+@test_loop.24 =    constant [?? x i8] c"Couldn't find even number divisible by \00"
 
 
 @test_loop.20 =    constant [?? x i8] c"First even number divisible by \00"

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -123,15 +123,6 @@ gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?#success##
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
 @test_loop.23 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @test_loop.22 to i64) }
 
 
@@ -148,6 +139,15 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 
 
 @test_loop.20 =    constant [?? x i8] c"First even number divisible by \00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/top_level_use.exp
+++ b/test-cases/final-dump/top_level_use.exp
@@ -28,13 +28,13 @@ module top-level code > public {impure} (0 calls)
  
 
 
+@"resource#top_level_use.res" =    global i64 undef
+
+
 declare external ccc  void @putchar(i8)    
 
 
 declare external ccc  void @print_int(i64)    
-
-
-@"resource#top_level_use.res" =    global i64 undef
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -170,16 +170,16 @@ gen#5([f##0:wybe.float], [i##0:wybe.int], [tmp#0##0:wybe.bool], [x##0:wybe.float
 declare external ccc  void @putchar(i8)    
 
 
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  i64 @"wybe.list.length1<0>"(i64, i64)    
+declare external fastcc  void @"wybe.io.print<5>"(i1)    
 
 
 declare external ccc  void @print_float(double)    
 
 
-declare external fastcc  void @"wybe.io.print<5>"(i1)    
+declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  i64 @"wybe.list.length1<0>"(i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/unique_position.exp
+++ b/test-cases/final-dump/unique_position.exp
@@ -58,15 +58,6 @@ printPosition(pos##0:unique_position.unique_position)<{<<wybe.io.io>>}; {<<wybe.
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
 @unique_position.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @unique_position.20 to i64) }
 
 
@@ -83,6 +74,15 @@ declare external ccc  void @print_int(i64)
 
 
 @unique_position.20 =    constant [?? x i8] c",\00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+
+
+declare external ccc  void @print_int(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/unique_position.exp
+++ b/test-cases/final-dump/unique_position.exp
@@ -67,22 +67,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@unique_position.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @unique_position.22 to i64) }
-
-
-@unique_position.22 =    constant [?? x i8] c")\00"
-
-
 @unique_position.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @unique_position.20 to i64) }
 
 
-@unique_position.20 =    constant [?? x i8] c",\00"
+@unique_position.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @unique_position.22 to i64) }
 
 
 @unique_position.19 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @unique_position.18 to i64) }
 
 
 @unique_position.18 =    constant [?? x i8] c" (\00"
+
+
+@unique_position.22 =    constant [?? x i8] c")\00"
+
+
+@unique_position.20 =    constant [?? x i8] c",\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -67,13 +67,7 @@ use_test()<{<<use_resource.count>>, <<wybe.io.io>>}; {<<use_resource.count>>, <<
  
 
 
-declare external ccc  void @putchar(i8)    
-
-
-declare external ccc  void @print_int(i64)    
-
-
-declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
+@"resource#use_resource.count" =    global i64 undef
 
 
 @use_resource.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.1 to i64) }
@@ -88,19 +82,13 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @use_resource.3 =    constant [?? x i8] c"Outer count (1): \00"
 
 
-@"resource#use_resource.count" =    global i64 undef
+declare external ccc  void @putchar(i8)    
 
 
-@use_resource.8 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.7 to i64) }
+declare external ccc  void @print_int(i64)    
 
 
-@use_resource.10 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.9 to i64) }
-
-
-@use_resource.7 =    constant [?? x i8] c"Inner count (4): \00"
-
-
-@use_resource.9 =    constant [?? x i8] c"Outer count (1): \00"
+declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -138,11 +126,11 @@ entry:
   %"1#tmp#5##0" = add   i64 %"1#tmp#3##0", 1 
   %"1#tmp#7##0" = add   i64 %"1#tmp#5##0", 1 
   %"1#tmp#9##0" = add   i64 %"1#tmp#7##0", 1 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.8, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#tmp#9##0")  
   tail call ccc  void  @putchar(i8  10)  
   store  i64 %"1#tmp#3##0", i64* @"resource#use_resource.count" 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.10, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#tmp#3##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -76,31 +76,31 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@use_resource.4 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.3 to i64) }
-
-
-@use_resource.3 =    constant [?? x i8] c"Outer count (1): \00"
-
-
 @use_resource.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.1 to i64) }
+
+
+@use_resource.4 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.3 to i64) }
 
 
 @use_resource.1 =    constant [?? x i8] c"Inner count (4): \00"
 
 
+@use_resource.3 =    constant [?? x i8] c"Outer count (1): \00"
+
+
 @"resource#use_resource.count" =    global i64 undef
-
-
-@use_resource.10 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.9 to i64) }
-
-
-@use_resource.9 =    constant [?? x i8] c"Outer count (1): \00"
 
 
 @use_resource.8 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.7 to i64) }
 
 
+@use_resource.10 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.9 to i64) }
+
+
 @use_resource.7 =    constant [?? x i8] c"Inner count (4): \00"
+
+
+@use_resource.9 =    constant [?? x i8] c"Outer count (1): \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    


### PR DESCRIPTION
This PR aims to make code generation and unbranching of closures slightly more intelligent

* Translation/Codegen monads have been refactored, with Codegen being a StateT of Codegen
  * This allows for the global constants/variables/externs to be shared across Codegen passes
    * Modifies the order of such, hence the test cases changing 
  * The word counter now is not passed around as an explicit argument between the Translation and Codegen monads
  * Malloced closures can also be shared--the closure env is constant wrt the closure so this is safe
* Closure procedures are now only generated if there is no previously generated closure proc for the given proc with identical constant arguments
  * This can be approved upon by sharing the generated procs across different unbranching passes, lets call that a TODO for now

Closes #186 