### PR TITLE
add --no-tcmc switch

### DIFF
--- a/src/Options.hs
+++ b/src/Options.hs
@@ -44,6 +44,7 @@ data Options = Options
                                   -- ^LLVM optimisation level, or invalid
     , optNoLLVMOpt    :: Bool     -- ^Don't run the LLVM optimisation passes
     , optNoMultiSpecz :: Bool     -- ^Disable multiple specialization
+    , optNoTCMC       :: Bool     -- ^Disable tail-call-modulo-construction optimization
     , optDumpLib      :: Bool     -- ^Also dump wybe.* modules when dumping
     , optVerbose      :: Bool     -- ^Be verbose in compiler output
     , optNoFont       :: Bool     -- ^Disable ISO font change codes in messages
@@ -66,6 +67,7 @@ defaultOptions = Options
   , optLLVMOptLevel = Right 3
   , optNoLLVMOpt    = False
   , optNoMultiSpecz = False
+  , optNoTCMC       = False
   , optDumpLib      = False
   , optVerbose      = False
   , optNoFont       = False
@@ -160,6 +162,9 @@ options =
  , Option []     ["no-multi-specz"]
      (NoArg (\opts -> opts { optNoMultiSpecz = True }))
      "disable multiple specialization"
+ , Option []     ["no-tcmc"]
+     (NoArg (\opts -> opts { optNoTCMC = True }))
+     "disable tail-call-modulo-construction optimization"
  , Option []     ["dump-lib"]
      (NoArg (\opts -> opts { optDumpLib = True }))
      "also dump wybe library when dumping"


### PR DESCRIPTION
Just like there is a `--no-multi-specz` switch which disables multiple specialization, I have added a `--no-tcmc`  switch which disables the tail-call-modulo-construction optimization.

I realise this may end up being a bit of a rabbit-hole if we keep adding switches for every possible optimization the Wybe compiler might perform, but I guess it is quite similar to how e.g.: clang has a bunch of `-f` flags to control each possible optimization (https://clang.llvm.org/docs/ClangCommandLineReference.html#target-independent-compilation-options). Perhaps there is a different naming convention all of these flags should use? For now I have stuck with `--no-xyz`.

There was one trick with the implementation: we want to keep calling `fixupCallsInProc` even if the optimization is disabled, since we may need to "fixup" calls to external libraries (i.e.: the Wybe standard library), which did already get TCMC-optimized.