### PR TITLE
Infer more LLVM types during codegen, remove some unused code

### DIFF
--- a/src/Blocks.hs
+++ b/src/Blocks.hs
@@ -721,7 +721,6 @@ cgenLPVM "mutate" _
           baseAddr <- cgenArg addrArg
           gcMutate baseAddr offsetArg valArg
           outRep <- typeRep' $ argType addrArg
-          when (outRep == Address) (return $ shouldnt "outRep != Address")
           assign (pullName outArg) baseAddr
 
 cgenLPVM "mutate" _ [_, _, _, destructiveArg, _, _, _] =

--- a/src/Blocks.hs
+++ b/src/Blocks.hs
@@ -1070,7 +1070,7 @@ castVar nm ty = do
     toTyRep <- typeRep' ty
     toTy <- llvmType' ty
     lift2 $ logBlocks $ "Coercing var " ++ show nm ++ " to " ++ show ty
-    (varOp,_) <- getVar (show nm)
+    varOp <- getVar (show nm)
     doCast varOp toTy
 
 

--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -690,6 +690,11 @@ csext :: C.Constant -> LLVMAST.Type -> Codegen C.Constant
 csext op ty = return $ C.SExt op ty
 
 
+-- Helpers for allocating, storing, loading
+doAlloca :: Type -> Codegen Operand
+doAlloca (PointerType ty _) = instr (ptr_t ty) $ Alloca ty Nothing 0 []
+doAlloca ty                 = instr (ptr_t ty) $ Alloca ty Nothing 0 []
+
 doLoad :: Type -> Operand -> Codegen Operand
 doLoad ty ptr = instr ty $ Load False ptr Nothing 0 []
 

