### PR TITLE
Fixed resourcefulness of partial applications

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1003,7 +1003,7 @@ procToPartial callFlows hasBang info@FirstInfo{firstInfoPartial=False,
     (closedTys, higherTys) = List.splitAt nClosed tys
     (closedFls, higherFls) = List.splitAt nClosed flows
     resful = any isResourcefulHigherOrder tys
-                || not (Set.null inRes || Set.null outRes)
+                || not (Set.null inRes && Set.null outRes)
     needsBang = resful || impurity > Pure
     higherTy = HigherOrderType (normaliseModifiers
                                 $ ProcModifiers detism MayInline


### PR DESCRIPTION
A bug I made allowed partial applications to have an inferred resourceful higher-order type if there were in *and* out flowing resources for the proc. This fixes that, as it should be in *or* out flowing.