### PR TITLE
Delay addition of `next` statement form Flatten to Unbranching

### DIFF
--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -365,8 +365,7 @@ flattenStmt' (Not tstStmt) pos SemiDet = do
 flattenStmt' (Not tstStmt) _pos detism =
     shouldnt $ "negation in a " ++ show detism ++ " context"
 flattenStmt' (Loop body defVars res) pos detism = do
-    body' <- flattenInner False detism
-             (flattenStmts (body ++ [Unplaced Next]) detism)
+    body' <- flattenInner False detism (flattenStmts body detism)
     emit pos $ Loop body' defVars res
 flattenStmt' for@(For pgens body) pos detism = do
     -- For loops are transformed into `do` loops

--- a/src/Unbranch.hs
+++ b/src/Unbranch.hs
@@ -500,7 +500,8 @@ unbranchStmt detism (Loop body exitVars res) pos stmts alt sense = do
     logUnbranch $ "  with entry vars " ++ showVarMap beforeVars
     brk <- maybeFactorContinuation detism exitVars' res' stmts alt sense
     logUnbranch $ "Generated break: " ++ showBody 4 brk
-    next <- factorLoopProc brk beforeVars pos detism res' body alt sense
+    next <- factorLoopProc brk beforeVars pos detism res' 
+                (body ++ [maybePlace Next pos]) alt sense
     logUnbranch $ "Generated next " ++ showStmt 4 (content next)
     logUnbranch "Finished handling loop"
     return [next]

--- a/test-cases/final-dump/loop_terminators.exp
+++ b/test-cases/final-dump/loop_terminators.exp
@@ -1,0 +1,149 @@
+======================================================================
+AFTER EVERYTHING:
+ Module loop_terminators
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : 
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+gen#1 > {inline} (2 calls)
+0: loop_terminators.gen#1<0>
+gen#1()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
+gen#2 > {inline} (2 calls)
+0: loop_terminators.gen#2<0>
+gen#2()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
+gen#3 > {inline} (1 calls)
+0: loop_terminators.gen#3<0>
+gen#3()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
+gen#4 > {inline} (1 calls)
+0: loop_terminators.gen#4<0>
+gen#4()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.string.c_string<0>("lol":wybe.string, ?tmp#2##0:wybe.c_string) #1 @control:nn:nn
+    foreign c {terminal,semipure} error_exit(c"loop_terminators:14:11":wybe.c_string, ~tmp#2##0:wybe.c_string) @control:nn:nn
+
+
+loop0 > {inline} (0 calls)
+0: loop_terminators.loop0<0>
+loop0()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
+loop1 > {inline} (0 calls)
+0: loop_terminators.loop1<0>
+loop1()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
+loop2 > {inline} (0 calls)
+0: loop_terminators.loop2<0>
+loop2()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
+loop3 > {inline} (0 calls)
+0: loop_terminators.loop3<0>
+loop3()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.string.c_string<0>("lol":wybe.string, ?tmp#0##0:wybe.c_string) #1 @control:nn:nn
+    foreign c {terminal,semipure} error_exit(c"loop_terminators:14:11":wybe.c_string, ~tmp#0##0:wybe.c_string) @control:nn:nn
+
+  LLVM code       :
+
+; ModuleID = 'loop_terminators'
+
+
+ 
+
+
+@loop_terminators.2 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @loop_terminators.1 to i64) }
+
+
+@loop_terminators.1 =    constant [?? x i8] c"lol\00"
+
+
+@loop_terminators.3 =    constant [?? x i8] c"loop_terminators:14:11\00"
+
+
+declare external ccc  void @error_exit(i64, i64)    
+
+
+declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)    
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"loop_terminators.gen#1<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.gen#2<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.gen#3<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.gen#4<0>"()    {
+entry:
+  %"1#tmp#2##0" = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_terminators.2, i32 0, i32 0) to i64))  
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_terminators.3, i32 0, i32 0) to i64), i64  %"1#tmp#2##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.loop0<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.loop1<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.loop2<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.loop3<0>"()    {
+entry:
+  %"1#tmp#0##0" = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_terminators.2, i32 0, i32 0) to i64))  
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_terminators.3, i32 0, i32 0) to i64), i64  %"1#tmp#0##0")  
+  ret void 
+}

--- a/test-cases/final-dump/loop_terminators.wybe
+++ b/test-cases/final-dump/loop_terminators.wybe
@@ -1,0 +1,15 @@
+def loop0 {
+    do { next }
+}
+
+def loop1 {
+    do { pass }
+}
+
+def loop2 {
+    do { break }
+}
+
+def loop3 {
+    do { !error("lol") }
+}


### PR DESCRIPTION
As the title says. 

Fixes #292 

The new test case raises a few questions though--

An infinite loop as I have used here doesn't look right. The looping procs should not be empty, but recursive calls to themselves. The issue though, is there is no *un-needed* outputs, so the recursive call is removed. I suspect `terminal` procs shouldn't be removed and should essentially always needed.

But when I try to declare them as terminal, the compiler says that the determinism is wrong. Perhaps I should raise another issue