### PR TITLE
remove trailing whitespace + rerun make src/README.md

### DIFF
--- a/WYBE.md
+++ b/WYBE.md
@@ -66,8 +66,8 @@ can be found with the following:
 
 #### Optimisation Options
 
-The `--llvm-opt-level` (`-O`) options specifies the level of optimisation used 
-within the LLVM compiler during the compilations stage of a Wybe module. By 
+The `--llvm-opt-level` (`-O`) options specifies the level of optimisation used
+within the LLVM compiler during the compilations stage of a Wybe module. By
 default this is set to 3, yet supports the values 0, 1, 2, or 3. More information
 can be found [here](https://llvm.org/docs/CommandGuide/llc.html#id1).
 
@@ -137,11 +137,11 @@ A higher order type has one of the two following forms
 
 > `{` *modifier*`,` ... `}` `(` *flow* *type*`,` ... `)`
 
-Two higher order types are considered compatible if they share the same flows 
+Two higher order types are considered compatible if they share the same flows
 and the type parameters are also compatible.
 
 The list of modifiers specify the modifiers of the higher order type. These modifiers
-can be a purity modifier, a determinism modifier, or `resource`. The special 
+can be a purity modifier, a determinism modifier, or `resource`. The special
 `resource` modifier states that this higher order term may use some resource.
 
 
@@ -172,14 +172,14 @@ The only Boolean constants are `true` and `false`.
 
 String constants are written as any number of characters between double quote
 (`"`) characters.  Character constants are written as a single character between
-single quote (`'`) characters. 
+single quote (`'`) characters.
 
-To denote a a C-style (null-terminated) string, a `c` precedes the first `"`. 
+To denote a a C-style (null-terminated) string, a `c` precedes the first `"`.
 This is provided for interoperability with external libraries.
 
-In both strings and character constants, the backslash (`\`) character is special, 
-altering the way the following character is interpreted.  The backslash and the 
-following character together are interpreted as a single character, according to 
+In both strings and character constants, the backslash (`\`) character is special,
+altering the way the following character is interpreted.  The backslash and the
+following character together are interpreted as a single character, according to
 the following character:
 
 | Character | Meaning                                 |
@@ -215,15 +215,15 @@ In general, procedure calls have the form:
 
 where *name* is the name of the procedure to call,
 and each *arg* is an expression specifying an input or output
-to that procedure. If there is a variable bound with the name *name* that has 
+to that procedure. If there is a variable bound with the name *name* that has
 a [higher order type](#higher-order-types) then this is a call to the higher order term.
 
-Sometimes you may wish to specify which module the procedure *name* exists in. 
+Sometimes you may wish to specify which module the procedure *name* exists in.
 You can further specify which module the procedure *name* is from by preceding
 *name* with a `.` separated module specification, such as *parent*`.`*mod*`.`*name*.
 
-As a convenience, if the first module name in a module specification is `_`, the 
-`_` is equivalent to the current module. For example in a module named `foo`, 
+As a convenience, if the first module name in a module specification is `_`, the
+`_` is equivalent to the current module. For example in a module named `foo`,
 `_.`*name* is equivalent to `foo.`*name*
 
 A procedure call must be preceded by an exclamation point (`!`) if it uses any
@@ -311,15 +311,15 @@ Expressions containing both output and input/output arguments are not permitted.
 
 ## <a name="partial-application"></a>Partial application
 
-If a function call is made with *fewer* arguments than is dictated by the 
-definition of procedure/function, the procedure is considered a partial 
+If a function call is made with *fewer* arguments than is dictated by the
+definition of procedure/function, the procedure is considered a partial
 application. The mode of all arguments must be an input (as the procedure is
 not called where used to produce any outputs).
 
 This binds the output name to a "partial application" of the procedure. The type
-of the output variable is a higher order type containing the types and flows of 
-the missing arguments. The higher order type's modifiers are dictated by the 
-modifiers of the partially applied procedure. 
+of the output variable is a higher order type containing the types and flows of
+the missing arguments. The higher order type's modifiers are dictated by the
+modifiers of the partially applied procedure.
 
 The `resource` modifier is applied if the procedure may use some resource. In this
 special case, the number of arguments may be no greater than the expected number
@@ -474,8 +474,8 @@ Anonymous procedures take the following forms:
 
 > `{` *modifier*`,` ... `}` `{` *stmts* `}`
 
-The parameters to an anonymous procedure take one of the following two forms: 
-numbered and unnumbered. When either form is used, all parameters to the 
+The parameters to an anonymous procedure take one of the following two forms:
+numbered and unnumbered. When either form is used, all parameters to the
 anonymous procedure must have the same form.
 
 > `@` *number*
@@ -483,20 +483,20 @@ anonymous procedure must have the same form.
 > `@`
 
 If parameters are unnumbered, then they are exactly equivalent to as if one had
-numbered the parameters from 1, following a left-to-right-top-to-bottom order 
-of the source code. The number of a parameter specifies the parameter's position of the procedure. 
+numbered the parameters from 1, following a left-to-right-top-to-bottom order
+of the source code. The number of a parameter specifies the parameter's position of the procedure.
 
 The types of parameters are inferred via their usage and can be annotated if necessary.
-The [mode](#modes) of a parameter is specified by the modes associated with it in the 
-contained statements-- if references to the parameter are either all inputs or 
-all outputs, then the parameter is as referenced, else it is in in/out mode. 
+The [mode](#modes) of a parameter is specified by the modes associated with it in the
+contained statements-- if references to the parameter are either all inputs or
+all outputs, then the parameter is as referenced, else it is in in/out mode.
 If using numbered parameters and some number is skipped, this parameter is considered
 an input.
 
 The modifiers here are exactly those found in a [higher order type](#higher-order-types).
-These modifiers act like the modifiers of a procedure or function declaration, stating the 
+These modifiers act like the modifiers of a procedure or function declaration, stating the
 purity and determinism of the anonymous procedure. The special `resource` modifier is
-allows all in-scope [resources](#resources) to be used within this anonymous 
+allows all in-scope [resources](#resources) to be used within this anonymous
 procedure.
 
 Some example anonymous procedures are as follows, with examples as to their use:
@@ -621,7 +621,7 @@ two elements are `e1` and `e2`, and the rest of which is `es`.  Note that what
 appears before the `|` symbol are individual list elements, separated by commas,
 and what appears after it is another list.  The empty list is denoted `[]`. The
 list constructor is named `[|]`, so the list `[e1,e2|es]` can also be written ``
-`[|]`(e1,`[|]`(e2,es))`` and the list `[1,2,3]` can be written 
+`[|]`(e1,`[|]`(e2,es))`` and the list `[1,2,3]` can be written
 `` `[|]`(1,`[|]`(2,`[|]`(3,[])))``.
 
 ## Declaring operator functions and procedures
@@ -1127,7 +1127,7 @@ prototype part of a function declaration:
 
 > *ctor*`(`*param*`:`*type*, ... *param*`:`*type*`)`
 
-In contrast to regular procedure prototypes, the parameter names are optional, 
+In contrast to regular procedure prototypes, the parameter names are optional,
 and can be removed, along with the accompanying `:`.
 
 If *name* is an infix operator symbol, you must surround it with backquotes, or
@@ -1147,7 +1147,7 @@ containing the specified data.  If you wish to carry out some computation to
 determine what values to store, you may write a function or procedure that calls
 the constructor.  Since Wybe does not require any special syntax to call a
 constructor (such as `new` in many object oriented languages), they are ordinary
-functions, aside from the fact that they are automatically generated. 
+functions, aside from the fact that they are automatically generated.
 
 The form of declaration above keeps the constructors of a type private; they may
 be used within the current module, but not outside.  To make the constructors
@@ -1179,7 +1179,7 @@ And this statement will unpack a coordinate `pos` into variables `x` and `y`:
 coordinate(?x,?y) = pos
 ```
 
-Additionally, two procedures are automatically generated for each named 
+Additionally, two procedures are automatically generated for each named
 *member*: one to access the member, and one to mutate it.
 The first has the prototype:
 
@@ -1324,8 +1324,8 @@ the operations on them.
 
 The basis of generic types is the *type variable*, which stands for a type we
 don't know yet, and thus is a variable in the type system.  A type variable is
-denoted by an uppercase letter followed by zero or more numbers.  Since we 
-rarely have more than one or two type variables in any given context, we 
+denoted by an uppercase letter followed by zero or more numbers.  Since we
+rarely have more than one or two type variables in any given context, we
 conventionally use a single upper case letter for a type variable.
 
 Generic types are defined in the same way as described above, except that:
@@ -1461,7 +1461,7 @@ the value at the start of *body* will be the same as the value before the `use`
 statement, and the value at the completion of the *body* will again be the same
 as the value before entering the `use` statement.
 Thus a `use` statement will not alter the existence or the values of the
-resources it names. This also applies to higher order terms that have a 
+resources it names. This also applies to higher order terms that have a
 `resource` modifier.
 
 
@@ -1549,7 +1549,7 @@ def bad2 use !io {
             !println("Read an x")
     |   else ::
             !read(_:char)
-            !println("Read something else")                    
+            !println("Read something else")
     }
 }
 ```
@@ -1566,7 +1566,7 @@ def ok2 use !io {
     read(?ch:char)
     case ch in {
         'x' :: !println("Read an x")
-    |   else:: !println("Read something else")                    
+    |   else:: !println("Read something else")
     }
 }
 ```
@@ -1672,26 +1672,26 @@ To support such cases, the Wybe compiler provides a *purity* system, allowing yo
 
 Wybe supports the following three levels of purity:
 
-- *pure*  
+- *pure*
 the default purity level.  An ordinary call, subject to omission or reordering.
 
-- *impure*  
+- *impure*
 an impure call that should not be reordered or omitted.  Impure procs must be declared to be so, and in general, a proc that calls an impure proc must itself be impure.
 
-- *semipure*  
+- *semipure*
 a proc that behaves as impure itself, and will not be reordered or omitted, however its impurity is not "contagious".  It may be called from an ordinary, pure proc without that proc becoming impure.
 
 In the absence of any declaration of impurity, your procedures and functions will be assumed to be pure.  An ordinary pure proc can call a semipure proc, but if it calls an impure proc, the compiler will report an error.  You can specify that your proc is pure despite calling impure procs by explicitly promising that it is pure.
 
 Purity is managed by including one of the following modifiers, between curly braces, in the proc declaration, between the `def` keyword and the procedure or function name:
 
-- `pure`  
+- `pure`
 promise that the proc is pure, despite calling impure procs.
 
-- `semipure`  
+- `semipure`
 specify that the proc is effectively impure, meaning that calls to it are not subject to normal optimisations, but that its callers are not rendered impure by calling it.
 
-- `impure`  
+- `impure`
 the proc is impure, so calls to it are not subject to normal optimisations, and its callers should also be considered impure unless explicitly promised to be pure with a `pure` modifier.
 
 Any call to an `impure` or `semipure` proc must be preceded with the `!` annotation, as if it were a call to a proc that used resources.  This reminds the reader that the call is not pure, and that they must be careful when reading or modifying the code.  For example, to prematurely exit the program, you can insert the following proc call:
@@ -1709,10 +1709,10 @@ The Wybe compiler optimises your code in some situations by replacing a proc cal
 
 If you wish to have finer control, you can do this by placing one of these two modifiers between curly braces between `def` and the procedure or function name:
 
-- `inline`  
+- `inline`
 force inlining of calls to this proc
 
-- `noinline`  
+- `noinline`
 prevent inlining of calls to this proc
 
 If you wish to include other modifiers along with one of these, include them all between the braces, in any order, separated by commas.
@@ -1833,78 +1833,78 @@ For more detail on the behaviour of these operations, please consult the
 In the following, all inputs and outputs listed as `int` can in fact be any integer type:  signed or unsigned, and any number of bits of precision.  However, all `int` inputs and outputs must be the same number of bits of precision.  All `bool` outputs may be any 1-bit integer type.
 
 
-- `foreign llvm add(`arg1:int, arg2:int`)`:int  
+- `foreign llvm add(`arg1:int, arg2:int`)`:int
 Integer addition
-- `foreign llvm sub(`arg1:int, arg2:int`)`:int  
+- `foreign llvm sub(`arg1:int, arg2:int`)`:int
 Integer subtraction
-- `foreign llvm mul(`arg1:int, arg2:int`)`:int   
+- `foreign llvm mul(`arg1:int, arg2:int`)`:int
 Integer multiplication
-- `foreign llvm udiv(`arg1:int, arg2:int`)`:int  
+- `foreign llvm udiv(`arg1:int, arg2:int`)`:int
 unsigned integer division
-- `foreign llvm sdiv(`arg1:int, arg2:int`)`:int  
+- `foreign llvm sdiv(`arg1:int, arg2:int`)`:int
 Signed integer division
-- `foreign llvm urem(`arg1:int, arg2:int`)`:int  
+- `foreign llvm urem(`arg1:int, arg2:int`)`:int
 unsigned integer remainder
-- `foreign llvm srem(`arg1:int, arg2:int`)`:int  
+- `foreign llvm srem(`arg1:int, arg2:int`)`:int
 Signed integer remainder
-- `foreign llvm icmp_eq(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_eq(`arg1:int, arg2:int`)`:bool
 Integer equality
-- `foreign llvm icmp_ne(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_ne(`arg1:int, arg2:int`)`:bool
 Integer disequality
-- `foreign llvm icmp_ugt(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_ugt(`arg1:int, arg2:int`)`:bool
 Integer unsigned strictly greater
-- `foreign llvm icmp_uge(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_uge(`arg1:int, arg2:int`)`:bool
 Integer unsigned greater or equal
-- `foreign llvm icmp_ult(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_ult(`arg1:int, arg2:int`)`:bool
 Integer unsigned strictly less
-- `foreign llvm icmp_ule(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_ule(`arg1:int, arg2:int`)`:bool
 Integer unsigned less or equal
-- `foreign llvm icmp_sgt(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_sgt(`arg1:int, arg2:int`)`:bool
 Integer unsigned strictly greater
-- `foreign llvm icmp_sge(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_sge(`arg1:int, arg2:int`)`:bool
 Integer signed greater or equal
-- `foreign llvm icmp_slt(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_slt(`arg1:int, arg2:int`)`:bool
 Integer signed strictly less
-- `foreign llvm icmp_sle(`arg1:int, arg2:int`)`:bool  
+- `foreign llvm icmp_sle(`arg1:int, arg2:int`)`:bool
 Integer signed less or equal
-- `foreign llvm shl(`arg1:int, arg2:int`)`:int  
+- `foreign llvm shl(`arg1:int, arg2:int`)`:int
 Left shift
-- `foreign llvm lshr(`arg1:int, arg2:int`)`:int  
+- `foreign llvm lshr(`arg1:int, arg2:int`)`:int
 Logical right shift (shift zeros in at right)
-- `foreign llvm ashr(`arg1:int, arg2:int`)`:int  
+- `foreign llvm ashr(`arg1:int, arg2:int`)`:int
 Arithmetic right shift (copy sign bit at right)
-- `foreign llvm or(`arg1:int, arg2:int`)`:int  
+- `foreign llvm or(`arg1:int, arg2:int`)`:int
 Bitwise or
-- `foreign llvm and(`arg1:int, arg2:int`)`:int  
+- `foreign llvm and(`arg1:int, arg2:int`)`:int
 Bitwise and
-- `foreign llvm xor(`arg1:int, arg2:int`)`:int  
+- `foreign llvm xor(`arg1:int, arg2:int`)`:int
 Bitwise exclusive or
 
 ##### Floating point operations
 
 Similar to above, all inputs and outputs listed as `float` can be any legal LLVM floating point type:  16, 32, 64, or 128 bits.  Again, in a single instruction, all the `float` inputs and outputs must be the same bit width.
 
-- `foreign llvm fadd(`arg1:float, arg2:float`)`:float  
+- `foreign llvm fadd(`arg1:float, arg2:float`)`:float
 Floating point addition
-- `foreign llvm fsub(`arg1:float, arg2:float`)`:float  
+- `foreign llvm fsub(`arg1:float, arg2:float`)`:float
 Floating point subtraction
-- `foreign llvm fmul(`arg1:float, arg2:float`)`:float  
+- `foreign llvm fmul(`arg1:float, arg2:float`)`:float
 Floating point multiplication
-- `foreign llvm fdiv(`arg1:float, arg2:float`)`:float  
+- `foreign llvm fdiv(`arg1:float, arg2:float`)`:float
 Floating point division
-- `foreign llvm frem(`arg1:float, arg2:float`)`:float  
+- `foreign llvm frem(`arg1:float, arg2:float`)`:float
 Floating point remainder
-- `foreign llvm fcmp_eq(`arg1:float, arg2:float`)`:bool  
+- `foreign llvm fcmp_eq(`arg1:float, arg2:float`)`:bool
 Floating point equality
-- `foreign llvm fcmp_ne(`arg1:float, arg2:float`)`:bool  
+- `foreign llvm fcmp_ne(`arg1:float, arg2:float`)`:bool
 Floating point disequality
-- `foreign llvm fcmp_slt(`arg1:float, arg2:float`)`:bool  
+- `foreign llvm fcmp_slt(`arg1:float, arg2:float`)`:bool
 Floating point (signed) strictly less
-- `foreign llvm fcmp_sle(`arg1:float, arg2:float`)`:bool  
+- `foreign llvm fcmp_sle(`arg1:float, arg2:float`)`:bool
 Floating point (signed) less or equal
-- `foreign llvm fcmp_sgt(`arg1:float, arg2:float`)`:bool  
+- `foreign llvm fcmp_sgt(`arg1:float, arg2:float`)`:bool
 Floating point (signed) strictly greater
-- `foreign llvm fcmp_sge(`arg1:float, arg2:float`)`:bool  
+- `foreign llvm fcmp_sge(`arg1:float, arg2:float`)`:bool
 Floating point (signed) greater or equal
 
 #####  <a name="conversion"></a>Integer/floating point conversion
@@ -1912,13 +1912,13 @@ Floating point (signed) greater or equal
 These operations convert between floating point and integer representations.
 They work for any bitwith float and integer types.
 
-- `foreign llvm uitofp(`arg1:int`)`:float  
+- `foreign llvm uitofp(`arg1:int`)`:float
 Convert unsigned integer to float
-- `foreign llvm sitofp(`arg1:int`)`:float  
+- `foreign llvm sitofp(`arg1:int`)`:float
 Convert signed integer to float
-- `foreign llvm fptoui(`arg1:float`)`:int  
+- `foreign llvm fptoui(`arg1:float`)`:int
 Convert float to unsigned integer
-- `foreign llvm fptosi(`arg1:float`)`:int  
+- `foreign llvm fptosi(`arg1:float`)`:int
 Convert float to signed integer
 
 
@@ -1932,16 +1932,16 @@ declaration has the form:
 
 where *rep* has one of these forms:
 
-- `address`  
+- `address`
 the type is a machine address, similar to the `void *` type in C.
-- *n* `bit` *numbertype*  
+- *n* `bit` *numbertype*
 a primitive number type comprising *n* bits, where *n* is any non-negative
 integer and *numbertype* is one of:
-  - `signed`  
+  - `signed`
   a signed integer type
-  - `unsigned`  
+  - `unsigned`
   an unsigned integer type
-  - `float`  
+  - `float`
   a floating point number; *n* must be 16, 32, 64, or 128.
 
 Like a `constructor` declaration, a `representation` declaration makes the
@@ -2008,15 +2008,15 @@ This specifies that the type of the variable *var* is *type2*, but that the type
 
 The LPVM instructions are low-level memory manipulation instructions.  Note
 these are foreign instructions specifying the *language* `lpvm` (rather than
-`llvm`). 
+`llvm`).
 
 
-- `foreign lpvm alloc(`*size:*`int`, `?`*struct:type*`)`  
+- `foreign lpvm alloc(`*size:*`int`, `?`*struct:type*`)`
 Allocate (at least) *size* bytes of memory and store the address in *struct*,
 which has its specified type.
 
 - `foreign lpvm access(`*struct:type*, *offset:*`int`, *size*:`int`,
