### PR TITLE
add missing pragma no_standard_library

### DIFF
--- a/wybelibs/wybe/machine_word.wybe
+++ b/wybelibs/wybe/machine_word.wybe
@@ -1,6 +1,6 @@
 # purpose: Standard Machine Word type, a low level type holding a machine address
 # since  : 0.1
 
-pragma no_standard_library
+pragma no_standard_library # Standard library can't depend on itself!
 
 representation is address

--- a/wybelibs/wybe/range.wybe
+++ b/wybelibs/wybe/range.wybe
@@ -1,7 +1,7 @@
 # purpose: Standard Range Library, an fixed-stride integer range
 # since  : 0.1
 
-pragma no_standard_library
+pragma no_standard_library # Standard library can't depend on itself!
 
 use wybe.int, wybe.bool
 


### PR DESCRIPTION
as part of trying to debug https://github.com/pschachte/wybe/issues/300, just realised that these two stdlib modules were missing the `pragma no_standard_library` that all the other modules have.
Is this intentional?