--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -167,7 +167,7 @@ data BlockState
 -- Stores assignments and generated operands
 data SymbolTable
      = SymbolTable {
-         stVars :: Map.Map String (Operand,LLVM.AST.Type)
+         stVars :: Map.Map String Operand
 
                       -- ^ Assigned names
        , stOpds :: Map.Map PrimArg Operand
@@ -446,13 +446,13 @@ assign :: String -> Operand -> Codegen ()
 assign var op = do
     logCodegen $ "SYMTAB: " ++ var ++ " <- " ++ show op ++ ":" ++ show (typeOf op)
     st <- gets symtab
-    modify $ \s -> s { symtab=st{stVars=Map.insert var (op,typeOf op) $ stVars st} }
+    modify $ \s -> s { symtab=st{stVars=Map.insert var op $ stVars st} }
 
 
 -- | Find and return the local operand by its given name from the symbol
 -- table. Only the first find will be returned so new names can shadow
 -- the same older names.
-getVar :: String -> Codegen (Operand,LLVM.AST.Type)
+getVar :: String -> Codegen Operand
 getVar var = do
     let err = shouldnt $ "Local variable not in scope: " ++ show var
     lcls <- gets (stVars . symtab)

--- a/src/Transform.hs
+++ b/src/Transform.hs
@@ -31,7 +31,7 @@ import           Util
 ----------------------------------------------------------------
 --
 -- Transform mutate instructions with correct destructive flag
--- This is the extra pass after found the alais analysis fixed point
+-- This is the extra pass after found the alias analysis fixed point
 --
 ----------------------------------------------------------------
 transformProc :: ProcDef -> Int -> Compiler ProcDef

--- a/test-cases/execution-test.sh
+++ b/test-cases/execution-test.sh
@@ -12,6 +12,11 @@ LIBDIR="../wybelibs"
 rm -f execution/*.o
 rm -f execution/*.out
 
+abort () {
+	printf "\033[0;31m$1\033[0;0m\n\n"
+	exit 1
+}
+
 for f in `ls execution/*.wybe`
 do
 	in=`echo -e "$f" | sed 's/.wybe$/.in/'`
@@ -24,19 +29,19 @@ do
         if [ -r $cmdline ] ; then
             cmd="$targ `cat $cmdline`"
         fi
-	$TIMEOUT 20 ../wybemk --force-all -L $LIBDIR $targ >/dev/null
+	$TIMEOUT 20 ../wybemk --force-all -L $LIBDIR $targ >/dev/null || abort "failed to compile $targ"
     $TIMEOUT 20 $cmd< $in &> $out
-	if [ ! -r $exp ] ; then 
+	if [ ! -r $exp ] ; then
 		printf "[31m?[39m"
 		NEW="$NEW\n    $out"
 	elif diff -q $exp $out >/dev/null 2>&1 ; then
 		printf "."
-	else 
+	else
 		printf "\n[34;1m**************** difference building $targ ****************[0m\n" >> ../ERRS
 		dwdiff -c -d '()<>~!@:?.%#' $exp $out >> ../ERRS 2>&1
 		printf "[31mX[39m"
 		FAILS="$FAILS\n    $out"
-	fi 
+	fi
 done
 echo -e
 if [ -n "$FAILS" ] ; then

--- a/test-cases/execution-test.sh
+++ b/test-cases/execution-test.sh
@@ -12,11 +12,6 @@ LIBDIR="../wybelibs"
 rm -f execution/*.o
 rm -f execution/*.out
 
-abort () {
-	printf "\033[0;31m$1\033[0;0m\n\n"
-	exit 1
-}
-
 for f in `ls execution/*.wybe`
 do
 	in=`echo -e "$f" | sed 's/.wybe$/.in/'`
@@ -29,19 +24,19 @@ do
         if [ -r $cmdline ] ; then
             cmd="$targ `cat $cmdline`"
         fi
-	$TIMEOUT 20 ../wybemk --force-all -L $LIBDIR $targ >/dev/null || abort "failed to compile $targ"
+	$TIMEOUT 20 ../wybemk --force-all -L $LIBDIR $targ >/dev/null
     $TIMEOUT 20 $cmd< $in &> $out
-	if [ ! -r $exp ] ; then
+	if [ ! -r $exp ] ; then 
 		printf "[31m?[39m"
 		NEW="$NEW\n    $out"
 	elif diff -q $exp $out >/dev/null 2>&1 ; then
 		printf "."
-	else
+	else 
 		printf "\n[34;1m**************** difference building $targ ****************[0m\n" >> ../ERRS
 		dwdiff -c -d '()<>~!@:?.%#' $exp $out >> ../ERRS 2>&1
 		printf "[31mX[39m"
 		FAILS="$FAILS\n    $out"
-	fi
+	fi 
 done
 echo -e
 if [ -n "$FAILS" ] ; then

--- a/test-cases/final-dump-test.sh
+++ b/test-cases/final-dump-test.sh
@@ -12,6 +12,11 @@ rm -f final-dump/*.bc
 rm -f final-dump/*.o
 rm -f final-dump/*.out
 
+abort () {
+	printf "\033[0;31m$1\033[0;0m\n\n"
+	exit 1
+}
+
 for f in `ls final-dump/*.wybe`
 do
 	out=`echo -e "$f" | sed 's/.wybe$/.out/'`
@@ -23,18 +28,18 @@ do
             -e 's/\[[0-9][0-9]* x i8\]/[?? x i8]/g' \
         > $out
 	# Add a newline to the end of a file if there isn't to resolve platform differences.
-	ed -s $out <<< w > /dev/null 2>&1
-	if [ ! -r $exp ] ; then 
+	ed -s $out <<< w > /dev/null 2>&1 || abort "failed to add newline to output, is ed installed?"
+	if [ ! -r $exp ] ; then
 		printf "[31m?[39m"
 		NEW="$NEW\n    $out"
 	elif diff -q $exp $out >/dev/null 2>&1 ; then
 		printf "."
-	else 
+	else
 		printf "\n[34;1m**************** difference building $targ ****************[0m\n" >> ../ERRS
 		dwdiff -c -d '()<>~!@:?.%#' $exp $out >> ../ERRS 2>&1
 		printf "[31mX[39m"
 		FAILS="$FAILS\n    $out"
-	fi 
+	fi
 done
 echo -e
 if [ -n "$FAILS" ] ; then

--- a/test-cases/final-dump-test.sh
+++ b/test-cases/final-dump-test.sh
@@ -12,11 +12,6 @@ rm -f final-dump/*.bc
 rm -f final-dump/*.o
 rm -f final-dump/*.out
 
-abort () {
-	printf "\033[0;31m$1\033[0;0m\n\n"
-	exit 1
-}
-
 for f in `ls final-dump/*.wybe`
 do
 	out=`echo -e "$f" | sed 's/.wybe$/.out/'`
@@ -28,18 +23,18 @@ do
             -e 's/\[[0-9][0-9]* x i8\]/[?? x i8]/g' \
         > $out
 	# Add a newline to the end of a file if there isn't to resolve platform differences.
-	ed -s $out <<< w > /dev/null 2>&1 || abort "failed to add newline to output, is ed installed?"
-	if [ ! -r $exp ] ; then
+	ed -s $out <<< w > /dev/null 2>&1
+	if [ ! -r $exp ] ; then 
 		printf "[31m?[39m"
 		NEW="$NEW\n    $out"
 	elif diff -q $exp $out >/dev/null 2>&1 ; then
 		printf "."
-	else
+	else 
 		printf "\n[34;1m**************** difference building $targ ****************[0m\n" >> ../ERRS
 		dwdiff -c -d '()<>~!@:?.%#' $exp $out >> ../ERRS 2>&1
 		printf "[31mX[39m"
 		FAILS="$FAILS\n    $out"
-	fi
+	fi 
 done
 echo -e
 if [ -n "$FAILS" ] ; then


### PR DESCRIPTION
I haven't had a chance to discuss this one yet, so I'd be open to any feedback (maybe there's something I'm missing why it's done the way it is?)

- When implementing new LPVM instructions, I accidentally introduced a couple of bugs by falsely claiming an operand was of type `x` (by writing `assign name op x`), when the operand was actually of a different type `y`.
- I learned that each LLVM `Operand` has a type, which can be retrieved with `typeOf operand`

Thus, I thought it might make sense to use the LLVM type of the operand itself, rather than passing in an extra argument. This also simplifies `doCast` and `consCast`.

I believe this code change shouldn't break any of the tests / final dumps. I'd be keen to hear what you think.

I also have an extra commit https://github.com/neon64/wybe/commit/dacb26958184579b1df9d221864e6118c80ba0c6 which removes all the `getelementptr i64, i64* %xyz, i64 0` instructions from `gcAccess` and `gcMutate` which afaik are just nops (I guess they get optimized out by LLVM pretty quickly, but it seemed a bit redundant to generate them in the first place). However, this change breaks nearly every single final-dump test, so I thought I'd keep it out of this PR for now.