-                        *start_offset*:`int`, `?`*member:type2*`)`  
+                        *start_offset*:`int`, `?`*member:type2*`)`
 Access the field of type *type2* at address *struct* + *offset*. The size of the
 structure is *size* bytes. The intention of the *start_offset* is to handle
 tagged pointers: a tagged pointer will appear to point *start_offset* bytes past
@@ -2025,7 +2025,7 @@ start of the structure to be found, so it can be copied.
 
 - `foreign lpvm mutate(`*struct:type*, `?`*struct2:type*,
                         *offset:*`int`, *destructive*:`bool`,
-                        *size*:`int`, *start_offset*:`int`, *member:type2*`)`  
+                        *size*:`int`, *start_offset*:`int`, *member:type2*`)`
 *struct2* is the same as *struct*, except that it has *member*, with type
 *type2*, at *struct* + *offset*. The start of the structure is actually
 *start_offset* bytes before *struct* in memory, and the size of the structure is
@@ -2052,7 +2052,7 @@ operation are all computed before executing that operation.  However, the
 compiler respects (purity declarations)[#purity]:  if a procedure is declared
 `impure` or `semipure`, calls to it will not be eliminated or reordered.
 
-Additionally, the Wybe library defines a unique type `phantom`, whose 
+Additionally, the Wybe library defines a unique type `phantom`, whose
 representation has zero bits.  The
 compiler automatically removes any input or output arguments whose types have
 zero bits when LLVM code is being generated, including calls to foreign code.

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -54,7 +54,7 @@ module AST (
   getParams, getPrimParams, getDetism, getProcDef, getProcPrimProto,
   mkTempName, updateProcDef, updateProcDefM,
   ModSpec, maybeModPrefix, ProcImpln(..), ProcDef(..), procInline, procCallCount,
-  getProcGlobalFlows, 
+  getProcGlobalFlows,
   primImpurity, flagsImpurity, flagsDetism,
   AliasMap, aliasMapToAliasPairs, ParameterID, parameterIDToVarName,
   parameterVarNameToID, SpeczVersion, CallProperty(..), generalVersion,
@@ -76,7 +76,7 @@ module AST (
   CallSiteID, SuperprocSpec(..), initSuperprocSpec, -- addSuperprocSpec,
   maybeGetClosureOf, isClosureProc, isClosureVariant,
   GlobalFlows(..), emptyGlobalFlows, univGlobalFlows, makeGlobalFlows,
-  addGlobalFlow, hasGlobalFlow, globalFlowsUnion, globalFlowsIntersection, 
+  addGlobalFlow, hasGlobalFlow, globalFlowsUnion, globalFlowsIntersection,
   -- *Stateful monad for the compilation process
   MessageLevel(..), updateCompiler,
   CompilerState(..), Compiler, runCompiler,
@@ -97,12 +97,12 @@ module AST (
   typeIsUnique,
   ResourceName, ResourceSpec(..), ResourceFlowSpec(..), ResourceImpln(..),
   initialisedResources,
-  addSimpleResource, lookupResource, 
-  specialResources, specialResourcesSet, isSpecialResource, 
+  addSimpleResource, lookupResource,
+  specialResources, specialResourcesSet, isSpecialResource,
   publicResource, resourcefulName,
   ProcModifiers(..), defaultProcModifiers, checkProcMods,
   setDetism, setInline, setImpurity, setVariant,
-  ProcVariant(..), Inlining(..), Impurity(..), 
+  ProcVariant(..), Inlining(..), Impurity(..),
   addProc, addProcDef, lookupProc, publicProc, callTargets,
   specialChar, specialName, specialName2,
   outputVariableName, outputStatusName,
@@ -1022,7 +1022,7 @@ specialResources =
         ("call_source_full_location",(callSourceLocation True,cStrType))
         ]
 
-        
+
 -- | The set of ResourceSpec that correspond to sepcial resources
 specialResourcesSet :: Set ResourceSpec
 specialResourcesSet = Set.map (ResourceSpec []) $ keysSet specialResources
@@ -1106,7 +1106,7 @@ inliningName NoInline   = "noinline"
 -- | The Wybe impurity system.
 data Impurity = PromisedPure  -- ^The proc is pure despite having impure parts
               | Pure          -- ^The proc is pure, and so are its parts
-              | Semipure      -- ^The proc is not pure, but callers can be pure 
+              | Semipure      -- ^The proc is not pure, but callers can be pure
               | Impure        -- ^The proc is impure and makes its callers so
     deriving (Eq, Ord, Show, Generic)
 
@@ -1232,15 +1232,15 @@ addProcDef procDef = do
     return spec
 
 
--- | Check a set of ProcModifiers, providing error messages for unknown and 
+-- | Check a set of ProcModifiers, providing error messages for unknown and
 -- conflicting mods
 checkProcMods :: String -> OptPos -> ProcModifiers -> Compiler ()
 checkProcMods context pos ProcModifiers{modifierUnknown=unknown,
                                         modifierConflict=conflicting} = do
-    mapM_ (errmsg pos . ("Unknown modifier '" ++) 
+    mapM_ (errmsg pos . ("Unknown modifier '" ++)
                       . (++ "' in " ++ context))
         unknown
-    mapM_ (errmsg pos . ("Modifier '" ++) 
+    mapM_ (errmsg pos . ("Modifier '" ++)
                       . (++ "' conflicts with earlier modifier in " ++ context))
         conflicting
 
@@ -1372,7 +1372,7 @@ data Module = Module {
   modTypeRep :: Maybe TypeRepresentation, -- ^Type representation, when known
   modInterface :: ModuleInterface, -- ^The public face of this module
   modInterfaceHash :: InterfaceHash,
-                                   -- ^Hash of the "modInterface" above 
+                                   -- ^Hash of the "modInterface" above
   modImplementation :: Maybe ModuleImplementation,
                                    -- ^the module's implementation
   procCount :: Int,                -- ^a counter for gensym-ed proc names
@@ -1440,7 +1440,7 @@ sameOriginModules mspec = do
 --                    <$> getLoadedModule m
 --     file <- origin mspec
 --     subMods <- Map.elems . modSubmods <$> getLoadedModuleImpln mspec
---     (same,diff) <- List.partition snd . zip subMods 
+--     (same,diff) <- List.partition snd . zip subMods
 --                    <$> mapM (((== file) <$>) . origin) subMods
 --     ((fst <$> diff) ++) . concat <$> mapM differentOriginModules (fst <$> same)
 
@@ -1516,7 +1516,7 @@ type InterfaceHash = Maybe String
 
 
 -- |Holds everything needed to compile code that uses a module
--- XXX Currently, the data in it is never used (except for computing the 
+-- XXX Currently, the data in it is never used (except for computing the
 --     interface hash). We should revise the design of this, and make the
 --     "compileModSCC" in Builder.hs only gets other modules' data from this
 --     instead of extracting directly form "ModuleImplementation".
@@ -1663,8 +1663,8 @@ lookupTypeRepresentation (TypeSpec modSpec name _) =
 lookupTypeRepresentation (HigherOrderType ProcModifiers{modifierDetism=detism} tfs) = do
     mbInReps <- sequenceRepFlowTypes ins
     mbOutReps <- sequenceRepFlowTypes outs
-    return $ Func <$> mbInReps 
-                  <*> ((++ [Signed 1 | detism == SemiDet]) 
+    return $ Func <$> mbInReps
+                  <*> ((++ [Signed 1 | detism == SemiDet])
                   <$> mbOutReps)
   where
     ins = List.filter (flowsIn . typeFlowMode) tfs
@@ -1947,7 +1947,7 @@ getProcGlobalFlows :: ProcSpec -> Compiler GlobalFlows
 getProcGlobalFlows pspec = do
     pDef <- getProcDef pspec
     case procImpln pDef of
-      ProcDefSrc _ -> 
+      ProcDefSrc _ ->
             let ProcProto _ params resFlows = procProto pDef
             in return $ makeGlobalFlows (paramType <$> params) resFlows
       ProcDefPrim _ (PrimProto _ _ gFlows) _ _ _ -> return gFlows
@@ -1961,16 +1961,16 @@ procCallCount proc = Map.foldr (+) 0 $ procCallers proc
 
 -- | What is the Impurity of the given Prim?
 primImpurity :: Prim -> Compiler Impurity
-primImpurity (PrimCall _ pspec _ _) 
+primImpurity (PrimCall _ pspec _ _)
     = procImpurity <$> getProcDef pspec
-primImpurity (PrimHigher _ (ArgProcRef pspec _ _) _) 
+primImpurity (PrimHigher _ (ArgProcRef pspec _ _) _)
     = procImpurity <$> getProcDef pspec
-primImpurity (PrimHigher _ ArgVar{argVarType=HigherOrderType 
+primImpurity (PrimHigher _ ArgVar{argVarType=HigherOrderType
                                 ProcModifiers{modifierImpurity=purity} _} _)
-    = return purity 
-primImpurity (PrimHigher _ fn _) 
+    = return purity
+primImpurity (PrimHigher _ fn _)
     = shouldnt $ "primImpurity of" ++ show fn
-primImpurity (PrimForeign _ _ flags _) 
+primImpurity (PrimForeign _ _ flags _)
     = return $ flagsImpurity flags
 
 
@@ -2001,7 +2001,7 @@ flagDetism _ "semidet"  = SemiDet
 flagDetism detism _     = detism
 
 
-data ProcVariant 
+data ProcVariant
     = RegularProc
     | ConstructorProc
     | DeconstructorProc
@@ -2077,8 +2077,8 @@ data ProcImpln
     deriving (Eq,Generic)
 
 
--- | Represents a set of globals flowing in and out. 
-data GlobalFlows 
+-- | Represents a set of globals flowing in and out.
+data GlobalFlows
     = GlobalFlows {
         globalFlowsIn :: UnivSet GlobalInfo,
         -- ^ The set of globals that flow in
@@ -2090,9 +2090,9 @@ data GlobalFlows
 
 instance Show GlobalFlows where
     show (GlobalFlows ins outs) =
-        "<" ++ showUnivSet show ins 
+        "<" ++ showUnivSet show ins
         ++ "; " ++ showUnivSet show outs
-        ++ ">" 
+        ++ ">"
 
 
 -- | An empty set of GlobalFlows
@@ -2101,26 +2101,26 @@ emptyGlobalFlows = GlobalFlows emptyUnivSet emptyUnivSet
 
 
 -- | The set of all GlobalFlows
-univGlobalFlows :: GlobalFlows 
+univGlobalFlows :: GlobalFlows
 univGlobalFlows = GlobalFlows UniversalSet UniversalSet
 
 
 -- | Given a list of Types and a set of ResourceFlowSpecs, make a GlobalFlows.
--- If any of the TypeSpecs are resourceful higher order, this is the 
+-- If any of the TypeSpecs are resourceful higher order, this is the
 -- univGlobalFlows, otherwise this is derived from the resources and flows.
 --
--- In the case we have a higher order resourceful argument, we may not know 
+-- In the case we have a higher order resourceful argument, we may not know
 -- exactly which global variables flow into or out of a procedure, and as such
 -- we take a conservative approach and assume all do.
 makeGlobalFlows :: [TypeSpec] -> Set ResourceFlowSpec -> GlobalFlows
 makeGlobalFlows tys resFlows
-    | any isResourcefulHigherOrder tys = univGlobalFlows 
+    | any isResourcefulHigherOrder tys = univGlobalFlows
     | otherwise = Set.fold addGlobalResourceFlows emptyGlobalFlows resFlows
-                
+
 
 -- |Add flows associated with a given resource to a set of GlobalFlows
 addGlobalResourceFlows :: ResourceFlowSpec -> GlobalFlows -> GlobalFlows
-addGlobalResourceFlows (ResourceFlowSpec res flow) gFlows 
+addGlobalResourceFlows (ResourceFlowSpec res flow) gFlows
     | isSpecialResource res = gFlows
     | otherwise = List.foldr (addGlobalFlow (GlobalResource res)) gFlows
                 $ [FlowIn | flowsIn flow] ++ [FlowOut | flowsOut flow]
@@ -2128,17 +2128,17 @@ addGlobalResourceFlows (ResourceFlowSpec res flow) gFlows
 
 -- | Add a GlobalInfo to the set of global flows associated with the given flow
 addGlobalFlow :: GlobalInfo -> PrimFlow -> GlobalFlows -> GlobalFlows
-addGlobalFlow info FlowIn gFlows@GlobalFlows{globalFlowsIn=ins} 
+addGlobalFlow info FlowIn gFlows@GlobalFlows{globalFlowsIn=ins}
     = gFlows{globalFlowsIn=whenFinite (Set.insert info) ins}
-addGlobalFlow info FlowOut gFlows@GlobalFlows{globalFlowsOut=outs} 
+addGlobalFlow info FlowOut gFlows@GlobalFlows{globalFlowsOut=outs}
     = gFlows{globalFlowsOut=whenFinite (Set.insert info) outs}
 
 
 -- | Test if the given flow of a global exists in the global flow set
 hasGlobalFlow :: GlobalFlows -> PrimFlow -> GlobalInfo -> Bool
-hasGlobalFlow gFlows@GlobalFlows{globalFlowsIn=ins} FlowIn info  
+hasGlobalFlow gFlows@GlobalFlows{globalFlowsIn=ins} FlowIn info
     = USet.member info ins
-hasGlobalFlow gFlows@GlobalFlows{globalFlowsOut=outs} FlowOut info  
+hasGlobalFlow gFlows@GlobalFlows{globalFlowsOut=outs} FlowOut info
     = USet.member info outs
 
 
@@ -2190,7 +2190,7 @@ data CallProperty
 -- "NonAliasedParam v1" is used for global CTGC, it means that the argument
 -- passed to parameter v1 is nonaliased.
     = NonAliasedParam ParameterID
-    -- Remove the placeholder below and add more items when adding new 
+    -- Remove the placeholder below and add more items when adding new
     -- specializations. The placeholder is used to avoid overlapping-patterns
     -- warning as well as the suggestion of using newtype instead of data from
     -- linter.
@@ -2213,7 +2213,7 @@ speczVersionToId = List.take 10 . show . sha1 . Data.Binary.encode
 
 
 -- | A map contains different specialization versions.
--- The key is the id of each version and the value is the 
+-- The key is the id of each version and the value is the
 -- actual implementation. A procBody can be "Nothing" when it's required but
 -- haven't been generated. All procBody will be generated before converting to
 -- llvm code.
@@ -2235,8 +2235,8 @@ aliasMapToAliasPairs :: AliasMap -> [(PrimVarName, PrimVarName)]
 aliasMapToAliasPairs aliasMap = Set.toList $ dsToTransitivePairs aliasMap
 
 
--- |Infomation about specialization versions the current proc directly uses. 
--- It's a mapping from call sites to the callee's "ProcSpec" and a set of 
+-- |Infomation about specialization versions the current proc directly uses.
+-- It's a mapping from call sites to the callee's "ProcSpec" and a set of
 -- "CallSiteProperty".
 -- For a given specialization version of the current proc, this info should be
 -- enough to compute all specz versions it required. A sample case is
@@ -2259,7 +2259,7 @@ data CallSiteProperty
 
 
 -- |Describing the interestingness of a proc. if something is interesting, that
--- means if we could provide some information about that thing, then we can 
+-- means if we could provide some information about that thing, then we can
 -- generate more specialized code.
 data InterestingCallProperty
     -- "InterestingUnaliased v" means that if parameter v is known as unaliased,
@@ -2298,7 +2298,7 @@ instance Show ProcImpln where
                             Nothing -> " Missing"
                             Just body -> showBlock 4 body)
                 |> intercalate "\n"
-        in  show pSpec ++ "\n" ++ show proto ++ ":" 
+        in  show pSpec ++ "\n" ++ show proto ++ ":"
                     ++ show analysis
                     ++ showBlock 4 body ++ speczBodies
 
@@ -2893,24 +2893,24 @@ seqToStmt stmts = Unplaced $ And stmts
 
 -- | Find the Impurity of a sequence of Stmts, the maximum impurity of all
 -- statements
-stmtsImpurity :: [Placed Stmt] -> Compiler Impurity 
-stmtsImpurity stmts = List.foldl max PromisedPure 
+stmtsImpurity :: [Placed Stmt] -> Compiler Impurity
+stmtsImpurity stmts = List.foldl max PromisedPure
                    <$> mapM (stmtImpurity . content) stmts
 
 -- | The Impurity of a statement
-stmtImpurity :: Stmt -> Compiler Impurity 
-stmtImpurity (ProcCall (First mod name mbId) _ _ _) = 
-    procImpurity <$> getProcDef 
-                        (ProcSpec mod name 
+stmtImpurity :: Stmt -> Compiler Impurity
+stmtImpurity (ProcCall (First mod name mbId) _ _ _) =
+    procImpurity <$> getProcDef
+                        (ProcSpec mod name
                             (trustFromJust "stmtImpurity" mbId) generalVersion)
-stmtImpurity (ProcCall (Higher fn) _ _ _) = 
+stmtImpurity (ProcCall (Higher fn) _ _ _) =
     case content fn of
-        Typed _ (HigherOrderType mods _) _ -> return $ modifierImpurity mods 
+        Typed _ (HigherOrderType mods _) _ -> return $ modifierImpurity mods
         _ -> return Impure -- assume the worst case
 stmtImpurity (ForeignCall _ _ flags _) = return $ flagsImpurity flags
 stmtImpurity (Cond cond thn els _ _ _) = stmtsImpurity $ cond:thn ++ els
 stmtImpurity (UseResources _ _ stmts) = stmtsImpurity stmts
-stmtImpurity (Case _ cases _) = 
+stmtImpurity (Case _ cases _) =
     stmtsImpurity . concat $ snd <$> cases
 stmtImpurity (And stmts) = stmtsImpurity stmts
 stmtImpurity (Or stmts _ _) = stmtsImpurity stmts
@@ -2927,7 +2927,7 @@ stmtImpurity Next = return Pure
 
 data ProcFunctor
     = First ModSpec ProcName (Maybe Int)
-       -- ^ A first-order procedure 
+       -- ^ A first-order procedure
     | Higher (Placed Exp)
        -- ^ A higher-order procedure
     deriving (Eq, Ord, Generic)
@@ -2973,8 +2973,8 @@ data StringVariant = WybeString | CString
    deriving (Eq,Ord,Generic)
 
 
--- Information about a global variable. 
--- A global vairbale is a variable that is available everywhere, 
+-- Information about a global variable.
+-- A global vairbale is a variable that is available everywhere,
 -- and can be access via an LPVM load instruction, or written to via an LPVM store
 data GlobalInfo = GlobalResource { globalResourceSpec :: ResourceSpec }
     deriving (Eq, Ord, Generic)
@@ -2984,7 +2984,7 @@ data GlobalInfo = GlobalResource { globalResourceSpec :: ResourceSpec }
 expIsVar :: Exp -> Bool
 expIsVar Var{}           = True
 expIsVar AnonParamVar{}  = True
-expIsVar (Typed exp _ _) = expIsVar exp 
+expIsVar (Typed exp _ _) = expIsVar exp
 expIsVar _               = False
 
 
@@ -3010,7 +3010,7 @@ expIsConstant exp@IntValue{}         = Just exp
 expIsConstant exp@FloatValue{}       = Just exp
 expIsConstant exp@CharValue{}        = Just exp
 expIsConstant exp@StringValue{}      = Just exp
-expIsConstant exp@(ProcRef _ closed) 
+expIsConstant exp@(ProcRef _ closed)
     | all (isJust . expIsConstant . content) closed = Just exp
     | otherwise                                     = Nothing
 expIsConstant (Typed exp _ _)        = expIsConstant exp
@@ -3171,12 +3171,12 @@ data PrimArg
 -- |Returns a list of all arguments to a prim, including global flows
 primArgs :: Prim -> ([PrimArg], GlobalFlows)
 primArgs (PrimCall _ _ args gFlows) = (args, gFlows)
-primArgs (PrimHigher _ fn args) 
-    = (fn:args, if isResourcefulHigherOrder $ argType fn 
+primArgs (PrimHigher _ fn args)
+    = (fn:args, if isResourcefulHigherOrder $ argType fn
                 then univGlobalFlows else emptyGlobalFlows)
-primArgs (PrimForeign "lpvm" "load" _ args@[ArgGlobal info _, _]) 
+primArgs (PrimForeign "lpvm" "load" _ args@[ArgGlobal info _, _])
     = (args, addGlobalFlow info FlowIn emptyGlobalFlows)
-primArgs (PrimForeign "lpvm" "store" _ args@[_, ArgGlobal info _]) 
+primArgs (PrimForeign "lpvm" "store" _ args@[_, ArgGlobal info _])
     = (args, addGlobalFlow info FlowOut emptyGlobalFlows)
 primArgs prim@(PrimForeign _ _ _ args) = (args, emptyGlobalFlows)
 
@@ -3222,7 +3222,7 @@ argIntegerValue _              = Nothing
 data ArgFlowType = Ordinary        -- ^An argument/parameter as written by user
                  | Resource ResourceSpec
                                    -- ^An argument to pass a resource
-                 | Free            -- ^An argument to be passed in the closure 
+                 | Free            -- ^An argument to be passed in the closure
                                    -- environment
      deriving (Eq,Ord,Generic)
 
@@ -3395,7 +3395,7 @@ expInputs (CaseExp exp cases deflt) =
 
 
 
--- |Return the set of variables that are inputs to the the specified list of 
+-- |Return the set of variables that are inputs to the the specified list of
 -- placed expressions.
 pexpListInputs :: [Placed Exp] -> Set VarName
 pexpListInputs = List.foldr (Set.union . expInputs . content) Set.empty
@@ -3445,7 +3445,7 @@ setPExpTypeFlow typeflow pexpr = setExpTypeFlow typeflow <$> pexpr
 varsInPrimArg :: PrimFlow -> PrimArg -> Set PrimVarName
 varsInPrimArg dir ArgVar{argVarName=var,argVarFlow=dir'}
     = if dir == dir' then Set.singleton var else Set.empty
-varsInPrimArg dir (ArgProcRef _ as _) 
+varsInPrimArg dir (ArgProcRef _ as _)
     = Set.unions $ Set.fromList (varsInPrimArg dir <$> as)
 varsInPrimArg _ ArgInt{}      = Set.empty
 varsInPrimArg _ ArgFloat{}    = Set.empty

--- a/src/ASTShow.hs
+++ b/src/ASTShow.hs
@@ -57,7 +57,7 @@ instance Show Module where
                  (if Map.null (modSubmods impl)
                   then ""
                   else "\n  submodules      : " ++
-                       showMap "" ", " "" (const "") showModSpec 
+                       showMap "" ", " "" (const "") showModSpec
                        (modSubmods impl)) ++
                  "\n  procs           : " ++ "\n" ++
                  (showMap "" "\n\n" "" (const "") (showProcDefs 0)
@@ -90,9 +90,9 @@ logDump :: LogSelection -> LogSelection -> String -> Compiler ()
 logDump = logDumpWith (const $ return Nothing)
 
 
--- |Dump the content of the specified module and all submodules, with the 
--- result of an optional action applied to each module if either of the 
--- specified log selectors have been selected for logging.  This is called 
+-- |Dump the content of the specified module and all submodules, with the
+-- result of an optional action applied to each module if either of the
+-- specified log selectors have been selected for logging.  This is called
 -- between the passes of those two selectors.
 logDumpWith :: (Module -> Compiler (Maybe String))
             -> LogSelection -> LogSelection -> String -> Compiler ()

--- a/src/Blocks.hs
+++ b/src/Blocks.hs
@@ -73,7 +73,7 @@ data ProcDefBlock =
 -- procedures can the prototype checked (match and eliminate unneeded
 -- arguments in cgen.)
 blockTransformModule :: ModSpec -> Compiler ()
-blockTransformModule thisMod = do 
+blockTransformModule thisMod = do
     reenterModule thisMod
     logBlocks $ "*** Translating Module: " ++ showModSpec thisMod
     modRec <- getModule id
@@ -111,7 +111,7 @@ blockTransformModule thisMod = do
     -- Translate
     (procBlocks, txState) <- mapM translateProc mangledProcs
                              `runStateT` emptyTranslation
-    
+
     let procBlocks' = List.concat procBlocks
     --------------------------------------------------
 
@@ -240,7 +240,7 @@ translateProc proc = do
     return $ block:blocks
 
 
--- Helper for `translateProc`. Translate the given `ProcBody` 
+-- Helper for `translateProc`. Translate the given `ProcBody`
 -- (A specialized version of a procedure).
 _translateProcImpl :: PrimProto -> Bool -> ProcBody -> Translation ProcDefBlock
 _translateProcImpl proto isClosure body = do
@@ -254,7 +254,7 @@ _translateProcImpl proto isClosure body = do
         logBlocks $ "proto: " ++ show proto'
                     ++ "body: " ++ show body'
                     ++ "\n" ++ replicate 50 '-' ++ "\n"
-    codestate <- doCodegenBody proto' body' 
+    codestate <- doCodegenBody proto' body'
                     `execStateT` emptyCodegen
     let pname = primProtoName proto
     let body' = createBlocks codestate
@@ -263,10 +263,10 @@ _translateProcImpl proto isClosure body = do
     return $ ProcDefBlock proto lldef
 
 -- | Updates a PrimProto and ProcBody as though the Free Params are accessed
--- via the closure environment 
+-- via the closure environment
 closeClosure :: PrimProto -> ProcBody -> (PrimProto, ProcBody)
 closeClosure proto@PrimProto{primProtoParams=params}
-             body@ProcBody{bodyPrims=prims} = 
+             body@ProcBody{bodyPrims=prims} =
     (proto{primProtoParams=
             envPrimParam:(setPrimParamType AnyType <$> actualParams)},
      body{bodyPrims=unpacker ++ prims})
@@ -533,7 +533,7 @@ cgen prim@(PrimHigher cId (ArgProcRef pspec closed _) args) = do
     logCodegen $ "Compiling " ++ show prim
               ++ " as first order call to " ++ show pspec'
               ++ " closed over " ++ show closed
-    cgen $ PrimCall cId pspec' (closed ++ args) univGlobalFlows 
+    cgen $ PrimCall cId pspec' (closed ++ args) univGlobalFlows
 
 cgen prim@(PrimHigher callSiteId fn@ArgVar{} args) = do
     logCodegen $ "Compiling " ++ show prim
@@ -637,8 +637,8 @@ cgenLLVMUnop name flags args =
 
 
 -- | Match PrimArgs with the paramaters in the given prototype. If a PrimArg's
--- counterpart in the prototype is unneeded, filtered out. Arguments 
--- are matched positionally, and are coerced to the type of corresponding 
+-- counterpart in the prototype is unneeded, filtered out. Arguments
+-- are matched positionally, and are coerced to the type of corresponding
 -- parameters.
 prepareArgs :: PrimProto -> [PrimArg] -> Codegen [PrimArg]
 prepareArgs proto args = prepareArgs' args $ primProtoParams proto
@@ -985,7 +985,7 @@ openPrimArg a = shouldnt $ "Can't Open!: "
                 ++ show (argFlowDirection a)
 
 
--- | 'cgenArg' makes an Operand of the input argument. 
+-- | 'cgenArg' makes an Operand of the input argument.
 -- * Variables return a casted version of their respective symbol table operand
 -- * Constants are generated with cgenArgConst, then wrapped in `cons`
 cgenArg :: PrimArg -> Codegen LLVMAST.Operand
@@ -1028,8 +1028,8 @@ cgenArg' arg = do
 -- * Ints, Floats, Chars, Undefs are of respective LLVMTypes
 -- * Strings are handled based on string variant
 --   * CString    - ptr to global constant of [N x i8]
---   * WybeString - ptr to global constant of { i64, i64 } with the second 
---                  element being as though it were a CString. This representation 
+--   * WybeString - ptr to global constant of { i64, i64 } with the second
+--                  element being as though it were a CString. This representation
 --                  is to comply with the stdlib string implementation
 cgenArgConst :: PrimArg -> Codegen C.Constant
 cgenArgConst arg = do
@@ -1112,10 +1112,10 @@ castVar nm ty = do
 
 primActualParams :: ProcSpec -> Codegen [PrimParam]
 primActualParams pspec = lift2 $ do
-    primParams <- protoRealParams . procImplnProto . procImpln 
+    primParams <- protoRealParams . procImplnProto . procImpln
               =<< getProcDef pspec
     let nonFreeParams = List.filter ((/= Free) . primParamFlowType) primParams
-    ifM (isClosureProc pspec) 
+    ifM (isClosureProc pspec)
         (return $ setPrimParamType AnyType <$> envPrimParam : nonFreeParams)
         (return nonFreeParams)
 
@@ -1320,15 +1320,15 @@ defaultLLVMType = repLLVMType defaultTypeRepresentation
 -- | Initialize and fill a new LLVMAST.Module with the translated
 -- global definitions (extern declarations and defined functions)
 -- of LPVM procedures in a module.
-newLLVMModule :: String -> String -> [ProcDefBlock] -> TranslationState 
+newLLVMModule :: String -> String -> [ProcDefBlock] -> TranslationState
               -> [ResourceSpec] -> Compiler LLVMAST.Module
 newLLVMModule name fname blocks (TranslationState _ consts vars exts) ress = do
     let defs = List.map blockDef blocks
         varDefs = LLVMAST.GlobalDefinition <$> Map.elems vars
-        constDefs = LLVMAST.GlobalDefinition <$> Map.elems consts 
+        constDefs = LLVMAST.GlobalDefinition <$> Map.elems consts
     resDefs <- catMaybes <$> mapM globalResourceExtern ress
     extDefs <- mapM declareExtern exts
-    let exs' = uniqueExterns (resDefs ++ varDefs ++ constDefs) 
+    let exs' = uniqueExterns (resDefs ++ varDefs ++ constDefs)
             ++ uniqueExterns (extDefs ++ [mallocExtern] ++ intrinsicExterns)
     return $ modWithDefinitions name fname $ exs' ++ defs
 

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -253,7 +253,7 @@ buildTargets targets = do
     showMessages
     stopOnError "building outputs"
     dumpOpt <- option optDumpOptLLVM
-    let dumper = if dumpOpt then logDumpWith ((Just <$>) . extractLLVM) 
+    let dumper = if dumpOpt then logDumpWith ((Just <$>) . extractLLVM)
                             else logDump
     dumper FinalDump FinalDump "EVERYTHING"
 
@@ -504,7 +504,7 @@ loadModuleFromSrcOrObj force modspec srcfile objfile maybeDir isLib = do
         -- XXX Currently we don't support fall back to source code.
         -- i.e. "loadModuleFromObjFile" never returns an empty list.
         -- We should consider to rebuild it from source code if
-        -- the "wybe object file version" is too old. 
+        -- the "wybe object file version" is too old.
         when (List.null loaded)
             (Error <!> "Wybe object file " ++ objfile
                        ++ " contained no modules")
@@ -874,7 +874,7 @@ updateInterfaceHash :: ModSpec -> Compiler ()
 updateInterfaceHash mspec = do
     reenterModule mspec
     -- update the mod interface based on the current implementation
-    -- XXX For now, mod interface is not used during the "compileModSCC", so 
+    -- XXX For now, mod interface is not used during the "compileModSCC", so
     --     we can update it at the end. But that is not desired, plz find
     --     comments of "ModuleInterface" in AST.hs for more details.
     impl <- trustFromJustM ("unimplemented module " ++ showModSpec mspec)
@@ -1027,7 +1027,7 @@ buildExecutable orderedSCCs targetMod target = do
             -- find dependencies (including module itself) that have a main
             logBuild $ "Dependencies: " ++ show depends
             let mainImports = fst <$> List.filter snd depends
-            -- We need to insert 
+            -- We need to insert
             logBuild $ "o Modules with 'main': " ++ showModSpecs mainImports
 
             let mainMod = []
@@ -1124,7 +1124,7 @@ buildMain mainImports = do
     let mainRes = Set.fromList [cmdResource "argc" ParamIn,
                                 cmdResource "argv" ParamIn,
                                 cmdResource "exit_code" ParamOut]
-    initRes <- Set.filter (`Set.notMember` Set.map resourceFlowRes mainRes) 
+    initRes <- Set.filter (`Set.notMember` Set.map resourceFlowRes mainRes)
              . Set.unions . (keysSet <$>)
             <$> mapM (initialisedResources `inModule`) mainImports
     let detism = setDetism Terminal

--- a/src/Callers.hs
+++ b/src/Callers.hs
@@ -55,7 +55,7 @@ type CallRec = Map ProcSpec Int
 
 noteCall :: ModSpec -> ProcSpec -> Bool -> Prim -> CallRec -> CallRec
 noteCall mod caller final prim rec =
-    List.foldr (noteCalls' mod) rec (localCallees mod prim) 
+    List.foldr (noteCalls' mod) rec (localCallees mod prim)
 
 
 noteCalls' :: ModSpec -> ProcSpec -> CallRec -> CallRec
@@ -126,11 +126,11 @@ localBodyCallees modspec body =
 
 -- | Find all callees in a given prim
 localCallees :: ModSpec -> Prim -> [ProcSpec]
-localCallees modspec (PrimCall _ pspec args _) 
+localCallees modspec (PrimCall _ pspec args _)
   = pspec{procSpeczVersion=generalVersion}:concatMap (argRefs modspec) args
-localCallees modspec (PrimHigher _ fn args) 
+localCallees modspec (PrimHigher _ fn args)
   = concatMap (argRefs modspec) (fn:args)
-localCallees modspec (PrimForeign _ _ _ args)  
+localCallees modspec (PrimForeign _ _ _ args)
   = concatMap (argRefs modspec) args
 
 -- | Find all callees in a given PromArg

--- a/src/Clause.hs
+++ b/src/Clause.hs
@@ -86,7 +86,7 @@ getCurrNumbering = gets nextVars
 
 -- |Set both current and next numberings to the specified mapping.
 putNumberings :: Numbering -> ClauseComp ()
-putNumberings numbering = 
+putNumberings numbering =
     modify (\st -> st {currVars = numbering, nextVars = numbering})
 
 
@@ -137,7 +137,7 @@ evalClauseComp clcomp =
 -- |Compile a ProcDefSrc to a ProcDefPrim, ie, compile a proc
 --  definition in source form to one in clausal form.
 compileProc :: ProcDef -> Int -> Compiler ProcDef
-compileProc proc procID = 
+compileProc proc procID =
     evalClauseComp $ do
         let ProcDefSrc body = procImpln proc
         let proto = procProto proc
@@ -163,7 +163,7 @@ compileProc proc procID =
         callSiteCount <- gets nextCallSiteID
         mSpec <- lift $ getModule modSpec
         let pSpec = ProcSpec mSpec procName procID Set.empty
-        return $ proc { procImpln = ProcDefPrim pSpec proto' compiled 
+        return $ proc { procImpln = ProcDefPrim pSpec proto' compiled
                                         emptyProcAnalysis Map.empty,
                         procCallSiteCount = callSiteCount}
 
@@ -198,7 +198,7 @@ compileBody stmts params detism = do
                 shouldnt $ "CompileBody of Cond with non-simple test:\n"
                            ++ show tstStmt
         -- XXX There shouldn't be any semidet code here any more
-        call@(ProcCall _ SemiDet _ _) -> 
+        call@(ProcCall _ SemiDet _ _) ->
             shouldnt "compileBody of SemiDet call"
         _ -> do
           prims <- mapM compileSimpleStmt stmts
@@ -273,7 +273,7 @@ compileSimpleStmt' call@(ProcCall func _ _ args) = do
                             procID
             let pSpec = ProcSpec mod name procID' generalVersion
             gFlows <- lift $ getProcGlobalFlows pSpec
-            return $ PrimCall callSiteID pSpec args' gFlows 
+            return $ PrimCall callSiteID pSpec args' gFlows
         Higher fn -> do
             fn' <- compileHigherFunc fn
             return $ PrimHigher callSiteID fn' args'
@@ -283,7 +283,7 @@ compileSimpleStmt' (ForeignCall lang name flags args) = do
 compileSimpleStmt' (TestBool expr) =
     -- Only for handling a TestBool other than as the condition of a Cond:
     compileSimpleStmt' $ content $ move (boolCast expr) (boolVarSet outputStatusName)
-compileSimpleStmt' Nop = 
+compileSimpleStmt' Nop =
     compileSimpleStmt' $ content $ move boolTrue (boolVarSet outputStatusName)
 compileSimpleStmt' Fail =
     compileSimpleStmt' $ content $ move boolFalse (boolVarSet outputStatusName)
@@ -330,7 +330,7 @@ compileArg' typ arg _ =
 compileHigherFunc :: Placed Exp -> ClauseComp PrimArg
 compileHigherFunc exp = do
     exps' <- placedApply compileArg exp
-    case exps' of 
+    case exps' of
         [arg] -> return arg
         _ -> shouldnt $ "compileHigherFunc of " ++ show exp
 
@@ -362,13 +362,13 @@ compileParam :: Numbering -> Numbering -> ProcName -> Param -> [PrimParam]
 compileParam startVars endVars procName param@(Param name ty flow ftype) =
     [PrimParam (PrimVarName name num) ty FlowIn ftype (ParamInfo False)
     | flowsIn flow
-    , let num = Map.findWithDefault 
+    , let num = Map.findWithDefault
                 (shouldnt ("compileParam for input param " ++ show param
                             ++ " of proc " ++ show procName))
                 name startVars]
     ++ [PrimParam (PrimVarName name num) ty FlowOut ftype (ParamInfo False)
     | flowsOut flow
-    , let num = Map.findWithDefault 
+    , let num = Map.findWithDefault
                 (shouldnt ("compileParam for output param " ++ show param
                             ++ " of proc " ++ show procName))
                 name endVars]

--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE OverloadedStrings          #-}
 
 module Codegen (
-  Codegen(..), CodegenState(..), BlockState(..), 
+  Codegen(..), CodegenState(..), BlockState(..),
   Translation(..), TranslationState(..), SymbolTable(..),
   emptyModule, addExtern, addGlobalConstant, getGlobalResource,
   emptyCodegen, emptyTranslation,
@@ -20,7 +20,7 @@ module Codegen (
   -- * Symbol storage
   alloca, store, local, assign, addOperand, load, getVar, localVar, preservingSymtab,
   makeGlobalResourceVariable,
-  operandType, doAlloca, doLoad, 
+  operandType, doAlloca, doLoad,
   bitcast, cbitcast, inttoptr, cinttoptr, ptrtoint, cptrtoint,
   trunc, ctrunc, zext, czext, sext, csext,
   -- * Types
@@ -142,7 +142,7 @@ type Names = Map.Map String Int
 data CodegenState
     = CodegenState {
         currentBlock :: Name     -- ^ Name of the active block to append to
-      , blocks       :: Map.Map Name BlockState 
+      , blocks       :: Map.Map Name BlockState
                                  -- ^ Blocks for function
       , blockCount   :: Int      -- ^ Incrementing count of basic blocks
       , symtab       :: SymbolTable
@@ -165,10 +165,10 @@ data BlockState
 
 -- | SymbolTable state.
 -- Stores assignments and generated operands
-data SymbolTable 
+data SymbolTable
      = SymbolTable {
-         stVars :: Map.Map String (Operand,TypeRepresentation) 
-         
+         stVars :: Map.Map String (Operand,TypeRepresentation)
+
                       -- ^ Assigned names
        , stOpds :: Map.Map PrimArg Operand
                       -- ^ Previously generated operands
@@ -184,10 +184,10 @@ type Codegen = StateT CodegenState Translation
 
 -- | TranslationState
 -- Stores data required across tranlating an LPVM module into an LLVm module
-data TranslationState 
+data TranslationState
     = TranslationState {
-        txCount   :: Word -- ^ Count of used virtual registers 
-      , txConsts  :: Map.Map (C.Constant, Type) Global 
+        txCount   :: Word -- ^ Count of used virtual registers
+      , txConsts  :: Map.Map (C.Constant, Type) Global
                           -- ^ Needed global constants
       , txVars    :: Map.Map GlobalInfo Global
                           -- ^ Needed global variables
@@ -221,7 +221,7 @@ addExtern prim = lift $ modify $ \s -> s { txExterns=prim:txExterns s}
 -- values into Global module level definitions. A UnName is generated too
 -- for reference.
 addGlobalConstant :: LLVMAST.Type -> C.Constant -> Codegen Name
-addGlobalConstant ty con = do 
+addGlobalConstant ty con = do
     modName <- lift2 $ showModSpec <$> getModuleSpec
     consts <- lift $ gets txConsts
     case Map.lookup (con, ty) consts of
@@ -252,10 +252,10 @@ getGlobalResource spec@(ResourceSpec mod nm) ty = do
 
 makeGlobalResourceVariable :: ResourceSpec -> Type -> Compiler Global
 makeGlobalResourceVariable spec@(ResourceSpec mod nm) ty = do
-    when (ty == VoidType) 
+    when (ty == VoidType)
         $ shouldnt $ "global resource " ++ show spec ++ " cant have voidtype"
-    let ref = Name $ fromString $ makeGlobalResourceName spec 
-    thisMod <- getModuleSpec 
+    let ref = Name $ fromString $ makeGlobalResourceName spec
+    thisMod <- getModuleSpec
     let init = if thisMod == mod
                then Just $ C.Undef ty
                else Nothing
@@ -340,7 +340,7 @@ emptyCodegen = CodegenState{ currentBlock=Name $ fromString entryBlockName
                            , symtab=SymbolTable Map.empty Map.empty
                            , names=Map.empty
                            }
-    
+
 
 -- | 'addBlock' creates and adds a new block to the current blocks
 addBlock :: String -> Codegen Name
@@ -471,7 +471,7 @@ preservingSymtab code = do
     return result
 
 addOperand :: PrimArg -> Operand -> Codegen ()
-addOperand arg opd = do  
+addOperand arg opd = do
     st <- gets symtab
     modify $ \s -> s { symtab=st{stOpds=Map.insert arg opd $ stOpds st} }
 
@@ -726,7 +726,7 @@ extractvalue st i = ExtractValue st [i] []
 
 -- * GetElementPtr helper
 getElementPtrInstr :: Operand -> [Integer] -> LLVMAST.Instruction
-getElementPtrInstr op idxs = 
+getElementPtrInstr op idxs =
   LLVMAST.GetElementPtr False op (cons . C.Int (fromIntegral wordSize) <$> idxs) []
 
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -9,7 +9,7 @@
 -- |Compiler configuration parameters.  These may vary between
 --  OSes.
 module Config (sourceExtension, objectExtension, executableExtension,
-               bitcodeExtension, assemblyExtension, archiveExtension, 
+               bitcodeExtension, assemblyExtension, archiveExtension,
                moduleDirectoryBasename, currentModuleAlias,
                wordSize, wordSizeBytes,
                availableTagBits, tagMask, smallestAllocatedAddress,
@@ -105,8 +105,8 @@ sharedLibDirName :: String
 sharedLibDirName = "lib/"
 
 
-localCacheLibDir :: IO FilePath 
-localCacheLibDir = do 
+localCacheLibDir :: IO FilePath
+localCacheLibDir = do
     homeDir <- getHomeDirectory
     return $ homeDir </> ".wybe/cache"
 
@@ -122,7 +122,7 @@ magicVersion =
 -- Look for "Link time dead code elimination" in "Emit.hs" for more detail
 linkerDeadStripArgs :: [String]
 linkerDeadStripArgs =
-    case buildOS of 
+    case buildOS of
         OSX   -> ["-dead_strip"]
         Linux -> ["-Wl,--gc-sections"]
         _     -> error "Unsupported operation system"
@@ -133,7 +133,7 @@ linkerDeadStripArgs =
 -- sections on Linux to fit the "-Wl,--gc-sections" above.
 functionDefSection :: String -> Maybe String
 functionDefSection label =
-    case buildOS of 
+    case buildOS of
         OSX   -> Nothing
         Linux -> Just $ ".text." ++ label
         _     -> error "Unsupported operation system"
@@ -143,7 +143,7 @@ functionDefSection label =
 -- since we don't need it on macOS.
 removeLPVMSection :: FilePath -> IO (Either String ())
 removeLPVMSection target =
-    case buildOS of 
+    case buildOS of
         OSX   -> return $ Right ()
         Linux -> do
             let args = ["--remove-section", "__LPVM.__lpvm", target]

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -172,7 +172,7 @@ passes lvl = defaultCuratedPassSetSpec { optLevel = Just lvl }
 -- representation of a LLVMAST.Module after the C++ module has been through
 -- a set of curated passes.
 withOptimisedModule :: Options -> LLVMAST.Module -> (Mod.Module -> IO a) -> IO a
-withOptimisedModule opts@Options{optLLVMOptLevel=lvl} llmod action = 
+withOptimisedModule opts@Options{optLLVMOptLevel=lvl} llmod action =
     withModule opts llmod $ \m -> do
         withPassManager (passes lvl') $ \pm -> do
             success <- runPassManager pm m

--- a/src/Expansion.hs
+++ b/src/Expansion.hs
@@ -46,7 +46,7 @@ procExpansion pspec def = do
                                 $ execStateT (expandBody body) st
     let params' = markParamNeededness isClosure used ins <$> params
     let proto' = proto {primProtoParams = params'}
-    let impln' = impln{ procImplnProto = proto', 
+    let impln' = impln{ procImplnProto = proto',
                         procImplnBody = body' }
     let def' = def { procImpln = impln',
                      procTmpCount = tmp',
@@ -300,7 +300,7 @@ expandArg arg@(ArgVar var ty flow ft _) = do
     if renameAll
     then case flow of
         FlowOut -> freshVar var ty ft
-        FlowIn -> 
+        FlowIn ->
             setArgType ty . setArgFlowType ft
             <$> gets (Map.findWithDefault arg var . renaming)
     else return arg

--- a/src/Macho.hs
+++ b/src/Macho.hs
@@ -1,6 +1,6 @@
 --  File     : Macho.hs
 --  Author   : Erik Charlebois, extended by Rishi Ranjan
---  Purpose  : Extended version of parser for Mach-O object format files 
+--  Purpose  : Extended version of parser for Mach-O object format files
 --  Original : hackage.haskell.org/package/macho-0.22
 --  Copyright: (c) Erik Charlebois.  All rights reserved.
 

--- a/src/Normalise.hs
+++ b/src/Normalise.hs
@@ -281,7 +281,7 @@ data CtorInfo = CtorInfo {
            ctorInfoName  :: ProcName,  -- ^ this constructor's name
            ctorInfoParams:: [(Param,Bool,TypeRepresentation,Int)],
                                        -- ^ params of this ctor, with their
-                                       -- anonymity (namedness), 
+                                       -- anonymity (namedness),
                                        -- representation and bit size
            ctorInfoPos   :: OptPos,    -- ^ file position of ctor
            ctorInfoTag   :: Int,       -- ^ this constructor's tag
@@ -664,7 +664,7 @@ deconstructorItems uniq ctorName typeSpec params numConsts numNonConsts tag
         ([tagCheck numConsts numNonConsts tag tagBits tagLimit (Just size) outputVariableName]
          -- Code to fetch all the fields
          ++ List.map (\(var,_,_,_,aligned) ->
-                        (maybePlace (ForeignCall "lpvm" "access" 
+                        (maybePlace (ForeignCall "lpvm" "access"
                             ["unique" | uniq]
                             [Unplaced $ Var outputVariableName ParamIn Ordinary,
                             Unplaced $ iVal (aligned - startOffset),
@@ -1093,8 +1093,8 @@ equalityField param =
 
 
 inlineModifiers :: ProcVariant -> Determinism -> ProcModifiers
-inlineModifiers variant detism 
-    = setInline Inline 
+inlineModifiers variant detism
+    = setInline Inline
     $ setVariant variant
     $ setDetism detism defaultProcModifiers
 

--- a/src/ObjectInterface.hs
+++ b/src/ObjectInterface.hs
@@ -18,7 +18,7 @@ import qualified Data.ByteString.Lazy as BL
 import           Data.Int
 import           Data.List as List
 import           Data.Maybe (isJust)
-import           Distribution.System       (buildOS, OS (..)) 
+import           Distribution.System       (buildOS, OS (..))
 import           System.Exit               (ExitCode (..))
 import           System.Process
 import System.FilePath (takeBaseName, (</>))
@@ -39,19 +39,19 @@ insertLPVMData tmpDir modBS objFile = do
     let modFile = takeBaseName objFile ++ ".module"
     let lpvmFile = tmpDir </> modFile
     BL.writeFile lpvmFile modBS
-    case buildOS of 
+    case buildOS of
         OSX   -> insertLPVMDataMacOS lpvmFile objFile
         Linux -> insertLPVMDataLinux lpvmFile objFile
         _     -> shouldnt "Unsupported operation system"
 
 
--- | Extract LPVM data from the given object file 
+-- | Extract LPVM data from the given object file
 -- and return it as [BL.ByteString].
 -- The first [FilePath] is for [tmpDir]
 extractLPVMData :: FilePath -> FilePath -> IO (Either String BL.ByteString)
 extractLPVMData tmpDir objFile =
-    case buildOS of 
-        OSX   -> extractLPVMDataMacOS tmpDir objFile 
+    case buildOS of
+        OSX   -> extractLPVMDataMacOS tmpDir objFile
         Linux -> extractLPVMDataLinux tmpDir objFile
         _     -> shouldnt "Unsupported operation system"
 
@@ -65,9 +65,9 @@ extractLPVMData tmpDir objFile =
 -- 1. Unit test for Roundtrip.
 -- 2. We currently use tools that aren't in Wybe dependencies such as [ld]
 --    and [objcopy]. Once we start to use a LLVM version that fully supports
---    [mach-o], we can use [llvm-objcopy] instead and unify the logic for 
+--    [mach-o], we can use [llvm-objcopy] instead and unify the logic for
 --    different os.
--- 3. The currently code is highly depends on tmp files and the we write 
+-- 3. The currently code is highly depends on tmp files and the we write
 --    the object file first then update it. It would be better if we could
 --    insert the LPVM data when we creating the object file and read LPVM
 --    data from it directly.
@@ -86,8 +86,8 @@ insertLPVMDataMacOS lpvmFile objFile = do
         _ -> return $ Left serr
 
 
--- | Use system [objcopy] to create a __LPVM.__lpvm section and put the 
--- given [BL.ByteString] into it. The section of ELF doesn't have a 
+-- | Use system [objcopy] to create a __LPVM.__lpvm section and put the
+-- given [BL.ByteString] into it. The section of ELF doesn't have a
 -- [Segment] field, so the section name is bit different.
 -- | Actual implementation of [insertLPVMData] for Linux
 -- Uses system [objcopy]
@@ -103,7 +103,7 @@ insertLPVMDataLinux lpvmFile objFile = do
 extractLPVMDataMacOS :: FilePath -> FilePath -> IO (Either String BL.ByteString)
 extractLPVMDataMacOS _ objFile = do
     objBS <- liftIO $ BL.readFile objFile
-    if not $ isMachoBytes objBS 
+    if not $ isMachoBytes objBS
         then return $ Left ("Not a recognised object file: " ++ objFile)
         else do
             let (_, macho) = parseMacho (BL.toStrict objBS)

--- a/src/Optimise.hs
+++ b/src/Optimise.hs
@@ -76,7 +76,7 @@ optimiseSccBottomUp' procs = do
 optimiseProcsBottomUp :: [ProcSpec] -> Compiler [Bool]
 optimiseProcsBottomUp procs = do
     inlines <- mapM optimiseProcBottomUp procs
-    -- Optimise may have removed some global flows, so we try to restrict the 
+    -- Optimise may have removed some global flows, so we try to restrict the
     -- interface
     inferGlobalFlows procs
     return inlines
@@ -100,7 +100,7 @@ optimiseProcDefBU pspec def = do
       " after optimisation:" ++ showProcDef 4 def' ++ "\n"
     return def'
 
-    
+
 optimiseProcTopDown :: ProcSpec -> Compiler ()
 optimiseProcTopDown pspec = do
     logOptimise $ ">>> Optimise (Top-down) " ++ show pspec
@@ -176,7 +176,7 @@ argCost arg = do
 ----------------------------------------------------------------
 
 
--- | Infer all global flows across the given procedures, 
+-- | Infer all global flows across the given procedures,
 -- updating their associated GlobalFlows to (possibly) smaller sets, and
 -- ensuring the global flows of all prims are correct
 inferGlobalFlows :: [ProcSpec] -> Compiler ()
@@ -189,7 +189,7 @@ inferGlobalFlows procs = do
 -- | Add all Global Flows from a given procedure to a set of GlobalFlows,
 -- ingoring calls to those that are in the Set of ProcSpecs
 addGlobalFlows :: Set ProcSpec -> GlobalFlows -> ProcSpec -> Compiler GlobalFlows
-addGlobalFlows procs gFlows pspec = 
+addGlobalFlows procs gFlows pspec =
     foldBodyPrims (const $ globalFlowsUnion . primGlobalFlows' procs)
                   gFlows globalFlowsUnion
         . procImplnBody . procImpln <$> getProcDef pspec
@@ -207,7 +207,7 @@ primGlobalFlows' _ prim = snd $ primArgs prim
 -- | Update the GlobalFlows of Prims of a ProcDef and the prototype with
 -- the given GlobalFlows
 updateProcDefGlobalFlows :: Set ProcSpec -> GlobalFlows -> ProcDef -> Compiler ProcDef
-updateProcDefGlobalFlows _ _ ProcDef{procImpln=ProcDefSrc{}} = 
+updateProcDefGlobalFlows _ _ ProcDef{procImpln=ProcDefSrc{}} =
     shouldnt "updateProcDefGlobalFlows on un-compiled code"
 updateProcDefGlobalFlows procs newFlows
         def@ProcDef{procImpln=impln@ProcDefPrim{
@@ -235,12 +235,12 @@ updateBodyGlobalFlows procs newFlows (ProcBody body fork) = do
 -- If the prim is a call to a proc in the Set of ProcSpecs, we update the
 -- GlobalFlows to the intersection of the given GlobalFlows and the current
 updatePrimGlobalFlows :: Set ProcSpec -> GlobalFlows -> Prim -> Compiler Prim
-updatePrimGlobalFlows procs newFlows (PrimCall cID pspec args gFlows) 
-    | pspec `Set.member` procs 
+updatePrimGlobalFlows procs newFlows (PrimCall cID pspec args gFlows)
+    | pspec `Set.member` procs
     = return $ PrimCall cID pspec args $ globalFlowsIntersection newFlows gFlows
     | otherwise = PrimCall cID pspec args <$> getProcGlobalFlows pspec
 updatePrimGlobalFlows _ _ prim = return prim
-    
+
 
 -- |Log a message, if we are logging optimisation activity.
 logOptimise :: String -> Compiler ()

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -18,7 +18,7 @@ import           Data.Map              as Map
 import           Data.Set              as Set
 import           Data.Either           as Either
 import           Text.Read             (readEither)
-import           Control.Monad 
+import           Control.Monad
 import           System.Console.GetOpt
 import           System.Environment
 import           System.Exit
@@ -37,7 +37,7 @@ data Options = Options
     , optLibDirs      :: [String] -- ^Directories where library files live
     , optLogAspects   :: Set LogSelection
                                   -- ^Which aspects to log
-                                 
+
     , optLogUnknown   :: Set String
                                   -- ^Unknown log aspects
     , optLLVMOptLevel :: Either String Word
@@ -65,7 +65,7 @@ defaultOptions = Options
   , optLogUnknown   = Set.empty
   , optLLVMOptLevel = Right 3
   , optNoLLVMOpt    = False
-  , optNoMultiSpecz = False 
+  , optNoMultiSpecz = False
   , optDumpLib      = False
   , optVerbose      = False
   , optNoFont       = False
@@ -211,18 +211,18 @@ handleCmdline = do
         putStrLn "The argument to this option should be a comma-separated"
         putStrLn "list (with no spaces) of these options:"
         putStr $ formatMapping logSelectionDescription
-        if badLogs 
+        if badLogs
         then do
             reportErrorExit opts
-                $ "Unknown log options: " 
+                $ "Unknown log options: "
                 ++ intercalate ", " (Set.toList unknown)
         else exitSuccess
     else let optLvl = optLLVMOptLevel opts
          in if isLeft optLvl
     then do
-        reportErrorExit opts 
-            $ "Unknown LLVM optimisation level: " 
-            ++ fromLeft "" optLvl 
+        reportErrorExit opts
+            $ "Unknown LLVM optimisation level: "
+            ++ fromLeft "" optLvl
     else if optShowVersion opts
     then do
         putStrLn $ "wybemk " ++ version ++ " (git " ++ gitHash ++ ")"
@@ -241,16 +241,16 @@ reportErrorExit :: Options -> String -> IO a
 reportErrorExit Options{optNoFont=noFont} msg = do
     unless noFont $ setSGR [SetColor Foreground Vivid Red]
     putStrLn $ "Error: " ++ msg
-    exitFailure 
+    exitFailure
 
 addLogAspects :: String -> Options -> Options
-addLogAspects aspectsStr opts@Options{optLogUnknown=unknown0, 
-                                      optLogAspects=aspects0} = 
+addLogAspects aspectsStr opts@Options{optLogUnknown=unknown0,
+                                      optLogAspects=aspects0} =
     let aspectList = separate ',' aspectsStr
-        (unknown', aspects') = partitionEithers $ getLogRequest <$> aspectList 
+        (unknown', aspects') = partitionEithers $ getLogRequest <$> aspectList
         unknown'' = Set.fromList unknown'
         aspects'' = let aspectSet = Set.fromList aspects'
-                    in if Set.member All aspectSet 
+                    in if Set.member All aspectSet
                        then Set.fromList allLogSelections else aspectSet
     in opts{optLogUnknown=unknown0 `Set.union` unknown'',
             optLogAspects=aspects0 `Set.union` aspects''}

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -116,7 +116,7 @@ typeItem :: Visibility -> Parser Item
 typeItem v = do
     pos <- tokenPosition <$> ident "type"
     modifiers <- List.foldl processTypeModifier defaultTypeModifiers
-                 <$> modifierList 
+                 <$> modifierList
     proto <- TypeProto <$> moduleName <*> typeVarNames
     (imp,items) <- typeImpln <|> typeCtors
     return $ TypeDecl v proto modifiers imp items (Just pos)
@@ -129,7 +129,7 @@ typeRepItem = do
     params <- typeVarNames
     ident "is"
     modifiers <- List.foldl processTypeModifier defaultTypeModifiers
-                 <$> modifierList 
+                 <$> modifierList
     rep <- typeRep
     return $ RepresentationDecl params modifiers rep $ Just keypos
 
@@ -140,7 +140,7 @@ dataCtorItemParser v = do
     pos <- tokenPosition <$> (ident "constructor" <|> ident "constructors")
     params <- typeVarNames
     modifiers <- List.foldl processTypeModifier defaultTypeModifiers
-                 <$> modifierList 
+                 <$> modifierList
     ctors <- ctorDecls
     return $ ConstructorDecl v params modifiers ctors $ Just pos
 
@@ -168,7 +168,7 @@ typeRep = do
 typeCtors :: Parser (TypeImpln,[Item])
 typeCtors = betweenB Brace $ do
     vis <- visibility
-    ctors <- ctorDecls 
+    ctors <- ctorDecls
     items <- option [] (separator *> items)
     return (TypeCtors vis ctors,items)
 
@@ -211,14 +211,14 @@ useBody v pos mods =
         else fail "inavlid use-block")
     <|> return (ImportMods v mods pos)
 
--- | Parse a top-level use statement with specified 
+-- | Parse a top-level use statement with specified
 topLevelUseStmt :: OptPos -> [ResourceSpec] -> Parser Item
 topLevelUseStmt pos ress = do
     body <- stmtSeq
     return $ StmtDecl (UseResources ress Nothing body) pos
 
 
--- | Convert a ModSpce to a ResourceSpec 
+-- | Convert a ModSpce to a ResourceSpec
 modSpecToResourceSpec :: ModSpec -> ResourceSpec
 modSpecToResourceSpec modspec = ResourceSpec (init modspec) (last modspec)
 
@@ -288,8 +288,8 @@ processTypeModifier tms unknown  = tms {tmUnknown = tmUnknown tms ++ [unknown]}
 -- then don't report any errors in the modifiers.  The position is the source
 -- location of the list of modifiers.
 processProcModifiers :: [String] -> ProcModifiers
-processProcModifiers 
-    = List.foldl (flip processProcModifier) defaultProcModifiers 
+processProcModifiers
+    = List.foldl (flip processProcModifier) defaultProcModifiers
 
 -- | Update a collection of ProcModifiers
 processProcModifier :: String -> ProcModifiers -> ProcModifiers
@@ -438,13 +438,13 @@ applyArguments term args =
     case term of
         call@Call{} ->
             return $ call {callArguments = callArguments call ++ args}
-        embraced@Embraced{embracedArg=Nothing, embracedPos=pos} -> 
+        embraced@Embraced{embracedArg=Nothing, embracedPos=pos} ->
             return $ embraced{embracedArg=Just $ Embraced pos Paren args Nothing}
         other -> fail $ "unexpected argument list following expression "
                         ++ show other
 
 applyEmbraced :: Term -> Term -> Parser Term
-applyEmbraced expr@(Embraced _ Brace _ Nothing) arg = 
+applyEmbraced expr@(Embraced _ Brace _ Nothing) arg =
     return expr{embracedArg=Just arg}
 applyEmbraced expr _ = fail $ "unexpected embraced expression following " ++ show expr
 
@@ -510,7 +510,7 @@ primaryTerm =
 parenthesisedTerm :: Parser Term
 parenthesisedTerm = do
     pos <- sourcePos
-    exps <- betweenB Paren (limitedTerm lowestParenthesisedPrecedence 
+    exps <- betweenB Paren (limitedTerm lowestParenthesisedPrecedence
                             `sepBy` comma)
     return $ Embraced pos Paren exps Nothing
 
@@ -670,13 +670,13 @@ applyPrefixOp tok term = do
         ("-", FloatConst _ num) -> return $ FloatConst pos (-num)
         ("-", Call{}) -> return $ call1 pos "-" term
         ("-", Foreign{}) -> return $ call1 pos "-" term
-        ("-", Embraced{embracedStyle=Paren,embraced=[expr]}) 
+        ("-", Embraced{embracedStyle=Paren,embraced=[expr]})
             -> return $ call1 pos "-" expr
         ("-", _) -> fail $ "cannot negate " ++ show term
         ("~", IntConst _ num) -> return $ IntConst pos (complement num)
         ("~", Call{}) -> return $ call1 pos "~" term
         ("~", Foreign{}) -> return $ call1 pos "~" term
-        ("~", Embraced{embracedStyle=Paren,embraced=[expr]}) 
+        ("~", Embraced{embracedStyle=Paren,embraced=[expr]})
             -> return $ call1 pos "~" expr
         ("~", _) -> fail $ "cannot negate " ++ show term
         ("?", Call{callVariableFlow=ParamIn}) -> return $ setCallFlow ParamOut term
@@ -805,20 +805,20 @@ identString = takeToken test
 -- | Parse a type variable name
 typeVarName :: Parser Ident
 typeVarName = takeToken test
- where 
+ where
     test (TokIdent s _) | isTypeVar s = Just s
     test _                            = Nothing
 
 
 -- | Parse a list of comma-separated TypeVarNames, between parentheses
-typeVarNames :: Parser [Ident] 
+typeVarNames :: Parser [Ident]
 typeVarNames = option [] (betweenB Paren $ typeVarName `sepBy` comma)
 
 
 -- | Parse a module name, any ident that is not a TypeVarName
-moduleName :: Parser Ident 
+moduleName :: Parser Ident
 moduleName = takeToken test
- where 
+ where
     test (TokIdent s _) | not $ isTypeVar s = Just s
     test _                                  = Nothing
 
@@ -981,8 +981,8 @@ termToStmt (Embraced _ Paren [body] Nothing) = termToStmt body
 termToStmt (Embraced _ Brace [body] Nothing) = termToStmt body
 termToStmt (Call pos [] "if" ParamIn [conditional]) =
     termToStmt conditional
-termToStmt (Call pos [] "case" ParamIn 
-                [Call _ [] "in" ParamIn 
+termToStmt (Call pos [] "case" ParamIn
+                [Call _ [] "in" ParamIn
                       [exp,Embraced _ Brace [body] Nothing]]) = do
     expr' <- termToExp exp
     (cases,deflt) <- termToCases termToBody body
@@ -1149,7 +1149,7 @@ termToExp (Embraced _ Paren [exp] Nothing) = termToExp exp
 termToExp body@(Embraced pos Brace _ Nothing) = do
     body' <- termToBody body
     return $ Placed (AnonProc defaultProcModifiers [] body' Nothing Nothing) pos
-termToExp mods@(Embraced pos Brace _ 
+termToExp mods@(Embraced pos Brace _
                     (Just body@(Embraced _ Brace _ _))) = do
     procMods <- termToProcModifiers mods
     anonProc <- content <$> termToExp body
@@ -1157,9 +1157,9 @@ termToExp mods@(Embraced pos Brace _
         AnonProc oldMods ps body clsd _ | oldMods == defaultProcModifiers
             -> return $ Placed (AnonProc procMods ps body clsd Nothing) pos
         _ -> syntaxError pos $ "malformed anonymous procedure " ++ show anonProc
-termToExp embraced@(Embraced pos _ _ _) = 
+termToExp embraced@(Embraced pos _ _ _) =
     syntaxError pos $ "malformed anonymous procedure " ++ show embraced
-termToExp (Call pos [] "case" ParamIn 
+termToExp (Call pos [] "case" ParamIn
             [Call _ [] "in" ParamIn [exp,Embraced _ Brace [body] Nothing]]) = do
     expr' <- termToExp exp
     (cases,deflt) <- termToCases termToExp body
@@ -1186,11 +1186,11 @@ termToExp str@StringConst{stringPos=pos}
 
 termToIdent :: TranslateTo Ident
 termToIdent (Call _ [] ident ParamIn []) = return ident
-termToIdent other 
+termToIdent other
     = syntaxError (termPos other) $ "invalid ident " ++ show other
 
-termToProcModifiers :: TranslateTo ProcModifiers 
-termToProcModifiers (Embraced _ Brace mods _) = 
+termToProcModifiers :: TranslateTo ProcModifiers
+termToProcModifiers (Embraced _ Brace mods _) =
     processProcModifiers <$> mapM termToIdent mods
 termToProcModifiers other
     = syntaxError (termPos other) $ "invalid modifiers " ++ show other
@@ -1226,13 +1226,13 @@ termToTypeSpec mods@(Embraced pos Brace _ (Just ty@(Embraced _ Paren _ Nothing))
     ty' <- termToTypeSpec ty
     case ty' of
         HigherOrderType _ params -> return $ HigherOrderType procMods params
-        _ -> syntaxError pos $ "invalid type spec " ++ show mods 
+        _ -> syntaxError pos $ "invalid type spec " ++ show mods
 termToTypeSpec (Embraced _ Paren args Nothing) =
     HigherOrderType defaultProcModifiers <$> mapM termToTypeFlow args
-termToTypeSpec (Call _ [] name ParamIn []) 
-  | isTypeVar name = 
+termToTypeSpec (Call _ [] name ParamIn [])
+  | isTypeVar name =
     return $ TypeVariable $ RealTypeVar name
-termToTypeSpec (Call _ mod name ParamIn params) 
+termToTypeSpec (Call _ mod name ParamIn params)
   | not $ isTypeVar name =
     TypeSpec mod name <$> mapM termToTypeSpec params
 termToTypeSpec other =
@@ -1282,10 +1282,10 @@ termToCtorField :: TranslateTo Param
 termToCtorField (Call _ [] ":" ParamIn [Call _ [] name ParamIn [],ty]) = do
     ty' <- termToTypeSpec ty
     return $ Param name ty' ParamIn Ordinary
-termToCtorField (Call pos [] name ParamIn []) 
+termToCtorField (Call pos [] name ParamIn [])
   | isTypeVar name = do
     return $ Param "" (TypeVariable $ RealTypeVar name) ParamIn Ordinary
-termToCtorField (Call pos mod name ParamIn params) 
+termToCtorField (Call pos mod name ParamIn params)
   | not $ isTypeVar name = do
     tyParams <- mapM termToTypeSpec params
     return $ Param "" (TypeSpec mod name tyParams) ParamIn Ordinary
@@ -1325,7 +1325,7 @@ data Term
         foreignFlags::[Ident],         -- ^the specified modifiers
         foreignArguments::[Term]       -- ^the specified arguments
     }
-    | Embraced { 
+    | Embraced {
         embracedPos::SourcePos,
         embracedStyle::BracketStyle,
         embraced::[Term],
@@ -1352,7 +1352,7 @@ instance Show Term where
         "foreign " ++ lang ++ " " ++ showFlags' flags ++ instr
         ++ showArguments args
     show (Embraced _ style embraced arg) =
-        bracketString True style ++ intercalate "," (show <$> embraced) 
+        bracketString True style ++ intercalate "," (show <$> embraced)
                                  ++ bracketString False style
                                  ++ maybe "" show arg
     show (IntConst _ int) = show int

--- a/src/Scanner.hs
+++ b/src/Scanner.hs
@@ -138,7 +138,7 @@ delimitString d s = delimStringStart d ++ tail (init $ show s)
                                        ++ delimStringEnd d
 
 
--- |Return the specified starting quote as a string. 
+-- |Return the specified starting quote as a string.
 delimStringStart :: StringDelim -> String
 delimStringStart DoubleQuote      = "\""
 delimStringStart BackQuote        = "`"
@@ -146,7 +146,7 @@ delimStringStart (LongQuote s)    = s
 delimStringStart (IdentQuote i s) = i ++ delimStringStart s
 
 
--- |Return the specified ending quote as a string. 
+-- |Return the specified ending quote as a string.
 delimStringEnd :: StringDelim -> String
 delimStringEnd DoubleQuote      = "\""
 delimStringEnd BackQuote        = "`"

--- a/src/Snippets.hs
+++ b/src/Snippets.hs
@@ -7,13 +7,13 @@
 
 module Snippets (castFromTo, castTo, withType, intType, intCast,
                  tagType, tagCast, phantomType, stringType, cStringType,
-                 isTypeVar, 
+                 isTypeVar,
                  varSet, varGet, varGetSet,
                  varSetTyped, varGetTyped, varGetSetTyped,
                  boolType, boolCast, boolTrue, boolFalse, boolBool,
                  boolVarSet, boolVarGet, intVarSet, intVarGet,
-                 lpvmCast, lpvmCastExp, lpvmCastToVar, iVal, 
-                 move, access, mutate, 
+                 lpvmCast, lpvmCastExp, lpvmCastToVar, iVal,
+                 move, access, mutate,
                  globalStore, globalLoad,
                  primMove, primAccess, primCast,
                  boolNegate, comparison, succeedTest, failTest, testVar, succeedIfSemiDet) where
@@ -29,7 +29,7 @@ castFromTo innerType outerType exp = Typed exp outerType $ Just innerType
 
 -- |An expression to cast a value to the specified type
 castTo :: Exp -> TypeSpec -> Exp
-castTo = flip $ castFromTo AnyType 
+castTo = flip $ castFromTo AnyType
 
 -- |An expression to constrain th subexpression to have the specified type
 withType :: Exp -> TypeSpec -> Exp
@@ -154,33 +154,33 @@ move :: Exp -> Exp -> Placed Stmt
 move src dest =
     Unplaced $ ForeignCall "llvm" "move" [] [Unplaced src, Unplaced dest]
 
-    
+
 -- |An instruction to access a value from some address
 access :: Exp -> Exp -> Exp -> Exp -> Exp -> Placed Stmt
 access addr offset size startOffset val =
-    Unplaced $ ForeignCall "lpvm" "acesss" [] 
+    Unplaced $ ForeignCall "lpvm" "acesss" []
              $ Unplaced <$> [addr, offset, size, startOffset, val]
 
-             
+
 -- |An instruction to mutate a value from some address
 mutate :: Exp -> Exp -> Exp -> Exp -> Exp -> Exp -> Exp -> Placed Stmt
 mutate addr0 addr1 offset destructive size startOffset val =
-    Unplaced $ ForeignCall "lpvm" "mutate" [] 
-             $ Unplaced <$> [addr0, addr1, offset, destructive, 
+    Unplaced $ ForeignCall "lpvm" "mutate" []
+             $ Unplaced <$> [addr0, addr1, offset, destructive,
                              size, startOffset, val]
 
 
 globalStore :: ResourceSpec -> TypeSpec -> Exp -> Placed Stmt
 globalStore rs ty src =
-    Unplaced $ ForeignCall "lpvm" "store" [] 
+    Unplaced $ ForeignCall "lpvm" "store" []
       [Unplaced src,
        Unplaced $ Typed (Global $ GlobalResource rs) ty Nothing]
 
 
 globalLoad :: ResourceSpec -> TypeSpec -> Exp -> Placed Stmt
 globalLoad rs ty dest =
-    Unplaced $ ForeignCall "lpvm" "load" [] 
-      [Unplaced $ Typed (Global $ GlobalResource rs) ty Nothing, 
+    Unplaced $ ForeignCall "lpvm" "load" []
+      [Unplaced $ Typed (Global $ GlobalResource rs) ty Nothing,
        Unplaced dest]
 
 
@@ -203,7 +203,7 @@ primMove :: PrimArg -> PrimArg -> Prim
 primMove src dest =
   PrimForeign "llvm" "move" [] [src, dest]
 
-  
+
 -- |A primitive access instruction
 primAccess :: PrimArg -> PrimArg -> PrimArg -> PrimArg -> PrimArg -> Prim
 primAccess struct offset size startOffset val =

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -85,7 +85,7 @@ validateProcDefTypes name def = do
 validateParamType :: Ident -> OptPos -> Bool -> Param -> Compiler Param
 validateParamType pname ppos public param = do
     let ty = paramType param
-    -- XXX For Issue #135, but this issues warnings about OK constructor decls 
+    -- XXX For Issue #135, but this issues warnings about OK constructor decls
     -- currMod <- getModuleSpec
     -- case ty of
     --     TypeSpec tmod tname _ | tname == last currMod && tmod == init currMod ->
@@ -154,7 +154,7 @@ instance Show RoughProcSpec where
     show (RoughProc mod name) = maybeModPrefix mod ++ name
 
 
--- |Type check a single module dependency SCC.  
+-- |Type check a single module dependency SCC.
 typeCheckModSCC :: [ModSpec] -> Compiler ()
 typeCheckModSCC scc = do
     logTypes $ "**** Type checking modules " ++ showModSpecs scc
@@ -255,9 +255,9 @@ data TypeError = ReasonParam ProcName Int OptPos
                | ReasonEqual Exp Exp OptPos
                    -- ^Expression types should be equal
                | ReasonHigher ProcName ProcName OptPos
-                   -- ^ Expression does not have correct higher type 
+                   -- ^ Expression does not have correct higher type
                | ReasonPartialFlow ProcName ProcName Int FlowDirection OptPos
-                   -- ^ ProcSpec does not have the correct type, in context 
+                   -- ^ ProcSpec does not have the correct type, in context
                | ReasonDeterminism String Determinism Determinism OptPos
                    -- ^Calling a proc in a more deterministic context
                | ReasonWeakDetism String Determinism Determinism OptPos
@@ -324,7 +324,7 @@ typeErrorMessage (ReasonParam name num pos) =
         ", parameter " ++ show num
 typeErrorMessage (ReasonOutputUndef proc param pos) =
     Message Error pos $
-        "Output parameter " ++ param ++ " not defined by proc " 
+        "Output parameter " ++ param ++ " not defined by proc "
         ++ showProcName proc
 typeErrorMessage (ReasonArgType isPartial name num pos) =
     Message Error pos $
@@ -461,7 +461,7 @@ typeErrorMessage ReasonShouldnt =
 typeErrorMessage (ReasonActuallyPure name impurity pos) =
     Message Warning pos $
         "Calling proc " ++ showProcName name ++ " with unneeded ! marker"
--- XXX These won't work until we better infer terminalness 
+-- XXX These won't work until we better infer terminalness
 -- typeErrorMessage (ReasonUndeclaredTerminal name pos) =
 --     Message Warning pos $
 --         "Proc " ++ name ++ " should be declared terminal"
@@ -474,7 +474,7 @@ typeErrorMessage (ReasonUnnreachable name pos) =
 --                       The Typed Monad
 ----------------------------------------------------------------
 
--- |The Typed monad is a state transformer monad carrying the 
+-- |The Typed monad is a state transformer monad carrying the
 --  typing state over the compiler monad.
 type Typed = StateT Typing Compiler
 
@@ -605,7 +605,7 @@ unifyTypes :: TypeError -> TypeSpec -> TypeSpec -> Typed TypeSpec
 unifyTypes reason t1 t2 = do
     t1' <- lift (lookupType "proc declaration" Nothing t1) >>= ultimateType
     t2' <- lift (lookupType "proc declaration" Nothing t2) >>= ultimateType
-    logTyped $ "Unifying types " ++ show t1 ++ " (-> " ++ show t1' 
+    logTyped $ "Unifying types " ++ show t1 ++ " (-> " ++ show t1'
                ++ ") and " ++ show t2 ++ " (-> " ++ show t2' ++ ")"
     t <- unifyTypes' reason t1' t2'
     logTyped $ "  Unification yields " ++ show t
@@ -672,7 +672,7 @@ invalidTypeError :: TypeError -> Typed TypeSpec
 invalidTypeError reason = typeError reason >> return InvalidType
 
 
--- | Checks if two types' are cyclic. 
+-- | Checks if two types' are cyclic.
 -- That is if one type variable is contained in the other
 occursCheck :: TypeSpec -> TypeSpec -> Bool
 occursCheck TypeVariable{} TypeVariable{} = False
@@ -725,7 +725,7 @@ localCalls idents (ProcCall (First m name _) _ _ _) _
 localCalls idents _ _ = idents
 
 
--- |Return the ultimate type of an expression. 
+-- |Return the ultimate type of an expression.
 expType :: Placed Exp -> Typed TypeSpec
 expType expr = do
     logTyped $ "Finding type of expr " ++ show expr
@@ -761,8 +761,8 @@ expType' (ProcRef pspec closed) _ = do
         freeTypes <- mapM ultimateType (List.drop nClosed pTypes')
         let resful = not $ Set.null res
         return $ HigherOrderType
-                    (normaliseModifiers 
-                        $ ProcModifiers detism MayInline 
+                    (normaliseModifiers
+                        $ ProcModifiers detism MayInline
                             impurity RegularProc resful [] [])
                     $ zipWith TypeFlow freeTypes freeFlows
     else do
@@ -796,22 +796,22 @@ expMode' _ expr =
     shouldnt $ "Expression '" ++ show expr ++ "' left after flattening"
 
 
--- | Transform gievn ProcModifiers and TypeFlows to SemiDet, transforming a 
+-- | Transform gievn ProcModifiers and TypeFlows to SemiDet, transforming a
 -- Det modified list of TypeFlows ending in an out flowing boolean typed into
 -- SemiDet
 typeFlowsToSemiDet :: ProcModifiers -> [TypeFlow] -> [TypeFlow]
                    -> (ProcModifiers, ([TypeSpec], [FlowDirection]))
 typeFlowsToSemiDet mods@ProcModifiers{modifierDetism=Det} tfs@(_:_) others
     | test == TypeFlow boolType ParamOut
-      && sameLength others semiTFs = (normaliseModifiers mods{modifierDetism=SemiDet}, 
+      && sameLength others semiTFs = (normaliseModifiers mods{modifierDetism=SemiDet},
                                       unzipTypeFlows semiTFs)
   where
     semiTFs = init tfs
     test = last tfs
 typeFlowsToSemiDet mods tfs _ = (normaliseModifiers mods, unzipTypeFlows tfs)
 
-normaliseModifiers :: ProcModifiers -> ProcModifiers 
-normaliseModifiers mods@ProcModifiers{modifierImpurity=imp} 
+normaliseModifiers :: ProcModifiers -> ProcModifiers
+normaliseModifiers mods@ProcModifiers{modifierImpurity=imp}
     = mods{modifierInline=MayInline,
            modifierImpurity=max imp Pure,
            modifierUnknown=[],
@@ -930,15 +930,15 @@ data CallInfo
 instance Show CallInfo where
     show (FirstInfo procSpec tys flows detism impurity inRes outRes partial) =
         (if partial then "partial application of " else "")
-        ++ showProcModifiers' (ProcModifiers detism MayInline impurity 
+        ++ showProcModifiers' (ProcModifiers detism MayInline impurity
                                 RegularProc False [] [])
         ++ show procSpec
         ++ "(" ++ intercalate "," (zipWith ((show .) . TypeFlow) tys flows) ++ ")"
         ++ if Set.null inRes && Set.null outRes
             then ""
-            else " use " 
+            else " use "
                  ++ intercalate ", "
-                    ((resourceName <$> Set.toList inRes) 
+                    ((resourceName <$> Set.toList inRes)
                      ++ (('?':) . resourceName <$> Set.toList outRes))
     show (HigherInfo fn) = show fn
 
@@ -981,8 +981,8 @@ testToBoolFn _ = Nothing
 
 -- |Check if ProcInfo can be transformed into a partial application, given a
 -- list of FlowDirections. This returns Just if the final FlowDirection is ParamOut
--- if the call has an arity lower than expected or, in the case of a resourceful 
--- call where the call does not have a ! prefix, at most 1 more than the expected 
+-- if the call has an arity lower than expected or, in the case of a resourceful
+-- call where the call does not have a ! prefix, at most 1 more than the expected
 -- arity. The Bool returned indicates if the call should have a ! or not
 procToPartial :: [FlowDirection] -> Bool -> CallInfo -> (Maybe CallInfo, Bool)
 procToPartial callFlows hasBang info@FirstInfo{firstInfoPartial=False,
@@ -1002,11 +1002,11 @@ procToPartial callFlows hasBang info@FirstInfo{firstInfoPartial=False,
     nClosed = length callFlows - 1
     (closedTys, higherTys) = List.splitAt nClosed tys
     (closedFls, higherFls) = List.splitAt nClosed flows
-    resful = any isResourcefulHigherOrder tys 
+    resful = any isResourcefulHigherOrder tys
                 || not (Set.null inRes || Set.null outRes)
     needsBang = resful || impurity > Pure
-    higherTy = HigherOrderType (normaliseModifiers 
-                                $ ProcModifiers detism MayInline 
+    higherTy = HigherOrderType (normaliseModifiers
+                                $ ProcModifiers detism MayInline
                                     impurity RegularProc resful [] [])
                     $ zipWith TypeFlow higherTys higherFls
 procToPartial _ _ _ = (Nothing, False)
@@ -1059,8 +1059,8 @@ typecheckProcDecl' m pdef = do
         let (calls, bodyRes) = bodyCallsResources False def
         logTyped $ "   containing calls: " ++ showBody 8 calls
         logTyped $ "   inner resources: " ++ show (fst <$> bodyRes)
-        let assignedVars = foldStmts 
-                                (const . const) 
+        let assignedVars = foldStmts
+                                (const . const)
                                 ((const .) . (. expOutputs) . Set.union)
                                 inputs def
         logTyped $ "   with assigned vars: " ++ show assignedVars
@@ -1069,7 +1069,7 @@ typecheckProcDecl' m pdef = do
         mapM_ (addDeclaredType name pos (length params)) $ zip params [1..]
         logTyped $ "Recording resource types: "
                    ++ intercalate ", " (show <$> Set.toList resources)
-        mapM_ (uncurry $ addResourceType (ReasonResourceDef name)) 
+        mapM_ (uncurry $ addResourceType (ReasonResourceDef name))
             $ (, pos) . resourceFlowRes <$> Set.toList resources
         ifOK pdef $ do
             mapM_ (placedApply (recordCasts name)) calls
@@ -1081,7 +1081,7 @@ typecheckProcDecl' m pdef = do
             -- mapM_ (uncurry $ unifyExprTypes pos) unifs
             calls' <- mapM (callInfos assignedVars) procCalls
             logTyping $ "  With calls:\n  " ++ intercalate "\n    " (show <$> calls')
-            let badCalls = List.map typingStmt 
+            let badCalls = List.map typingStmt
                          $ List.filter (List.null . typingInfos) calls'
             mapM_ (\pcall -> case content pcall of
                     ProcCall (First _ callee _) _ _ _ ->
@@ -1159,7 +1159,7 @@ addDeclaredType procname pos arity (Param name typ flow _,argNum) = do
 
 
 -- | Record the types of available resources as local variables
-addResourceType :: (ResourceSpec -> OptPos -> TypeError) 
+addResourceType :: (ResourceSpec -> OptPos -> TypeError)
                 -> ResourceSpec -> OptPos  -> Typed ()
 addResourceType errFn rspec pos = do
     resDef <- lift $ lookupResource rspec
@@ -1239,22 +1239,22 @@ updateParamTypes =
 
 -- |Return a list of the proc and foreign calls recursively in a list of
 -- statements, along with the resources that occur in `use` blocks.
-bodyCallsResources :: Bool -> [Placed Stmt] 
+bodyCallsResources :: Bool -> [Placed Stmt]
                    -> ([Placed Stmt], [(ResourceSpec, OptPos)])
-bodyCallsResources nested stmts = 
-    List.foldl combineBodyCallResources ([],[]) 
+bodyCallsResources nested stmts =
+    List.foldl combineBodyCallResources ([],[])
     $ bodyCallsResources' nested <$> stmts
 
-bodyCallsResources' :: Bool -> Placed Stmt 
+bodyCallsResources' :: Bool -> Placed Stmt
                     -> ([Placed Stmt], [(ResourceSpec, OptPos)])
 bodyCallsResources' nested pstmt =
     let expCalls = foldStmts (const . const) expStmts [] [pstmt]
         expCalls' = bodyCallsResources True <$> expCalls
         calls = bodyCalls'' nested (content pstmt) (place pstmt)
-    in if nested then calls 
+    in if nested then calls
        else List.foldl combineBodyCallResources calls expCalls'
 
-bodyCalls'' :: Bool -> Stmt -> OptPos 
+bodyCalls'' :: Bool -> Stmt -> OptPos
             -> ([Placed Stmt], [(ResourceSpec, OptPos)])
 bodyCalls'' _ stmt@ProcCall{} pos = ([stmt `maybePlace` pos], [])
 bodyCalls'' _ stmt@ForeignCall{} pos = ([stmt `maybePlace` pos], [])
@@ -1267,7 +1267,7 @@ bodyCalls'' nested (Cond cond thn els _ _ _) _ =
         (els', elsRes) = bodyCallsResources nested els
     in  (cond' ++ thn' ++ els', condRes ++ thnRes ++ elsRes)
 bodyCalls'' nested (Loop stmts _ _) _ = bodyCallsResources nested stmts
-bodyCalls'' nested (UseResources res _ stmts) pos = 
+bodyCalls'' nested (UseResources res _ stmts) pos =
     let (calls, res') = bodyCallsResources nested stmts
     in (calls, ((, pos) <$> res) ++ res')
 bodyCalls'' _ For{} _ = shouldnt "bodyCalls: flattening left For stmt"
@@ -1309,8 +1309,8 @@ foreignTypeEquivs _ = []
 
 -- |Get matching CallInfos for the supplied statement (which must be a call)
 callInfos :: Set VarName -> Placed Stmt -> Typed StmtTypings
-callInfos vars pstmt = do 
-    let stmt = content pstmt 
+callInfos vars pstmt = do
+    let stmt = content pstmt
     case stmt of
         ProcCall (First m name procId) d resful _ -> do
             varTy <- varType name >>= ultimateType
@@ -1398,7 +1398,7 @@ typecheckCalls m name pos (stmtTyping@(StmtTypings pstmt typs):calls)
     logTyped $ "Type checking call " ++ show pstmt
     logTyped $ "Candidate types:\n    " ++ intercalate "\n    " (show <$> typs)
     let (stmt, stmtPos) = unPlace pstmt
-    let (mod, callee, pexps, resful) 
+    let (mod, callee, pexps, resful)
             = case stmt of
                 ProcCall (First mod callee _) _ resful pexps ->
                     (mod, callee, pexps, resful)
@@ -1470,7 +1470,7 @@ matchTypes :: Ident -> Ident -> OptPos -> Bool -> [TypeSpec] -> [FlowDirection]
            -> CallInfo -> Typed (MaybeErr (CallInfo,Typing))
 matchTypes caller callee pos hasBang callTypes callFlows
         calleeInfo@FirstInfo{firstInfoTypes=tys}
-    -- Handle case whre call should have a ! but doesnt, and the call 
+    -- Handle case whre call should have a ! but doesnt, and the call
     -- can be made partial
     | not hasBang && needsBang && isJust partialCallInfo
     = matchTypeList callee pos callTypes calleeInfo'''
@@ -1501,23 +1501,23 @@ matchTypes caller callee pos _ callTypes callFlows
     fnTy <- expType (Unplaced fn) >>= ultimateType
     logTyped $ "Checking call " ++ show fn ++ ":" ++ show fnTy
             ++ " with type " ++ show callTFs
-    typing <- 
+    typing <-
         case fnTy of
             HigherOrderType mods tfs -> do
                 -- This handles the reification of higher order tests <-> bool fns
                 -- For first order cases, see `boolFnToTest' and `testToBoolFn'
                 let nCallTFs = length callTFs
                     nTFs = length tfs
-                    tfs' | nCallTFs == nTFs - 1 
-                           && last tfs == TypeFlow boolType ParamOut 
-                           && modifierDetism mods == Det  
-                         = init tfs 
-                         | nCallTFs == nTFs + 1 
-                           && last callTFs == TypeFlow boolType ParamOut 
-                           && modifierDetism mods == SemiDet  
-                         = tfs ++ [last callTFs] 
+                    tfs' | nCallTFs == nTFs - 1
+                           && last tfs == TypeFlow boolType ParamOut
+                           && modifierDetism mods == Det
+                         = init tfs
+                         | nCallTFs == nTFs + 1
+                           && last callTFs == TypeFlow boolType ParamOut
+                           && modifierDetism mods == SemiDet
+                         = tfs ++ [last callTFs]
                          | otherwise = tfs
-                snd <$> getTyping (unifyTypeList' callee pos callTypes 
+                snd <$> getTyping (unifyTypeList' callee pos callTypes
                                         (typeFlowType <$> tfs'))
             _ ->
                 snd <$> getTyping (unifyTypes (ReasonHigher caller callee pos) fnTy
@@ -1547,7 +1547,7 @@ matchTypeList _ _ _ info = shouldnt $ "matchTypeList on " ++ show info
 
 
 unifyTypeList' :: ProcName -> OptPos -> [TypeSpec] -> [TypeSpec] -> Typed [TypeSpec]
-unifyTypeList' callee pos callerTypes calleeTypes 
+unifyTypeList' callee pos callerTypes calleeTypes
     = zipWith3M (unifyTypes . flip (ReasonArgType False callee) pos)
                         [1..] callerTypes calleeTypes
 
@@ -1559,7 +1559,7 @@ invalidType (HigherOrderType _ tfs) = any (invalidType . typeFlowType) tfs
 invalidType _ = False
 
 
--- | Canonicalise a list of types, with type variables starting from the 
+-- | Canonicalise a list of types, with type variables starting from the
 -- supplied Int
 canonicalise :: Int -> [TypeSpec] -> ([TypeSpec],Int)
 canonicalise ctr tys = fst $ canonicaliseList Map.empty ctr tys
@@ -1824,7 +1824,7 @@ exactModeMatch :: [(FlowDirection,Bool,Maybe VarName)]
 exactModeMatch modes info@FirstInfo{firstInfoPartial=False}
     = all (uncurry (==)) $ actualFormalModes modes info
 exactModeMatch modes info@FirstInfo{firstInfoPartial=True}
-    = all (==(ParamIn,ParamIn)) (init formalModes) 
+    = all (==(ParamIn,ParamIn)) (init formalModes)
         && last formalModes == (ParamOut, ParamOut)
     where formalModes = actualFormalModes modes info
 exactModeMatch _ _ = True
@@ -2047,7 +2047,7 @@ modecheckStmt m name defPos assigned detism tmpCount final
         bindings <- mapFromUnivSetM ultimateVarType Set.empty
                     $ bindingVars assigned3
         impurity <- lift $ stmtsImpurity tstStmt'
-        let stmts' = if impurity > Pure 
+        let stmts' = if impurity > Pure
                      -- if the test is non-pure, need to keep the test around
                      then Not (seqToStmt tstStmt') `maybePlace` pos:elsStmts'
                      -- otherwise, the cond must fail and wont bind anything
@@ -2099,8 +2099,8 @@ modecheckStmt m name defPos assigned detism tmpCount final
     resfulBoundPre <- resfulBoundVars resVars assigned
     resfulBoundPost <- resfulBoundVars resVars assigned''
     let boundVars = bindingVars assigned''
-    let vars = whenFinite (Set.\\ (Map.keysSet resfulBoundPost 
-                                    Set.\\ Map.keysSet resfulBoundPre)) boundVars                 
+    let vars = whenFinite (Set.\\ (Map.keysSet resfulBoundPost
+                                    Set.\\ Map.keysSet resfulBoundPre)) boundVars
     return
         ([maybePlace (UseResources resources' (Just resfulBoundPre) stmts')
           pos]
@@ -2110,9 +2110,9 @@ modecheckStmt m name defPos assigned detism tmpCount final
   where
     resfulBoundVars resVars bindings = do
         let boundVars = bindingVars bindings
-        varTys <- mapFromUnivSetM ultimateVarType 
+        varTys <- mapFromUnivSetM ultimateVarType
                     (USet.toSet Set.empty boundVars) boundVars
-        let filter nm ty = nm `USet.member` resVars 
+        let filter nm ty = nm `USet.member` resVars
                         || isResourcefulHigherOrder ty
         return $ Map.filterWithKey filter varTys
 -- XXX Need to implement these correctly:
@@ -2155,7 +2155,7 @@ modecheckStmt m name defPos assigned detism tmpCount final
     return ([maybePlace Next pos],bindingStateAfterNext assigned, tmpCount)
 
 
--- | Mode check a list of Placed Exps, 
+-- | Mode check a list of Placed Exps,
 -- returning the mode checked Placed Exps and tmp counter
 modeCheckExps :: ModSpec -> ProcName -> OptPos -> BindingState -> Determinism
              -> Int -> [Placed Exp] -> Typed ([Placed Exp],Int)
@@ -2181,10 +2181,10 @@ modeCheckExp m name defPos assigned _ tmpCount
     (ss',_,tmpCount') <- modecheckStmts m name defPos (addBindings inArgs assigned)
                              detism tmpCount True ss
     let paramVars = expVar . content . paramToVar <$> params
-    let vars = foldStmts (const . const) 
+    let vars = foldStmts (const . const)
                          ((const .) . (. expInputs) . Set.union) Set.empty ss'
     let toClose = vars `Set.difference` Set.fromList paramVars
-    varDict <- mapFromUnivSetM ultimateVarType Set.empty 
+    varDict <- mapFromUnivSetM ultimateVarType Set.empty
                 $ bindingVars assigned
     let closed = Map.filterWithKey (const . flip Set.member toClose) varDict
     params' <- updateParamTypes params
@@ -2293,7 +2293,7 @@ finaliseCall m name defPos assigned detism resourceful tmpCount final pos args
             ++ [ReasonResourceUnavail matchName res pos
                 | res <- Set.toList
                     $ missingBindings
-                      (Set.map resourceName 
+                      (Set.map resourceName
                        (inResources Set.\\ specialResourcesSet
                                     Set.\\ outOfScope))
                       assigned]

--- a/src/Unbranch.hs
+++ b/src/Unbranch.hs
@@ -168,7 +168,7 @@ testInExp = boolVarGet outputStatusName
 -- | Get the index a test output should be if the given params are from a
 -- SemiDet proc
 testOutIndex :: [Param] -> Int
-testOutIndex = length . takeWhile (((==Free) ||| (==Ordinary)) . paramFlowType) 
+testOutIndex = length . takeWhile (((==Free) ||| (==Ordinary)) . paramFlowType)
 
 
 -- | Add a test output param to the list of params, as well as the index of the
@@ -177,25 +177,25 @@ addTestOutParam :: [Param] -> [Param]
 addTestOutParam params = insertAt (testOutIndex params) testOutParam params
 
 
--- | Add a tmp var to the list of expressions in the position dictated by the 
+-- | Add a tmp var to the list of expressions in the position dictated by the
 -- ProcFunctor to determinise a statement
 addTestOutExp :: ProcFunctor -> [Placed Exp] -> Unbrancher ([Placed Exp], Exp)
 addTestOutExp func args = do
     testResultVar <- tempVar
     (nParams, detism) <- case func of
-        Higher fn -> 
+        Higher fn ->
             case content fn of
                 Typed _ (HigherOrderType mods params) _ -> do
                     return (length params, modifierDetism mods)
                 _ -> shouldnt "badly typed higher in addTestOutExp"
         First mod nm pId -> do
-            ProcDef{procProto=ProcProto _ params _, procDetism=detism} 
-                <- lift $ getProcDef $ ProcSpec mod nm 
-                                        (trustFromJust "addTestOutExp" pId) 
+            ProcDef{procProto=ProcProto _ params _, procDetism=detism}
+                <- lift $ getProcDef $ ProcSpec mod nm
+                                        (trustFromJust "addTestOutExp" pId)
                                         generalVersion
             return (testOutIndex params, detism)
     let idx = selectDetism (nParams - 1) nParams detism
-    return (insertAt idx (Unplaced $ boolVarSet testResultVar) args, 
+    return (insertAt idx (Unplaced $ boolVarSet testResultVar) args,
             boolVarGet testResultVar)
 
 ----------------------------------------------------------------
@@ -207,7 +207,7 @@ addTestOutExp func args = do
 type Unbrancher = StateT UnbrancherState Compiler
 
 data UnbrancherState = Unbrancher {
-    brLoopInfo   :: Maybe LoopInfo, 
+    brLoopInfo   :: Maybe LoopInfo,
                                   -- ^If in a loop, break and continue stmts
     brVars       :: VarDict,      -- ^Types of variables defined up to here
     brTempCtr    :: Int,          -- ^Number of next temp variable to make
@@ -352,7 +352,7 @@ unbranchStmts detism (stmt:stmts) alt sense = do
 --   considers the sense of the test: if True, execution should go to the
 --   following statements on success and the alternative statements on
 --   failure; if False, then vice-versa. The following statements are
---   represented as a pair of a list of not yet unbranched statements 
+--   represented as a pair of a list of not yet unbranched statements
 --   and a list of unbranched alternative statements. The alternative
 --   statements will have been factored out into a call to a fresh
 --   procedure if necessary (ie, if it will be used in more than one case,
@@ -569,9 +569,9 @@ mkCond True exp pos thn els condVars vars
               else if thnSrcContent == boolFalse && elsSrcContent == boolTrue
                    then boolNegate exp dest
                    else maybePlace
-                        (Cond test thn els 
+                        (Cond test thn els
                             (Just condVars) (Just vars) (Just Set.empty)) pos]
-      _ -> [maybePlace (Cond test thn els 
+      _ -> [maybePlace (Cond test thn els
                             (Just condVars) (Just vars) (Just Set.empty)) pos]
   where test = Unplaced $ TestBool exp
 
@@ -580,7 +580,7 @@ mkCond True exp pos thn els condVars vars
 -- statements by turning them into a fresh proc if necessary.  The resulting
 -- statement list will have been unbranched.
 maybeFactorContinuation :: Determinism -> VarDict -> Set ResourceSpec
-                        -> [Placed Stmt] -> [Placed Stmt] -> Bool 
+                        -> [Placed Stmt] -> [Placed Stmt] -> Bool
                         -> Unbrancher [Placed Stmt]
 maybeFactorContinuation detism vars res stmts alt sense = do
     logUnbranch $ "Maybe factor " ++ show detism ++ " continuation: "
@@ -613,16 +613,16 @@ inputParams params =
          if flowsIn dir then Map.insert v ty vdict else vdict)
     Map.empty params
 
-    
+
 -- | Unbranch a type, ensuring that all higher order types are no longer SemiDet
 unbranchType :: TypeSpec -> TypeSpec
 unbranchType (TypeSpec mod nm params) = TypeSpec mod nm $ unbranchType <$> params
-unbranchType (HigherOrderType mods tfs) = 
+unbranchType (HigherOrderType mods tfs) =
     let (tys, flows) = unzipTypeFlows tfs
         tfs' = zipWith TypeFlow (unbranchType <$> tys) flows
-    in selectDetism 
+    in selectDetism
             (HigherOrderType mods tfs')
-            (HigherOrderType mods{modifierDetism=Det} 
+            (HigherOrderType mods{modifierDetism=Det}
                 $ tfs' ++ [TypeFlow boolType ParamOut])
             (modifierDetism mods)
 unbranchType ty = ty
@@ -673,7 +673,7 @@ unbranchExp exp@(AnonProc mods params pstmts clsd res) pos = do
     procDef' <- lift $ unbranchProc procDef tmpCtr
     logUnbranch $ "  Resultant hoisted proc: " ++ show procProto
     procSpec <- lift $ addProcDef procDef'
-    addClosure procSpec freeVars pos name 
+    addClosure procSpec freeVars pos name
 unbranchExp exp@(ProcRef ps free) pos = do
     free' <- unbranchExps free
     isClosure <- lift $ isClosureProc ps
@@ -683,9 +683,9 @@ unbranchExp exp@(ProcRef ps free) pos = do
 unbranchExp exp pos = return $ maybePlace exp pos
 
 
--- | Create and add a closure of the given ProcSpec with the given name 
+-- | Create and add a closure of the given ProcSpec with the given name
 -- and free variables
-addClosure :: ProcSpec -> [Placed Exp] -> OptPos -> String 
+addClosure :: ProcSpec -> [Placed Exp] -> OptPos -> String
            -> Unbrancher (Placed Exp)
 addClosure regularProcSpec@(ProcSpec mod nm pID _) free pos name = do
     ProcDef{procDetism=detism, procInlining=inlining, procImpurity=impurity,
@@ -699,9 +699,9 @@ addClosure regularProcSpec@(ProcSpec mod nm pID _) free pos name = do
         Nothing -> do
             let pDefClosure =
                     ProcDef name (ProcProto name params' res)
-                    (ProcDefSrc [Unplaced $ ProcCall (First mod nm $ Just pID) 
+                    (ProcDefSrc [Unplaced $ ProcCall (First mod nm $ Just pID)
                                                 detism False args])
-                    Nothing 0 0 Map.empty Private detism inlining impurity 
+                    Nothing 0 0 Map.empty Private detism inlining impurity
                     (ClosureProc regularProcSpec) NoSuperproc
             logUnbranch $ "Creating closure for " ++ show regularProcSpec
             logUnbranch $ "  with params: " ++ show params'
@@ -710,7 +710,7 @@ addClosure regularProcSpec@(ProcSpec mod nm pID _) free pos name = do
             pDefClosure' <- lift $ unbranchProc pDefClosure 0
             closureProcSpec <- lift $ addProcDef pDefClosure'
             logUnbranch $ "  Resultant closure proc: " ++ show closureProcSpec
-            modify $ \s -> s{brClosures=Map.insert (regularProcSpec, constMap) 
+            modify $ \s -> s{brClosures=Map.insert (regularProcSpec, constMap)
                                         closureProcSpec $ brClosures s}
             return $ ProcRef closureProcSpec free `maybePlace` pos
 
@@ -720,24 +720,24 @@ addClosure regularProcSpec@(ProcSpec mod nm pID _) free pos name = do
 -- params are the closure's params, the args are the arguments to the inner call,
 -- and the free variables represent the variables that are free to the closure.
 -- This removes params/free variables where the expression is a known constant
-makeFreeParams :: [Param] -> [Placed Exp] 
+makeFreeParams :: [Param] -> [Placed Exp]
                -> ([Param], [Placed Exp], Map Integer Exp)
 makeFreeParams params exps = makeFreeParams' 1 params $ unPlace <$> exps
 
 
-makeFreeParams' :: Integer -> [Param] -> [(Exp, OptPos)] 
+makeFreeParams' :: Integer -> [Param] -> [(Exp, OptPos)]
                 -> ([Param], [Placed Exp], Map Integer Exp)
 makeFreeParams' _ params [] = (params', paramToVar <$> params', Map.empty)
   where params' = freeParamToOrdinary . unbranchParam <$> params
 makeFreeParams' _ [] _ = shouldnt "too many exps for params"
-makeFreeParams' idx ((Param nm pTy fl _):params) ((Typed exp ty cast,pos):exps) 
+makeFreeParams' idx ((Param nm pTy fl _):params) ((Typed exp ty cast,pos):exps)
     | flowsOut fl = shouldnt "out flowing free param"
     | otherwise   = (param':params', exp' `maybePlace` pos:exps', constMap')
-  where 
+  where
     (params', exps', constMap) = makeFreeParams' (idx + 1) params exps
     param' = Param nm (unbranchType pTy) ParamIn Free
     mbExp = expIsConstant exp
-    exp' = Typed (fromMaybe (Var nm ParamIn Free) $ expIsConstant exp) ty' cast' 
+    exp' = Typed (fromMaybe (Var nm ParamIn Free) $ expIsConstant exp) ty' cast'
     constMap' = if isJust mbExp
                 then Map.insert idx exp' constMap
                 else constMap
@@ -752,17 +752,17 @@ freeParamToOrdinary param@(Param _ _ _ Free) = param{paramFlowType=Ordinary}
 freeParamToOrdinary param                    = param
 
 
--- |Get Free Param and Typed Var for the given VarName and TypeSpec 
+-- |Get Free Param and Typed Var for the given VarName and TypeSpec
 freeParamVar :: VarName -> TypeSpec -> (Param, Placed Exp)
-freeParamVar nm ty = 
-    let ty' = unbranchType ty 
-    in (Param nm ty' ParamIn Free, 
+freeParamVar nm ty =
+    let ty' = unbranchType ty
+    in (Param nm ty' ParamIn Free,
         Unplaced $ Typed (Var nm ParamIn Free) ty' Nothing)
 
 
 -- |Add the output variables defined by the expression to the symbol
---  table. Since the expression is already flattened (excluding AnonProcs), 
---  it will only be a constant, in which case it doesn't define any variables, 
+--  table. Since the expression is already flattened (excluding AnonProcs),
+--  it will only be a constant, in which case it doesn't define any variables,
 --  or a variable, in which case it might.
 defArg :: Exp -> Unbrancher ()
 defArg = ifIsVarDef defVar (return ())
@@ -828,7 +828,7 @@ factorLoopProc break inVars pos detism res stmts alt sense = do
     return next
 
 varExp :: FlowDirection -> VarName -> TypeSpec -> Placed Exp
-varExp flow var ty 
+varExp flow var ty
     = Unplaced $ Typed (Var var flow Ordinary) (unbranchType ty) Nothing
 
 
@@ -848,7 +848,7 @@ newProcProto name inVars res = do
     let inParams  = [unbranchParam $ Param v ty ParamIn Ordinary
                     | (v,ty) <- Map.toList inVars]
     outParams <- gets brOutParams
-    return $ ProcProto name (inParams ++ outParams) 
+    return $ ProcProto name (inParams ++ outParams)
            $ Set.map (`ResourceFlowSpec` ParamInOut) res
 
 

--- a/src/UnivSet.hs
+++ b/src/UnivSet.hs
@@ -31,7 +31,7 @@ import qualified Data.Functor as UnivSet
 --
 ----------------------------------------------------------------
 
-data UnivSet a 
+data UnivSet a
     = FiniteSet (Set a)
     | UniversalSet
     deriving (Eq, Ord, Show, Generic)
@@ -55,7 +55,7 @@ intersection (FiniteSet s1) (FiniteSet s2) = FiniteSet $ s1 `S.intersection` s2
 -- | Subtract the given UnivSet from an ordinary set.
 subtractUnivSet :: Ord a => Set a -> UnivSet a -> Set a
 subtractUnivSet _ UniversalSet    = S.empty
-subtractUnivSet s1 (FiniteSet s2) = s1 S.\\ s2 
+subtractUnivSet s1 (FiniteSet s2) = s1 S.\\ s2
 
 
 -- | Is the specified value a member of the given UnivSet?

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -127,9 +127,9 @@ type DisjointSet a = Set (Set a)
 
 
 _findOneInSet :: (a -> Bool) -> Set a -> Maybe a
-_findOneInSet f = 
-    Set.foldr 
-        (\x result -> 
+_findOneInSet f =
+    Set.foldr
+        (\x result ->
             case result of
                 Just _ -> result
                 Nothing -> if f x then Just x else Nothing
@@ -137,30 +137,30 @@ _findOneInSet f =
 
 
 addOneToDS :: Ord a => a -> DisjointSet a -> DisjointSet a
-addOneToDS x ds = 
+addOneToDS x ds =
     case _findOneInSet (Set.member x) ds of
         Just _ -> ds
-        Nothing -> 
+        Nothing ->
             Set.insert (Set.singleton x) ds
 
 
 addConnectedGroupToDS :: Ord a => [a] -> DisjointSet a -> DisjointSet a
-addConnectedGroupToDS l ds = 
-    case l of 
+addConnectedGroupToDS l ds =
+    case l of
         [] -> ds
-        x:xs -> 
+        x:xs ->
             let ds' = addOneToDS x ds in
             List.foldl (flip (unionTwoInDS x)) ds' xs
 
 
 unionTwoInDS :: Ord a => a -> a -> DisjointSet a -> DisjointSet a
-unionTwoInDS x y ds = 
-    let xSet = _findOneInSet (Set.member x) ds in 
-    let ySet = _findOneInSet (Set.member y) ds in 
+unionTwoInDS x y ds =
+    let xSet = _findOneInSet (Set.member x) ds in
+    let ySet = _findOneInSet (Set.member y) ds in
         if (isJust xSet) && (xSet == ySet)
         then ds
-        else 
-            let (ds', newSet') = case xSet of 
+        else
+            let (ds', newSet') = case xSet of
                     Nothing -> (ds, Set.singleton x)
                     Just xSet -> (Set.delete xSet ds, xSet)
             in
@@ -177,19 +177,19 @@ combineTwoDS =
 
 
 removeOneFromDS :: Ord a => a -> DisjointSet a -> DisjointSet a
-removeOneFromDS x ds = 
-    case _findOneInSet (Set.member x) ds of 
+removeOneFromDS x ds =
+    case _findOneInSet (Set.member x) ds of
         Nothing -> ds
-        Just xSet -> 
+        Just xSet ->
             let xSet' = Set.delete x xSet in
             let ds' = Set.delete xSet ds in
-                if Set.null xSet' 
+                if Set.null xSet'
                     then ds'
                     else  Set.insert xSet' ds'
 
 
 removeFromDS :: Ord a => Set a -> DisjointSet a -> DisjointSet a
-removeFromDS set = 
+removeFromDS set =
     filterDS (\x -> not $ Set.member x set)
 
 
@@ -201,14 +201,14 @@ removeSingletonFromDS =
 -- return a set of items that the given item is connected to.
 connectedItemsInDS :: Ord a => a -> DisjointSet a -> Set a
 connectedItemsInDS x ds =
-    case _findOneInSet (Set.member x) ds of 
+    case _findOneInSet (Set.member x) ds of
         Nothing -> Set.empty
         Just xSet -> Set.delete x xSet
 
 
 -- The map function must be a bijection, i.e. 1-to-1 mapping.
 mapDS :: (Ord a, Ord b) => (a -> b) -> DisjointSet a -> DisjointSet b
-mapDS f = 
+mapDS f =
     Set.map (Set.map f)
 
 
@@ -294,7 +294,7 @@ lift2 act = lift $ lift act
 
 _localCachePathOfFile :: FilePath -> IO (FilePath, FilePath)
 _localCachePathOfFile file = do
-    localCacheLibDir <- localCacheLibDir 
+    localCacheLibDir <- localCacheLibDir
     let cacheFilename = show (hashWith SHA1 (B8.pack file))
     let cacheFilePath = localCacheLibDir </> cacheFilename
     let cacheFileMeta = cacheFilePath <.> "meta"
@@ -311,7 +311,7 @@ _getFileHash :: FilePath -> IO String
 _getFileHash file = do
     exist <- doesFileExist file
     if exist
-    then do 
+    then do
         content <- BL.readFile file
         return $ show (hashlazy content :: Digest SHA1)
     else return ""
@@ -319,14 +319,14 @@ _getFileHash file = do
 
 -- | Given a file path and return the actual file that should be used.
 -- It can the original file or a local cache file.
-useLocalCacheFileIfPossible :: FilePath -> IO FilePath 
+useLocalCacheFileIfPossible :: FilePath -> IO FilePath
 useLocalCacheFileIfPossible file = do
     (cacheFile, meta) <- _localCachePathOfFile file
     cacheFileExist <- doesFileExist cacheFile
     metaExist <- doesFileExist meta
     valid <-
         if cacheFileExist && metaExist
-        then do 
+        then do
             srcFileHash <- _getFileHash file
             hashInMeta <- readFile meta
             return (srcFileHash == hashInMeta)
@@ -341,9 +341,9 @@ useLocalCacheFileIfPossible file = do
 
 -- | Given a file path and return the file path to the local cache
 -- file of the actual file.
-createLocalCacheFile :: FilePath -> IO FilePath 
-createLocalCacheFile file = do 
-    localCacheLibDir  <- localCacheLibDir 
+createLocalCacheFile :: FilePath -> IO FilePath
+createLocalCacheFile file = do
+    localCacheLibDir  <- localCacheLibDir
     createDirectoryIfMissing True localCacheLibDir
     (cacheFile, meta) <- _localCachePathOfFile file
     srcFileHash <- _getFileHash file


### PR DESCRIPTION
I'm hoping this might make future PRs simpler by getting rid of inconsistent trailing whitespace.

To create this diff, I went and ran "trim trailing whitespace" in my editor for each file in `src/`.

I wonder for the future, whether adopting some sort of autoformatter / linter might make this easier? I've used `hlint` before, but I don't think it does whitespace/formatting stuff.