### PR TITLE
Improved backwards analysis with global flows

### DIFF
--- a/src/BodyBuilder.hs
+++ b/src/BodyBuilder.hs
@@ -1234,9 +1234,14 @@ bkwdBuildStmt defs prim pos = do
           | otherwise -> do
               modify $ \s -> s { bkwdGlobalStored = Set.insert info gStored }
               bkwdBuildStmt' defs args' gFlows prim pos
+      (PrimForeign "lpvm" "load" [] _, [ArgGlobal info _, _]) -> do
+          modify $ \s -> s { bkwdGlobalStored = Set.delete info gStored }
+          bkwdBuildStmt' defs args' gFlows prim pos
       _ -> do
           let filter info = not $ hasGlobalFlow gFlows FlowIn info
-          modify $ \s -> s { bkwdGlobalStored = Set.filter filter gStored }
+          let outs = USet.toSet Set.empty $ globalFlowsOut gFlows
+          modify $ \s -> s { bkwdGlobalStored = Set.filter filter 
+                                                $ gStored `Set.union` outs }
           bkwdBuildStmt' defs args' gFlows prim pos
 
 

--- a/test-cases/final-dump/out_global_overwritten.exp
+++ b/test-cases/final-dump/out_global_overwritten.exp
@@ -1,0 +1,65 @@
+======================================================================
+AFTER EVERYTHING:
+ Module out_global_overwritten
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : out_global_overwritten.<0>
+  imports         : use wybe
+  resources       : res: fromList [(out_global_overwritten.res,wybe.int @out_global_overwritten:nn:nn)]
+  procs           : 
+
+module top-level code > public {impure} (0 calls)
+0: out_global_overwritten.<0>
+()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(10:wybe.int, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+
+out > {noinline} (1 calls)
+0: out_global_overwritten.out<0>
+out()<{}; {<<out_global_overwritten.res>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm store(11:wybe.int, <<out_global_overwritten.res>>:wybe.int) @out_global_overwritten:nn:nn
+
+  LLVM code       :
+
+; ModuleID = 'out_global_overwritten'
+
+
+ 
+
+
+@"resource#out_global_overwritten.res" =    global i64 undef
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"out_global_overwritten.<0>"()    {
+entry:
+  tail call ccc  void  @print_int(i64  10)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"out_global_overwritten.out<0>"()    {
+entry:
+  store  i64 11, i64* @"resource#out_global_overwritten.res" 
+  ret void 
+}

--- a/test-cases/final-dump/out_global_overwritten.wybe
+++ b/test-cases/final-dump/out_global_overwritten.wybe
@@ -1,0 +1,9 @@
+resource res:int
+
+def {noinline} out use ?res { ?res = 11 }
+
+use res in { 
+    !out # this can be removed -- following statements overwrite only flowing global
+    ?res = 10 
+    !println(res) # value res can be inferred from (re)assignment
+} # this whole use block can be removed -- res is definitely unchanged

--- a/test-cases/final-dump/out_only_global_flow.exp
+++ b/test-cases/final-dump/out_only_global_flow.exp
@@ -1,0 +1,73 @@
+======================================================================
+AFTER EVERYTHING:
+ Module out_only_global_flow
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : out_only_global_flow.<0>
+  imports         : use wybe
+  resources       : res: fromList [(out_only_global_flow.res,wybe.int @out_only_global_flow:nn:nn)]
+  procs           : 
+
+module top-level code > public {impure} (0 calls)
+0: out_only_global_flow.<0>
+()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm load(<<out_only_global_flow.res>>:wybe.int, ?%tmp#0##0:wybe.int) @out_only_global_flow:nn:nn
+    out_only_global_flow.out<0><{}; {<<out_only_global_flow.res>>}> #0 @out_only_global_flow:nn:nn
+    foreign lpvm load(<<out_only_global_flow.res>>:wybe.int, ?%res##1:wybe.int) @out_only_global_flow:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(~res##1:wybe.int, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#0##0:wybe.int, <<out_only_global_flow.res>>:wybe.int) @out_only_global_flow:nn:nn
+
+
+out > {noinline} (1 calls)
+0: out_only_global_flow.out<0>
+out()<{}; {<<out_only_global_flow.res>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm store(11:wybe.int, <<out_only_global_flow.res>>:wybe.int) @out_only_global_flow:nn:nn
+
+  LLVM code       :
+
+; ModuleID = 'out_only_global_flow'
+
+
+ 
+
+
+@"resource#out_only_global_flow.res" =    global i64 undef
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"out_only_global_flow.<0>"()    {
+entry:
+  %1 = load  i64, i64* @"resource#out_only_global_flow.res" 
+  tail call fastcc  void  @"out_only_global_flow.out<0>"()  
+  %2 = load  i64, i64* @"resource#out_only_global_flow.res" 
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  store  i64 %1, i64* @"resource#out_only_global_flow.res" 
+  ret void 
+}
+
+
+define external fastcc  void @"out_only_global_flow.out<0>"()    {
+entry:
+  store  i64 11, i64* @"resource#out_only_global_flow.res" 
+  ret void 
+}

--- a/test-cases/final-dump/out_only_global_flow.wybe
+++ b/test-cases/final-dump/out_only_global_flow.wybe
@@ -1,0 +1,9 @@
+resource res:int
+
+def {noinline} out use ?res { ?res = 11 }
+
+use res in {
+    ?res = 10
+    !out
+    !println(res)
+}


### PR DESCRIPTION
As the title says. This strengthens the definition of neededness in terms of global flows
i.e., assuming a prim is pure and has no regular *needed* outputs, a prim is needed iff the outwards global flows of the prim are not overwritten by some later prim

### E.g.1:
```
resource res:int

def {noinline} out use ?res { ?res = 11 }

use res in {
    ?res = 10
    !out
    !println(res)
}
```

The `?res = 10` assignment is redundant

### E.g.2: 
```
resource res:int

def {noinline} out use ?res { ?res = 11 }

use res in { 
    !out
    ?res = 10 
    !println(res)
}
```
No global flows for `res` occur in the top-level, as the `!out` call can now be omitted. 
This applies to all prims where the outwards global flows are overwritten later on.
