### PR TITLE
Remove redundant getelementptr from gcAccess

### DIFF
--- a/src/Blocks.hs
+++ b/src/Blocks.hs
@@ -447,10 +447,10 @@ codegenBody body = do
             M.void $ ret =<< buildOutputOp
         PrimFork var ty _ fbody -> do
             cgen prims False
-            codegenFork var ty fbody 
+            codegenFork var ty fbody
 
 
--- | Code generation for a conditional branch. 
+-- | Code generation for a conditional branch.
 -- XXX revise when LPVM can be transformed to have n>3-ary branches
 codegenFork :: PrimVarName -> TypeSpec -> [ProcBody] -> Codegen ()
 codegenFork _ _ [] = shouldnt "fork with no branches"
@@ -465,7 +465,7 @@ codegenFork var ty [bElse,bThen] = do
 codegenFork var ty bodies  = do
     let nBodies = length bodies
     let blockPrefix = "switch." ++ show nBodies ++ "."
-    names@(deflt:rest) <- mapM (addBlock . (blockPrefix ++) . show) 
+    names@(deflt:rest) <- mapM (addBlock . (blockPrefix ++) . show)
                             [1..nBodies]
     brOp <- castVar var ty FlowIn
     let bits = getBits $ typeOf brOp
@@ -1674,23 +1674,9 @@ gcAccess ptr outTy = do
     let ptrTy = ptr_t outTy
     ptr' <- doCast ptr ptrTy
     logCodegen $ "doCast produced " ++ show ptr'
-
-    -- TODO: is getelementptr here redundant? we always index the 0th thing...
-    let getel = getElementPtrInstr ptr' [0]
-    logCodegen $ "getel = " ++ show getel
-    accessPtr <- instr ptrTy getel
-    logCodegen $ "accessPtr = " ++ show accessPtr
-    let loadInstr = load accessPtr
+    let loadInstr = load ptr'
     logCodegen $ "loadInstr = " ++ show loadInstr
-    instr outTy $ loadInstr
-
-
-    -- inttoptr loadedOp outTy
-    -- case outTy of
-    --     (PointerType ty _) -> do
-    --         loadedOp <- instr opType $ load accessPtr
-    --         inttoptr loadedOp outTy
-    --     _ -> instr opType $ load accessPtr
+    instr outTy loadInstr
 
 
 -- | Index the pointer at the given offset and store the given operand value
@@ -1708,12 +1694,8 @@ gcMutate baseAddr offsetArg valArg = do
     logCodegen $ "inttoptr " ++ show finalAddr ++ " " ++ show ptrTy
     logCodegen $ "inttoptr produced " ++ show ptr'
 
-    let getel = getElementPtrInstr ptr' [0]
-    logCodegen $ "getel = " ++ show getel
-    accessPtr <- instr ptrTy getel
-    logCodegen $ "accessPtr = " ++ show accessPtr
     val <- cgenArg valArg
-    store accessPtr val
+    store ptr' val
 
 
 -- | Get the LLVMAST.Type the given pointer type points to.

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -170,22 +170,20 @@ entry:
   %3 = tail call ccc  i8*  @wybe_malloc(i32  %2)  
   %4 = ptrtoint i8* %3 to i64 
   %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  store  i64 %0, i64* %6 
-  %7 = add   i64 %4, 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %1, i64* %9 
+  store  i64 %0, i64* %5 
+  %6 = add   i64 %4, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %1, i64* %7 
   store  i64 %4, i64* @"resource#command_line.arguments" 
   store  i64 ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.0, i32 0, i32 0) to i64), i64* @"resource#command_line.command" 
-  %10 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
-  %11 = extractvalue {i64, i64, i1} %10, 0 
-  %12 = extractvalue {i64, i64, i1} %10, 1 
-  %13 = extractvalue {i64, i64, i1} %10, 2 
-  br i1 %13, label %if.then, label %if.else 
+  %8 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
+  %9 = extractvalue {i64, i64, i1} %8, 0 
+  %10 = extractvalue {i64, i64, i1} %8, 1 
+  %11 = extractvalue {i64, i64, i1} %8, 2 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  store  i64 %12, i64* @"resource#command_line.arguments" 
-  store  i64 %11, i64* @"resource#command_line.command" 
+  store  i64 %10, i64* @"resource#command_line.arguments" 
+  store  i64 %9, i64* @"resource#command_line.command" 
   store  i64 0, i64* @"resource#command_line.exit_code" 
   ret void 
 if.else:
@@ -838,22 +836,20 @@ entry:
   %3 = tail call ccc  i8*  @wybe_malloc(i32  %2)  
   %4 = ptrtoint i8* %3 to i64 
   %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  store  i64 %0, i64* %6 
-  %7 = add   i64 %4, 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %1, i64* %9 
+  store  i64 %0, i64* %5 
+  %6 = add   i64 %4, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %1, i64* %7 
   store  i64 %4, i64* @"resource#command_line.arguments" 
   store  i64 ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.0, i32 0, i32 0) to i64), i64* @"resource#command_line.command" 
-  %10 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
-  %11 = extractvalue {i64, i64, i1} %10, 0 
-  %12 = extractvalue {i64, i64, i1} %10, 1 
-  %13 = extractvalue {i64, i64, i1} %10, 2 
-  br i1 %13, label %if.then, label %if.else 
+  %8 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
+  %9 = extractvalue {i64, i64, i1} %8, 0 
+  %10 = extractvalue {i64, i64, i1} %8, 1 
+  %11 = extractvalue {i64, i64, i1} %8, 2 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  store  i64 %12, i64* @"resource#command_line.arguments" 
-  store  i64 %11, i64* @"resource#command_line.command" 
+  store  i64 %10, i64* @"resource#command_line.arguments" 
+  store  i64 %9, i64* @"resource#command_line.command" 
   store  i64 0, i64* @"resource#command_line.exit_code" 
   ret void 
 if.else:
@@ -1363,145 +1359,133 @@ entry:
 if.then:
   %1 = add   i64 %"d##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = sub   i64 %4, 1 
-  %6 = trunc i64 32 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = inttoptr i64 %"d##0" to i8* 
-  %11 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
-  %12 = add   i64 %8, 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 %5, i64* %14 
-  %15 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %8, i1  1)  
-  %16 = insertvalue {i64, i1} undef, i64 %15, 0 
-  %17 = insertvalue {i64, i1} %16, i1 1, 1 
-  ret {i64, i1} %17 
+  %3 = load  i64, i64* %2 
+  %4 = sub   i64 %3, 1 
+  %5 = trunc i64 32 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i8* 
+  %9 = inttoptr i64 %"d##0" to i8* 
+  %10 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
+  %11 = add   i64 %7, 8 
+  %12 = inttoptr i64 %11 to i64* 
+  store  i64 %4, i64* %12 
+  %13 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %7, i1  1)  
+  %14 = insertvalue {i64, i1} undef, i64 %13, 0 
+  %15 = insertvalue {i64, i1} %14, i1 1, 1 
+  ret {i64, i1} %15 
 if.else:
-  %18 = icmp eq i8 %"action##0", 115 
-  br i1 %18, label %if.then1, label %if.else1 
+  %16 = icmp eq i8 %"action##0", 115 
+  br i1 %16, label %if.then1, label %if.else1 
 if.then1:
-  %19 = add   i64 %"d##0", 8 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  %22 = load  i64, i64* %21 
-  %23 = add   i64 %22, 1 
-  %24 = trunc i64 32 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i8* 
-  %28 = inttoptr i64 %"d##0" to i8* 
-  %29 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %27, i8*  %28, i32  %29, i1  0)  
-  %30 = add   i64 %26, 8 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 %23, i64* %32 
-  %33 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %26, i1  1)  
-  %34 = insertvalue {i64, i1} undef, i64 %33, 0 
-  %35 = insertvalue {i64, i1} %34, i1 1, 1 
-  ret {i64, i1} %35 
+  %17 = add   i64 %"d##0", 8 
+  %18 = inttoptr i64 %17 to i64* 
+  %19 = load  i64, i64* %18 
+  %20 = add   i64 %19, 1 
+  %21 = trunc i64 32 to i32  
+  %22 = tail call ccc  i8*  @wybe_malloc(i32  %21)  
+  %23 = ptrtoint i8* %22 to i64 
+  %24 = inttoptr i64 %23 to i8* 
+  %25 = inttoptr i64 %"d##0" to i8* 
+  %26 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %24, i8*  %25, i32  %26, i1  0)  
+  %27 = add   i64 %23, 8 
+  %28 = inttoptr i64 %27 to i64* 
+  store  i64 %20, i64* %28 
+  %29 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %23, i1  1)  
+  %30 = insertvalue {i64, i1} undef, i64 %29, 0 
+  %31 = insertvalue {i64, i1} %30, i1 1, 1 
+  ret {i64, i1} %31 
 if.else1:
-  %36 = icmp eq i8 %"action##0", 119 
-  br i1 %36, label %if.then2, label %if.else2 
+  %32 = icmp eq i8 %"action##0", 119 
+  br i1 %32, label %if.then2, label %if.else2 
 if.then2:
-  %37 = inttoptr i64 %"d##0" to i64* 
-  %38 = getelementptr  i64, i64* %37, i64 0 
-  %39 = load  i64, i64* %38 
-  %40 = sub   i64 %39, 1 
+  %33 = inttoptr i64 %"d##0" to i64* 
+  %34 = load  i64, i64* %33 
+  %35 = sub   i64 %34, 1 
+  %36 = trunc i64 32 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i8* 
+  %40 = inttoptr i64 %"d##0" to i8* 
   %41 = trunc i64 32 to i32  
-  %42 = tail call ccc  i8*  @wybe_malloc(i32  %41)  
-  %43 = ptrtoint i8* %42 to i64 
-  %44 = inttoptr i64 %43 to i8* 
-  %45 = inttoptr i64 %"d##0" to i8* 
-  %46 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %44, i8*  %45, i32  %46, i1  0)  
-  %47 = inttoptr i64 %43 to i64* 
-  %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 %40, i64* %48 
-  %49 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %43, i1  1)  
-  %50 = insertvalue {i64, i1} undef, i64 %49, 0 
-  %51 = insertvalue {i64, i1} %50, i1 1, 1 
-  ret {i64, i1} %51 
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %39, i8*  %40, i32  %41, i1  0)  
+  %42 = inttoptr i64 %38 to i64* 
+  store  i64 %35, i64* %42 
+  %43 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %38, i1  1)  
+  %44 = insertvalue {i64, i1} undef, i64 %43, 0 
+  %45 = insertvalue {i64, i1} %44, i1 1, 1 
+  ret {i64, i1} %45 
 if.else2:
-  %52 = icmp eq i8 %"action##0", 101 
-  br i1 %52, label %if.then3, label %if.else3 
+  %46 = icmp eq i8 %"action##0", 101 
+  br i1 %46, label %if.then3, label %if.else3 
 if.then3:
-  %53 = inttoptr i64 %"d##0" to i64* 
-  %54 = getelementptr  i64, i64* %53, i64 0 
-  %55 = load  i64, i64* %54 
-  %56 = add   i64 %55, 1 
-  %57 = trunc i64 32 to i32  
-  %58 = tail call ccc  i8*  @wybe_malloc(i32  %57)  
-  %59 = ptrtoint i8* %58 to i64 
-  %60 = inttoptr i64 %59 to i8* 
-  %61 = inttoptr i64 %"d##0" to i8* 
-  %62 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %60, i8*  %61, i32  %62, i1  0)  
-  %63 = inttoptr i64 %59 to i64* 
-  %64 = getelementptr  i64, i64* %63, i64 0 
-  store  i64 %56, i64* %64 
-  %65 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %59, i1  1)  
-  %66 = insertvalue {i64, i1} undef, i64 %65, 0 
-  %67 = insertvalue {i64, i1} %66, i1 1, 1 
-  ret {i64, i1} %67 
+  %47 = inttoptr i64 %"d##0" to i64* 
+  %48 = load  i64, i64* %47 
+  %49 = add   i64 %48, 1 
+  %50 = trunc i64 32 to i32  
+  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
+  %52 = ptrtoint i8* %51 to i64 
+  %53 = inttoptr i64 %52 to i8* 
+  %54 = inttoptr i64 %"d##0" to i8* 
+  %55 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %53, i8*  %54, i32  %55, i1  0)  
+  %56 = inttoptr i64 %52 to i64* 
+  store  i64 %49, i64* %56 
+  %57 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %52, i1  1)  
+  %58 = insertvalue {i64, i1} undef, i64 %57, 0 
+  %59 = insertvalue {i64, i1} %58, i1 1, 1 
+  ret {i64, i1} %59 
 if.else3:
-  %68 = icmp eq i8 %"action##0", 117 
-  br i1 %68, label %if.then4, label %if.else4 
+  %60 = icmp eq i8 %"action##0", 117 
+  br i1 %60, label %if.then4, label %if.else4 
 if.then4:
-  %69 = add   i64 %"d##0", 16 
-  %70 = inttoptr i64 %69 to i64* 
-  %71 = getelementptr  i64, i64* %70, i64 0 
-  %72 = load  i64, i64* %71 
-  %73 = add   i64 %72, 1 
-  %74 = trunc i64 32 to i32  
-  %75 = tail call ccc  i8*  @wybe_malloc(i32  %74)  
-  %76 = ptrtoint i8* %75 to i64 
-  %77 = inttoptr i64 %76 to i8* 
-  %78 = inttoptr i64 %"d##0" to i8* 
-  %79 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %77, i8*  %78, i32  %79, i1  0)  
-  %80 = add   i64 %76, 16 
-  %81 = inttoptr i64 %80 to i64* 
-  %82 = getelementptr  i64, i64* %81, i64 0 
-  store  i64 %73, i64* %82 
-  %83 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %76, i1  1)  
-  %84 = insertvalue {i64, i1} undef, i64 %83, 0 
-  %85 = insertvalue {i64, i1} %84, i1 1, 1 
-  ret {i64, i1} %85 
+  %61 = add   i64 %"d##0", 16 
+  %62 = inttoptr i64 %61 to i64* 
+  %63 = load  i64, i64* %62 
+  %64 = add   i64 %63, 1 
+  %65 = trunc i64 32 to i32  
+  %66 = tail call ccc  i8*  @wybe_malloc(i32  %65)  
+  %67 = ptrtoint i8* %66 to i64 
+  %68 = inttoptr i64 %67 to i8* 
+  %69 = inttoptr i64 %"d##0" to i8* 
+  %70 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %68, i8*  %69, i32  %70, i1  0)  
+  %71 = add   i64 %67, 16 
+  %72 = inttoptr i64 %71 to i64* 
+  store  i64 %64, i64* %72 
+  %73 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %67, i1  1)  
+  %74 = insertvalue {i64, i1} undef, i64 %73, 0 
+  %75 = insertvalue {i64, i1} %74, i1 1, 1 
+  ret {i64, i1} %75 
 if.else4:
-  %86 = icmp eq i8 %"action##0", 100 
-  br i1 %86, label %if.then5, label %if.else5 
+  %76 = icmp eq i8 %"action##0", 100 
+  br i1 %76, label %if.then5, label %if.else5 
 if.then5:
-  %87 = add   i64 %"d##0", 16 
+  %77 = add   i64 %"d##0", 16 
+  %78 = inttoptr i64 %77 to i64* 
+  %79 = load  i64, i64* %78 
+  %80 = sub   i64 %79, 1 
+  %81 = trunc i64 32 to i32  
+  %82 = tail call ccc  i8*  @wybe_malloc(i32  %81)  
+  %83 = ptrtoint i8* %82 to i64 
+  %84 = inttoptr i64 %83 to i8* 
+  %85 = inttoptr i64 %"d##0" to i8* 
+  %86 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %84, i8*  %85, i32  %86, i1  0)  
+  %87 = add   i64 %83, 16 
   %88 = inttoptr i64 %87 to i64* 
-  %89 = getelementptr  i64, i64* %88, i64 0 
-  %90 = load  i64, i64* %89 
-  %91 = sub   i64 %90, 1 
-  %92 = trunc i64 32 to i32  
-  %93 = tail call ccc  i8*  @wybe_malloc(i32  %92)  
-  %94 = ptrtoint i8* %93 to i64 
-  %95 = inttoptr i64 %94 to i8* 
-  %96 = inttoptr i64 %"d##0" to i8* 
-  %97 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %95, i8*  %96, i32  %97, i1  0)  
-  %98 = add   i64 %94, 16 
-  %99 = inttoptr i64 %98 to i64* 
-  %100 = getelementptr  i64, i64* %99, i64 0 
-  store  i64 %91, i64* %100 
-  %101 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %94, i1  1)  
-  %102 = insertvalue {i64, i1} undef, i64 %101, 0 
-  %103 = insertvalue {i64, i1} %102, i1 1, 1 
-  ret {i64, i1} %103 
+  store  i64 %80, i64* %88 
+  %89 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %83, i1  1)  
+  %90 = insertvalue {i64, i1} undef, i64 %89, 0 
+  %91 = insertvalue {i64, i1} %90, i1 1, 1 
+  ret {i64, i1} %91 
 if.else5:
-  %104 = tail call fastcc  i64  @"drone.gen#2<0>"(i64  %"d##0", i1  0)  
-  %105 = insertvalue {i64, i1} undef, i64 %104, 0 
-  %106 = insertvalue {i64, i1} %105, i1 0, 1 
-  ret {i64, i1} %106 
+  %92 = tail call fastcc  i64  @"drone.gen#2<0>"(i64  %"d##0", i1  0)  
+  %93 = insertvalue {i64, i1} undef, i64 %92, 0 
+  %94 = insertvalue {i64, i1} %93, i1 0, 1 
+  ret {i64, i1} %94 
 }
 
 
@@ -1512,103 +1496,91 @@ entry:
 if.then:
   %1 = add   i64 %"d##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = sub   i64 %4, 1 
-  %6 = add   i64 %"d##0", 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %5, i64* %8 
-  %9 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  %3 = load  i64, i64* %2 
+  %4 = sub   i64 %3, 1 
+  %5 = add   i64 %"d##0", 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %4, i64* %6 
+  %7 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %8 = insertvalue {i64, i1} undef, i64 %7, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %12 = icmp eq i8 %"action##0", 115 
-  br i1 %12, label %if.then1, label %if.else1 
+  %10 = icmp eq i8 %"action##0", 115 
+  br i1 %10, label %if.then1, label %if.else1 
 if.then1:
-  %13 = add   i64 %"d##0", 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  %16 = load  i64, i64* %15 
-  %17 = add   i64 %16, 1 
-  %18 = add   i64 %"d##0", 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 %17, i64* %20 
-  %21 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %22 = insertvalue {i64, i1} undef, i64 %21, 0 
-  %23 = insertvalue {i64, i1} %22, i1 1, 1 
-  ret {i64, i1} %23 
+  %11 = add   i64 %"d##0", 8 
+  %12 = inttoptr i64 %11 to i64* 
+  %13 = load  i64, i64* %12 
+  %14 = add   i64 %13, 1 
+  %15 = add   i64 %"d##0", 8 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %14, i64* %16 
+  %17 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %18 = insertvalue {i64, i1} undef, i64 %17, 0 
+  %19 = insertvalue {i64, i1} %18, i1 1, 1 
+  ret {i64, i1} %19 
 if.else1:
-  %24 = icmp eq i8 %"action##0", 119 
-  br i1 %24, label %if.then2, label %if.else2 
+  %20 = icmp eq i8 %"action##0", 119 
+  br i1 %20, label %if.then2, label %if.else2 
 if.then2:
-  %25 = inttoptr i64 %"d##0" to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = sub   i64 %27, 1 
-  %29 = inttoptr i64 %"d##0" to i64* 
-  %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %28, i64* %30 
-  %31 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %32 = insertvalue {i64, i1} undef, i64 %31, 0 
-  %33 = insertvalue {i64, i1} %32, i1 1, 1 
-  ret {i64, i1} %33 
+  %21 = inttoptr i64 %"d##0" to i64* 
+  %22 = load  i64, i64* %21 
+  %23 = sub   i64 %22, 1 
+  %24 = inttoptr i64 %"d##0" to i64* 
+  store  i64 %23, i64* %24 
+  %25 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %26 = insertvalue {i64, i1} undef, i64 %25, 0 
+  %27 = insertvalue {i64, i1} %26, i1 1, 1 
+  ret {i64, i1} %27 
 if.else2:
-  %34 = icmp eq i8 %"action##0", 101 
-  br i1 %34, label %if.then3, label %if.else3 
+  %28 = icmp eq i8 %"action##0", 101 
+  br i1 %28, label %if.then3, label %if.else3 
 if.then3:
-  %35 = inttoptr i64 %"d##0" to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %38 = add   i64 %37, 1 
-  %39 = inttoptr i64 %"d##0" to i64* 
-  %40 = getelementptr  i64, i64* %39, i64 0 
-  store  i64 %38, i64* %40 
-  %41 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %42 = insertvalue {i64, i1} undef, i64 %41, 0 
-  %43 = insertvalue {i64, i1} %42, i1 1, 1 
-  ret {i64, i1} %43 
+  %29 = inttoptr i64 %"d##0" to i64* 
+  %30 = load  i64, i64* %29 
+  %31 = add   i64 %30, 1 
+  %32 = inttoptr i64 %"d##0" to i64* 
+  store  i64 %31, i64* %32 
+  %33 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %34 = insertvalue {i64, i1} undef, i64 %33, 0 
+  %35 = insertvalue {i64, i1} %34, i1 1, 1 
+  ret {i64, i1} %35 
 if.else3:
-  %44 = icmp eq i8 %"action##0", 117 
-  br i1 %44, label %if.then4, label %if.else4 
+  %36 = icmp eq i8 %"action##0", 117 
+  br i1 %36, label %if.then4, label %if.else4 
 if.then4:
-  %45 = add   i64 %"d##0", 16 
-  %46 = inttoptr i64 %45 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  %48 = load  i64, i64* %47 
-  %49 = add   i64 %48, 1 
-  %50 = add   i64 %"d##0", 16 
-  %51 = inttoptr i64 %50 to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %49, i64* %52 
+  %37 = add   i64 %"d##0", 16 
+  %38 = inttoptr i64 %37 to i64* 
+  %39 = load  i64, i64* %38 
+  %40 = add   i64 %39, 1 
+  %41 = add   i64 %"d##0", 16 
+  %42 = inttoptr i64 %41 to i64* 
+  store  i64 %40, i64* %42 
+  %43 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %44 = insertvalue {i64, i1} undef, i64 %43, 0 
+  %45 = insertvalue {i64, i1} %44, i1 1, 1 
+  ret {i64, i1} %45 
+if.else4:
+  %46 = icmp eq i8 %"action##0", 100 
+  br i1 %46, label %if.then5, label %if.else5 
+if.then5:
+  %47 = add   i64 %"d##0", 16 
+  %48 = inttoptr i64 %47 to i64* 
+  %49 = load  i64, i64* %48 
+  %50 = sub   i64 %49, 1 
+  %51 = add   i64 %"d##0", 16 
+  %52 = inttoptr i64 %51 to i64* 
+  store  i64 %50, i64* %52 
   %53 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
   %54 = insertvalue {i64, i1} undef, i64 %53, 0 
   %55 = insertvalue {i64, i1} %54, i1 1, 1 
   ret {i64, i1} %55 
-if.else4:
-  %56 = icmp eq i8 %"action##0", 100 
-  br i1 %56, label %if.then5, label %if.else5 
-if.then5:
-  %57 = add   i64 %"d##0", 16 
-  %58 = inttoptr i64 %57 to i64* 
-  %59 = getelementptr  i64, i64* %58, i64 0 
-  %60 = load  i64, i64* %59 
-  %61 = sub   i64 %60, 1 
-  %62 = add   i64 %"d##0", 16 
-  %63 = inttoptr i64 %62 to i64* 
-  %64 = getelementptr  i64, i64* %63, i64 0 
-  store  i64 %61, i64* %64 
-  %65 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %66 = insertvalue {i64, i1} undef, i64 %65, 0 
-  %67 = insertvalue {i64, i1} %66, i1 1, 1 
-  ret {i64, i1} %67 
 if.else5:
-  %68 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  0)  
-  %69 = insertvalue {i64, i1} undef, i64 %68, 0 
-  %70 = insertvalue {i64, i1} %69, i1 0, 1 
-  ret {i64, i1} %70 
+  %56 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  0)  
+  %57 = insertvalue {i64, i1} undef, i64 %56, 0 
+  %58 = insertvalue {i64, i1} %57, i1 0, 1 
+  ret {i64, i1} %58 
 }
 
 
@@ -1618,20 +1590,16 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
   store  i64 0, i64* %7 
-  %8 = add   i64 %2, 16 
+  %8 = add   i64 %2, 24 
   %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 0, i64* %10 
-  %11 = add   i64 %2, 24 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 0, i64* %13 
+  store  i64 0, i64* %9 
   ret i64 %2 
 }
 
@@ -1652,21 +1620,19 @@ entry:
 if.then:
   %0 = add   i64 %"d##0", 24 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %3, 1 
-  %5 = trunc i64 32 to i32  
-  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
-  %7 = ptrtoint i8* %6 to i64 
-  %8 = inttoptr i64 %7 to i8* 
-  %9 = inttoptr i64 %"d##0" to i8* 
-  %10 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
-  %11 = add   i64 %7, 24 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %4, i64* %13 
-  ret i64 %7 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %2, 1 
+  %4 = trunc i64 32 to i32  
+  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
+  %6 = ptrtoint i8* %5 to i64 
+  %7 = inttoptr i64 %6 to i8* 
+  %8 = inttoptr i64 %"d##0" to i8* 
+  %9 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
+  %10 = add   i64 %6, 24 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 %3, i64* %11 
+  ret i64 %6 
 if.else:
   ret i64 %"d##0" 
 }
@@ -1678,13 +1644,11 @@ entry:
 if.then:
   %0 = add   i64 %"d##0", 24 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %3, 1 
-  %5 = add   i64 %"d##0", 24 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %4, i64* %7 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %2, 1 
+  %4 = add   i64 %"d##0", 24 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %3, i64* %5 
   ret i64 %"d##0" 
 if.else:
   ret i64 %"d##0" 
@@ -1732,43 +1696,39 @@ if.else:
 if.then1:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.3, i32 0, i32 0) to i64))  
   %4 = inttoptr i64 %"d##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.5, i32 0, i32 0) to i64))  
-  %7 = add   i64 %"d##0", 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %6 = add   i64 %"d##0", 8 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  tail call ccc  void  @print_int(i64  %8)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.5, i32 0, i32 0) to i64))  
-  %11 = add   i64 %"d##0", 16 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
+  %9 = add   i64 %"d##0", 16 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.7, i32 0, i32 0) to i64))  
+  %12 = add   i64 %"d##0", 24 
+  %13 = inttoptr i64 %12 to i64* 
   %14 = load  i64, i64* %13 
   tail call ccc  void  @print_int(i64  %14)  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.7, i32 0, i32 0) to i64))  
-  %15 = add   i64 %"d##0", 24 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  %18 = load  i64, i64* %17 
-  tail call ccc  void  @print_int(i64  %18)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.else1:
-  %19 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
-  %20 = extractvalue {i64, i1} %19, 0 
-  %21 = extractvalue {i64, i1} %19, 1 
-  %22 = icmp eq i1 %21, 0 
-  br i1 %22, label %if.then2, label %if.else2 
+  %15 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
+  %16 = extractvalue {i64, i1} %15, 0 
+  %17 = extractvalue {i64, i1} %15, 1 
+  %18 = icmp eq i1 %17, 0 
+  br i1 %18, label %if.then2, label %if.else2 
 if.then2:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %20)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %16)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %20)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %16)  
   ret void 
 }
 
@@ -1788,43 +1748,39 @@ if.else:
 if.then1:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.3, i32 0, i32 0) to i64))  
   %4 = inttoptr i64 %"d##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.5, i32 0, i32 0) to i64))  
-  %7 = add   i64 %"d##0", 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %6 = add   i64 %"d##0", 8 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  tail call ccc  void  @print_int(i64  %8)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.5, i32 0, i32 0) to i64))  
-  %11 = add   i64 %"d##0", 16 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
+  %9 = add   i64 %"d##0", 16 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.7, i32 0, i32 0) to i64))  
+  %12 = add   i64 %"d##0", 24 
+  %13 = inttoptr i64 %12 to i64* 
   %14 = load  i64, i64* %13 
   tail call ccc  void  @print_int(i64  %14)  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.7, i32 0, i32 0) to i64))  
-  %15 = add   i64 %"d##0", 24 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  %18 = load  i64, i64* %17 
-  tail call ccc  void  @print_int(i64  %18)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.else1:
-  %19 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
-  %20 = extractvalue {i64, i1} %19, 0 
-  %21 = extractvalue {i64, i1} %19, 1 
-  %22 = icmp eq i1 %21, 0 
-  br i1 %22, label %if.then2, label %if.else2 
+  %15 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
+  %16 = extractvalue {i64, i1} %15, 0 
+  %17 = extractvalue {i64, i1} %15, 1 
+  %18 = icmp eq i1 %17, 0 
+  br i1 %18, label %if.then2, label %if.else2 
 if.then2:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %20)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %16)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %20)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %16)  
   ret void 
 }
 
@@ -1833,27 +1789,23 @@ define external fastcc  void @"drone.print_info<0>"(i64  %"d##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.3, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"d##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.5, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"d##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"d##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.5, i32 0, i32 0) to i64))  
-  %7 = add   i64 %"d##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
+  %5 = add   i64 %"d##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  tail call ccc  void  @print_int(i64  %7)  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"d##0", 24 
+  %9 = inttoptr i64 %8 to i64* 
   %10 = load  i64, i64* %9 
   tail call ccc  void  @print_int(i64  %10)  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.7, i32 0, i32 0) to i64))  
-  %11 = add   i64 %"d##0", 24 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  tail call ccc  void  @print_int(i64  %14)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -2050,50 +2002,42 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"drone.drone_info.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#left##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#left##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"#left##0", 24 
+  %9 = inttoptr i64 %8 to i64* 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"#left##0", 24 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  %15 = inttoptr i64 %"#right##0" to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#right##0", 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
+  %11 = inttoptr i64 %"#right##0" to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"#right##0", 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = add   i64 %"#right##0", 16 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = load  i64, i64* %17 
+  %19 = add   i64 %"#right##0", 24 
+  %20 = inttoptr i64 %19 to i64* 
   %21 = load  i64, i64* %20 
-  %22 = add   i64 %"#right##0", 16 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  %25 = load  i64, i64* %24 
-  %26 = add   i64 %"#right##0", 24 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  %29 = load  i64, i64* %28 
-  %30 = icmp eq i64 %2, %17 
-  br i1 %30, label %if.then, label %if.else 
+  %22 = icmp eq i64 %1, %12 
+  br i1 %22, label %if.then, label %if.else 
 if.then:
-  %31 = icmp eq i64 %6, %21 
-  br i1 %31, label %if.then1, label %if.else1 
+  %23 = icmp eq i64 %4, %15 
+  br i1 %23, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %32 = icmp eq i64 %10, %25 
-  br i1 %32, label %if.then2, label %if.else2 
+  %24 = icmp eq i64 %7, %18 
+  br i1 %24, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %33 = icmp eq i64 %14, %29 
-  ret i1 %33 
+  %25 = icmp eq i64 %10, %21 
+  ret i1 %25 
 if.else2:
   ret i1 0 
 }
@@ -2103,9 +2047,8 @@ define external fastcc  i64 @"drone.drone_info.count<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 24 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -2120,8 +2063,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 24 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -2132,20 +2074,16 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
-  %8 = add   i64 %2, 16 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"z##0", i64* %7 
+  %8 = add   i64 %2, 24 
   %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"z##0", i64* %10 
-  %11 = add   i64 %2, 24 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"count##0", i64* %13 
+  store  i64 %"count##0", i64* %9 
   ret i64 %2 
 }
 
@@ -2153,34 +2091,29 @@ entry:
 define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#result##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#result##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"#result##0", 24 
+  %9 = inttoptr i64 %8 to i64* 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"#result##0", 24 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  %15 = insertvalue {i64, i64, i64, i64} undef, i64 %2, 0 
-  %16 = insertvalue {i64, i64, i64, i64} %15, i64 %6, 1 
-  %17 = insertvalue {i64, i64, i64, i64} %16, i64 %10, 2 
-  %18 = insertvalue {i64, i64, i64, i64} %17, i64 %14, 3 
-  ret {i64, i64, i64, i64} %18 
+  %11 = insertvalue {i64, i64, i64, i64} undef, i64 %1, 0 
+  %12 = insertvalue {i64, i64, i64, i64} %11, i64 %4, 1 
+  %13 = insertvalue {i64, i64, i64, i64} %12, i64 %7, 2 
+  %14 = insertvalue {i64, i64, i64, i64} %13, i64 %10, 3 
+  ret {i64, i64, i64, i64} %14 
 }
 
 
 define external fastcc  i64 @"drone.drone_info.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -2194,8 +2127,7 @@ entry:
   %5 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -2204,9 +2136,8 @@ define external fastcc  i64 @"drone.drone_info.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -2221,8 +2152,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -2231,9 +2161,8 @@ define external fastcc  i64 @"drone.drone_info.z<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -2248,8 +2177,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 16 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -2257,56 +2185,48 @@ entry:
 define external fastcc  i1 @"drone.drone_info.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#left##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#left##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"#left##0", 24 
+  %9 = inttoptr i64 %8 to i64* 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"#left##0", 24 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  %15 = inttoptr i64 %"#right##0" to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#right##0", 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
+  %11 = inttoptr i64 %"#right##0" to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"#right##0", 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = add   i64 %"#right##0", 16 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = load  i64, i64* %17 
+  %19 = add   i64 %"#right##0", 24 
+  %20 = inttoptr i64 %19 to i64* 
   %21 = load  i64, i64* %20 
-  %22 = add   i64 %"#right##0", 16 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  %25 = load  i64, i64* %24 
-  %26 = add   i64 %"#right##0", 24 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  %29 = load  i64, i64* %28 
-  %30 = icmp eq i64 %2, %17 
-  br i1 %30, label %if.then, label %if.else 
+  %22 = icmp eq i64 %1, %12 
+  br i1 %22, label %if.then, label %if.else 
 if.then:
-  %31 = icmp eq i64 %6, %21 
-  br i1 %31, label %if.then1, label %if.else1 
+  %23 = icmp eq i64 %4, %15 
+  br i1 %23, label %if.then1, label %if.else1 
 if.else:
-  %37 = xor i1 0, 1 
-  ret i1 %37 
+  %29 = xor i1 0, 1 
+  ret i1 %29 
 if.then1:
-  %32 = icmp eq i64 %10, %25 
-  br i1 %32, label %if.then2, label %if.else2 
+  %24 = icmp eq i64 %7, %18 
+  br i1 %24, label %if.then2, label %if.else2 
 if.else1:
-  %36 = xor i1 0, 1 
-  ret i1 %36 
+  %28 = xor i1 0, 1 
+  ret i1 %28 
 if.then2:
-  %33 = icmp eq i64 %29, %14 
-  %34 = xor i1 %33, 1 
-  ret i1 %34 
+  %25 = icmp eq i64 %21, %10 
+  %26 = xor i1 %25, 1 
+  ret i1 %26 
 if.else2:
-  %35 = xor i1 0, 1 
-  ret i1 %35 
+  %27 = xor i1 0, 1 
+  ret i1 %27 
 }
 
 ----------------------------------------------------------------------

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -239,22 +239,20 @@ entry:
   %3 = tail call ccc  i8*  @wybe_malloc(i32  %2)  
   %4 = ptrtoint i8* %3 to i64 
   %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  store  i64 %0, i64* %6 
-  %7 = add   i64 %4, 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %1, i64* %9 
+  store  i64 %0, i64* %5 
+  %6 = add   i64 %4, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %1, i64* %7 
   store  i64 %4, i64* @"resource#command_line.arguments" 
   store  i64 ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.0, i32 0, i32 0) to i64), i64* @"resource#command_line.command" 
-  %10 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
-  %11 = extractvalue {i64, i64, i1} %10, 0 
-  %12 = extractvalue {i64, i64, i1} %10, 1 
-  %13 = extractvalue {i64, i64, i1} %10, 2 
-  br i1 %13, label %if.then, label %if.else 
+  %8 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
+  %9 = extractvalue {i64, i64, i1} %8, 0 
+  %10 = extractvalue {i64, i64, i1} %8, 1 
+  %11 = extractvalue {i64, i64, i1} %8, 2 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  store  i64 %12, i64* @"resource#command_line.arguments" 
-  store  i64 %11, i64* @"resource#command_line.command" 
+  store  i64 %10, i64* @"resource#command_line.arguments" 
+  store  i64 %9, i64* @"resource#command_line.command" 
   store  i64 0, i64* @"resource#command_line.exit_code" 
   ret void 
 if.else:
@@ -1188,22 +1186,20 @@ entry:
   %3 = tail call ccc  i8*  @wybe_malloc(i32  %2)  
   %4 = ptrtoint i8* %3 to i64 
   %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  store  i64 %0, i64* %6 
-  %7 = add   i64 %4, 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %1, i64* %9 
+  store  i64 %0, i64* %5 
+  %6 = add   i64 %4, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %1, i64* %7 
   store  i64 %4, i64* @"resource#command_line.arguments" 
   store  i64 ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.0, i32 0, i32 0) to i64), i64* @"resource#command_line.command" 
-  %10 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
-  %11 = extractvalue {i64, i64, i1} %10, 0 
-  %12 = extractvalue {i64, i64, i1} %10, 1 
-  %13 = extractvalue {i64, i64, i1} %10, 2 
-  br i1 %13, label %if.then, label %if.else 
+  %8 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
+  %9 = extractvalue {i64, i64, i1} %8, 0 
+  %10 = extractvalue {i64, i64, i1} %8, 1 
+  %11 = extractvalue {i64, i64, i1} %8, 2 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  store  i64 %12, i64* @"resource#command_line.arguments" 
-  store  i64 %11, i64* @"resource#command_line.command" 
+  store  i64 %10, i64* @"resource#command_line.arguments" 
+  store  i64 %9, i64* @"resource#command_line.command" 
   store  i64 0, i64* @"resource#command_line.exit_code" 
   ret void 
 if.else:
@@ -1778,16 +1774,14 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"v##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = alloca i64 
-   call fastcc  void  @"int_list.extend<0>"(i64  %"lst##0", i64  %2, i64*  %8)  
-  %9 = load  i64, i64* %8 
-  ret i64 %9 
+  store  i64 %"v##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = alloca i64 
+   call fastcc  void  @"int_list.extend<0>"(i64  %"lst##0", i64  %2, i64*  %6)  
+  %7 = load  i64, i64* %6 
+  ret i64 %7 
 }
 
 
@@ -1797,16 +1791,14 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"v##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = alloca i64 
-   call fastcc  void  @"int_list.extend<0>[410bae77d3]"(i64  %"lst##0", i64  %2, i64*  %8)  
-  %9 = load  i64, i64* %8 
-  ret i64 %9 
+  store  i64 %"v##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = alloca i64 
+   call fastcc  void  @"int_list.extend<0>[410bae77d3]"(i64  %"lst##0", i64  %2, i64*  %6)  
+  %7 = load  i64, i64* %6 
+  ret i64 %7 
 }
 
 
@@ -1816,22 +1808,20 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = tail call fastcc  i64  @"int_list.count<0>"(i64  %7, i64  %"x##0")  
-  %9 = icmp eq i64 %3, %"x##0" 
-  br i1 %9, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = tail call fastcc  i64  @"int_list.count<0>"(i64  %5, i64  %"x##0")  
+  %7 = icmp eq i64 %2, %"x##0" 
+  br i1 %7, label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %10 = add   i64 %8, 1 
-  ret i64 %10 
-if.else1:
+  %8 = add   i64 %6, 1 
   ret i64 %8 
+if.else1:
+  ret i64 %6 
 }
 
 
@@ -1841,22 +1831,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst1##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst1##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst1##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  store  i64 %10, i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.extend<0>"(i64  %7, i64  %"lst2##0", i64*  %14)  
+  store  i64 %8, i64* %"#result##0" 
+  musttail call fastcc  void  @"int_list.extend<0>"(i64  %5, i64  %"lst2##0", i64*  %11)  
   ret void 
 if.else:
   store  i64 %"lst2##0", i64* %"#result##0" 
@@ -1871,12 +1858,11 @@ entry:
 if.then:
   %1 = add   i64 %"lst1##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"lst1##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"lst1##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
   store  i64 %"lst1##0", i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.extend<0>[410bae77d3]"(i64  %4, i64  %"lst2##0", i64*  %6)  
+  musttail call fastcc  void  @"int_list.extend<0>[410bae77d3]"(i64  %3, i64  %"lst2##0", i64*  %5)  
   ret void 
 if.else:
   store  i64 %"lst2##0", i64* %"#result##0" 
@@ -1900,18 +1886,16 @@ if.then:
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"start##0", i64* %5 
-  %6 = add   i64 %3, 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"result##0", i64* %8 
-  %9 = add   i64 %"start##0", %"step##0" 
-  %10 = musttail call fastcc  i64  @"int_list.gen#2<0>"(i64  %3, i64  %9, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
-  ret i64 %10 
+  store  i64 %"start##0", i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %"result##0", i64* %6 
+  %7 = add   i64 %"start##0", %"step##0" 
+  %8 = musttail call fastcc  i64  @"int_list.gen#2<0>"(i64  %3, i64  %7, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
+  ret i64 %8 
 if.else:
-  %11 = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"result##0", i64  0)  
-  ret i64 %11 
+  %9 = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"result##0", i64  0)  
+  ret i64 %9 
 }
 
 
@@ -1924,18 +1908,16 @@ if.then:
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"start##0", i64* %5 
-  %6 = add   i64 %3, 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"result##0", i64* %8 
-  %9 = add   i64 %"start##0", %"step##0" 
-  %10 = musttail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  %3, i64  %9, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
-  ret i64 %10 
+  store  i64 %"start##0", i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %"result##0", i64* %6 
+  %7 = add   i64 %"start##0", %"step##0" 
+  %8 = musttail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  %3, i64  %7, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
+  ret i64 %8 
 if.else:
-  %11 = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"result##0", i64  0)  
-  ret i64 %11 
+  %9 = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"result##0", i64  0)  
+  ret i64 %9 
 }
 
 
@@ -1945,15 +1927,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"start##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"result##0", i64* %7 
-  %8 = add   i64 %"start##0", %"step##0" 
-  %9 = musttail call fastcc  i64  @"int_list.gen#2<0>"(i64  %2, i64  %8, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
-  ret i64 %9 
+  store  i64 %"start##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"result##0", i64* %5 
+  %6 = add   i64 %"start##0", %"step##0" 
+  %7 = musttail call fastcc  i64  @"int_list.gen#2<0>"(i64  %2, i64  %6, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
+  ret i64 %7 
 }
 
 
@@ -1963,31 +1943,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp sge i64 %3, %"v##0" 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp sge i64 %2, %"v##0" 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   store  i64 0, i64* %"#result##0" 
   ret void 
 if.then1:
-  %9 = trunc i64 16 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i64* 
+  store  i64 %2, i64* %10 
+  %11 = add   i64 %9, 8 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %3, i64* %13 
-  %14 = add   i64 %11, 8 
-  %15 = inttoptr i64 %14 to i64* 
-  store  i64 %11, i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.greater<0>"(i64  %7, i64  %"v##0", i64*  %15)  
+  store  i64 %9, i64* %"#result##0" 
+  musttail call fastcc  void  @"int_list.greater<0>"(i64  %5, i64  %"v##0", i64*  %12)  
   ret void 
 if.else1:
-  musttail call fastcc  void  @"int_list.greater<0>"(i64  %7, i64  %"v##0", i64*  %"#result##0")  
+  musttail call fastcc  void  @"int_list.greater<0>"(i64  %5, i64  %"v##0", i64*  %"#result##0")  
   ret void 
 }
 
@@ -1998,25 +1975,23 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp sge i64 %3, %"v##0" 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp sge i64 %2, %"v##0" 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   store  i64 0, i64* %"#result##0" 
   ret void 
 if.then1:
-  %9 = add   i64 %"lst##0", 8 
-  %10 = inttoptr i64 %9 to i64* 
+  %7 = add   i64 %"lst##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 %"lst##0", i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.greater<0>[410bae77d3]"(i64  %7, i64  %"v##0", i64*  %10)  
+  musttail call fastcc  void  @"int_list.greater<0>[410bae77d3]"(i64  %5, i64  %"v##0", i64*  %8)  
   ret void 
 if.else1:
-  musttail call fastcc  void  @"int_list.greater<0>[410bae77d3]"(i64  %7, i64  %"v##0", i64*  %"#result##0")  
+  musttail call fastcc  void  @"int_list.greater<0>[410bae77d3]"(i64  %5, i64  %"v##0", i64*  %"#result##0")  
   ret void 
 }
 
@@ -2034,22 +2009,20 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, %"x##0" 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, %"x##0" 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret i64 -1 
 if.then1:
   ret i64 %"idx##0" 
 if.else1:
-  %9 = add   i64 %"idx##0", 1 
-  %10 = musttail call fastcc  i64  @"int_list.index_helper<0>"(i64  %7, i64  %9, i64  %"x##0")  
-  ret i64 %10 
+  %7 = add   i64 %"idx##0", 1 
+  %8 = musttail call fastcc  i64  @"int_list.index_helper<0>"(i64  %5, i64  %7, i64  %"x##0")  
+  ret i64 %8 
 }
 
 
@@ -2062,40 +2035,35 @@ if.then:
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"v##0", i64* %5 
-  %6 = add   i64 %3, 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"lst##0", i64* %8 
+  store  i64 %"v##0", i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %"lst##0", i64* %6 
   store  i64 %3, i64* %"#result##0" 
   ret void 
 if.else:
-  %9 = icmp ne i64 %"lst##0", 0 
-  br i1 %9, label %if.then1, label %if.else1 
+  %7 = icmp ne i64 %"lst##0", 0 
+  br i1 %7, label %if.then1, label %if.else1 
 if.then1:
-  %10 = inttoptr i64 %"lst##0" to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
+  %8 = inttoptr i64 %"lst##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %"lst##0", 8 
+  %11 = inttoptr i64 %10 to i64* 
   %12 = load  i64, i64* %11 
-  %13 = add   i64 %"lst##0", 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  %16 = load  i64, i64* %15 
-  %17 = sub   i64 %"idx##0", 1 
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %12, i64* %22 
-  %23 = add   i64 %20, 8 
-  %24 = inttoptr i64 %23 to i64* 
-  store  i64 %20, i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.insert<0>"(i64  %16, i64  %17, i64  %"v##0", i64*  %24)  
+  %13 = sub   i64 %"idx##0", 1 
+  %14 = trunc i64 16 to i32  
+  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
+  %16 = ptrtoint i8* %15 to i64 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %9, i64* %17 
+  %18 = add   i64 %16, 8 
+  %19 = inttoptr i64 %18 to i64* 
+  store  i64 %16, i64* %"#result##0" 
+  musttail call fastcc  void  @"int_list.insert<0>"(i64  %12, i64  %13, i64  %"v##0", i64*  %19)  
   ret void 
 if.else1:
-  %25 = sub   i64 %"idx##0", 1 
-  musttail call fastcc  void  @"int_list.insert<0>"(i64  %"lst##0", i64  %25, i64  %"v##0", i64*  %"#result##0")  
+  %20 = sub   i64 %"idx##0", 1 
+  musttail call fastcc  void  @"int_list.insert<0>"(i64  %"lst##0", i64  %20, i64  %"v##0", i64*  %"#result##0")  
   ret void 
 }
 
@@ -2109,31 +2077,28 @@ if.then:
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"v##0", i64* %5 
-  %6 = add   i64 %3, 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"lst##0", i64* %8 
+  store  i64 %"v##0", i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %"lst##0", i64* %6 
   store  i64 %3, i64* %"#result##0" 
   ret void 
 if.else:
-  %9 = icmp ne i64 %"lst##0", 0 
-  br i1 %9, label %if.then1, label %if.else1 
+  %7 = icmp ne i64 %"lst##0", 0 
+  br i1 %7, label %if.then1, label %if.else1 
 if.then1:
-  %10 = add   i64 %"lst##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = sub   i64 %"idx##0", 1 
-  %15 = add   i64 %"lst##0", 8 
-  %16 = inttoptr i64 %15 to i64* 
+  %8 = add   i64 %"lst##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = load  i64, i64* %9 
+  %11 = sub   i64 %"idx##0", 1 
+  %12 = add   i64 %"lst##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
   store  i64 %"lst##0", i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.insert<0>[410bae77d3]"(i64  %13, i64  %14, i64  %"v##0", i64*  %16)  
+  musttail call fastcc  void  @"int_list.insert<0>[410bae77d3]"(i64  %10, i64  %11, i64  %"v##0", i64*  %13)  
   ret void 
 if.else1:
-  %17 = sub   i64 %"idx##0", 1 
-  musttail call fastcc  void  @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %17, i64  %"v##0", i64*  %"#result##0")  
+  %14 = sub   i64 %"idx##0", 1 
+  musttail call fastcc  void  @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %14, i64  %"v##0", i64*  %"#result##0")  
   ret void 
 }
 
@@ -2144,31 +2109,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp slt i64 %3, %"v##0" 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp slt i64 %2, %"v##0" 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   store  i64 0, i64* %"#result##0" 
   ret void 
 if.then1:
-  %9 = trunc i64 16 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i64* 
+  store  i64 %2, i64* %10 
+  %11 = add   i64 %9, 8 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %3, i64* %13 
-  %14 = add   i64 %11, 8 
-  %15 = inttoptr i64 %14 to i64* 
-  store  i64 %11, i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.lesser<0>"(i64  %7, i64  %"v##0", i64*  %15)  
+  store  i64 %9, i64* %"#result##0" 
+  musttail call fastcc  void  @"int_list.lesser<0>"(i64  %5, i64  %"v##0", i64*  %12)  
   ret void 
 if.else1:
-  musttail call fastcc  void  @"int_list.lesser<0>"(i64  %7, i64  %"v##0", i64*  %"#result##0")  
+  musttail call fastcc  void  @"int_list.lesser<0>"(i64  %5, i64  %"v##0", i64*  %"#result##0")  
   ret void 
 }
 
@@ -2179,32 +2141,29 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %"idx##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %"idx##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   store  i64 0, i64* %"#result##0" 
   ret void 
 if.then1:
-  store  i64 %7, i64* %"#result##0" 
+  store  i64 %5, i64* %"#result##0" 
   ret void 
 if.else1:
-  %9 = sub   i64 %"idx##0", 1 
-  %10 = trunc i64 16 to i32  
-  %11 = tail call ccc  i8*  @wybe_malloc(i32  %10)  
-  %12 = ptrtoint i8* %11 to i64 
+  %7 = sub   i64 %"idx##0", 1 
+  %8 = trunc i64 16 to i32  
+  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
+  %10 = ptrtoint i8* %9 to i64 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 %2, i64* %11 
+  %12 = add   i64 %10, 8 
   %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 %3, i64* %14 
-  %15 = add   i64 %12, 8 
-  %16 = inttoptr i64 %15 to i64* 
-  store  i64 %12, i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.pop<0>"(i64  %7, i64  %9, i64*  %16)  
+  store  i64 %10, i64* %"#result##0" 
+  musttail call fastcc  void  @"int_list.pop<0>"(i64  %5, i64  %7, i64*  %13)  
   ret void 
 }
 
@@ -2216,22 +2175,21 @@ entry:
 if.then:
   %1 = add   i64 %"lst##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = icmp eq i64 %"idx##0", 0 
-  br i1 %5, label %if.then1, label %if.else1 
+  %3 = load  i64, i64* %2 
+  %4 = icmp eq i64 %"idx##0", 0 
+  br i1 %4, label %if.then1, label %if.else1 
 if.else:
   store  i64 0, i64* %"#result##0" 
   ret void 
 if.then1:
-  store  i64 %4, i64* %"#result##0" 
+  store  i64 %3, i64* %"#result##0" 
   ret void 
 if.else1:
-  %6 = sub   i64 %"idx##0", 1 
-  %7 = add   i64 %"lst##0", 8 
-  %8 = inttoptr i64 %7 to i64* 
+  %5 = sub   i64 %"idx##0", 1 
+  %6 = add   i64 %"lst##0", 8 
+  %7 = inttoptr i64 %6 to i64* 
   store  i64 %"lst##0", i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.pop<0>[410bae77d3]"(i64  %4, i64  %6, i64*  %8)  
+  musttail call fastcc  void  @"int_list.pop<0>[410bae77d3]"(i64  %3, i64  %5, i64*  %7)  
   ret void 
 }
 
@@ -2242,15 +2200,13 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  tail call ccc  void  @print_int(i64  %3)  
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"x##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  32)  
-  musttail call fastcc  void  @"int_list.print<0>"(i64  %7)  
+  musttail call fastcc  void  @"int_list.print<0>"(i64  %5)  
   ret void 
 if.else:
   ret void 
@@ -2278,31 +2234,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, %"v##0" 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, %"v##0" 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   store  i64 0, i64* %"#result##0" 
   ret void 
 if.then1:
-  store  i64 %7, i64* %"#result##0" 
+  store  i64 %5, i64* %"#result##0" 
   ret void 
 if.else1:
-  %9 = trunc i64 16 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i64* 
+  store  i64 %2, i64* %10 
+  %11 = add   i64 %9, 8 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %3, i64* %13 
-  %14 = add   i64 %11, 8 
-  %15 = inttoptr i64 %14 to i64* 
-  store  i64 %11, i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.remove<0>"(i64  %7, i64  %"v##0", i64*  %15)  
+  store  i64 %9, i64* %"#result##0" 
+  musttail call fastcc  void  @"int_list.remove<0>"(i64  %5, i64  %"v##0", i64*  %12)  
   ret void 
 }
 
@@ -2313,25 +2266,23 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, %"v##0" 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, %"v##0" 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   store  i64 0, i64* %"#result##0" 
   ret void 
 if.then1:
-  store  i64 %7, i64* %"#result##0" 
+  store  i64 %5, i64* %"#result##0" 
   ret void 
 if.else1:
-  %9 = add   i64 %"lst##0", 8 
-  %10 = inttoptr i64 %9 to i64* 
+  %7 = add   i64 %"lst##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 %"lst##0", i64* %"#result##0" 
-  musttail call fastcc  void  @"int_list.remove<0>[410bae77d3]"(i64  %7, i64  %"v##0", i64*  %10)  
+  musttail call fastcc  void  @"int_list.remove<0>[410bae77d3]"(i64  %5, i64  %"v##0", i64*  %8)  
   ret void 
 }
 
@@ -2349,24 +2300,20 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"acc##0", i64* %15 
-  %16 = musttail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %7, i64  %10)  
-  ret i64 %16 
+  store  i64 %"acc##0", i64* %11 
+  %12 = musttail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %5, i64  %8)  
+  ret i64 %12 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -2379,14 +2326,12 @@ entry:
 if.then:
   %1 = add   i64 %"lst##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"lst##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"acc##0", i64* %7 
-  %8 = musttail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %4, i64  %"lst##0")  
-  ret i64 %8 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"lst##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"acc##0", i64* %5 
+  %6 = musttail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %3, i64  %"lst##0")  
+  ret i64 %6 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -2398,34 +2343,30 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = alloca i64 
+   call fastcc  void  @"int_list.lesser<0>"(i64  %5, i64  %2, i64*  %6)  
   %7 = load  i64, i64* %6 
-  %8 = alloca i64 
-   call fastcc  void  @"int_list.lesser<0>"(i64  %7, i64  %3, i64*  %8)  
-  %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %9)  
-  %11 = alloca i64 
-   call fastcc  void  @"int_list.greater<0>"(i64  %7, i64  %3, i64*  %11)  
-  %12 = load  i64, i64* %11 
-  %13 = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %12)  
-  %14 = trunc i64 16 to i32  
-  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
-  %16 = ptrtoint i8* %15 to i64 
+  %8 = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %7)  
+  %9 = alloca i64 
+   call fastcc  void  @"int_list.greater<0>"(i64  %5, i64  %2, i64*  %9)  
+  %10 = load  i64, i64* %9 
+  %11 = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %10)  
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 %2, i64* %15 
+  %16 = add   i64 %14, 8 
   %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %3, i64* %18 
-  %19 = add   i64 %16, 8 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 %13, i64* %21 
-  %22 = alloca i64 
-   call fastcc  void  @"int_list.extend<0>[410bae77d3]"(i64  %10, i64  %16, i64*  %22)  
-  %23 = load  i64, i64* %22 
-  ret i64 %23 
+  store  i64 %11, i64* %17 
+  %18 = alloca i64 
+   call fastcc  void  @"int_list.extend<0>[410bae77d3]"(i64  %8, i64  %14, i64*  %18)  
+  %19 = load  i64, i64* %18 
+  ret i64 %19 
 if.else:
   ret i64 0 
 }
@@ -2437,28 +2378,25 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = alloca i64 
+   call fastcc  void  @"int_list.lesser<0>"(i64  %5, i64  %2, i64*  %6)  
   %7 = load  i64, i64* %6 
-  %8 = alloca i64 
-   call fastcc  void  @"int_list.lesser<0>"(i64  %7, i64  %3, i64*  %8)  
-  %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %9)  
-  %11 = alloca i64 
-   call fastcc  void  @"int_list.greater<0>[410bae77d3]"(i64  %7, i64  %3, i64*  %11)  
-  %12 = load  i64, i64* %11 
-  %13 = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %12)  
-  %14 = add   i64 %"lst##0", 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 %13, i64* %16 
-  %17 = alloca i64 
-   call fastcc  void  @"int_list.extend<0>[410bae77d3]"(i64  %10, i64  %"lst##0", i64*  %17)  
-  %18 = load  i64, i64* %17 
-  ret i64 %18 
+  %8 = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %7)  
+  %9 = alloca i64 
+   call fastcc  void  @"int_list.greater<0>[410bae77d3]"(i64  %5, i64  %2, i64*  %9)  
+  %10 = load  i64, i64* %9 
+  %11 = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %10)  
+  %12 = add   i64 %"lst##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 %11, i64* %13 
+  %14 = alloca i64 
+   call fastcc  void  @"int_list.extend<0>[410bae77d3]"(i64  %8, i64  %"lst##0", i64*  %14)  
+  %15 = load  i64, i64* %14 
+  ret i64 %15 
 if.else:
   ret i64 0 
 }
@@ -2641,32 +2579,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"#right##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"#right##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
-  %18 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %18 
+  %14 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %14 
 if.then1:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"#right##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#right##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#right##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp eq i64 %3, %11 
-  br i1 %16, label %if.then2, label %if.else2 
+  %12 = icmp eq i64 %2, %8 
+  br i1 %12, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %17 = musttail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %15)  
-  ret i1 %17 
+  %13 = musttail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %5, i64  %11)  
+  ret i1 %13 
 if.else2:
   ret i1 0 
 }
@@ -2678,12 +2612,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"head##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"tail##0", i64* %7 
+  store  i64 %"head##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"tail##0", i64* %5 
   ret i64 %2 
 }
 
@@ -2694,21 +2626,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -2718,15 +2648,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -2743,15 +2672,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -2768,15 +2696,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -2794,15 +2721,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -281,35 +281,32 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 101, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 102, i64* %7 
-  %8 = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %2)  
+  store  i64 101, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 102, i64* %5 
+  %6 = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.9, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
-  %9 = trunc i64 16 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
-  %12 = inttoptr i64 %11 to i8* 
-  %13 = inttoptr i64 %8 to i8* 
-  %14 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
-  %15 = inttoptr i64 %11 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 555, i64* %16 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i8* 
+  %11 = inttoptr i64 %6 to i8* 
+  %12 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %10, i8*  %11, i32  %12, i1  0)  
+  %13 = inttoptr i64 %9 to i64* 
+  store  i64 555, i64* %13 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.9, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.15, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
   ret void 
 }
 
@@ -320,53 +317,47 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 101, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 102, i64* %7 
-  %8 = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %2)  
+  store  i64 101, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 102, i64* %5 
+  %6 = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.17, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.9, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
-  %9 = add   i64 %8, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  %12 = load  i64, i64* %11 
-  %13 = trunc i64 16 to i32  
-  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
-  %15 = ptrtoint i8* %14 to i64 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  store  i64 33333333, i64* %17 
-  %18 = add   i64 %15, 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 %12, i64* %20 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
+  %7 = add   i64 %6, 8 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = trunc i64 16 to i32  
+  %11 = tail call ccc  i8*  @wybe_malloc(i32  %10)  
+  %12 = ptrtoint i8* %11 to i64 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 33333333, i64* %13 
+  %14 = add   i64 %12, 8 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 %9, i64* %15 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.19, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %15)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %12)  
+  %16 = trunc i64 16 to i32  
+  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
+  %18 = ptrtoint i8* %17 to i64 
+  %19 = inttoptr i64 %18 to i8* 
+  %20 = inttoptr i64 %2 to i8* 
   %21 = trunc i64 16 to i32  
-  %22 = tail call ccc  i8*  @wybe_malloc(i32  %21)  
-  %23 = ptrtoint i8* %22 to i64 
-  %24 = inttoptr i64 %23 to i8* 
-  %25 = inttoptr i64 %2 to i8* 
-  %26 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %24, i8*  %25, i32  %26, i1  0)  
-  %27 = inttoptr i64 %23 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 555, i64* %28 
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i1  0)  
+  %22 = inttoptr i64 %18 to i64* 
+  store  i64 555, i64* %22 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.21, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.23, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %23)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %18)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.19, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %15)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %12)  
   ret void 
 }
 
@@ -377,35 +368,32 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 101, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 102, i64* %7 
-  %8 = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %2)  
+  store  i64 101, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 102, i64* %5 
+  %6 = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.25, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.9, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
-  %9 = trunc i64 16 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
-  %12 = inttoptr i64 %11 to i8* 
-  %13 = inttoptr i64 %2 to i8* 
-  %14 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
-  %15 = inttoptr i64 %11 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 555, i64* %16 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i8* 
+  %11 = inttoptr i64 %2 to i8* 
+  %12 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %10, i8*  %11, i32  %12, i1  0)  
+  %13 = inttoptr i64 %9 to i64* 
+  store  i64 555, i64* %13 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.27, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.23, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
   ret void 
 }
 
@@ -416,17 +404,14 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.29, i32 0, i32 0) to i64))  
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %6 = inttoptr i64 %2 to i64* 
+  %7 = load  i64, i64* %6 
+  tail call ccc  void  @print_int(i64  %7)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -515,15 +500,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -647,24 +630,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -676,12 +655,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -689,24 +666,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -720,8 +694,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -730,9 +703,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -747,8 +719,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -756,26 +727,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -127,17 +127,15 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 20, i64* %7 
-  %8 = tail call fastcc  i64  @"alias2.pcopy<0>"(i64  %2)  
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 20, i64* %5 
+  %6 = tail call fastcc  i64  @"alias2.pcopy<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
   ret void 
 }
 
@@ -148,26 +146,20 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = inttoptr i64 %"p1##0" to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %2 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %10, i64* %12 
-  %13 = add   i64 %"p1##0", 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
-  %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %16, i64* %19 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = inttoptr i64 %"p1##0" to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = inttoptr i64 %2 to i64* 
+  store  i64 %7, i64* %8 
+  %9 = add   i64 %"p1##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %2, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 %11, i64* %13 
   ret i64 %2 
 }
 
@@ -178,26 +170,20 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = inttoptr i64 %"p1##0" to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %2 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %10, i64* %12 
-  %13 = add   i64 %"p1##0", 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
-  %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %16, i64* %19 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = inttoptr i64 %"p1##0" to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = inttoptr i64 %2 to i64* 
+  store  i64 %7, i64* %8 
+  %9 = add   i64 %"p1##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %2, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 %11, i64* %13 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.9, i32 0, i32 0) to i64))  
@@ -289,15 +275,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -421,24 +405,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -450,12 +430,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -463,24 +441,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -494,8 +469,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -504,9 +478,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -521,8 +494,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -530,26 +502,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -138,28 +138,25 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 1, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = tail call fastcc  i64  @"alias3.replicate1<0>"(i64  %2)  
+  store  i64 1, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = tail call fastcc  i64  @"alias3.replicate1<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
-  %9 = inttoptr i64 %2 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 555, i64* %10 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
+  %7 = inttoptr i64 %2 to i64* 
+  store  i64 555, i64* %7 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.9, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
   ret void 
 }
 
@@ -178,12 +175,10 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 2, i64* %7 
-  %8 = add   i64 %2, 8 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 2, i64* %10 
+  store  i64 2, i64* %6 
+  %7 = add   i64 %2, 8 
+  %8 = inttoptr i64 %7 to i64* 
+  store  i64 2, i64* %8 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.5, i32 0, i32 0) to i64))  
@@ -275,15 +270,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -407,24 +400,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -436,12 +425,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -449,24 +436,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -480,8 +464,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -490,9 +473,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -507,8 +489,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -516,26 +497,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -142,28 +142,25 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 100, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 100, i64* %7 
-  %8 = tail call fastcc  i64  @"alias4.replicate1<0>"(i64  %2)  
+  store  i64 100, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 100, i64* %5 
+  %6 = tail call fastcc  i64  @"alias4.replicate1<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
-  %9 = inttoptr i64 %2 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 555, i64* %10 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
+  %7 = inttoptr i64 %2 to i64* 
+  store  i64 555, i64* %7 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.9, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
   ret void 
 }
 
@@ -174,29 +171,23 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.11, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %6 = inttoptr i64 %2 to i64* 
+  %7 = load  i64, i64* %6 
+  tail call ccc  void  @print_int(i64  %7)  
   tail call ccc  void  @putchar(i8  10)  
-  %11 = inttoptr i64 %"p1##0" to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %13, i64* %15 
-  %16 = add   i64 %2, 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 200, i64* %18 
+  %8 = inttoptr i64 %"p1##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = inttoptr i64 %2 to i64* 
+  store  i64 %9, i64* %10 
+  %11 = add   i64 %2, 8 
+  %12 = inttoptr i64 %11 to i64* 
+  store  i64 200, i64* %12 
   ret i64 %2 
 }
 --------------------------------------------------
@@ -284,15 +275,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -416,24 +405,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -445,12 +430,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -458,24 +441,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -489,8 +469,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -499,9 +478,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -516,8 +494,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -525,26 +502,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -142,17 +142,15 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 100, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 900, i64* %7 
-  %8 = tail call fastcc  i64  @"alias_cyclic.updateX<0>"(i64  %2)  
+  store  i64 100, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 900, i64* %5 
+  %6 = tail call fastcc  i64  @"alias_cyclic.updateX<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_cyclic.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_cyclic.3, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
   ret void 
 }
 
@@ -160,9 +158,50 @@ entry:
 define external fastcc  i64 @"alias_cyclic.updateX<0>"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 101 
+  br i1 %2, label %if.then, label %if.else 
+if.then:
+  ret i64 %"p1##0" 
+if.else:
+  %3 = add   i64 %1, 1 
+  %4 = trunc i64 16 to i32  
+  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
+  %6 = ptrtoint i8* %5 to i64 
+  %7 = inttoptr i64 %6 to i8* 
+  %8 = inttoptr i64 %"p1##0" to i8* 
+  %9 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
+  %10 = inttoptr i64 %6 to i64* 
+  store  i64 %3, i64* %10 
+  %11 = musttail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %6)  
+  ret i64 %11 
+}
+
+
+define external fastcc  i64 @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")    {
+entry:
+  %0 = inttoptr i64 %"p1##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 101 
+  br i1 %2, label %if.then, label %if.else 
+if.then:
+  ret i64 %"p1##0" 
+if.else:
+  %3 = add   i64 %1, 1 
+  %4 = inttoptr i64 %"p1##0" to i64* 
+  store  i64 %3, i64* %4 
+  %5 = musttail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0")  
+  ret i64 %5 
+}
+
+
+define external fastcc  i64 @"alias_cyclic.updateY<0>"(i64  %"p1##0")    {
+entry:
+  %0 = add   i64 %"p1##0", 8 
+  %1 = inttoptr i64 %0 to i64* 
   %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 101 
+  %3 = icmp sgt i64 %2, 901 
   br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
@@ -175,58 +214,11 @@ if.else:
   %9 = inttoptr i64 %"p1##0" to i8* 
   %10 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
-  %11 = inttoptr i64 %7 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
+  %11 = add   i64 %7, 8 
+  %12 = inttoptr i64 %11 to i64* 
   store  i64 %4, i64* %12 
-  %13 = musttail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %7)  
+  %13 = musttail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %7)  
   ret i64 %13 
-}
-
-
-define external fastcc  i64 @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")    {
-entry:
-  %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 101 
-  br i1 %3, label %if.then, label %if.else 
-if.then:
-  ret i64 %"p1##0" 
-if.else:
-  %4 = add   i64 %2, 1 
-  %5 = inttoptr i64 %"p1##0" to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  store  i64 %4, i64* %6 
-  %7 = musttail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0")  
-  ret i64 %7 
-}
-
-
-define external fastcc  i64 @"alias_cyclic.updateY<0>"(i64  %"p1##0")    {
-entry:
-  %0 = add   i64 %"p1##0", 8 
-  %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 901 
-  br i1 %4, label %if.then, label %if.else 
-if.then:
-  ret i64 %"p1##0" 
-if.else:
-  %5 = add   i64 %3, 1 
-  %6 = trunc i64 16 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = inttoptr i64 %"p1##0" to i8* 
-  %11 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
-  %12 = add   i64 %8, 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 %5, i64* %14 
-  %15 = musttail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %8)  
-  ret i64 %15 
 }
 
 
@@ -234,20 +226,18 @@ define external fastcc  i64 @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0"
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 901 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 901 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = add   i64 %"p1##0", 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %5, i64* %8 
-  %9 = musttail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")  
-  ret i64 %9 
+  %4 = add   i64 %2, 1 
+  %5 = add   i64 %"p1##0", 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %4, i64* %6 
+  %7 = musttail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")  
+  ret i64 %7 
 }
 --------------------------------------------------
  Module position
@@ -334,15 +324,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -466,24 +454,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -495,12 +479,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -508,24 +490,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -539,8 +518,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -549,9 +527,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -566,8 +543,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -575,26 +551,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -110,28 +110,24 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 101, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.1, i32 0, i32 0) to i64), i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 101, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.1, i32 0, i32 0) to i64), i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 9401, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 9401, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
+  store  i64 %2, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %10)  
+  tail call fastcc  void  @"student.printStudent<0>"(i64  %8)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %10)  
+  tail call fastcc  void  @"student.printStudent<0>"(i64  %8)  
   ret void 
 }
 --------------------------------------------------
@@ -257,23 +253,19 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 90048, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.1, i32 0, i32 0) to i64), i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 90048, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.1, i32 0, i32 0) to i64), i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 12345, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 12345, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %10)  
+  store  i64 %2, i64* %11 
+  tail call fastcc  void  @"student.printStudent<0>"(i64  %8)  
   ret void 
 }
 
@@ -282,26 +274,22 @@ define external fastcc  void @"student.printStudent<0>"(i64  %"stu##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.3, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"stu##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call ccc  void  @putchar(i8  10)  
-  %3 = add   i64 %"stu##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
+  %2 = add   i64 %"stu##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.5, i32 0, i32 0) to i64))  
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  tail call ccc  void  @print_int(i64  %9)  
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  tail call ccc  void  @print_int(i64  %6)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.7, i32 0, i32 0) to i64))  
-  %10 = add   i64 %6, 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %13)  
+  %7 = add   i64 %4, 8 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  %9)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -427,24 +415,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"student.course.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  ret i1 %15 
+  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -453,9 +437,8 @@ if.else:
 define external fastcc  i64 @"student.course.code<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -469,8 +452,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -481,12 +463,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"code##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"name##0", i64* %7 
+  store  i64 %"code##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"name##0", i64* %5 
   ret i64 %2 
 }
 
@@ -494,15 +474,13 @@ entry:
 define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
@@ -510,9 +488,8 @@ define external fastcc  i64 @"student.course.name<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -527,8 +504,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -536,28 +512,24 @@ entry:
 define external fastcc  i1 @"student.course.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module student.student
@@ -704,43 +676,35 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"student.student.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = inttoptr i64 %6 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
+  %11 = inttoptr i64 %4 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %4, 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = inttoptr i64 %9 to i64* 
   %17 = load  i64, i64* %16 
-  %18 = add   i64 %6, 8 
+  %18 = add   i64 %9, 8 
   %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = inttoptr i64 %13 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = add   i64 %13, 8 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %29 = icmp eq i64 %24, %17 
-  br i1 %29, label %if.then1, label %if.else1 
+  %20 = load  i64, i64* %19 
+  %21 = icmp eq i64 %17, %12 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %30 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %21, i64  %28)  
-  ret i1 %30 
+  %22 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %15, i64  %20)  
+  ret i1 %22 
 if.else1:
   ret i1 0 
 }
@@ -749,9 +713,8 @@ if.else1:
 define external fastcc  i64 @"student.student.id<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -765,8 +728,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -775,9 +737,8 @@ define external fastcc  i64 @"student.student.major<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -792,8 +753,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -804,12 +764,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"id##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"major##0", i64* %7 
+  store  i64 %"id##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"major##0", i64* %5 
   ret i64 %2 
 }
 
@@ -817,61 +775,51 @@ entry:
 define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"student.student.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = inttoptr i64 %6 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
+  %11 = inttoptr i64 %4 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %4, 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = inttoptr i64 %9 to i64* 
   %17 = load  i64, i64* %16 
-  %18 = add   i64 %6, 8 
+  %18 = add   i64 %9, 8 
   %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = inttoptr i64 %13 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = add   i64 %13, 8 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %29 = icmp eq i64 %24, %17 
-  br i1 %29, label %if.then1, label %if.else1 
+  %20 = load  i64, i64* %19 
+  %21 = icmp eq i64 %17, %12 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
-  %33 = xor i1 0, 1 
-  ret i1 %33 
+  %25 = xor i1 0, 1 
+  ret i1 %25 
 if.then1:
-  %30 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %21, i64  %28)  
-  %31 = xor i1 %30, 1 
-  ret i1 %31 
+  %22 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %15, i64  %20)  
+  %23 = xor i1 %22, 1 
+  ret i1 %23 
 if.else1:
-  %32 = xor i1 0, 1 
-  ret i1 %32 
+  %24 = xor i1 0, 1 
+  ret i1 %24 
 }

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -101,8 +101,7 @@ define external fastcc  void @"alias_des.foo<0>"()    {
 entry:
   %0 = tail call fastcc  i64  @"alias_des.replicate<0>"()  
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  store  i64 20000, i64* %2 
+  store  i64 20000, i64* %1 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %0)  
   ret void 
@@ -115,42 +114,34 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 101, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 102, i64* %7 
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = trunc i64 16 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %10, i64* %15 
-  %16 = add   i64 %13, 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 102, i64* %18 
-  %19 = inttoptr i64 %2 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 10000, i64* %20 
-  %21 = add   i64 %2, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = add   i64 %24, 1 
-  %26 = add   i64 %13, 8 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 %25, i64* %28 
+  store  i64 101, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 102, i64* %5 
+  %6 = inttoptr i64 %2 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = trunc i64 16 to i32  
+  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
+  %10 = ptrtoint i8* %9 to i64 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 %7, i64* %11 
+  %12 = add   i64 %10, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 102, i64* %13 
+  %14 = inttoptr i64 %2 to i64* 
+  store  i64 10000, i64* %14 
+  %15 = add   i64 %2, 8 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = add   i64 %17, 1 
+  %19 = add   i64 %10, 8 
+  %20 = inttoptr i64 %19 to i64* 
+  store  i64 %18, i64* %20 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %13)  
-  ret i64 %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  ret i64 %10 
 }
 --------------------------------------------------
  Module position
@@ -237,15 +228,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -369,24 +358,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -398,12 +383,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -411,24 +394,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -442,8 +422,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -452,9 +431,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -469,8 +447,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -478,26 +455,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -54,15 +54,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 100, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 100, i64* %7 
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 200, i64* %9 
+  store  i64 100, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 100, i64* %5 
+  %6 = inttoptr i64 %2 to i64* 
+  store  i64 200, i64* %6 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des2.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   ret void 
@@ -152,15 +149,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -284,24 +279,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -313,12 +304,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -326,24 +315,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -357,8 +343,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -367,9 +352,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -384,8 +368,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -393,26 +376,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -125,32 +125,26 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 222, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 0, i64* %10 
-  %11 = trunc i64 24 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 222, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 0, i64* %7 
+  %8 = trunc i64 24 to i32  
+  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
+  %10 = ptrtoint i8* %9 to i64 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 0, i64* %11 
+  %12 = add   i64 %10, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 111, i64* %13 
+  %14 = add   i64 %10, 16 
+  %15 = inttoptr i64 %14 to i64* 
   store  i64 0, i64* %15 
-  %16 = add   i64 %13, 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 111, i64* %18 
-  %19 = add   i64 %13, 16 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 0, i64* %21 
-  %22 = tail call fastcc  i64  @"alias_fork1.simpleMerge<0>"(i64  %2, i64  %13)  
-  %23 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %22, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork1.1, i32 0, i32 0) to i64))  
+  %16 = tail call fastcc  i64  @"alias_fork1.simpleMerge<0>"(i64  %2, i64  %10)  
+  %17 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %16, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork1.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork1.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -170,89 +164,73 @@ entry:
 if.then:
   %1 = add   i64 %"tl##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"tl##0", 16 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  %8 = load  i64, i64* %7 
-  %9 = icmp ne i64 %"tr##0", 0 
-  br i1 %9, label %if.then1, label %if.else1 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"tl##0", 16 
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  %7 = icmp ne i64 %"tr##0", 0 
+  br i1 %7, label %if.then1, label %if.else1 
 if.else:
-  %52 = trunc i64 24 to i32  
-  %53 = tail call ccc  i8*  @wybe_malloc(i32  %52)  
-  %54 = ptrtoint i8* %53 to i64 
-  %55 = inttoptr i64 %54 to i64* 
-  %56 = getelementptr  i64, i64* %55, i64 0 
-  store  i64 0, i64* %56 
-  %57 = add   i64 %54, 8 
-  %58 = inttoptr i64 %57 to i64* 
-  %59 = getelementptr  i64, i64* %58, i64 0 
-  store  i64 0, i64* %59 
-  %60 = add   i64 %54, 16 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  store  i64 0, i64* %62 
-  ret i64 %54 
-if.then1:
-  %10 = add   i64 %"tr##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"tr##0", 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = icmp slt i64 %4, %13 
-  br i1 %18, label %if.then2, label %if.else2 
-if.else1:
-  %41 = trunc i64 24 to i32  
-  %42 = tail call ccc  i8*  @wybe_malloc(i32  %41)  
-  %43 = ptrtoint i8* %42 to i64 
+  %39 = trunc i64 24 to i32  
+  %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
+  %41 = ptrtoint i8* %40 to i64 
+  %42 = inttoptr i64 %41 to i64* 
+  store  i64 0, i64* %42 
+  %43 = add   i64 %41, 8 
   %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 0, i64* %45 
-  %46 = add   i64 %43, 8 
-  %47 = inttoptr i64 %46 to i64* 
-  %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 0, i64* %48 
-  %49 = add   i64 %43, 16 
-  %50 = inttoptr i64 %49 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 0, i64* %51 
-  ret i64 %43 
-if.then2:
-  %19 = trunc i64 24 to i32  
-  %20 = tail call ccc  i8*  @wybe_malloc(i32  %19)  
-  %21 = ptrtoint i8* %20 to i64 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"tl##0", i64* %23 
-  %24 = add   i64 %21, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  store  i64 %13, i64* %26 
-  %27 = add   i64 %21, 16 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  store  i64 %17, i64* %29 
-  ret i64 %21 
-if.else2:
-  %30 = trunc i64 24 to i32  
-  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
-  %32 = ptrtoint i8* %31 to i64 
-  %33 = inttoptr i64 %32 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  store  i64 %"tr##0", i64* %34 
-  %35 = add   i64 %32, 8 
+  store  i64 0, i64* %44 
+  %45 = add   i64 %41, 16 
+  %46 = inttoptr i64 %45 to i64* 
+  store  i64 0, i64* %46 
+  ret i64 %41 
+if.then1:
+  %8 = add   i64 %"tr##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = load  i64, i64* %9 
+  %11 = add   i64 %"tr##0", 16 
+  %12 = inttoptr i64 %11 to i64* 
+  %13 = load  i64, i64* %12 
+  %14 = icmp slt i64 %3, %10 
+  br i1 %14, label %if.then2, label %if.else2 
+if.else1:
+  %31 = trunc i64 24 to i32  
+  %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
+  %33 = ptrtoint i8* %32 to i64 
+  %34 = inttoptr i64 %33 to i64* 
+  store  i64 0, i64* %34 
+  %35 = add   i64 %33, 8 
   %36 = inttoptr i64 %35 to i64* 
-  %37 = getelementptr  i64, i64* %36, i64 0 
-  store  i64 %4, i64* %37 
-  %38 = add   i64 %32, 16 
-  %39 = inttoptr i64 %38 to i64* 
-  %40 = getelementptr  i64, i64* %39, i64 0 
-  store  i64 %8, i64* %40 
-  ret i64 %32 
+  store  i64 0, i64* %36 
+  %37 = add   i64 %33, 16 
+  %38 = inttoptr i64 %37 to i64* 
+  store  i64 0, i64* %38 
+  ret i64 %33 
+if.then2:
+  %15 = trunc i64 24 to i32  
+  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
+  %17 = ptrtoint i8* %16 to i64 
+  %18 = inttoptr i64 %17 to i64* 
+  store  i64 %"tl##0", i64* %18 
+  %19 = add   i64 %17, 8 
+  %20 = inttoptr i64 %19 to i64* 
+  store  i64 %10, i64* %20 
+  %21 = add   i64 %17, 16 
+  %22 = inttoptr i64 %21 to i64* 
+  store  i64 %13, i64* %22 
+  ret i64 %17 
+if.else2:
+  %23 = trunc i64 24 to i32  
+  %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
+  %25 = ptrtoint i8* %24 to i64 
+  %26 = inttoptr i64 %25 to i64* 
+  store  i64 %"tr##0", i64* %26 
+  %27 = add   i64 %25, 8 
+  %28 = inttoptr i64 %27 to i64* 
+  store  i64 %3, i64* %28 
+  %29 = add   i64 %25, 16 
+  %30 = inttoptr i64 %29 to i64* 
+  store  i64 %6, i64* %30 
+  ret i64 %25 
 }
 --------------------------------------------------
  Module mytree
@@ -361,21 +339,18 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"t##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"t##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"t##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %3, i64  %"prefix##0")  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %12)  
-  tail call ccc  void  @print_int(i64  %7)  
-  %13 = musttail call fastcc  i64  @"mytree.printTree1<0>"(i64  %11, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64))  
-  ret i64 %13 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"t##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"t##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %2, i64  %"prefix##0")  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  %9)  
+  tail call ccc  void  @print_int(i64  %5)  
+  %10 = musttail call fastcc  i64  @"mytree.printTree1<0>"(i64  %8, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64))  
+  ret i64 %10 
 if.else:
   ret i64 %"prefix##0" 
 }
@@ -604,45 +579,39 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#left##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp ne i64 %"#right##0", 0 
-  br i1 %12, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#left##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = icmp ne i64 %"#right##0", 0 
+  br i1 %9, label %if.then1, label %if.else1 
 if.else:
-  %27 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %27 
+  %21 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %21 
 if.then1:
-  %13 = inttoptr i64 %"#right##0" to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = add   i64 %"#right##0", 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
-  %20 = add   i64 %"#right##0", 16 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %15)  
-  br i1 %24, label %if.then2, label %if.else2 
+  %10 = inttoptr i64 %"#right##0" to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"#right##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#right##0", 16 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %2, i64  %11)  
+  br i1 %18, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %25 = icmp eq i64 %7, %19 
-  br i1 %25, label %if.then3, label %if.else3 
+  %19 = icmp eq i64 %5, %14 
+  br i1 %19, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %26 = musttail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %23)  
-  ret i1 %26 
+  %20 = musttail call fastcc  i1  @"mytree.tree.=<0>"(i64  %8, i64  %17)  
+  ret i1 %20 
 if.else3:
   ret i1 0 
 }
@@ -661,15 +630,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -687,15 +655,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -705,15 +672,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -730,15 +696,14 @@ if.then:
   %6 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -748,16 +713,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"left##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"key##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"right##0", i64* %10 
+  store  i64 %"left##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"key##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"right##0", i64* %7 
   ret i64 %2 
 }
 
@@ -768,27 +730,24 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#result##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i64, i64, i1} undef, i64 %3, 0 
-  %13 = insertvalue {i64, i64, i64, i1} %12, i64 %7, 1 
-  %14 = insertvalue {i64, i64, i64, i1} %13, i64 %11, 2 
-  %15 = insertvalue {i64, i64, i64, i1} %14, i1 1, 3 
-  ret {i64, i64, i64, i1} %15 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = insertvalue {i64, i64, i64, i1} undef, i64 %2, 0 
+  %10 = insertvalue {i64, i64, i64, i1} %9, i64 %5, 1 
+  %11 = insertvalue {i64, i64, i64, i1} %10, i64 %8, 2 
+  %12 = insertvalue {i64, i64, i64, i1} %11, i1 1, 3 
+  ret {i64, i64, i64, i1} %12 
 if.else:
-  %16 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %17 = insertvalue {i64, i64, i64, i1} %16, i64 undef, 1 
-  %18 = insertvalue {i64, i64, i64, i1} %17, i64 undef, 2 
-  %19 = insertvalue {i64, i64, i64, i1} %18, i1 0, 3 
-  ret {i64, i64, i64, i1} %19 
+  %13 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %14 = insertvalue {i64, i64, i64, i1} %13, i64 undef, 1 
+  %15 = insertvalue {i64, i64, i64, i1} %14, i64 undef, 2 
+  %16 = insertvalue {i64, i64, i64, i1} %15, i1 0, 3 
+  ret {i64, i64, i64, i1} %16 
 }
 
 
@@ -799,15 +758,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 16 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -825,15 +783,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 16 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -148,47 +148,40 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 0, i64* %10 
-  %11 = tail call fastcc  i64  @"alias_fork2.simpleMerge<0>"(i64  %2)  
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 0, i64* %7 
+  %8 = tail call fastcc  i64  @"alias_fork2.simpleMerge<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %12 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %11, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.3, i32 0, i32 0) to i64))  
+  %9 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %8, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.5, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %13 = icmp ne i64 %2, 0 
-  br i1 %13, label %if.then, label %if.else 
+  %10 = icmp ne i64 %2, 0 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  %16 = load  i64, i64* %15 
-  %17 = trunc i64 24 to i32  
-  %18 = tail call ccc  i8*  @wybe_malloc(i32  %17)  
-  %19 = ptrtoint i8* %18 to i64 
+  %11 = inttoptr i64 %2 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = trunc i64 24 to i32  
+  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
+  %15 = ptrtoint i8* %14 to i64 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %12, i64* %16 
+  %17 = add   i64 %15, 8 
+  %18 = inttoptr i64 %17 to i64* 
+  store  i64 1000, i64* %18 
+  %19 = add   i64 %15, 16 
   %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 %16, i64* %21 
-  %22 = add   i64 %19, 8 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  store  i64 1000, i64* %24 
-  %25 = add   i64 %19, 16 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  store  i64 0, i64* %27 
-  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %11, i64  %19)  
+  store  i64 0, i64* %20 
+  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %8, i64  %15)  
   ret void 
 if.else:
-  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %11, i64  %2)  
+  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %8, i64  %2)  
   ret void 
 }
 
@@ -217,16 +210,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"tl##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 200, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 0, i64* %10 
+  store  i64 %"tl##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 200, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 0, i64* %7 
   ret i64 %2 
 }
 --------------------------------------------------
@@ -336,21 +326,18 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"t##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"t##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"t##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %3, i64  %"prefix##0")  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %12)  
-  tail call ccc  void  @print_int(i64  %7)  
-  %13 = musttail call fastcc  i64  @"mytree.printTree1<0>"(i64  %11, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64))  
-  ret i64 %13 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"t##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"t##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %2, i64  %"prefix##0")  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  %9)  
+  tail call ccc  void  @print_int(i64  %5)  
+  %10 = musttail call fastcc  i64  @"mytree.printTree1<0>"(i64  %8, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64))  
+  ret i64 %10 
 if.else:
   ret i64 %"prefix##0" 
 }
@@ -579,45 +566,39 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#left##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp ne i64 %"#right##0", 0 
-  br i1 %12, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#left##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = icmp ne i64 %"#right##0", 0 
+  br i1 %9, label %if.then1, label %if.else1 
 if.else:
-  %27 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %27 
+  %21 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %21 
 if.then1:
-  %13 = inttoptr i64 %"#right##0" to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = add   i64 %"#right##0", 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
-  %20 = add   i64 %"#right##0", 16 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %15)  
-  br i1 %24, label %if.then2, label %if.else2 
+  %10 = inttoptr i64 %"#right##0" to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"#right##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#right##0", 16 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %2, i64  %11)  
+  br i1 %18, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %25 = icmp eq i64 %7, %19 
-  br i1 %25, label %if.then3, label %if.else3 
+  %19 = icmp eq i64 %5, %14 
+  br i1 %19, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %26 = musttail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %23)  
-  ret i1 %26 
+  %20 = musttail call fastcc  i1  @"mytree.tree.=<0>"(i64  %8, i64  %17)  
+  ret i1 %20 
 if.else3:
   ret i1 0 
 }
@@ -636,15 +617,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -662,15 +642,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -680,15 +659,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -705,15 +683,14 @@ if.then:
   %6 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -723,16 +700,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"left##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"key##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"right##0", i64* %10 
+  store  i64 %"left##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"key##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"right##0", i64* %7 
   ret i64 %2 
 }
 
@@ -743,27 +717,24 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#result##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i64, i64, i1} undef, i64 %3, 0 
-  %13 = insertvalue {i64, i64, i64, i1} %12, i64 %7, 1 
-  %14 = insertvalue {i64, i64, i64, i1} %13, i64 %11, 2 
-  %15 = insertvalue {i64, i64, i64, i1} %14, i1 1, 3 
-  ret {i64, i64, i64, i1} %15 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = insertvalue {i64, i64, i64, i1} undef, i64 %2, 0 
+  %10 = insertvalue {i64, i64, i64, i1} %9, i64 %5, 1 
+  %11 = insertvalue {i64, i64, i64, i1} %10, i64 %8, 2 
+  %12 = insertvalue {i64, i64, i64, i1} %11, i1 1, 3 
+  ret {i64, i64, i64, i1} %12 
 if.else:
-  %16 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %17 = insertvalue {i64, i64, i64, i1} %16, i64 undef, 1 
-  %18 = insertvalue {i64, i64, i64, i1} %17, i64 undef, 2 
-  %19 = insertvalue {i64, i64, i64, i1} %18, i1 0, 3 
-  ret {i64, i64, i64, i1} %19 
+  %13 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %14 = insertvalue {i64, i64, i64, i1} %13, i64 undef, 1 
+  %15 = insertvalue {i64, i64, i64, i1} %14, i64 undef, 2 
+  %16 = insertvalue {i64, i64, i64, i1} %15, i1 0, 3 
+  ret {i64, i64, i64, i1} %16 
 }
 
 
@@ -774,15 +745,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 16 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -800,15 +770,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 16 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -107,34 +107,28 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 100, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 0, i64* %10 
-  %11 = trunc i64 24 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = add   i64 %13, 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 200, i64* %18 
-  %19 = add   i64 %13, 16 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 0, i64* %21 
-  %22 = tail call fastcc  i64  @"alias_fork3.simpleSlice<0>"(i64  %13)  
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 100, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 0, i64* %7 
+  %8 = trunc i64 24 to i32  
+  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
+  %10 = ptrtoint i8* %9 to i64 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 %2, i64* %11 
+  %12 = add   i64 %10, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 200, i64* %13 
+  %14 = add   i64 %10, 16 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 0, i64* %15 
+  %16 = tail call fastcc  i64  @"alias_fork3.simpleSlice<0>"(i64  %10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %23 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %22, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.3, i32 0, i32 0) to i64))  
+  %17 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %16, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.5, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -148,25 +142,21 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tr##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 if.else:
-  %4 = trunc i64 24 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 0, i64* %8 
-  %9 = add   i64 %6, 8 
+  %3 = trunc i64 24 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 0, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
+  store  i64 -1, i64* %8 
+  %9 = add   i64 %5, 16 
   %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 -1, i64* %11 
-  %12 = add   i64 %6, 16 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 0, i64* %14 
-  ret i64 %6 
+  store  i64 0, i64* %10 
+  ret i64 %5 
 }
 --------------------------------------------------
  Module mytree
@@ -275,21 +265,18 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"t##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"t##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"t##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %3, i64  %"prefix##0")  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %12)  
-  tail call ccc  void  @print_int(i64  %7)  
-  %13 = musttail call fastcc  i64  @"mytree.printTree1<0>"(i64  %11, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64))  
-  ret i64 %13 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"t##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"t##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %2, i64  %"prefix##0")  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  %9)  
+  tail call ccc  void  @print_int(i64  %5)  
+  %10 = musttail call fastcc  i64  @"mytree.printTree1<0>"(i64  %8, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64))  
+  ret i64 %10 
 if.else:
   ret i64 %"prefix##0" 
 }
@@ -518,45 +505,39 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#left##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp ne i64 %"#right##0", 0 
-  br i1 %12, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#left##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = icmp ne i64 %"#right##0", 0 
+  br i1 %9, label %if.then1, label %if.else1 
 if.else:
-  %27 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %27 
+  %21 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %21 
 if.then1:
-  %13 = inttoptr i64 %"#right##0" to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = add   i64 %"#right##0", 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
-  %20 = add   i64 %"#right##0", 16 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %15)  
-  br i1 %24, label %if.then2, label %if.else2 
+  %10 = inttoptr i64 %"#right##0" to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"#right##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#right##0", 16 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %2, i64  %11)  
+  br i1 %18, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %25 = icmp eq i64 %7, %19 
-  br i1 %25, label %if.then3, label %if.else3 
+  %19 = icmp eq i64 %5, %14 
+  br i1 %19, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %26 = musttail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %23)  
-  ret i1 %26 
+  %20 = musttail call fastcc  i1  @"mytree.tree.=<0>"(i64  %8, i64  %17)  
+  ret i1 %20 
 if.else3:
   ret i1 0 
 }
@@ -575,15 +556,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -601,15 +581,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -619,15 +598,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -644,15 +622,14 @@ if.then:
   %6 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -662,16 +639,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"left##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"key##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"right##0", i64* %10 
+  store  i64 %"left##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"key##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"right##0", i64* %7 
   ret i64 %2 
 }
 
@@ -682,27 +656,24 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#result##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i64, i64, i1} undef, i64 %3, 0 
-  %13 = insertvalue {i64, i64, i64, i1} %12, i64 %7, 1 
-  %14 = insertvalue {i64, i64, i64, i1} %13, i64 %11, 2 
-  %15 = insertvalue {i64, i64, i64, i1} %14, i1 1, 3 
-  ret {i64, i64, i64, i1} %15 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = insertvalue {i64, i64, i64, i1} undef, i64 %2, 0 
+  %10 = insertvalue {i64, i64, i64, i1} %9, i64 %5, 1 
+  %11 = insertvalue {i64, i64, i64, i1} %10, i64 %8, 2 
+  %12 = insertvalue {i64, i64, i64, i1} %11, i1 1, 3 
+  ret {i64, i64, i64, i1} %12 
 if.else:
-  %16 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %17 = insertvalue {i64, i64, i64, i1} %16, i64 undef, 1 
-  %18 = insertvalue {i64, i64, i64, i1} %17, i64 undef, 2 
-  %19 = insertvalue {i64, i64, i64, i1} %18, i1 0, 3 
-  ret {i64, i64, i64, i1} %19 
+  %13 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %14 = insertvalue {i64, i64, i64, i1} %13, i64 undef, 1 
+  %15 = insertvalue {i64, i64, i64, i1} %14, i64 undef, 2 
+  %16 = insertvalue {i64, i64, i64, i1} %15, i1 0, 3 
+  ret {i64, i64, i64, i1} %16 
 }
 
 
@@ -713,15 +684,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 16 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -739,15 +709,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 16 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -74,21 +74,19 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 1, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>"(i64  %2)  
-  %9 = extractvalue {i64, i64} %8, 0 
-  %10 = extractvalue {i64, i64} %8, 1 
+  store  i64 1, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>"(i64  %2)  
+  %7 = extractvalue {i64, i64} %6, 0 
+  %8 = extractvalue {i64, i64} %6, 1 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.3, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
   ret void 
 }
 --------------------------------------------------
@@ -154,29 +152,27 @@ define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1##0")    {
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 1 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = trunc i64 16 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = inttoptr i64 %"p1##0" to i8* 
-  %11 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
-  %12 = add   i64 %8, 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 %5, i64* %14 
-  %15 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %8)  
-  %16 = extractvalue {i64, i64} %15, 0 
-  %17 = extractvalue {i64, i64} %15, 1 
-  ret i64 %17 
+  %4 = add   i64 %2, 1 
+  %5 = trunc i64 16 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
+  %10 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
+  %11 = add   i64 %7, 8 
+  %12 = inttoptr i64 %11 to i64* 
+  store  i64 %4, i64* %12 
+  %13 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
+  %14 = extractvalue {i64, i64} %13, 0 
+  %15 = extractvalue {i64, i64} %13, 1 
+  ret i64 %15 
 }
 
 
@@ -184,22 +180,20 @@ define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 1 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = add   i64 %"p1##0", 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %5, i64* %8 
-  %9 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
-  %10 = extractvalue {i64, i64} %9, 0 
-  %11 = extractvalue {i64, i64} %9, 1 
-  ret i64 %11 
+  %4 = add   i64 %2, 1 
+  %5 = add   i64 %"p1##0", 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %4, i64* %6 
+  %7 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
+  %8 = extractvalue {i64, i64} %7, 0 
+  %9 = extractvalue {i64, i64} %7, 1 
+  ret i64 %9 
 }
 --------------------------------------------------
  Module alias_mfoo
@@ -293,97 +287,85 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 1 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 1 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 3, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 3, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 3, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.1, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %6, 1 
-  ret {i64, i64} %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %5)  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %5, 1 
+  ret {i64, i64} %10 
 if.else:
-  %14 = add   i64 %2, 1 
-  %15 = trunc i64 16 to i32  
-  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
-  %17 = ptrtoint i8* %16 to i64 
-  %18 = inttoptr i64 %17 to i8* 
-  %19 = inttoptr i64 %"p1##0" to i8* 
+  %11 = add   i64 %1, 1 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i8* 
+  %16 = inttoptr i64 %"p1##0" to i8* 
+  %17 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i1  0)  
+  %18 = inttoptr i64 %14 to i64* 
+  store  i64 %11, i64* %18 
+  %19 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %14)  
   %20 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %18, i8*  %19, i32  %20, i1  0)  
-  %21 = inttoptr i64 %17 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %14, i64* %22 
-  %23 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %17)  
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 2, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 2, i64* %31 
-  %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %23, 1 
-  ret {i64, i64} %33 
+  %21 = tail call ccc  i8*  @wybe_malloc(i32  %20)  
+  %22 = ptrtoint i8* %21 to i64 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 2, i64* %23 
+  %24 = add   i64 %22, 8 
+  %25 = inttoptr i64 %24 to i64* 
+  store  i64 2, i64* %25 
+  %26 = insertvalue {i64, i64} undef, i64 %22, 0 
+  %27 = insertvalue {i64, i64} %26, i64 %19, 1 
+  ret {i64, i64} %27 
 }
 
 
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 1 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 1 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 3, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 3, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 3, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.1, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %6, 1 
-  ret {i64, i64} %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %5)  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %5, 1 
+  ret {i64, i64} %10 
 if.else:
-  %14 = add   i64 %2, 1 
-  %15 = inttoptr i64 %"p1##0" to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 %14, i64* %16 
-  %17 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 2, i64* %22 
-  %23 = add   i64 %20, 8 
-  %24 = inttoptr i64 %23 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 2, i64* %25 
-  %26 = insertvalue {i64, i64} undef, i64 %20, 0 
-  %27 = insertvalue {i64, i64} %26, i64 %17, 1 
-  ret {i64, i64} %27 
+  %11 = add   i64 %1, 1 
+  %12 = inttoptr i64 %"p1##0" to i64* 
+  store  i64 %11, i64* %12 
+  %13 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
+  %14 = trunc i64 16 to i32  
+  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
+  %16 = ptrtoint i8* %15 to i64 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 2, i64* %17 
+  %18 = add   i64 %16, 8 
+  %19 = inttoptr i64 %18 to i64* 
+  store  i64 2, i64* %19 
+  %20 = insertvalue {i64, i64} undef, i64 %16, 0 
+  %21 = insertvalue {i64, i64} %20, i64 %13, 1 
+  ret {i64, i64} %21 
 }
 --------------------------------------------------
  Module position
@@ -470,15 +452,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -602,24 +582,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -631,12 +607,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -644,24 +618,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -675,8 +646,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -685,9 +655,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -702,8 +671,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -711,26 +679,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -62,29 +62,27 @@ define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1##0")    {
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 1 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = trunc i64 16 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = inttoptr i64 %"p1##0" to i8* 
-  %11 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
-  %12 = add   i64 %8, 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 %5, i64* %14 
-  %15 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %8)  
-  %16 = extractvalue {i64, i64} %15, 0 
-  %17 = extractvalue {i64, i64} %15, 1 
-  ret i64 %17 
+  %4 = add   i64 %2, 1 
+  %5 = trunc i64 16 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
+  %10 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
+  %11 = add   i64 %7, 8 
+  %12 = inttoptr i64 %11 to i64* 
+  store  i64 %4, i64* %12 
+  %13 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
+  %14 = extractvalue {i64, i64} %13, 0 
+  %15 = extractvalue {i64, i64} %13, 1 
+  ret i64 %15 
 }
 
 
@@ -92,22 +90,20 @@ define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 1 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = add   i64 %"p1##0", 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %5, i64* %8 
-  %9 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
-  %10 = extractvalue {i64, i64} %9, 0 
-  %11 = extractvalue {i64, i64} %9, 1 
-  ret i64 %11 
+  %4 = add   i64 %2, 1 
+  %5 = add   i64 %"p1##0", 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %4, i64* %6 
+  %7 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
+  %8 = extractvalue {i64, i64} %7, 0 
+  %9 = extractvalue {i64, i64} %7, 1 
+  ret i64 %9 
 }
 --------------------------------------------------
  Module alias_mfoo
@@ -201,97 +197,85 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 1 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 1 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 3, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 3, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 3, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.1, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %6, 1 
-  ret {i64, i64} %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %5)  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %5, 1 
+  ret {i64, i64} %10 
 if.else:
-  %14 = add   i64 %2, 1 
-  %15 = trunc i64 16 to i32  
-  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
-  %17 = ptrtoint i8* %16 to i64 
-  %18 = inttoptr i64 %17 to i8* 
-  %19 = inttoptr i64 %"p1##0" to i8* 
+  %11 = add   i64 %1, 1 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i8* 
+  %16 = inttoptr i64 %"p1##0" to i8* 
+  %17 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i1  0)  
+  %18 = inttoptr i64 %14 to i64* 
+  store  i64 %11, i64* %18 
+  %19 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %14)  
   %20 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %18, i8*  %19, i32  %20, i1  0)  
-  %21 = inttoptr i64 %17 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %14, i64* %22 
-  %23 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %17)  
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 2, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 2, i64* %31 
-  %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %23, 1 
-  ret {i64, i64} %33 
+  %21 = tail call ccc  i8*  @wybe_malloc(i32  %20)  
+  %22 = ptrtoint i8* %21 to i64 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 2, i64* %23 
+  %24 = add   i64 %22, 8 
+  %25 = inttoptr i64 %24 to i64* 
+  store  i64 2, i64* %25 
+  %26 = insertvalue {i64, i64} undef, i64 %22, 0 
+  %27 = insertvalue {i64, i64} %26, i64 %19, 1 
+  ret {i64, i64} %27 
 }
 
 
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 1 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 1 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 3, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 3, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 3, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.1, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %6, 1 
-  ret {i64, i64} %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %5)  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %5, 1 
+  ret {i64, i64} %10 
 if.else:
-  %14 = add   i64 %2, 1 
-  %15 = inttoptr i64 %"p1##0" to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 %14, i64* %16 
-  %17 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 2, i64* %22 
-  %23 = add   i64 %20, 8 
-  %24 = inttoptr i64 %23 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 2, i64* %25 
-  %26 = insertvalue {i64, i64} undef, i64 %20, 0 
-  %27 = insertvalue {i64, i64} %26, i64 %17, 1 
-  ret {i64, i64} %27 
+  %11 = add   i64 %1, 1 
+  %12 = inttoptr i64 %"p1##0" to i64* 
+  store  i64 %11, i64* %12 
+  %13 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
+  %14 = trunc i64 16 to i32  
+  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
+  %16 = ptrtoint i8* %15 to i64 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 2, i64* %17 
+  %18 = add   i64 %16, 8 
+  %19 = inttoptr i64 %18 to i64* 
+  store  i64 2, i64* %19 
+  %20 = insertvalue {i64, i64} undef, i64 %16, 0 
+  %21 = insertvalue {i64, i64} %20, i64 %13, 1 
+  ret {i64, i64} %21 
 }
 --------------------------------------------------
  Module position
@@ -378,15 +362,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -510,24 +492,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -539,12 +517,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -552,24 +528,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -583,8 +556,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -593,9 +565,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -610,8 +581,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -619,26 +589,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -62,29 +62,27 @@ define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1##0")    {
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 1 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = trunc i64 16 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = inttoptr i64 %"p1##0" to i8* 
-  %11 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
-  %12 = add   i64 %8, 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 %5, i64* %14 
-  %15 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %8)  
-  %16 = extractvalue {i64, i64} %15, 0 
-  %17 = extractvalue {i64, i64} %15, 1 
-  ret i64 %17 
+  %4 = add   i64 %2, 1 
+  %5 = trunc i64 16 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
+  %10 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
+  %11 = add   i64 %7, 8 
+  %12 = inttoptr i64 %11 to i64* 
+  store  i64 %4, i64* %12 
+  %13 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
+  %14 = extractvalue {i64, i64} %13, 0 
+  %15 = extractvalue {i64, i64} %13, 1 
+  ret i64 %15 
 }
 
 
@@ -92,22 +90,20 @@ define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 1 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = add   i64 %"p1##0", 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %5, i64* %8 
-  %9 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
-  %10 = extractvalue {i64, i64} %9, 0 
-  %11 = extractvalue {i64, i64} %9, 1 
-  ret i64 %11 
+  %4 = add   i64 %2, 1 
+  %5 = add   i64 %"p1##0", 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %4, i64* %6 
+  %7 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
+  %8 = extractvalue {i64, i64} %7, 0 
+  %9 = extractvalue {i64, i64} %7, 1 
+  ret i64 %9 
 }
 --------------------------------------------------
  Module alias_mfoo
@@ -201,97 +197,85 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 1 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 1 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 3, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 3, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 3, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.1, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %6, 1 
-  ret {i64, i64} %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %5)  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %5, 1 
+  ret {i64, i64} %10 
 if.else:
-  %14 = add   i64 %2, 1 
-  %15 = trunc i64 16 to i32  
-  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
-  %17 = ptrtoint i8* %16 to i64 
-  %18 = inttoptr i64 %17 to i8* 
-  %19 = inttoptr i64 %"p1##0" to i8* 
+  %11 = add   i64 %1, 1 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i8* 
+  %16 = inttoptr i64 %"p1##0" to i8* 
+  %17 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i1  0)  
+  %18 = inttoptr i64 %14 to i64* 
+  store  i64 %11, i64* %18 
+  %19 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %14)  
   %20 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %18, i8*  %19, i32  %20, i1  0)  
-  %21 = inttoptr i64 %17 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %14, i64* %22 
-  %23 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %17)  
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 2, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 2, i64* %31 
-  %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %23, 1 
-  ret {i64, i64} %33 
+  %21 = tail call ccc  i8*  @wybe_malloc(i32  %20)  
+  %22 = ptrtoint i8* %21 to i64 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 2, i64* %23 
+  %24 = add   i64 %22, 8 
+  %25 = inttoptr i64 %24 to i64* 
+  store  i64 2, i64* %25 
+  %26 = insertvalue {i64, i64} undef, i64 %22, 0 
+  %27 = insertvalue {i64, i64} %26, i64 %19, 1 
+  ret {i64, i64} %27 
 }
 
 
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 1 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 1 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 3, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 3, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 3, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.1, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %6, 1 
-  ret {i64, i64} %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %5)  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %5, 1 
+  ret {i64, i64} %10 
 if.else:
-  %14 = add   i64 %2, 1 
-  %15 = inttoptr i64 %"p1##0" to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 %14, i64* %16 
-  %17 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 2, i64* %22 
-  %23 = add   i64 %20, 8 
-  %24 = inttoptr i64 %23 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 2, i64* %25 
-  %26 = insertvalue {i64, i64} undef, i64 %20, 0 
-  %27 = insertvalue {i64, i64} %26, i64 %17, 1 
-  ret {i64, i64} %27 
+  %11 = add   i64 %1, 1 
+  %12 = inttoptr i64 %"p1##0" to i64* 
+  store  i64 %11, i64* %12 
+  %13 = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
+  %14 = trunc i64 16 to i32  
+  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
+  %16 = ptrtoint i8* %15 to i64 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 2, i64* %17 
+  %18 = add   i64 %16, 8 
+  %19 = inttoptr i64 %18 to i64* 
+  store  i64 2, i64* %19 
+  %20 = insertvalue {i64, i64} undef, i64 %16, 0 
+  %21 = insertvalue {i64, i64} %20, i64 %13, 1 
+  ret {i64, i64} %21 
 }
 --------------------------------------------------
  Module position
@@ -378,15 +362,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -510,24 +492,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -539,12 +517,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -552,24 +528,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -583,8 +556,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -593,9 +565,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -610,8 +581,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -619,26 +589,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -71,12 +71,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 10, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 10, i64* %7 
+  store  i64 10, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 10, i64* %5 
   tail call fastcc  void  @"alias_mod_param.foo<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mod_param.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
@@ -94,8 +92,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1111, i64* %7 
+  store  i64 1111, i64* %6 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mod_param.3, i32 0, i32 0) to i64))  
   musttail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   ret void 
@@ -185,15 +182,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -317,24 +312,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -346,12 +337,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -359,24 +348,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -390,8 +376,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -400,9 +385,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -417,8 +401,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -426,26 +409,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -174,41 +174,38 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 101, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 102, i64* %7 
-  %8 = tail call fastcc  {i64, i64}  @"alias_multifunc.replicate1<0>"(i64  %2)  
-  %9 = extractvalue {i64, i64} %8, 0 
-  %10 = extractvalue {i64, i64} %8, 1 
+  store  i64 101, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 102, i64* %5 
+  %6 = tail call fastcc  {i64, i64}  @"alias_multifunc.replicate1<0>"(i64  %2)  
+  %7 = extractvalue {i64, i64} %6, 0 
+  %8 = extractvalue {i64, i64} %6, 1 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.7, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %11 = trunc i64 16 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i8* 
-  %15 = inttoptr i64 %2 to i8* 
-  %16 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %14, i8*  %15, i32  %16, i1  0)  
-  %17 = inttoptr i64 %13 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 555, i64* %18 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  %9 = trunc i64 16 to i32  
+  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
+  %11 = ptrtoint i8* %10 to i64 
+  %12 = inttoptr i64 %11 to i8* 
+  %13 = inttoptr i64 %2 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = inttoptr i64 %11 to i64* 
+  store  i64 555, i64* %15 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %13)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.7, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
   ret void 
 }
 
@@ -219,22 +216,19 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.13, i32 0, i32 0) to i64))  
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %6 = inttoptr i64 %2 to i64* 
+  %7 = load  i64, i64* %6 
+  tail call ccc  void  @print_int(i64  %7)  
   tail call ccc  void  @putchar(i8  10)  
-  %11 = tail call fastcc  i64  @"alias_multifunc.replicate2<0>"(i64  %"p1##0")  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %11, 1 
-  ret {i64, i64} %13 
+  %8 = tail call fastcc  i64  @"alias_multifunc.replicate2<0>"(i64  %"p1##0")  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %8, 1 
+  ret {i64, i64} %10 
 }
 
 
@@ -244,17 +238,14 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.15, i32 0, i32 0) to i64))  
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %6 = inttoptr i64 %2 to i64* 
+  %7 = load  i64, i64* %6 
+  tail call ccc  void  @print_int(i64  %7)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -343,15 +334,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -475,24 +464,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -504,12 +489,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -517,24 +500,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -548,8 +528,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -558,9 +537,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -575,8 +553,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -584,26 +561,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -161,46 +161,42 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 10, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 10, i64* %7 
-  %8 = tail call fastcc  {i64, i64}  @"alias_multifunc1.replicate1<0>"(i64  %2)  
-  %9 = extractvalue {i64, i64} %8, 0 
-  %10 = extractvalue {i64, i64} %8, 1 
+  store  i64 10, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 10, i64* %5 
+  %6 = tail call fastcc  {i64, i64}  @"alias_multifunc1.replicate1<0>"(i64  %2)  
+  %7 = extractvalue {i64, i64} %6, 0 
+  %8 = extractvalue {i64, i64} %6, 1 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.7, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %11 = inttoptr i64 %9 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2222222, i64* %12 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  %9 = inttoptr i64 %7 to i64* 
+  store  i64 2222222, i64* %9 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
-  %13 = trunc i64 16 to i32  
-  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
-  %15 = ptrtoint i8* %14 to i64 
-  %16 = inttoptr i64 %15 to i8* 
-  %17 = inttoptr i64 %2 to i8* 
-  %18 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %16, i8*  %17, i32  %18, i1  0)  
-  %19 = inttoptr i64 %15 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 11, i64* %20 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
+  %10 = trunc i64 16 to i32  
+  %11 = tail call ccc  i8*  @wybe_malloc(i32  %10)  
+  %12 = ptrtoint i8* %11 to i64 
+  %13 = inttoptr i64 %12 to i8* 
+  %14 = inttoptr i64 %2 to i8* 
+  %15 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
+  %16 = inttoptr i64 %12 to i64* 
+  store  i64 11, i64* %16 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.15, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %15)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %12)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.7, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
   ret void 
 }
 
@@ -217,11 +213,10 @@ entry:
   %7 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %5, i8*  %6, i32  %7, i1  0)  
   %8 = inttoptr i64 %4 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 22, i64* %9 
-  %10 = insertvalue {i64, i64} undef, i64 %4, 0 
-  %11 = insertvalue {i64, i64} %10, i64 %1, 1 
-  ret {i64, i64} %11 
+  store  i64 22, i64* %8 
+  %9 = insertvalue {i64, i64} undef, i64 %4, 0 
+  %10 = insertvalue {i64, i64} %9, i64 %1, 1 
+  ret {i64, i64} %10 
 }
 
 
@@ -231,17 +226,14 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.17, i32 0, i32 0) to i64))  
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %6 = inttoptr i64 %2 to i64* 
+  %7 = load  i64, i64* %6 
+  tail call ccc  void  @print_int(i64  %7)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -330,15 +322,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -462,24 +452,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -491,12 +477,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -504,24 +488,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -535,8 +516,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -545,9 +525,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -562,8 +541,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -571,26 +549,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -144,41 +144,38 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 10, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 10, i64* %7 
-  %8 = tail call fastcc  {i64, i64}  @"alias_multifunc2.replicate1<0>"(i64  %2)  
-  %9 = extractvalue {i64, i64} %8, 0 
-  %10 = extractvalue {i64, i64} %8, 1 
+  store  i64 10, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 10, i64* %5 
+  %6 = tail call fastcc  {i64, i64}  @"alias_multifunc2.replicate1<0>"(i64  %2)  
+  %7 = extractvalue {i64, i64} %6, 0 
+  %8 = extractvalue {i64, i64} %6, 1 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.7, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %11 = trunc i64 16 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i8* 
-  %15 = inttoptr i64 %2 to i8* 
-  %16 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %14, i8*  %15, i32  %16, i1  0)  
-  %17 = inttoptr i64 %13 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 11, i64* %18 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  %9 = trunc i64 16 to i32  
+  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
+  %11 = ptrtoint i8* %10 to i64 
+  %12 = inttoptr i64 %11 to i8* 
+  %13 = inttoptr i64 %2 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = inttoptr i64 %11 to i64* 
+  store  i64 11, i64* %15 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %13)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.7, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
   ret void 
 }
 
@@ -195,11 +192,10 @@ entry:
   %7 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %5, i8*  %6, i32  %7, i1  0)  
   %8 = inttoptr i64 %4 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 22, i64* %9 
-  %10 = insertvalue {i64, i64} undef, i64 %4, 0 
-  %11 = insertvalue {i64, i64} %10, i64 %1, 1 
-  ret {i64, i64} %11 
+  store  i64 22, i64* %8 
+  %9 = insertvalue {i64, i64} undef, i64 %4, 0 
+  %10 = insertvalue {i64, i64} %9, i64 %1, 1 
+  ret {i64, i64} %10 
 }
 
 
@@ -209,17 +205,14 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.13, i32 0, i32 0) to i64))  
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %6 = inttoptr i64 %2 to i64* 
+  %7 = load  i64, i64* %6 
+  tail call ccc  void  @print_int(i64  %7)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -308,15 +301,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -440,24 +431,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -469,12 +456,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -482,24 +467,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -513,8 +495,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -523,9 +504,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -540,8 +520,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -549,26 +528,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -132,35 +132,32 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 10, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 10, i64* %7 
-  %8 = tail call fastcc  i64  @"alias_multifunc3.replicate1<0>"(i64  %2)  
+  store  i64 10, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 10, i64* %5 
+  %6 = tail call fastcc  i64  @"alias_multifunc3.replicate1<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
-  %9 = trunc i64 16 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
-  %12 = inttoptr i64 %11 to i8* 
-  %13 = inttoptr i64 %2 to i8* 
-  %14 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
-  %15 = inttoptr i64 %11 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 999, i64* %16 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i8* 
+  %11 = inttoptr i64 %2 to i8* 
+  %12 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %10, i8*  %11, i32  %12, i1  0)  
+  %13 = inttoptr i64 %9 to i64* 
+  store  i64 999, i64* %13 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.9, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
   ret void 
 }
 
@@ -175,8 +172,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1111, i64* %7 
+  store  i64 1111, i64* %6 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.11, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.13, i32 0, i32 0) to i64))  
@@ -270,15 +266,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -402,24 +396,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -431,12 +421,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -444,24 +432,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -475,8 +460,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -485,9 +469,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -502,8 +485,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -511,26 +493,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -193,37 +193,35 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 10, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 10, i64* %7 
-  %8 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate1<0>"(i64  %2)  
-  %9 = extractvalue {i64, i64} %8, 0 
-  %10 = extractvalue {i64, i64} %8, 1 
+  store  i64 10, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 10, i64* %5 
+  %6 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate1<0>"(i64  %2)  
+  %7 = extractvalue {i64, i64} %6, 0 
+  %8 = extractvalue {i64, i64} %6, 1 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.7, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %11 = tail call fastcc  i64  @"alias_multifunc4.replicate21<0>"()  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  %9 = tail call fastcc  i64  @"alias_multifunc4.replicate21<0>"()  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %12 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate22<0>"()  
-  %13 = extractvalue {i64, i64} %12, 0 
-  %14 = extractvalue {i64, i64} %12, 1 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  %10 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate22<0>"()  
+  %11 = extractvalue {i64, i64} %10, 0 
+  %12 = extractvalue {i64, i64} %10, 1 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.15, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %13)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.17, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %14)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %12)  
   ret void 
 }
 
@@ -234,28 +232,24 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 99, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 99, i64* %7 
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = trunc i64 16 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i8* 
-  %15 = inttoptr i64 %"pa##0" to i8* 
-  %16 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %14, i8*  %15, i32  %16, i1  0)  
-  %17 = inttoptr i64 %13 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %10, i64* %18 
-  %19 = insertvalue {i64, i64} undef, i64 %13, 0 
-  %20 = insertvalue {i64, i64} %19, i64 %"pa##0", 1 
-  ret {i64, i64} %20 
+  store  i64 99, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 99, i64* %5 
+  %6 = inttoptr i64 %2 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = trunc i64 16 to i32  
+  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
+  %10 = ptrtoint i8* %9 to i64 
+  %11 = inttoptr i64 %10 to i8* 
+  %12 = inttoptr i64 %"pa##0" to i8* 
+  %13 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %11, i8*  %12, i32  %13, i1  0)  
+  %14 = inttoptr i64 %10 to i64* 
+  store  i64 %7, i64* %14 
+  %15 = insertvalue {i64, i64} undef, i64 %10, 0 
+  %16 = insertvalue {i64, i64} %15, i64 %"pa##0", 1 
+  ret {i64, i64} %16 
 }
 
 
@@ -265,24 +259,21 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 99999, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 99999, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = inttoptr i64 %10 to i8* 
-  %12 = inttoptr i64 %2 to i8* 
-  %13 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %11, i8*  %12, i32  %13, i1  0)  
-  %14 = inttoptr i64 %10 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 1111111111, i64* %15 
+  store  i64 99999, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 99999, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i8* 
+  %10 = inttoptr i64 %2 to i8* 
+  %11 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
+  %12 = inttoptr i64 %8 to i64* 
+  store  i64 1111111111, i64* %12 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.19, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
   ret i64 %2 
 }
 
@@ -293,29 +284,26 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 99999, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 99999, i64* %7 
+  store  i64 99999, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 99999, i64* %5 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.21, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = inttoptr i64 %10 to i8* 
-  %12 = inttoptr i64 %2 to i8* 
-  %13 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %11, i8*  %12, i32  %13, i1  0)  
-  %14 = inttoptr i64 %10 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 1111111111, i64* %15 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i8* 
+  %10 = inttoptr i64 %2 to i8* 
+  %11 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
+  %12 = inttoptr i64 %8 to i64* 
+  store  i64 1111111111, i64* %12 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.23, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %16 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %17 = insertvalue {i64, i64} %16, i64 %10, 1 
-  ret {i64, i64} %17 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  %13 = insertvalue {i64, i64} undef, i64 %2, 0 
+  %14 = insertvalue {i64, i64} %13, i64 %8, 1 
+  ret {i64, i64} %14 
 }
 --------------------------------------------------
  Module position
@@ -402,15 +390,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -534,24 +520,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -563,12 +545,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -576,24 +556,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -607,8 +584,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -617,9 +593,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -634,8 +609,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -643,26 +617,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -154,55 +154,50 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 100, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 101, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 100, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 101, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 -200, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 -200, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 -201, i64* %15 
+  store  i64 -201, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %16 = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %2, i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  %12 = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %2, i64  %8)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.11, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %16)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %12)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %17 = trunc i64 16 to i32  
-  %18 = tail call ccc  i8*  @wybe_malloc(i32  %17)  
-  %19 = ptrtoint i8* %18 to i64 
-  %20 = inttoptr i64 %19 to i8* 
-  %21 = inttoptr i64 %2 to i8* 
-  %22 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %20, i8*  %21, i32  %22, i1  0)  
-  %23 = inttoptr i64 %19 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  store  i64 -1000, i64* %24 
+  %13 = trunc i64 16 to i32  
+  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
+  %15 = ptrtoint i8* %14 to i64 
+  %16 = inttoptr i64 %15 to i8* 
+  %17 = inttoptr i64 %2 to i8* 
+  %18 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %16, i8*  %17, i32  %18, i1  0)  
+  %19 = inttoptr i64 %15 to i64* 
+  store  i64 -1000, i64* %19 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.15, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %19)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %15)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.17, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %16)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %12)  
   ret void 
 }
 
@@ -210,13 +205,12 @@ entry:
 define external fastcc  i64 @"alias_recursion1.if_test<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
   %0 = inttoptr i64 %"a##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 0 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 0 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = musttail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %"b##0", i64  %"a##0")  
-  ret i64 %4 
+  %3 = musttail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %"b##0", i64  %"a##0")  
+  ret i64 %3 
 if.else:
   ret i64 %"a##0" 
 }
@@ -305,15 +299,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -437,24 +429,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -466,12 +454,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -479,24 +465,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -510,8 +493,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -520,9 +502,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -537,8 +518,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -546,26 +526,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -171,23 +171,21 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 1, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>"(i64  %2)  
-  %9 = extractvalue {i64, i64} %8, 0 
-  %10 = extractvalue {i64, i64} %8, 1 
+  store  i64 1, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>"(i64  %2)  
+  %7 = extractvalue {i64, i64} %6, 0 
+  %8 = extractvalue {i64, i64} %6, 1 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.7, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
   ret void 
 }
 
@@ -196,29 +194,27 @@ define external fastcc  i64 @"alias_scc_proc.bar<0>"(i64  %"p1##0")    {
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 1 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = trunc i64 16 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = inttoptr i64 %"p1##0" to i8* 
-  %11 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
-  %12 = add   i64 %8, 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 %5, i64* %14 
-  %15 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %8)  
-  %16 = extractvalue {i64, i64} %15, 0 
-  %17 = extractvalue {i64, i64} %15, 1 
-  ret i64 %17 
+  %4 = add   i64 %2, 1 
+  %5 = trunc i64 16 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
+  %10 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
+  %11 = add   i64 %7, 8 
+  %12 = inttoptr i64 %11 to i64* 
+  store  i64 %4, i64* %12 
+  %13 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %7)  
+  %14 = extractvalue {i64, i64} %13, 0 
+  %15 = extractvalue {i64, i64} %13, 1 
+  ret i64 %15 
 }
 
 
@@ -226,119 +222,105 @@ define external fastcc  i64 @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0") 
 entry:
   %0 = add   i64 %"p1##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp sgt i64 %3, 1 
-  br i1 %4, label %if.then, label %if.else 
+  %2 = load  i64, i64* %1 
+  %3 = icmp sgt i64 %2, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %5 = add   i64 %3, 1 
-  %6 = add   i64 %"p1##0", 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %5, i64* %8 
-  %9 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")  
-  %10 = extractvalue {i64, i64} %9, 0 
-  %11 = extractvalue {i64, i64} %9, 1 
-  ret i64 %11 
+  %4 = add   i64 %2, 1 
+  %5 = add   i64 %"p1##0", 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %4, i64* %6 
+  %7 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")  
+  %8 = extractvalue {i64, i64} %7, 0 
+  %9 = extractvalue {i64, i64} %7, 1 
+  ret i64 %9 
 }
 
 
 define external fastcc  {i64, i64} @"alias_scc_proc.foo<0>"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 1 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 1 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 3, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 3, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 3, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.9, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %6, 1 
-  ret {i64, i64} %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %5)  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %5, 1 
+  ret {i64, i64} %10 
 if.else:
-  %14 = add   i64 %2, 1 
-  %15 = trunc i64 16 to i32  
-  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
-  %17 = ptrtoint i8* %16 to i64 
-  %18 = inttoptr i64 %17 to i8* 
-  %19 = inttoptr i64 %"p1##0" to i8* 
+  %11 = add   i64 %1, 1 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i8* 
+  %16 = inttoptr i64 %"p1##0" to i8* 
+  %17 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i1  0)  
+  %18 = inttoptr i64 %14 to i64* 
+  store  i64 %11, i64* %18 
+  %19 = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %14)  
   %20 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %18, i8*  %19, i32  %20, i1  0)  
-  %21 = inttoptr i64 %17 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %14, i64* %22 
-  %23 = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %17)  
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 2, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 2, i64* %31 
-  %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %23, 1 
-  ret {i64, i64} %33 
+  %21 = tail call ccc  i8*  @wybe_malloc(i32  %20)  
+  %22 = ptrtoint i8* %21 to i64 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 2, i64* %23 
+  %24 = add   i64 %22, 8 
+  %25 = inttoptr i64 %24 to i64* 
+  store  i64 2, i64* %25 
+  %26 = insertvalue {i64, i64} undef, i64 %22, 0 
+  %27 = insertvalue {i64, i64} %26, i64 %19, 1 
+  ret {i64, i64} %27 
 }
 
 
 define external fastcc  {i64, i64} @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
   %0 = inttoptr i64 %"p1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = icmp sgt i64 %2, 1 
-  br i1 %3, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = icmp sgt i64 %1, 1 
+  br i1 %2, label %if.then, label %if.else 
 if.then:
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 3, i64* %6 
+  %7 = add   i64 %5, 8 
+  %8 = inttoptr i64 %7 to i64* 
   store  i64 3, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 3, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.9, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %12 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %13 = insertvalue {i64, i64} %12, i64 %6, 1 
-  ret {i64, i64} %13 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %5)  
+  %9 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %10 = insertvalue {i64, i64} %9, i64 %5, 1 
+  ret {i64, i64} %10 
 if.else:
-  %14 = add   i64 %2, 1 
-  %15 = inttoptr i64 %"p1##0" to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 %14, i64* %16 
-  %17 = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 2, i64* %22 
-  %23 = add   i64 %20, 8 
-  %24 = inttoptr i64 %23 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 2, i64* %25 
-  %26 = insertvalue {i64, i64} undef, i64 %20, 0 
-  %27 = insertvalue {i64, i64} %26, i64 %17, 1 
-  ret {i64, i64} %27 
+  %11 = add   i64 %1, 1 
+  %12 = inttoptr i64 %"p1##0" to i64* 
+  store  i64 %11, i64* %12 
+  %13 = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")  
+  %14 = trunc i64 16 to i32  
+  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
+  %16 = ptrtoint i8* %15 to i64 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 2, i64* %17 
+  %18 = add   i64 %16, 8 
+  %19 = inttoptr i64 %18 to i64* 
+  store  i64 2, i64* %19 
+  %20 = insertvalue {i64, i64} undef, i64 %16, 0 
+  %21 = insertvalue {i64, i64} %20, i64 %13, 1 
+  ret {i64, i64} %21 
 }
 --------------------------------------------------
  Module position
@@ -425,15 +407,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -557,24 +537,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -586,12 +562,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -599,24 +573,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -630,8 +601,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -640,9 +610,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -657,8 +626,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -666,26 +634,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -76,41 +76,34 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 100, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 100, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 100, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 100, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 1, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 1, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i8* 
-  %20 = inttoptr i64 %2 to i8* 
-  %21 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i1  0)  
-  %22 = inttoptr i64 %18 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 200, i64* %23 
-  %24 = inttoptr i64 %18 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  %26 = load  i64, i64* %25 
-  tail call ccc  void  @print_int(i64  %26)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i8* 
+  %16 = inttoptr i64 %2 to i8* 
+  %17 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i1  0)  
+  %18 = inttoptr i64 %14 to i64* 
+  store  i64 200, i64* %18 
+  %19 = inttoptr i64 %14 to i64* 
+  %20 = load  i64, i64* %19 
+  tail call ccc  void  @print_int(i64  %20)  
   tail call ccc  void  @putchar(i8  10)  
-  %27 = inttoptr i64 %10 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  %29 = load  i64, i64* %28 
-  tail call ccc  void  @print_int(i64  %29)  
+  %21 = inttoptr i64 %8 to i64* 
+  %22 = load  i64, i64* %21 
+  tail call ccc  void  @print_int(i64  %22)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -233,24 +226,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"alias_type1.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -262,12 +251,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -275,24 +262,21 @@ entry:
 define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"alias_type1.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -306,8 +290,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -316,9 +299,8 @@ define external fastcc  i64 @"alias_type1.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -333,8 +315,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -342,28 +323,24 @@ entry:
 define external fastcc  i1 @"alias_type1.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module alias_type1.posrec
@@ -507,43 +484,35 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"alias_type1.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = inttoptr i64 %6 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
+  %11 = inttoptr i64 %4 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %4, 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = inttoptr i64 %9 to i64* 
   %17 = load  i64, i64* %16 
-  %18 = add   i64 %6, 8 
+  %18 = add   i64 %9, 8 
   %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = inttoptr i64 %13 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = add   i64 %13, 8 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %29 = icmp eq i64 %24, %17 
-  br i1 %29, label %if.then1, label %if.else1 
+  %20 = load  i64, i64* %19 
+  %21 = icmp eq i64 %17, %12 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %30 = icmp eq i64 %21, %28 
-  ret i1 %30 
+  %22 = icmp eq i64 %15, %20 
+  ret i1 %22 
 if.else1:
   ret i1 0 
 }
@@ -552,9 +521,8 @@ if.else1:
 define external fastcc  i64 @"alias_type1.posrec.a<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -568,8 +536,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -578,9 +545,8 @@ define external fastcc  i64 @"alias_type1.posrec.p<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -595,8 +561,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -607,12 +572,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"a##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"p##0", i64* %7 
+  store  i64 %"a##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"p##0", i64* %5 
   ret i64 %2 
 }
 
@@ -620,61 +583,51 @@ entry:
 define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"alias_type1.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = inttoptr i64 %6 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
+  %11 = inttoptr i64 %4 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %4, 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = inttoptr i64 %9 to i64* 
   %17 = load  i64, i64* %16 
-  %18 = add   i64 %6, 8 
+  %18 = add   i64 %9, 8 
   %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = inttoptr i64 %13 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = add   i64 %13, 8 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %29 = icmp eq i64 %24, %17 
-  br i1 %29, label %if.then1, label %if.else1 
+  %20 = load  i64, i64* %19 
+  %21 = icmp eq i64 %17, %12 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
-  %33 = xor i1 0, 1 
-  ret i1 %33 
+  %25 = xor i1 0, 1 
+  ret i1 %25 
 if.then1:
-  %30 = icmp eq i64 %28, %21 
-  %31 = xor i1 %30, 1 
-  ret i1 %31 
+  %22 = icmp eq i64 %20, %15 
+  %23 = xor i1 %22, 1 
+  ret i1 %23 
 if.else1:
-  %32 = xor i1 0, 1 
-  ret i1 %32 
+  %24 = xor i1 0, 1 
+  ret i1 %24 
 }

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -78,55 +78,46 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 100, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 100, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 100, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 100, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 1, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i8* 
-  %20 = inttoptr i64 %10 to i8* 
-  %21 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i1  0)  
-  %22 = add   i64 %18, 8 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  store  i64 2, i64* %24 
+  store  i64 1, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i8* 
+  %16 = inttoptr i64 %8 to i8* 
+  %17 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i1  0)  
+  %18 = add   i64 %14, 8 
+  %19 = inttoptr i64 %18 to i64* 
+  store  i64 2, i64* %19 
+  %20 = trunc i64 16 to i32  
+  %21 = tail call ccc  i8*  @wybe_malloc(i32  %20)  
+  %22 = ptrtoint i8* %21 to i64 
+  %23 = inttoptr i64 %22 to i8* 
+  %24 = inttoptr i64 %2 to i8* 
   %25 = trunc i64 16 to i32  
-  %26 = tail call ccc  i8*  @wybe_malloc(i32  %25)  
-  %27 = ptrtoint i8* %26 to i64 
-  %28 = inttoptr i64 %27 to i8* 
-  %29 = inttoptr i64 %2 to i8* 
-  %30 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %28, i8*  %29, i32  %30, i1  0)  
-  %31 = inttoptr i64 %27 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 200, i64* %32 
-  %33 = inttoptr i64 %27 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  %35 = load  i64, i64* %34 
-  tail call ccc  void  @print_int(i64  %35)  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %23, i8*  %24, i32  %25, i1  0)  
+  %26 = inttoptr i64 %22 to i64* 
+  store  i64 200, i64* %26 
+  %27 = inttoptr i64 %22 to i64* 
+  %28 = load  i64, i64* %27 
+  tail call ccc  void  @print_int(i64  %28)  
   tail call ccc  void  @putchar(i8  10)  
-  %36 = inttoptr i64 %18 to i64* 
-  %37 = getelementptr  i64, i64* %36, i64 0 
-  %38 = load  i64, i64* %37 
-  %39 = inttoptr i64 %38 to i64* 
-  %40 = getelementptr  i64, i64* %39, i64 0 
-  %41 = load  i64, i64* %40 
-  tail call ccc  void  @print_int(i64  %41)  
+  %29 = inttoptr i64 %14 to i64* 
+  %30 = load  i64, i64* %29 
+  %31 = inttoptr i64 %30 to i64* 
+  %32 = load  i64, i64* %31 
+  tail call ccc  void  @print_int(i64  %32)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -249,24 +240,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"alias_type2.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -278,12 +265,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -291,24 +276,21 @@ entry:
 define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"alias_type2.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -322,8 +304,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -332,9 +313,8 @@ define external fastcc  i64 @"alias_type2.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -349,8 +329,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -358,28 +337,24 @@ entry:
 define external fastcc  i1 @"alias_type2.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module alias_type2.posrec
@@ -523,43 +498,35 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"alias_type2.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  %10 = inttoptr i64 %1 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %1, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %6 to i64* 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
+  %17 = add   i64 %6, 8 
   %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  %21 = inttoptr i64 %9 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = add   i64 %9, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = icmp eq i64 %16, %23 
-  br i1 %28, label %if.then, label %if.else 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %11, %16 
+  br i1 %20, label %if.then, label %if.else 
 if.then:
-  %29 = icmp eq i64 %27, %20 
-  br i1 %29, label %if.then1, label %if.else1 
+  %21 = icmp eq i64 %19, %14 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %30 = icmp eq i64 %6, %13 
-  ret i1 %30 
+  %22 = icmp eq i64 %4, %9 
+  ret i1 %22 
 if.else1:
   ret i1 0 
 }
@@ -569,9 +536,8 @@ define external fastcc  i64 @"alias_type2.posrec.a<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -586,8 +552,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -595,9 +560,8 @@ entry:
 define external fastcc  i64 @"alias_type2.posrec.p<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -611,8 +575,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -623,12 +586,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"p##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"a##0", i64* %7 
+  store  i64 %"p##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"a##0", i64* %5 
   ret i64 %2 
 }
 
@@ -636,61 +597,51 @@ entry:
 define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"alias_type2.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  %10 = inttoptr i64 %1 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %1, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %6 to i64* 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
+  %17 = add   i64 %6, 8 
   %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  %21 = inttoptr i64 %9 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = add   i64 %9, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = icmp eq i64 %16, %23 
-  br i1 %28, label %if.then, label %if.else 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %11, %16 
+  br i1 %20, label %if.then, label %if.else 
 if.then:
-  %29 = icmp eq i64 %27, %20 
-  br i1 %29, label %if.then1, label %if.else1 
+  %21 = icmp eq i64 %19, %14 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
-  %33 = xor i1 0, 1 
-  ret i1 %33 
+  %25 = xor i1 0, 1 
+  ret i1 %25 
 if.then1:
-  %30 = icmp eq i64 %6, %13 
-  %31 = xor i1 %30, 1 
-  ret i1 %31 
+  %22 = icmp eq i64 %4, %9 
+  %23 = xor i1 %22, 1 
+  ret i1 %23 
 if.else1:
-  %32 = xor i1 0, 1 
-  ret i1 %32 
+  %24 = xor i1 0, 1 
+  ret i1 %24 
 }

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -81,57 +81,46 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 100, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 100, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 100, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 100, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 1, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 2, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i8* 
-  %28 = inttoptr i64 %10 to i8* 
-  %29 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %27, i8*  %28, i32  %29, i1  0)  
-  %30 = inttoptr i64 %26 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %18, i64* %31 
-  %32 = inttoptr i64 %2 to i64* 
-  %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 200, i64* %33 
-  %34 = inttoptr i64 %2 to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  %36 = load  i64, i64* %35 
-  tail call ccc  void  @print_int(i64  %36)  
+  store  i64 1, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 2, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i8* 
+  %22 = inttoptr i64 %8 to i8* 
+  %23 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i1  0)  
+  %24 = inttoptr i64 %20 to i64* 
+  store  i64 %14, i64* %24 
+  %25 = inttoptr i64 %2 to i64* 
+  store  i64 200, i64* %25 
+  %26 = inttoptr i64 %2 to i64* 
+  %27 = load  i64, i64* %26 
+  tail call ccc  void  @print_int(i64  %27)  
   tail call ccc  void  @putchar(i8  10)  
-  %37 = inttoptr i64 %26 to i64* 
-  %38 = getelementptr  i64, i64* %37, i64 0 
-  %39 = load  i64, i64* %38 
-  %40 = inttoptr i64 %39 to i64* 
-  %41 = getelementptr  i64, i64* %40, i64 0 
-  %42 = load  i64, i64* %41 
-  tail call ccc  void  @print_int(i64  %42)  
+  %28 = inttoptr i64 %20 to i64* 
+  %29 = load  i64, i64* %28 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = load  i64, i64* %30 
+  tail call ccc  void  @print_int(i64  %31)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -254,24 +243,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"alias_type3.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -283,12 +268,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -296,24 +279,21 @@ entry:
 define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"alias_type3.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -327,8 +307,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -337,9 +316,8 @@ define external fastcc  i64 @"alias_type3.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -354,8 +332,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -363,28 +340,24 @@ entry:
 define external fastcc  i1 @"alias_type3.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module alias_type3.posrec
@@ -528,43 +501,35 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"alias_type3.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  %10 = inttoptr i64 %1 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %1, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %6 to i64* 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
+  %17 = add   i64 %6, 8 
   %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  %21 = inttoptr i64 %9 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = add   i64 %9, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = icmp eq i64 %16, %23 
-  br i1 %28, label %if.then, label %if.else 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %11, %16 
+  br i1 %20, label %if.then, label %if.else 
 if.then:
-  %29 = icmp eq i64 %27, %20 
-  br i1 %29, label %if.then1, label %if.else1 
+  %21 = icmp eq i64 %19, %14 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %30 = icmp eq i64 %6, %13 
-  ret i1 %30 
+  %22 = icmp eq i64 %4, %9 
+  ret i1 %22 
 if.else1:
   ret i1 0 
 }
@@ -574,9 +539,8 @@ define external fastcc  i64 @"alias_type3.posrec.a<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -591,8 +555,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -600,9 +563,8 @@ entry:
 define external fastcc  i64 @"alias_type3.posrec.p<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -616,8 +578,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -628,12 +589,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"p##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"a##0", i64* %7 
+  store  i64 %"p##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"a##0", i64* %5 
   ret i64 %2 
 }
 
@@ -641,61 +600,51 @@ entry:
 define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"alias_type3.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  %10 = inttoptr i64 %1 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %1, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %6 to i64* 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
+  %17 = add   i64 %6, 8 
   %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  %21 = inttoptr i64 %9 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = add   i64 %9, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = icmp eq i64 %16, %23 
-  br i1 %28, label %if.then, label %if.else 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %11, %16 
+  br i1 %20, label %if.then, label %if.else 
 if.then:
-  %29 = icmp eq i64 %27, %20 
-  br i1 %29, label %if.then1, label %if.else1 
+  %21 = icmp eq i64 %19, %14 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
-  %33 = xor i1 0, 1 
-  ret i1 %33 
+  %25 = xor i1 0, 1 
+  ret i1 %25 
 if.then1:
-  %30 = icmp eq i64 %6, %13 
-  %31 = xor i1 %30, 1 
-  ret i1 %31 
+  %22 = icmp eq i64 %4, %9 
+  %23 = xor i1 %22, 1 
+  ret i1 %23 
 if.else1:
-  %32 = xor i1 0, 1 
-  ret i1 %32 
+  %24 = xor i1 0, 1 
+  ret i1 %24 
 }

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -92,23 +92,19 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 100, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 100, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 100, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 100, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 1, i64* %15 
-  tail call fastcc  void  @"alias_type4.foo<0>[410bae77d3]"(i64  %10)  
+  store  i64 1, i64* %11 
+  tail call fastcc  void  @"alias_type4.foo<0>[410bae77d3]"(i64  %8)  
   ret void 
 }
 
@@ -116,22 +112,19 @@ entry:
 define external fastcc  void @"alias_type4.foo<0>"(i64  %"r1##0")    {
 entry:
   %0 = inttoptr i64 %"r1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = trunc i64 16 to i32  
-  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
-  %5 = ptrtoint i8* %4 to i64 
-  %6 = inttoptr i64 %5 to i8* 
-  %7 = inttoptr i64 %2 to i8* 
-  %8 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %6, i8*  %7, i32  %8, i1  0)  
-  %9 = inttoptr i64 %5 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 1111, i64* %10 
-  %11 = inttoptr i64 %5 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
+  %1 = load  i64, i64* %0 
+  %2 = trunc i64 16 to i32  
+  %3 = tail call ccc  i8*  @wybe_malloc(i32  %2)  
+  %4 = ptrtoint i8* %3 to i64 
+  %5 = inttoptr i64 %4 to i8* 
+  %6 = inttoptr i64 %1 to i8* 
+  %7 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %5, i8*  %6, i32  %7, i1  0)  
+  %8 = inttoptr i64 %4 to i64* 
+  store  i64 1111, i64* %8 
+  %9 = inttoptr i64 %4 to i64* 
+  %10 = load  i64, i64* %9 
+  tail call ccc  void  @print_int(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -140,15 +133,12 @@ entry:
 define external fastcc  void @"alias_type4.foo<0>[410bae77d3]"(i64  %"r1##0")    {
 entry:
   %0 = inttoptr i64 %"r1##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 1111, i64* %4 
-  %5 = inttoptr i64 %2 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  tail call ccc  void  @print_int(i64  %7)  
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64* 
+  store  i64 1111, i64* %2 
+  %3 = inttoptr i64 %1 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -271,24 +261,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"alias_type4.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -300,12 +286,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -313,24 +297,21 @@ entry:
 define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"alias_type4.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -344,8 +325,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -354,9 +334,8 @@ define external fastcc  i64 @"alias_type4.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -371,8 +350,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -380,28 +358,24 @@ entry:
 define external fastcc  i1 @"alias_type4.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module alias_type4.posrec
@@ -545,43 +519,35 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"alias_type4.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  %10 = inttoptr i64 %1 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %1, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %6 to i64* 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
+  %17 = add   i64 %6, 8 
   %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  %21 = inttoptr i64 %9 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = add   i64 %9, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = icmp eq i64 %16, %23 
-  br i1 %28, label %if.then, label %if.else 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %11, %16 
+  br i1 %20, label %if.then, label %if.else 
 if.then:
-  %29 = icmp eq i64 %27, %20 
-  br i1 %29, label %if.then1, label %if.else1 
+  %21 = icmp eq i64 %19, %14 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %30 = icmp eq i64 %6, %13 
-  ret i1 %30 
+  %22 = icmp eq i64 %4, %9 
+  ret i1 %22 
 if.else1:
   ret i1 0 
 }
@@ -591,9 +557,8 @@ define external fastcc  i64 @"alias_type4.posrec.a<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -608,8 +573,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -617,9 +581,8 @@ entry:
 define external fastcc  i64 @"alias_type4.posrec.p<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -633,8 +596,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -645,12 +607,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"p##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"a##0", i64* %7 
+  store  i64 %"p##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"a##0", i64* %5 
   ret i64 %2 
 }
 
@@ -658,61 +618,51 @@ entry:
 define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"alias_type4.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  %10 = inttoptr i64 %1 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %1, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %6 to i64* 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
+  %17 = add   i64 %6, 8 
   %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  %21 = inttoptr i64 %9 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = add   i64 %9, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = icmp eq i64 %16, %23 
-  br i1 %28, label %if.then, label %if.else 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %11, %16 
+  br i1 %20, label %if.then, label %if.else 
 if.then:
-  %29 = icmp eq i64 %27, %20 
-  br i1 %29, label %if.then1, label %if.else1 
+  %21 = icmp eq i64 %19, %14 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
-  %33 = xor i1 0, 1 
-  ret i1 %33 
+  %25 = xor i1 0, 1 
+  ret i1 %25 
 if.then1:
-  %30 = icmp eq i64 %6, %13 
-  %31 = xor i1 %30, 1 
-  ret i1 %31 
+  %22 = icmp eq i64 %4, %9 
+  %23 = xor i1 %22, 1 
+  ret i1 %23 
 if.else1:
-  %32 = xor i1 0, 1 
-  ret i1 %32 
+  %24 = xor i1 0, 1 
+  ret i1 %24 
 }

--- a/test-cases/final-dump/alloc_args.exp
+++ b/test-cases/final-dump/alloc_args.exp
@@ -62,8 +62,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
+  store  i64 0, i64* %3 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -417,25 +417,21 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i1* 
-  %4 = getelementptr  i1, i1* %3, i64 0 
-  store  i1 0, i1* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
+  store  i1 0, i1* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
   store  i64 1, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 1, i64* %10 
-  %11 = trunc i64 8 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 1, i64* %15 
-  %16 = or i64 %13, 1 
-  %17 = tail call fastcc  i1  @"anon_field.=<0>"(i64  %2, i64  %16)  
-  br i1 %17, label %if.then, label %if.else 
+  %8 = trunc i64 8 to i32  
+  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
+  %10 = ptrtoint i8* %9 to i64 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 1, i64* %11 
+  %12 = or i64 %10, 1 
+  %13 = tail call fastcc  i1  @"anon_field.=<0>"(i64  %2, i64  %12)  
+  br i1 %13, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -454,85 +450,75 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#left##0" to i1* 
-  %3 = getelementptr  i1, i1* %2, i64 0 
-  %4 = load  i1, i1* %3 
-  %5 = add   i64 %"#left##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  %8 = load  i64, i64* %7 
-  %9 = add   i64 %"#left##0", 16 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  %12 = load  i64, i64* %11 
-  %13 = and i64 %"#right##0", 3 
-  %14 = icmp eq i64 %13, 0 
-  br i1 %14, label %if.then1, label %if.else1 
+  %3 = load  i1, i1* %2 
+  %4 = add   i64 %"#left##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  %7 = add   i64 %"#left##0", 16 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = and i64 %"#right##0", 3 
+  %11 = icmp eq i64 %10, 0 
+  br i1 %11, label %if.then1, label %if.else1 
 if.else:
-  %29 = icmp eq i64 %0, 1 
-  br i1 %29, label %if.then4, label %if.else4 
+  %23 = icmp eq i64 %0, 1 
+  br i1 %23, label %if.then4, label %if.else4 
 if.then1:
-  %15 = inttoptr i64 %"#right##0" to i1* 
-  %16 = getelementptr  i1, i1* %15, i64 0 
-  %17 = load  i1, i1* %16 
-  %18 = add   i64 %"#right##0", 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = add   i64 %"#right##0", 16 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  %25 = load  i64, i64* %24 
-  %26 = icmp eq i64 %8, %21 
-  br i1 %26, label %if.then2, label %if.else2 
+  %12 = inttoptr i64 %"#right##0" to i1* 
+  %13 = load  i1, i1* %12 
+  %14 = add   i64 %"#right##0", 8 
+  %15 = inttoptr i64 %14 to i64* 
+  %16 = load  i64, i64* %15 
+  %17 = add   i64 %"#right##0", 16 
+  %18 = inttoptr i64 %17 to i64* 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %6, %16 
+  br i1 %20, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %27 = icmp eq i1 %4, %17 
-  br i1 %27, label %if.then3, label %if.else3 
+  %21 = icmp eq i1 %3, %13 
+  br i1 %21, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %28 = icmp eq i64 %12, %25 
-  ret i1 %28 
+  %22 = icmp eq i64 %9, %19 
+  ret i1 %22 
 if.else3:
   ret i1 0 
 if.then4:
-  %30 = add   i64 %"#left##0", -1 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  %33 = load  i64, i64* %32 
-  %34 = and i64 %"#right##0", 3 
-  %35 = icmp eq i64 %34, 1 
-  br i1 %35, label %if.then5, label %if.else5 
+  %24 = add   i64 %"#left##0", -1 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = load  i64, i64* %25 
+  %27 = and i64 %"#right##0", 3 
+  %28 = icmp eq i64 %27, 1 
+  br i1 %28, label %if.then5, label %if.else5 
 if.else4:
-  %41 = icmp eq i64 %0, 2 
-  br i1 %41, label %if.then6, label %if.else6 
+  %33 = icmp eq i64 %0, 2 
+  br i1 %33, label %if.then6, label %if.else6 
 if.then5:
-  %36 = add   i64 %"#right##0", -1 
-  %37 = inttoptr i64 %36 to i64* 
-  %38 = getelementptr  i64, i64* %37, i64 0 
-  %39 = load  i64, i64* %38 
-  %40 = icmp eq i64 %33, %39 
-  ret i1 %40 
+  %29 = add   i64 %"#right##0", -1 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = load  i64, i64* %30 
+  %32 = icmp eq i64 %26, %31 
+  ret i1 %32 
 if.else5:
   ret i1 0 
 if.then6:
-  %42 = add   i64 %"#left##0", -2 
-  %43 = inttoptr i64 %42 to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  %45 = load  i64, i64* %44 
-  %46 = and i64 %"#right##0", 3 
-  %47 = icmp eq i64 %46, 2 
-  br i1 %47, label %if.then7, label %if.else7 
+  %34 = add   i64 %"#left##0", -2 
+  %35 = inttoptr i64 %34 to i64* 
+  %36 = load  i64, i64* %35 
+  %37 = and i64 %"#right##0", 3 
+  %38 = icmp eq i64 %37, 2 
+  br i1 %38, label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %48 = add   i64 %"#right##0", -2 
-  %49 = inttoptr i64 %48 to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  %51 = load  i64, i64* %50 
-  %52 = icmp eq i64 %45, %51 
-  ret i1 %52 
+  %39 = add   i64 %"#right##0", -2 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = load  i64, i64* %40 
+  %42 = icmp eq i64 %36, %41 
+  ret i1 %42 
 if.else7:
   ret i1 0 
 }
@@ -544,10 +530,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"bar#1##0", i64* %4 
-  %5 = or i64 %2, 1 
-  ret i64 %5 
+  store  i64 %"bar#1##0", i64* %3 
+  %4 = or i64 %2, 1 
+  ret i64 %4 
 }
 
 
@@ -559,15 +544,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -1 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -577,10 +561,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"field##0", i64* %4 
-  %5 = or i64 %2, 2 
-  ret i64 %5 
+  store  i64 %"field##0", i64* %3 
+  %4 = or i64 %2, 2 
+  ret i64 %4 
 }
 
 
@@ -592,15 +575,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -2 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -612,15 +594,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -2 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -641,15 +622,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -2 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -659,16 +639,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i1* 
-  %4 = getelementptr  i1, i1* %3, i64 0 
-  store  i1 %"foo#2##0", i1* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"foo#1##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"i##0", i64* %10 
+  store  i1 %"foo#2##0", i1* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"foo#1##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"i##0", i64* %7 
   ret i64 %2 
 }
 
@@ -680,27 +657,24 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#result##0" to i1* 
-  %3 = getelementptr  i1, i1* %2, i64 0 
-  %4 = load  i1, i1* %3 
-  %5 = add   i64 %"#result##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  %8 = load  i64, i64* %7 
-  %9 = add   i64 %"#result##0", 16 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  %12 = load  i64, i64* %11 
-  %13 = insertvalue {i64, i1, i64, i1} undef, i64 %8, 0 
-  %14 = insertvalue {i64, i1, i64, i1} %13, i1 %4, 1 
-  %15 = insertvalue {i64, i1, i64, i1} %14, i64 %12, 2 
-  %16 = insertvalue {i64, i1, i64, i1} %15, i1 1, 3 
-  ret {i64, i1, i64, i1} %16 
+  %3 = load  i1, i1* %2 
+  %4 = add   i64 %"#result##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  %7 = add   i64 %"#result##0", 16 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1, i64, i1} undef, i64 %6, 0 
+  %11 = insertvalue {i64, i1, i64, i1} %10, i1 %3, 1 
+  %12 = insertvalue {i64, i1, i64, i1} %11, i64 %9, 2 
+  %13 = insertvalue {i64, i1, i64, i1} %12, i1 1, 3 
+  ret {i64, i1, i64, i1} %13 
 if.else:
-  %17 = insertvalue {i64, i1, i64, i1} undef, i64 undef, 0 
-  %18 = insertvalue {i64, i1, i64, i1} %17, i1 undef, 1 
-  %19 = insertvalue {i64, i1, i64, i1} %18, i64 undef, 2 
-  %20 = insertvalue {i64, i1, i64, i1} %19, i1 0, 3 
-  ret {i64, i1, i64, i1} %20 
+  %14 = insertvalue {i64, i1, i64, i1} undef, i64 undef, 0 
+  %15 = insertvalue {i64, i1, i64, i1} %14, i1 undef, 1 
+  %16 = insertvalue {i64, i1, i64, i1} %15, i64 undef, 2 
+  %17 = insertvalue {i64, i1, i64, i1} %16, i1 0, 3 
+  ret {i64, i1, i64, i1} %17 
 }
 
 
@@ -710,19 +684,16 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i1* 
-  %4 = getelementptr  i1, i1* %3, i64 0 
-  store  i1 0, i1* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
+  store  i1 0, i1* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
   store  i64 1, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 1, i64* %10 
-  %11 = and i64 %2, 3 
-  %12 = icmp eq i64 %11, 0 
-  br i1 %12, label %if.then, label %if.else 
+  %8 = and i64 %2, 3 
+  %9 = icmp eq i64 %8, 0 
+  br i1 %9, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -740,32 +711,26 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i1* 
-  %4 = getelementptr  i1, i1* %3, i64 0 
-  store  i1 0, i1* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
+  store  i1 0, i1* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
   store  i64 1, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 1, i64* %10 
-  %11 = trunc i64 24 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i1* 
-  %15 = getelementptr  i1, i1* %14, i64 0 
-  store  i1 0, i1* %15 
-  %16 = add   i64 %13, 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 2, i64* %18 
-  %19 = add   i64 %13, 16 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 1, i64* %21 
-  %22 = tail call fastcc  i1  @"anon_field.=<0>"(i64  %2, i64  %13)  
-  br i1 %22, label %if.then, label %if.else 
+  %8 = trunc i64 24 to i32  
+  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
+  %10 = ptrtoint i8* %9 to i64 
+  %11 = inttoptr i64 %10 to i1* 
+  store  i1 0, i1* %11 
+  %12 = add   i64 %10, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 2, i64* %13 
+  %14 = add   i64 %10, 16 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = tail call fastcc  i1  @"anon_field.=<0>"(i64  %2, i64  %10)  
+  br i1 %16, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -783,19 +748,17 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 1, i64* %4 
-  %5 = or i64 %2, 2 
-  %6 = and i64 %5, 3 
-  %7 = icmp eq i64 %6, 2 
-  br i1 %7, label %if.then, label %if.else 
+  store  i64 1, i64* %3 
+  %4 = or i64 %2, 2 
+  %5 = and i64 %4, 3 
+  %6 = icmp eq i64 %5, 2 
+  br i1 %6, label %if.then, label %if.else 
 if.then:
-  %8 = add   i64 %5, -2 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp ne i64 %11, 2 
-  br i1 %12, label %if.then1, label %if.else1 
+  %7 = add   i64 %4, -2 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = icmp ne i64 %9, 2 
+  br i1 %10, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
@@ -815,15 +778,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", 16 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -842,15 +804,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %5, i8*  %6, i32  %7, i1  0)  
   %8 = add   i64 %4, 16 
   %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"#field##0", i64* %10 
-  %11 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %12 = insertvalue {i64, i1} %11, i1 1, 1 
-  ret {i64, i1} %12 
+  store  i64 %"#field##0", i64* %9 
+  %10 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
 if.else:
-  %13 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %14 = insertvalue {i64, i1} %13, i1 0, 1 
-  ret {i64, i1} %14 
+  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -963,24 +924,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"anon_field.quux.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -990,9 +947,8 @@ define external fastcc  i64 @"anon_field.quux.j<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -1007,8 +963,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -1019,12 +974,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"quuz#1##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"j##0", i64* %7 
+  store  i64 %"quuz#1##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"j##0", i64* %5 
   ret i64 %2 
 }
 
@@ -1032,41 +985,35 @@ entry:
 define external fastcc  {i64, i64} @"anon_field.quux.quuz<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"anon_field.quux.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/anon_field_variable.exp
+++ b/test-cases/final-dump/anon_field_variable.exp
@@ -155,11 +155,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = and i64 %2, 1 
-  %6 = icmp eq i64 %5, 0 
-  br i1 %6, label %if.then, label %if.else 
+  store  i64 0, i64* %3 
+  %4 = and i64 %2, 1 
+  %5 = icmp eq i64 %4, 0 
+  br i1 %5, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field_variable.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -175,18 +174,15 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"bar#1##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"field##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"bar#3##0", i64* %10 
-  %11 = or i64 %2, 1 
-  ret i64 %11 
+  store  i64 %"bar#1##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"field##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"bar#3##0", i64* %7 
+  %8 = or i64 %2, 1 
+  ret i64 %8 
 }
 
 
@@ -198,27 +194,24 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -1 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = add   i64 %"#result##0", 7 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#result##0", 15 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = insertvalue {i64, i64, i64, i1} undef, i64 %5, 0 
-  %15 = insertvalue {i64, i64, i64, i1} %14, i64 %9, 1 
-  %16 = insertvalue {i64, i64, i64, i1} %15, i64 %13, 2 
-  %17 = insertvalue {i64, i64, i64, i1} %16, i1 1, 3 
-  ret {i64, i64, i64, i1} %17 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#result##0", 7 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"#result##0", 15 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = load  i64, i64* %9 
+  %11 = insertvalue {i64, i64, i64, i1} undef, i64 %4, 0 
+  %12 = insertvalue {i64, i64, i64, i1} %11, i64 %7, 1 
+  %13 = insertvalue {i64, i64, i64, i1} %12, i64 %10, 2 
+  %14 = insertvalue {i64, i64, i64, i1} %13, i1 1, 3 
+  ret {i64, i64, i64, i1} %14 
 if.else:
-  %18 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i64, i64, i1} %18, i64 undef, 1 
-  %20 = insertvalue {i64, i64, i64, i1} %19, i64 undef, 2 
-  %21 = insertvalue {i64, i64, i64, i1} %20, i1 0, 3 
-  ret {i64, i64, i64, i1} %21 
+  %15 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %16 = insertvalue {i64, i64, i64, i1} %15, i64 undef, 1 
+  %17 = insertvalue {i64, i64, i64, i1} %16, i64 undef, 2 
+  %18 = insertvalue {i64, i64, i64, i1} %17, i1 0, 3 
+  ret {i64, i64, i64, i1} %18 
 }
 
 
@@ -230,15 +223,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", 7 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -259,15 +251,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, 7 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -277,8 +268,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"foo#1##0", i64* %4 
+  store  i64 %"foo#1##0", i64* %3 
   ret i64 %2 
 }
 
@@ -290,13 +280,12 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#result##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }

--- a/test-cases/final-dump/bug214.exp
+++ b/test-cases/final-dump/bug214.exp
@@ -315,12 +315,10 @@ entry:
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %0, i64* %5 
-  %6 = add   i64 %3, 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 0, i64* %8 
+  store  i64 %0, i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 0, i64* %6 
   tail call fastcc  void  @"bug214.gen#2<0>"(i64  %0, i64  %3, i64  %0, i64  %3, i64  %0)  
   ret void 
 }
@@ -329,35 +327,31 @@ entry:
 define external fastcc  i1 @"bug214.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  {i64, i64}  @"bug214.position.position<1>"(i64  %2)  
-  %15 = extractvalue {i64, i64} %14, 0 
-  %16 = extractvalue {i64, i64} %14, 1 
-  %17 = tail call fastcc  {i64, i64}  @"bug214.position.position<1>"(i64  %9)  
-  %18 = extractvalue {i64, i64} %17, 0 
-  %19 = extractvalue {i64, i64} %17, 1 
-  %20 = tail call fastcc  i1  @"wybe.int.=<0>"(i64  %15, i64  %18)  
-  br i1 %20, label %if.then, label %if.else 
+  %10 = tail call fastcc  {i64, i64}  @"bug214.position.position<1>"(i64  %1)  
+  %11 = extractvalue {i64, i64} %10, 0 
+  %12 = extractvalue {i64, i64} %10, 1 
+  %13 = tail call fastcc  {i64, i64}  @"bug214.position.position<1>"(i64  %6)  
+  %14 = extractvalue {i64, i64} %13, 0 
+  %15 = extractvalue {i64, i64} %13, 1 
+  %16 = tail call fastcc  i1  @"wybe.int.=<0>"(i64  %11, i64  %14)  
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  %21 = tail call fastcc  i1  @"wybe.int.=<0>"(i64  %16, i64  %19)  
-  br i1 %21, label %if.then1, label %if.else1 
+  %17 = tail call fastcc  i1  @"wybe.int.=<0>"(i64  %12, i64  %15)  
+  br i1 %17, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %22 = icmp eq i64 %6, %13 
-  ret i1 %22 
+  %18 = icmp eq i64 %4, %9 
+  ret i1 %18 
 if.else1:
   ret i1 0 
 }
@@ -367,9 +361,8 @@ define external fastcc  i64 @"bug214.aim<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -384,8 +377,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -396,30 +388,25 @@ entry:
   tail call fastcc  void  @"bug214.position.print<0>"(i64  %"pos##0")  
   tail call ccc  void  @putchar(i8  32)  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = mul   i64 %2, %6 
-  tail call ccc  void  @print_int(i64  %7)  
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = mul   i64 %1, %4 
+  tail call ccc  void  @print_int(i64  %5)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.3, i32 0, i32 0) to i64))  
-  %8 = inttoptr i64 %"sub##0" to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call fastcc  void  @"bug214.position.print<0>"(i64  %10)  
+  %6 = inttoptr i64 %"sub##0" to i64* 
+  %7 = load  i64, i64* %6 
+  tail call fastcc  void  @"bug214.position.print<0>"(i64  %7)  
   tail call ccc  void  @putchar(i8  32)  
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %7, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %10, 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = mul   i64 %13, %17 
-  tail call ccc  void  @print_int(i64  %18)  
+  %12 = load  i64, i64* %11 
+  %13 = mul   i64 %9, %12 
+  tail call ccc  void  @print_int(i64  %13)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -452,62 +439,56 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"pos##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %3, %"units##0" 
-  %5 = trunc i64 16 to i32  
-  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
-  %7 = ptrtoint i8* %6 to i64 
-  %8 = inttoptr i64 %7 to i8* 
-  %9 = inttoptr i64 %"pos##0" to i8* 
-  %10 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
-  %11 = inttoptr i64 %7 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %4, i64* %12 
-  ret i64 %7 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %2, %"units##0" 
+  %4 = trunc i64 16 to i32  
+  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
+  %6 = ptrtoint i8* %5 to i64 
+  %7 = inttoptr i64 %6 to i8* 
+  %8 = inttoptr i64 %"pos##0" to i8* 
+  %9 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
+  %10 = inttoptr i64 %6 to i64* 
+  store  i64 %3, i64* %10 
+  ret i64 %6 
 if.else:
-  %13 = icmp eq i2 %"dir##0", 1 
-  br i1 %13, label %if.then1, label %if.else1 
+  %11 = icmp eq i2 %"dir##0", 1 
+  br i1 %11, label %if.then1, label %if.else1 
 if.then1:
-  %14 = add   i64 %"pos##0", 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %17, %"units##0" 
-  %19 = trunc i64 16 to i32  
-  %20 = tail call ccc  i8*  @wybe_malloc(i32  %19)  
-  %21 = ptrtoint i8* %20 to i64 
-  %22 = inttoptr i64 %21 to i8* 
-  %23 = inttoptr i64 %"pos##0" to i8* 
-  %24 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %22, i8*  %23, i32  %24, i1  0)  
-  %25 = add   i64 %21, 8 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  store  i64 %18, i64* %27 
-  ret i64 %21 
+  %12 = add   i64 %"pos##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %14, %"units##0" 
+  %16 = trunc i64 16 to i32  
+  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
+  %18 = ptrtoint i8* %17 to i64 
+  %19 = inttoptr i64 %18 to i8* 
+  %20 = inttoptr i64 %"pos##0" to i8* 
+  %21 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i1  0)  
+  %22 = add   i64 %18, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 %15, i64* %23 
+  ret i64 %18 
 if.else1:
-  %28 = icmp eq i2 %"dir##0", 2 
-  br i1 %28, label %if.then2, label %if.else2 
+  %24 = icmp eq i2 %"dir##0", 2 
+  br i1 %24, label %if.then2, label %if.else2 
 if.then2:
-  %29 = add   i64 %"pos##0", 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  %32 = load  i64, i64* %31 
-  %33 = sub   i64 %32, %"units##0" 
+  %25 = add   i64 %"pos##0", 8 
+  %26 = inttoptr i64 %25 to i64* 
+  %27 = load  i64, i64* %26 
+  %28 = sub   i64 %27, %"units##0" 
+  %29 = trunc i64 16 to i32  
+  %30 = tail call ccc  i8*  @wybe_malloc(i32  %29)  
+  %31 = ptrtoint i8* %30 to i64 
+  %32 = inttoptr i64 %31 to i8* 
+  %33 = inttoptr i64 %"pos##0" to i8* 
   %34 = trunc i64 16 to i32  
-  %35 = tail call ccc  i8*  @wybe_malloc(i32  %34)  
-  %36 = ptrtoint i8* %35 to i64 
-  %37 = inttoptr i64 %36 to i8* 
-  %38 = inttoptr i64 %"pos##0" to i8* 
-  %39 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %37, i8*  %38, i32  %39, i1  0)  
-  %40 = add   i64 %36, 8 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %33, i64* %42 
-  ret i64 %36 
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %32, i8*  %33, i32  %34, i1  0)  
+  %35 = add   i64 %31, 8 
+  %36 = inttoptr i64 %35 to i64* 
+  store  i64 %28, i64* %36 
+  ret i64 %31 
 if.else2:
   ret i64 %"pos##0" 
 }
@@ -519,102 +500,89 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"sub##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %6, %"units##0" 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = inttoptr i64 %10 to i8* 
-  %12 = inttoptr i64 %3 to i8* 
+  %2 = load  i64, i64* %1 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %4, %"units##0" 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i8* 
+  %10 = inttoptr i64 %2 to i8* 
+  %11 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
+  %12 = inttoptr i64 %8 to i64* 
+  store  i64 %5, i64* %12 
   %13 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %11, i8*  %12, i32  %13, i1  0)  
-  %14 = inttoptr i64 %10 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %7, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i8* 
-  %20 = inttoptr i64 %"sub##0" to i8* 
-  %21 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i1  0)  
-  %22 = inttoptr i64 %18 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  %24 = inttoptr i64 %18 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  %26 = load  i64, i64* %25 
-  %27 = add   i64 %26, 8 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  %30 = load  i64, i64* %29 
-  %31 = add   i64 %18, 8 
-  %32 = inttoptr i64 %31 to i64* 
-  %33 = getelementptr  i64, i64* %32, i64 0 
-  %34 = load  i64, i64* %33 
-  %35 = mul   i64 %34, %"units##0" 
-  %36 = add   i64 %30, %35 
-  %37 = trunc i64 16 to i32  
-  %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
-  %39 = ptrtoint i8* %38 to i64 
-  %40 = inttoptr i64 %39 to i8* 
-  %41 = inttoptr i64 %26 to i8* 
-  %42 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %40, i8*  %41, i32  %42, i1  0)  
-  %43 = add   i64 %39, 8 
-  %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 %36, i64* %45 
-  %46 = inttoptr i64 %18 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %39, i64* %47 
-  ret i64 %18 
+  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
+  %15 = ptrtoint i8* %14 to i64 
+  %16 = inttoptr i64 %15 to i8* 
+  %17 = inttoptr i64 %"sub##0" to i8* 
+  %18 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %16, i8*  %17, i32  %18, i1  0)  
+  %19 = inttoptr i64 %15 to i64* 
+  store  i64 %8, i64* %19 
+  %20 = inttoptr i64 %15 to i64* 
+  %21 = load  i64, i64* %20 
+  %22 = add   i64 %21, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  %24 = load  i64, i64* %23 
+  %25 = add   i64 %15, 8 
+  %26 = inttoptr i64 %25 to i64* 
+  %27 = load  i64, i64* %26 
+  %28 = mul   i64 %27, %"units##0" 
+  %29 = add   i64 %24, %28 
+  %30 = trunc i64 16 to i32  
+  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
+  %32 = ptrtoint i8* %31 to i64 
+  %33 = inttoptr i64 %32 to i8* 
+  %34 = inttoptr i64 %21 to i8* 
+  %35 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i1  0)  
+  %36 = add   i64 %32, 8 
+  %37 = inttoptr i64 %36 to i64* 
+  store  i64 %29, i64* %37 
+  %38 = inttoptr i64 %15 to i64* 
+  store  i64 %32, i64* %38 
+  ret i64 %15 
 if.else:
-  %48 = icmp eq i2 %"dir##0", 1 
-  br i1 %48, label %if.then1, label %if.else1 
+  %39 = icmp eq i2 %"dir##0", 1 
+  br i1 %39, label %if.then1, label %if.else1 
 if.then1:
-  %49 = add   i64 %"sub##0", 8 
-  %50 = inttoptr i64 %49 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  %52 = load  i64, i64* %51 
-  %53 = add   i64 %52, %"units##0" 
-  %54 = trunc i64 16 to i32  
-  %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
-  %56 = ptrtoint i8* %55 to i64 
-  %57 = inttoptr i64 %56 to i8* 
-  %58 = inttoptr i64 %"sub##0" to i8* 
-  %59 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %57, i8*  %58, i32  %59, i1  0)  
-  %60 = add   i64 %56, 8 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  store  i64 %53, i64* %62 
-  ret i64 %56 
+  %40 = add   i64 %"sub##0", 8 
+  %41 = inttoptr i64 %40 to i64* 
+  %42 = load  i64, i64* %41 
+  %43 = add   i64 %42, %"units##0" 
+  %44 = trunc i64 16 to i32  
+  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
+  %46 = ptrtoint i8* %45 to i64 
+  %47 = inttoptr i64 %46 to i8* 
+  %48 = inttoptr i64 %"sub##0" to i8* 
+  %49 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i1  0)  
+  %50 = add   i64 %46, 8 
+  %51 = inttoptr i64 %50 to i64* 
+  store  i64 %43, i64* %51 
+  ret i64 %46 
 if.else1:
-  %63 = icmp eq i2 %"dir##0", 2 
-  br i1 %63, label %if.then2, label %if.else2 
+  %52 = icmp eq i2 %"dir##0", 2 
+  br i1 %52, label %if.then2, label %if.else2 
 if.then2:
-  %64 = add   i64 %"sub##0", 8 
-  %65 = inttoptr i64 %64 to i64* 
-  %66 = getelementptr  i64, i64* %65, i64 0 
-  %67 = load  i64, i64* %66 
-  %68 = sub   i64 %67, %"units##0" 
-  %69 = trunc i64 16 to i32  
-  %70 = tail call ccc  i8*  @wybe_malloc(i32  %69)  
-  %71 = ptrtoint i8* %70 to i64 
-  %72 = inttoptr i64 %71 to i8* 
-  %73 = inttoptr i64 %"sub##0" to i8* 
-  %74 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %72, i8*  %73, i32  %74, i1  0)  
-  %75 = add   i64 %71, 8 
-  %76 = inttoptr i64 %75 to i64* 
-  %77 = getelementptr  i64, i64* %76, i64 0 
-  store  i64 %68, i64* %77 
-  ret i64 %71 
+  %53 = add   i64 %"sub##0", 8 
+  %54 = inttoptr i64 %53 to i64* 
+  %55 = load  i64, i64* %54 
+  %56 = sub   i64 %55, %"units##0" 
+  %57 = trunc i64 16 to i32  
+  %58 = tail call ccc  i8*  @wybe_malloc(i32  %57)  
+  %59 = ptrtoint i8* %58 to i64 
+  %60 = inttoptr i64 %59 to i8* 
+  %61 = inttoptr i64 %"sub##0" to i8* 
+  %62 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %60, i8*  %61, i32  %62, i1  0)  
+  %63 = add   i64 %59, 8 
+  %64 = inttoptr i64 %63 to i64* 
+  store  i64 %56, i64* %64 
+  ret i64 %59 
 if.else2:
   ret i64 %"sub##0" 
 }
@@ -623,9 +591,8 @@ if.else2:
 define external fastcc  i64 @"bug214.sub_pos<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -639,8 +606,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -651,12 +617,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"sub_pos##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"aim##0", i64* %7 
+  store  i64 %"sub_pos##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"aim##0", i64* %5 
   ret i64 %2 
 }
 
@@ -664,55 +628,49 @@ entry:
 define external fastcc  {i64, i64} @"bug214.submarine<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"bug214.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  {i64, i64}  @"bug214.position.position<1>"(i64  %2)  
-  %15 = extractvalue {i64, i64} %14, 0 
-  %16 = extractvalue {i64, i64} %14, 1 
-  %17 = tail call fastcc  {i64, i64}  @"bug214.position.position<1>"(i64  %9)  
-  %18 = extractvalue {i64, i64} %17, 0 
-  %19 = extractvalue {i64, i64} %17, 1 
-  %20 = tail call fastcc  i1  @"wybe.int.=<0>"(i64  %15, i64  %18)  
-  br i1 %20, label %if.then, label %if.else 
+  %10 = tail call fastcc  {i64, i64}  @"bug214.position.position<1>"(i64  %1)  
+  %11 = extractvalue {i64, i64} %10, 0 
+  %12 = extractvalue {i64, i64} %10, 1 
+  %13 = tail call fastcc  {i64, i64}  @"bug214.position.position<1>"(i64  %6)  
+  %14 = extractvalue {i64, i64} %13, 0 
+  %15 = extractvalue {i64, i64} %13, 1 
+  %16 = tail call fastcc  i1  @"wybe.int.=<0>"(i64  %11, i64  %14)  
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  %21 = tail call fastcc  i1  @"wybe.int.=<0>"(i64  %16, i64  %19)  
-  br i1 %21, label %if.then1, label %if.else1 
+  %17 = tail call fastcc  i1  @"wybe.int.=<0>"(i64  %12, i64  %15)  
+  br i1 %17, label %if.then1, label %if.else1 
 if.else:
-  %25 = xor i1 0, 1 
-  ret i1 %25 
+  %21 = xor i1 0, 1 
+  ret i1 %21 
 if.then1:
-  %22 = icmp eq i64 %6, %13 
-  %23 = xor i1 %22, 1 
-  ret i1 %23 
+  %18 = icmp eq i64 %4, %9 
+  %19 = xor i1 %18, 1 
+  ret i1 %19 
 if.else1:
-  %24 = xor i1 0, 1 
-  ret i1 %24 
+  %20 = xor i1 0, 1 
+  ret i1 %20 
 }
 --------------------------------------------------
  Module bug214.direction
@@ -1071,24 +1029,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"bug214.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -1100,12 +1054,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
   ret i64 %2 
 }
 
@@ -1116,12 +1068,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -1129,15 +1079,13 @@ entry:
 define external fastcc  {i64, i64} @"bug214.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
@@ -1145,15 +1093,13 @@ define external fastcc  void @"bug214.position.print<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   musttail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.position.5, i32 0, i32 0) to i64))  
   ret void 
 }
@@ -1162,9 +1108,8 @@ entry:
 define external fastcc  i64 @"bug214.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -1178,8 +1123,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -1188,9 +1132,8 @@ define external fastcc  i64 @"bug214.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -1205,8 +1148,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -1214,26 +1156,22 @@ entry:
 define external fastcc  i1 @"bug214.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -138,39 +138,32 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 10, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 10, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 12, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 %2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  %24 = inttoptr i64 %10 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  %26 = load  i64, i64* %25 
+  store  i64 12, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 %2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = inttoptr i64 %8 to i64* 
+  %19 = load  i64, i64* %18 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %26)  
+  tail call ccc  void  @print_int(i64  %19)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"caret.gen#1<0>[410bae77d3]"(i64  %18)  
+  tail call fastcc  void  @"caret.gen#1<0>[410bae77d3]"(i64  %14)  
   ret void 
 }
 
@@ -178,122 +171,106 @@ entry:
 define external fastcc  i64 @"caret.expand_region<0>"(i64  %"reg##0", i64  %"point##0")    {
 entry:
   %0 = inttoptr i64 %"reg##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64* 
+  %3 = load  i64, i64* %2 
+  %4 = inttoptr i64 %"point##0" to i64* 
   %5 = load  i64, i64* %4 
-  %6 = inttoptr i64 %"point##0" to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  %8 = load  i64, i64* %7 
-  %9 = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %5, i64  %8)  
-  %10 = trunc i64 16 to i32  
-  %11 = tail call ccc  i8*  @wybe_malloc(i32  %10)  
-  %12 = ptrtoint i8* %11 to i64 
-  %13 = inttoptr i64 %12 to i8* 
-  %14 = inttoptr i64 %2 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = inttoptr i64 %12 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  store  i64 %9, i64* %17 
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"reg##0" to i8* 
-  %23 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i1  0)  
-  %24 = inttoptr i64 %20 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %12, i64* %25 
-  %26 = add   i64 %12, 8 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  %29 = load  i64, i64* %28 
-  %30 = add   i64 %"point##0", 8 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  %33 = load  i64, i64* %32 
-  %34 = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %29, i64  %33)  
-  %35 = trunc i64 16 to i32  
-  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
-  %37 = ptrtoint i8* %36 to i64 
-  %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %12 to i8* 
-  %40 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i1  0)  
-  %41 = add   i64 %37, 8 
-  %42 = inttoptr i64 %41 to i64* 
-  %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %34, i64* %43 
-  %44 = trunc i64 16 to i32  
-  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
-  %46 = ptrtoint i8* %45 to i64 
-  %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %20 to i8* 
+  %6 = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %3, i64  %5)  
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i8* 
+  %11 = inttoptr i64 %1 to i8* 
+  %12 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %10, i8*  %11, i32  %12, i1  0)  
+  %13 = inttoptr i64 %9 to i64* 
+  store  i64 %6, i64* %13 
+  %14 = trunc i64 16 to i32  
+  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
+  %16 = ptrtoint i8* %15 to i64 
+  %17 = inttoptr i64 %16 to i8* 
+  %18 = inttoptr i64 %"reg##0" to i8* 
+  %19 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %17, i8*  %18, i32  %19, i1  0)  
+  %20 = inttoptr i64 %16 to i64* 
+  store  i64 %9, i64* %20 
+  %21 = add   i64 %9, 8 
+  %22 = inttoptr i64 %21 to i64* 
+  %23 = load  i64, i64* %22 
+  %24 = add   i64 %"point##0", 8 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = load  i64, i64* %25 
+  %27 = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %23, i64  %26)  
+  %28 = trunc i64 16 to i32  
+  %29 = tail call ccc  i8*  @wybe_malloc(i32  %28)  
+  %30 = ptrtoint i8* %29 to i64 
+  %31 = inttoptr i64 %30 to i8* 
+  %32 = inttoptr i64 %9 to i8* 
+  %33 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %31, i8*  %32, i32  %33, i1  0)  
+  %34 = add   i64 %30, 8 
+  %35 = inttoptr i64 %34 to i64* 
+  store  i64 %27, i64* %35 
+  %36 = trunc i64 16 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i8* 
+  %40 = inttoptr i64 %16 to i8* 
+  %41 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %39, i8*  %40, i32  %41, i1  0)  
+  %42 = inttoptr i64 %38 to i64* 
+  store  i64 %30, i64* %42 
+  %43 = add   i64 %38, 8 
+  %44 = inttoptr i64 %43 to i64* 
+  %45 = load  i64, i64* %44 
+  %46 = inttoptr i64 %45 to i64* 
+  %47 = load  i64, i64* %46 
+  %48 = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %47, i64  %5)  
   %49 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i1  0)  
-  %50 = inttoptr i64 %46 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %37, i64* %51 
-  %52 = add   i64 %46, 8 
-  %53 = inttoptr i64 %52 to i64* 
-  %54 = getelementptr  i64, i64* %53, i64 0 
-  %55 = load  i64, i64* %54 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  %58 = load  i64, i64* %57 
-  %59 = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %58, i64  %8)  
-  %60 = trunc i64 16 to i32  
-  %61 = tail call ccc  i8*  @wybe_malloc(i32  %60)  
-  %62 = ptrtoint i8* %61 to i64 
-  %63 = inttoptr i64 %62 to i8* 
-  %64 = inttoptr i64 %55 to i8* 
-  %65 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %63, i8*  %64, i32  %65, i1  0)  
-  %66 = inttoptr i64 %62 to i64* 
-  %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 %59, i64* %67 
+  %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
+  %51 = ptrtoint i8* %50 to i64 
+  %52 = inttoptr i64 %51 to i8* 
+  %53 = inttoptr i64 %45 to i8* 
+  %54 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %52, i8*  %53, i32  %54, i1  0)  
+  %55 = inttoptr i64 %51 to i64* 
+  store  i64 %48, i64* %55 
+  %56 = trunc i64 16 to i32  
+  %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
+  %58 = ptrtoint i8* %57 to i64 
+  %59 = inttoptr i64 %58 to i8* 
+  %60 = inttoptr i64 %38 to i8* 
+  %61 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %59, i8*  %60, i32  %61, i1  0)  
+  %62 = add   i64 %58, 8 
+  %63 = inttoptr i64 %62 to i64* 
+  store  i64 %51, i64* %63 
+  %64 = add   i64 %51, 8 
+  %65 = inttoptr i64 %64 to i64* 
+  %66 = load  i64, i64* %65 
+  %67 = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %66, i64  %26)  
   %68 = trunc i64 16 to i32  
   %69 = tail call ccc  i8*  @wybe_malloc(i32  %68)  
   %70 = ptrtoint i8* %69 to i64 
   %71 = inttoptr i64 %70 to i8* 
-  %72 = inttoptr i64 %46 to i8* 
+  %72 = inttoptr i64 %51 to i8* 
   %73 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %71, i8*  %72, i32  %73, i1  0)  
   %74 = add   i64 %70, 8 
   %75 = inttoptr i64 %74 to i64* 
-  %76 = getelementptr  i64, i64* %75, i64 0 
-  store  i64 %62, i64* %76 
-  %77 = add   i64 %62, 8 
-  %78 = inttoptr i64 %77 to i64* 
-  %79 = getelementptr  i64, i64* %78, i64 0 
-  %80 = load  i64, i64* %79 
-  %81 = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %80, i64  %33)  
-  %82 = trunc i64 16 to i32  
-  %83 = tail call ccc  i8*  @wybe_malloc(i32  %82)  
-  %84 = ptrtoint i8* %83 to i64 
-  %85 = inttoptr i64 %84 to i8* 
-  %86 = inttoptr i64 %62 to i8* 
-  %87 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %85, i8*  %86, i32  %87, i1  0)  
-  %88 = add   i64 %84, 8 
-  %89 = inttoptr i64 %88 to i64* 
-  %90 = getelementptr  i64, i64* %89, i64 0 
-  store  i64 %81, i64* %90 
-  %91 = trunc i64 16 to i32  
-  %92 = tail call ccc  i8*  @wybe_malloc(i32  %91)  
-  %93 = ptrtoint i8* %92 to i64 
-  %94 = inttoptr i64 %93 to i8* 
-  %95 = inttoptr i64 %70 to i8* 
-  %96 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %94, i8*  %95, i32  %96, i1  0)  
-  %97 = add   i64 %93, 8 
-  %98 = inttoptr i64 %97 to i64* 
-  %99 = getelementptr  i64, i64* %98, i64 0 
-  store  i64 %84, i64* %99 
-  ret i64 %93 
+  store  i64 %67, i64* %75 
+  %76 = trunc i64 16 to i32  
+  %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
+  %78 = ptrtoint i8* %77 to i64 
+  %79 = inttoptr i64 %78 to i8* 
+  %80 = inttoptr i64 %58 to i8* 
+  %81 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %79, i8*  %80, i32  %81, i1  0)  
+  %82 = add   i64 %78, 8 
+  %83 = inttoptr i64 %82 to i64* 
+  store  i64 %70, i64* %83 
+  ret i64 %78 
 }
 
 
@@ -301,27 +278,23 @@ define external fastcc  void @"caret.gen#1<0>"(i64  %"reg##0")    {
 entry:
   %0 = add   i64 %"reg##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %6, 1 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = inttoptr i64 %10 to i8* 
-  %12 = inttoptr i64 %3 to i8* 
-  %13 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %11, i8*  %12, i32  %13, i1  0)  
-  %14 = inttoptr i64 %10 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %7, i64* %15 
-  %16 = inttoptr i64 %10 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  %18 = load  i64, i64* %17 
+  %2 = load  i64, i64* %1 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %4, 1 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i8* 
+  %10 = inttoptr i64 %2 to i8* 
+  %11 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
+  %12 = inttoptr i64 %8 to i64* 
+  store  i64 %5, i64* %12 
+  %13 = inttoptr i64 %8 to i64* 
+  %14 = load  i64, i64* %13 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %18)  
+  tail call ccc  void  @print_int(i64  %14)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -331,20 +304,16 @@ define external fastcc  void @"caret.gen#1<0>[410bae77d3]"(i64  %"reg##0")    {
 entry:
   %0 = add   i64 %"reg##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %6, 1 
-  %8 = inttoptr i64 %3 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %7, i64* %9 
-  %10 = inttoptr i64 %3 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  %12 = load  i64, i64* %11 
+  %2 = load  i64, i64* %1 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %4, 1 
+  %6 = inttoptr i64 %2 to i64* 
+  store  i64 %5, i64* %6 
+  %7 = inttoptr i64 %2 to i64* 
+  %8 = load  i64, i64* %7 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %12)  
+  tail call ccc  void  @print_int(i64  %8)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -513,62 +482,50 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"caret.region.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  %10 = inttoptr i64 %1 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %1, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %6 to i64* 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
+  %17 = add   i64 %6, 8 
   %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  %21 = inttoptr i64 %9 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = add   i64 %9, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = icmp eq i64 %16, %23 
-  br i1 %28, label %if.then, label %if.else 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %11, %16 
+  br i1 %20, label %if.then, label %if.else 
 if.then:
-  %29 = icmp eq i64 %27, %20 
-  br i1 %29, label %if.then1, label %if.else1 
+  %21 = icmp eq i64 %19, %14 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %30 = inttoptr i64 %6 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  %32 = load  i64, i64* %31 
-  %33 = add   i64 %6, 8 
-  %34 = inttoptr i64 %33 to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  %36 = load  i64, i64* %35 
-  %37 = inttoptr i64 %13 to i64* 
-  %38 = getelementptr  i64, i64* %37, i64 0 
-  %39 = load  i64, i64* %38 
-  %40 = add   i64 %13, 8 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  %43 = load  i64, i64* %42 
-  %44 = icmp eq i64 %32, %39 
-  br i1 %44, label %if.then2, label %if.else2 
+  %22 = inttoptr i64 %4 to i64* 
+  %23 = load  i64, i64* %22 
+  %24 = add   i64 %4, 8 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = load  i64, i64* %25 
+  %27 = inttoptr i64 %9 to i64* 
+  %28 = load  i64, i64* %27 
+  %29 = add   i64 %9, 8 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = load  i64, i64* %30 
+  %32 = icmp eq i64 %23, %28 
+  br i1 %32, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %45 = icmp eq i64 %36, %43 
-  ret i1 %45 
+  %33 = icmp eq i64 %26, %31 
+  ret i1 %33 
 if.else2:
   ret i1 0 
 }
@@ -577,9 +534,8 @@ if.else2:
 define external fastcc  i64 @"caret.region.lower_left<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -593,8 +549,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -605,12 +560,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"lower_left##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"upper_right##0", i64* %7 
+  store  i64 %"lower_left##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"upper_right##0", i64* %5 
   ret i64 %2 
 }
 
@@ -618,15 +571,13 @@ entry:
 define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
@@ -634,9 +585,8 @@ define external fastcc  i64 @"caret.region.upper_right<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -651,8 +601,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -660,68 +609,56 @@ entry:
 define external fastcc  i1 @"caret.region.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = inttoptr i64 %2 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
+  %10 = inttoptr i64 %1 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %1, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = inttoptr i64 %6 to i64* 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %2, 8 
+  %17 = add   i64 %6, 8 
   %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  %21 = inttoptr i64 %9 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = add   i64 %9, 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = icmp eq i64 %16, %23 
-  br i1 %28, label %if.then, label %if.else 
+  %19 = load  i64, i64* %18 
+  %20 = icmp eq i64 %11, %16 
+  br i1 %20, label %if.then, label %if.else 
 if.then:
-  %29 = icmp eq i64 %27, %20 
-  br i1 %29, label %if.then1, label %if.else1 
+  %21 = icmp eq i64 %19, %14 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
-  %49 = xor i1 0, 1 
-  ret i1 %49 
+  %37 = xor i1 0, 1 
+  ret i1 %37 
 if.then1:
-  %30 = inttoptr i64 %6 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  %32 = load  i64, i64* %31 
-  %33 = add   i64 %6, 8 
-  %34 = inttoptr i64 %33 to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  %36 = load  i64, i64* %35 
-  %37 = inttoptr i64 %13 to i64* 
-  %38 = getelementptr  i64, i64* %37, i64 0 
-  %39 = load  i64, i64* %38 
-  %40 = add   i64 %13, 8 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  %43 = load  i64, i64* %42 
-  %44 = icmp eq i64 %32, %39 
-  br i1 %44, label %if.then2, label %if.else2 
+  %22 = inttoptr i64 %4 to i64* 
+  %23 = load  i64, i64* %22 
+  %24 = add   i64 %4, 8 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = load  i64, i64* %25 
+  %27 = inttoptr i64 %9 to i64* 
+  %28 = load  i64, i64* %27 
+  %29 = add   i64 %9, 8 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = load  i64, i64* %30 
+  %32 = icmp eq i64 %23, %28 
+  br i1 %32, label %if.then2, label %if.else2 
 if.else1:
-  %48 = xor i1 0, 1 
-  ret i1 %48 
+  %36 = xor i1 0, 1 
+  ret i1 %36 
 if.then2:
-  %45 = icmp eq i64 %36, %43 
-  %46 = xor i1 %45, 1 
-  ret i1 %46 
+  %33 = icmp eq i64 %26, %31 
+  %34 = xor i1 %33, 1 
+  ret i1 %34 
 if.else2:
-  %47 = xor i1 0, 1 
-  ret i1 %47 
+  %35 = xor i1 0, 1 
+  ret i1 %35 
 }
 --------------------------------------------------
  Module position
@@ -808,15 +745,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -940,24 +875,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -969,12 +900,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -982,24 +911,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -1013,8 +939,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -1023,9 +948,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -1040,8 +964,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -1049,26 +972,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/cases.exp
+++ b/test-cases/final-dump/cases.exp
@@ -63,11 +63,10 @@ entry:
 if.then:
   %1 = add   i64 %"lst##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = tail call fastcc  i64  @"cases.len<0>"(i64  %4)  
-  %6 = add   i64 %5, 1 
-  ret i64 %6 
+  %3 = load  i64, i64* %2 
+  %4 = tail call fastcc  i64  @"cases.len<0>"(i64  %3)  
+  %5 = add   i64 %4, 1 
+  ret i64 %5 
 if.else:
   ret i64 0 
 }
@@ -80,11 +79,10 @@ entry:
 if.then:
   %1 = add   i64 %"lst##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = tail call fastcc  i64  @"cases.len2<0>"(i64  %4)  
-  %6 = add   i64 %5, 1 
-  ret i64 %6 
+  %3 = load  i64, i64* %2 
+  %4 = tail call fastcc  i64  @"cases.len2<0>"(i64  %3)  
+  %5 = add   i64 %4, 1 
+  ret i64 %5 
 if.else:
   ret i64 0 
 }

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -131,19 +131,17 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp ne i64 %"#right##0", 0 
-  br i1 %4, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = icmp ne i64 %"#right##0", 0 
+  br i1 %3, label %if.then1, label %if.else1 
 if.else:
-  %9 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %9 
+  %7 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %7 
 if.then1:
-  %5 = inttoptr i64 %"#right##0" to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, %7 
-  ret i1 %8 
+  %4 = inttoptr i64 %"#right##0" to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, %5 
+  ret i1 %6 
 if.else1:
   ret i1 0 
 }
@@ -155,8 +153,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"value##0", i64* %4 
+  store  i64 %"value##0", i64* %3 
   ret i64 %2 
 }
 
@@ -167,15 +164,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -191,15 +187,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -216,15 +211,14 @@ if.then:
   %6 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -93,26 +93,21 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 1000, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
+  store  i64 1000, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1000, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
   store  i64 1000, i64* %7 
   %8 = add   i64 %2, 16 
   %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 1000, i64* %10 
-  %11 = add   i64 %2, 16 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 8000, i64* %13 
+  store  i64 8000, i64* %9 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @coordinate.1, i32 0, i32 0) to i64))  
-  %14 = add   i64 %2, 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  tail call ccc  void  @print_int(i64  %17)  
+  %10 = add   i64 %2, 16 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  tail call ccc  void  @print_int(i64  %12)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @coordinate.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  1000)  
@@ -281,37 +276,31 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"coordinate.Coordinate.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#left##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %"#right##0" to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"#right##0", 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#right##0", 16 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = icmp eq i64 %2, %13 
-  br i1 %22, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#left##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %"#right##0", 8 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"#right##0", 16 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = icmp eq i64 %1, %9 
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  %23 = icmp eq i64 %6, %17 
-  br i1 %23, label %if.then1, label %if.else1 
+  %17 = icmp eq i64 %4, %12 
+  br i1 %17, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %24 = icmp eq i64 %10, %21 
-  ret i1 %24 
+  %18 = icmp eq i64 %7, %15 
+  ret i1 %18 
 if.else1:
   ret i1 0 
 }
@@ -323,16 +312,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"z##0", i64* %10 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"z##0", i64* %7 
   ret i64 %2 
 }
 
@@ -340,29 +326,25 @@ entry:
 define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#result##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = insertvalue {i64, i64, i64} undef, i64 %2, 0 
-  %12 = insertvalue {i64, i64, i64} %11, i64 %6, 1 
-  %13 = insertvalue {i64, i64, i64} %12, i64 %10, 2 
-  ret {i64, i64, i64} %13 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#result##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = insertvalue {i64, i64, i64} undef, i64 %1, 0 
+  %9 = insertvalue {i64, i64, i64} %8, i64 %4, 1 
+  %10 = insertvalue {i64, i64, i64} %9, i64 %7, 2 
+  ret {i64, i64, i64} %10 
 }
 
 
 define external fastcc  i64 @"coordinate.Coordinate.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -376,8 +358,7 @@ entry:
   %5 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -386,9 +367,8 @@ define external fastcc  i64 @"coordinate.Coordinate.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -403,8 +383,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -413,9 +392,8 @@ define external fastcc  i64 @"coordinate.Coordinate.z<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -430,8 +408,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 16 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -439,40 +416,34 @@ entry:
 define external fastcc  i1 @"coordinate.Coordinate.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#left##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %"#right##0" to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"#right##0", 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#right##0", 16 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = icmp eq i64 %2, %13 
-  br i1 %22, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#left##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %"#right##0", 8 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"#right##0", 16 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = icmp eq i64 %1, %9 
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  %23 = icmp eq i64 %6, %17 
-  br i1 %23, label %if.then1, label %if.else1 
+  %17 = icmp eq i64 %4, %12 
+  br i1 %17, label %if.then1, label %if.else1 
 if.else:
-  %27 = xor i1 0, 1 
-  ret i1 %27 
+  %21 = xor i1 0, 1 
+  ret i1 %21 
 if.then1:
-  %24 = icmp eq i64 %10, %21 
-  %25 = xor i1 %24, 1 
-  ret i1 %25 
+  %18 = icmp eq i64 %7, %15 
+  %19 = xor i1 %18, 1 
+  ret i1 %19 
 if.else1:
-  %26 = xor i1 0, 1 
-  ret i1 %26 
+  %20 = xor i1 0, 1 
+  ret i1 %20 
 }

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -296,8 +296,8 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %26 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %26 
+  %24 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %24 
 if.then1:
   %3 = lshr  i64 %"#left##0", 1 
   %4 = and i64 %3, 255 
@@ -324,25 +324,23 @@ if.else3:
 if.then4:
   %14 = add   i64 %"#left##0", -1 
   %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = icmp ne i64 %"#right##0", 0 
-  br i1 %18, label %if.then5, label %if.else5 
+  %16 = load  i64, i64* %15 
+  %17 = icmp ne i64 %"#right##0", 0 
+  br i1 %17, label %if.then5, label %if.else5 
 if.else4:
   ret i1 0 
 if.then5:
-  %19 = and i64 %"#right##0", 1 
-  %20 = icmp eq i64 %19, 1 
-  br i1 %20, label %if.then6, label %if.else6 
+  %18 = and i64 %"#right##0", 1 
+  %19 = icmp eq i64 %18, 1 
+  br i1 %19, label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %21 = add   i64 %"#right##0", -1 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = musttail call fastcc  i1  @"ctor_char.=<0>"(i64  %17, i64  %24)  
-  ret i1 %25 
+  %20 = add   i64 %"#right##0", -1 
+  %21 = inttoptr i64 %20 to i64* 
+  %22 = load  i64, i64* %21 
+  %23 = musttail call fastcc  i1  @"ctor_char.=<0>"(i64  %16, i64  %22)  
+  ret i1 %23 
 if.else6:
   ret i1 0 
 }
@@ -468,10 +466,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"other_ctor#1##0", i64* %4 
-  %5 = or i64 %2, 1 
-  ret i64 %5 
+  store  i64 %"other_ctor#1##0", i64* %3 
+  %4 = or i64 %2, 1 
+  ret i64 %4 
 }
 
 
@@ -484,21 +481,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -1 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -356,8 +356,8 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %39 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %39 
+  %35 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %35 
 if.then1:
   %3 = lshr  i64 %"#left##0", 2 
   %4 = and i64 %3, 255 
@@ -384,50 +384,46 @@ if.else3:
 if.then4:
   %14 = add   i64 %"#left##0", -1 
   %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = icmp ne i64 %"#right##0", 0 
-  br i1 %18, label %if.then5, label %if.else5 
+  %16 = load  i64, i64* %15 
+  %17 = icmp ne i64 %"#right##0", 0 
+  br i1 %17, label %if.then5, label %if.else5 
 if.else4:
-  %26 = icmp eq i64 %1, 2 
-  br i1 %26, label %if.then7, label %if.else7 
+  %24 = icmp eq i64 %1, 2 
+  br i1 %24, label %if.then7, label %if.else7 
 if.then5:
-  %19 = and i64 %"#right##0", 3 
-  %20 = icmp eq i64 %19, 1 
-  br i1 %20, label %if.then6, label %if.else6 
+  %18 = and i64 %"#right##0", 3 
+  %19 = icmp eq i64 %18, 1 
+  br i1 %19, label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %21 = add   i64 %"#right##0", -1 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = musttail call fastcc  i1  @"ctor_char2.=<0>"(i64  %17, i64  %24)  
-  ret i1 %25 
+  %20 = add   i64 %"#right##0", -1 
+  %21 = inttoptr i64 %20 to i64* 
+  %22 = load  i64, i64* %21 
+  %23 = musttail call fastcc  i1  @"ctor_char2.=<0>"(i64  %16, i64  %22)  
+  ret i1 %23 
 if.else6:
   ret i1 0 
 if.then7:
-  %27 = add   i64 %"#left##0", -2 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  %30 = load  i64, i64* %29 
-  %31 = icmp ne i64 %"#right##0", 0 
-  br i1 %31, label %if.then8, label %if.else8 
+  %25 = add   i64 %"#left##0", -2 
+  %26 = inttoptr i64 %25 to i64* 
+  %27 = load  i64, i64* %26 
+  %28 = icmp ne i64 %"#right##0", 0 
+  br i1 %28, label %if.then8, label %if.else8 
 if.else7:
   ret i1 0 
 if.then8:
-  %32 = and i64 %"#right##0", 3 
-  %33 = icmp eq i64 %32, 2 
-  br i1 %33, label %if.then9, label %if.else9 
+  %29 = and i64 %"#right##0", 3 
+  %30 = icmp eq i64 %29, 2 
+  br i1 %30, label %if.then9, label %if.else9 
 if.else8:
   ret i1 0 
 if.then9:
-  %34 = add   i64 %"#right##0", -2 
-  %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %38 = musttail call fastcc  i1  @"ctor_char2.=<0>"(i64  %30, i64  %37)  
-  ret i1 %38 
+  %31 = add   i64 %"#right##0", -2 
+  %32 = inttoptr i64 %31 to i64* 
+  %33 = load  i64, i64* %32 
+  %34 = musttail call fastcc  i1  @"ctor_char2.=<0>"(i64  %27, i64  %33)  
+  ret i1 %34 
 if.else9:
   ret i1 0 
 }
@@ -439,10 +435,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"another_ctor#1##0", i64* %4 
-  %5 = or i64 %2, 2 
-  ret i64 %5 
+  store  i64 %"another_ctor#1##0", i64* %3 
+  %4 = or i64 %2, 2 
+  ret i64 %4 
 }
 
 
@@ -455,21 +450,20 @@ if.then:
   %2 = icmp eq i64 %1, 2 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -2 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -593,10 +587,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"other_ctor#1##0", i64* %4 
-  %5 = or i64 %2, 1 
-  ret i64 %5 
+  store  i64 %"other_ctor#1##0", i64* %3 
+  %4 = or i64 %2, 1 
+  ret i64 %4 
 }
 
 
@@ -609,21 +602,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -1 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -377,26 +377,23 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 9, i64* %4 
-  %5 = tail call fastcc  i64  @"dead_cell_size.foo<0>"(i64  %2)  
-  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %5)  
-  %6 = trunc i64 8 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 9, i64* %10 
-  %11 = tail call fastcc  i64  @"dead_cell_size.bar<0>[410bae77d3]"(i64  %8)  
-  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %11)  
-  %12 = trunc i64 8 to i32  
-  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
-  %14 = ptrtoint i8* %13 to i64 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 9, i64* %16 
-  %17 = tail call fastcc  i64  @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %14)  
-  tail call fastcc  void  @"dead_cell_size.print_t2<0>"(i64  %17)  
+  store  i64 9, i64* %3 
+  %4 = tail call fastcc  i64  @"dead_cell_size.foo<0>"(i64  %2)  
+  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %4)  
+  %5 = trunc i64 8 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i64* 
+  store  i64 9, i64* %8 
+  %9 = tail call fastcc  i64  @"dead_cell_size.bar<0>[410bae77d3]"(i64  %7)  
+  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %9)  
+  %10 = trunc i64 8 to i32  
+  %11 = tail call ccc  i8*  @wybe_malloc(i32  %10)  
+  %12 = ptrtoint i8* %11 to i64 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 9, i64* %13 
+  %14 = tail call fastcc  i64  @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %12)  
+  tail call fastcc  void  @"dead_cell_size.print_t2<0>"(i64  %14)  
   ret void 
 }
 
@@ -413,16 +410,14 @@ if.else:
   ret i64 %"x##0" 
 if.then1:
   %3 = inttoptr i64 %"x##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = trunc i64 8 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %5, i64* %10 
-  %11 = or i64 %8, 2 
-  ret i64 %11 
+  %4 = load  i64, i64* %3 
+  %5 = trunc i64 8 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i64* 
+  store  i64 %4, i64* %8 
+  %9 = or i64 %7, 2 
+  ret i64 %9 
 if.else1:
   ret i64 %"x##0" 
 }
@@ -455,32 +450,28 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %16 = trunc i64 8 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 -1, i64* %20 
-  ret i64 %18 
+  %13 = trunc i64 8 to i32  
+  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
+  %15 = ptrtoint i8* %14 to i64 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 -1, i64* %16 
+  ret i64 %15 
 if.then1:
   %3 = inttoptr i64 %"x##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = trunc i64 8 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %5, i64* %10 
-  ret i64 %8 
+  %4 = load  i64, i64* %3 
+  %5 = trunc i64 8 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i64* 
+  store  i64 %4, i64* %8 
+  ret i64 %7 
 if.else1:
-  %11 = trunc i64 8 to i32  
-  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
-  %13 = ptrtoint i8* %12 to i64 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 -1, i64* %15 
-  ret i64 %13 
+  %9 = trunc i64 8 to i32  
+  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
+  %11 = ptrtoint i8* %10 to i64 
+  %12 = inttoptr i64 %11 to i64* 
+  store  i64 -1, i64* %12 
+  ret i64 %11 
 }
 
 
@@ -493,13 +484,12 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %8 = trunc i64 8 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 -1, i64* %12 
-  ret i64 %10 
+  %7 = trunc i64 8 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i64* 
+  store  i64 -1, i64* %10 
+  ret i64 %9 
 if.then1:
   ret i64 %"x##0" 
 if.else1:
@@ -507,8 +497,7 @@ if.else1:
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
   %5 = ptrtoint i8* %4 to i64 
   %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 -1, i64* %7 
+  store  i64 -1, i64* %6 
   ret i64 %5 
 }
 
@@ -525,24 +514,20 @@ if.else:
   ret i64 %"x##0" 
 if.then1:
   %3 = inttoptr i64 %"x##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = trunc i64 24 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %5, i64* %10 
-  %11 = add   i64 %8, 8 
+  %4 = load  i64, i64* %3 
+  %5 = trunc i64 24 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i64* 
+  store  i64 %4, i64* %8 
+  %9 = add   i64 %7, 8 
+  %10 = inttoptr i64 %9 to i64* 
+  store  i64 2, i64* %10 
+  %11 = add   i64 %7, 16 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 2, i64* %13 
-  %14 = add   i64 %8, 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 3, i64* %16 
-  %17 = or i64 %8, 1 
-  ret i64 %17 
+  store  i64 3, i64* %12 
+  %13 = or i64 %7, 1 
+  ret i64 %13 
 if.else1:
   ret i64 %"x##0" 
 }
@@ -568,48 +553,43 @@ if.else1:
   ret void 
 if.then2:
   %4 = inttoptr i64 %"x##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
+  %5 = load  i64, i64* %4 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %6)  
+  tail call ccc  void  @print_int(i64  %5)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
-  %7 = icmp eq i64 %2, 1 
-  br i1 %7, label %if.then3, label %if.else3 
+  %6 = icmp eq i64 %2, 1 
+  br i1 %6, label %if.then3, label %if.else3 
 if.then3:
-  %8 = add   i64 %"x##0", -1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = add   i64 %"x##0", 7 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
+  %7 = add   i64 %"x##0", -1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %"x##0", 7 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"x##0", 15 
+  %14 = inttoptr i64 %13 to i64* 
   %15 = load  i64, i64* %14 
-  %16 = add   i64 %"x##0", 15 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.7, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %11)  
+  tail call ccc  void  @print_int(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.9, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %12)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %15)  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.9, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %19)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
-  %20 = icmp eq i64 %2, 2 
-  br i1 %20, label %if.then4, label %if.else4 
+  %16 = icmp eq i64 %2, 2 
+  br i1 %16, label %if.then4, label %if.else4 
 if.then4:
-  %21 = add   i64 %"x##0", -2 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
+  %17 = add   i64 %"x##0", -2 
+  %18 = inttoptr i64 %17 to i64* 
+  %19 = load  i64, i64* %18 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.11, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %24)  
+  tail call ccc  void  @print_int(i64  %19)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -632,10 +612,9 @@ if.else:
   br i1 %1, label %if.then1, label %if.else1 
 if.then1:
   %2 = inttoptr i64 %"x##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
+  %3 = load  i64, i64* %2 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.15, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %4)  
+  tail call ccc  void  @print_int(i64  %3)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -1176,104 +1155,94 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %57 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %57 
+  %47 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %47 
 if.then1:
   %3 = inttoptr i64 %"#left##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = icmp ne i64 %"#right##0", 0 
-  br i1 %6, label %if.then2, label %if.else2 
+  %4 = load  i64, i64* %3 
+  %5 = icmp ne i64 %"#right##0", 0 
+  br i1 %5, label %if.then2, label %if.else2 
 if.else1:
-  %13 = icmp eq i64 %1, 1 
-  br i1 %13, label %if.then4, label %if.else4 
+  %11 = icmp eq i64 %1, 1 
+  br i1 %11, label %if.then4, label %if.else4 
 if.then2:
-  %7 = and i64 %"#right##0", 3 
-  %8 = icmp eq i64 %7, 0 
-  br i1 %8, label %if.then3, label %if.else3 
+  %6 = and i64 %"#right##0", 3 
+  %7 = icmp eq i64 %6, 0 
+  br i1 %7, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp eq i64 %5, %11 
-  ret i1 %12 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = icmp eq i64 %4, %9 
+  ret i1 %10 
 if.else3:
   ret i1 0 
 if.then4:
-  %14 = add   i64 %"#left##0", -1 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
+  %12 = add   i64 %"#left##0", -1 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#left##0", 7 
+  %16 = inttoptr i64 %15 to i64* 
   %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#left##0", 7 
+  %18 = add   i64 %"#left##0", 15 
   %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = add   i64 %"#left##0", 15 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  %25 = load  i64, i64* %24 
-  %26 = icmp ne i64 %"#right##0", 0 
-  br i1 %26, label %if.then5, label %if.else5 
+  %20 = load  i64, i64* %19 
+  %21 = icmp ne i64 %"#right##0", 0 
+  br i1 %21, label %if.then5, label %if.else5 
 if.else4:
-  %44 = icmp eq i64 %1, 2 
-  br i1 %44, label %if.then9, label %if.else9 
+  %36 = icmp eq i64 %1, 2 
+  br i1 %36, label %if.then9, label %if.else9 
 if.then5:
-  %27 = and i64 %"#right##0", 3 
-  %28 = icmp eq i64 %27, 1 
-  br i1 %28, label %if.then6, label %if.else6 
+  %22 = and i64 %"#right##0", 3 
+  %23 = icmp eq i64 %22, 1 
+  br i1 %23, label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %29 = add   i64 %"#right##0", -1 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
+  %24 = add   i64 %"#right##0", -1 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = load  i64, i64* %25 
+  %27 = add   i64 %"#right##0", 7 
+  %28 = inttoptr i64 %27 to i64* 
+  %29 = load  i64, i64* %28 
+  %30 = add   i64 %"#right##0", 15 
+  %31 = inttoptr i64 %30 to i64* 
   %32 = load  i64, i64* %31 
-  %33 = add   i64 %"#right##0", 7 
-  %34 = inttoptr i64 %33 to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  %36 = load  i64, i64* %35 
-  %37 = add   i64 %"#right##0", 15 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  %40 = load  i64, i64* %39 
-  %41 = icmp eq i64 %17, %32 
-  br i1 %41, label %if.then7, label %if.else7 
+  %33 = icmp eq i64 %14, %26 
+  br i1 %33, label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %42 = icmp eq i64 %21, %36 
-  br i1 %42, label %if.then8, label %if.else8 
+  %34 = icmp eq i64 %17, %29 
+  br i1 %34, label %if.then8, label %if.else8 
 if.else7:
   ret i1 0 
 if.then8:
-  %43 = icmp eq i64 %25, %40 
-  ret i1 %43 
+  %35 = icmp eq i64 %20, %32 
+  ret i1 %35 
 if.else8:
   ret i1 0 
 if.then9:
-  %45 = add   i64 %"#left##0", -2 
-  %46 = inttoptr i64 %45 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  %48 = load  i64, i64* %47 
-  %49 = icmp ne i64 %"#right##0", 0 
-  br i1 %49, label %if.then10, label %if.else10 
+  %37 = add   i64 %"#left##0", -2 
+  %38 = inttoptr i64 %37 to i64* 
+  %39 = load  i64, i64* %38 
+  %40 = icmp ne i64 %"#right##0", 0 
+  br i1 %40, label %if.then10, label %if.else10 
 if.else9:
   ret i1 0 
 if.then10:
-  %50 = and i64 %"#right##0", 3 
-  %51 = icmp eq i64 %50, 2 
-  br i1 %51, label %if.then11, label %if.else11 
+  %41 = and i64 %"#right##0", 3 
+  %42 = icmp eq i64 %41, 2 
+  br i1 %42, label %if.then11, label %if.else11 
 if.else10:
   ret i1 0 
 if.then11:
-  %52 = add   i64 %"#right##0", -2 
-  %53 = inttoptr i64 %52 to i64* 
-  %54 = getelementptr  i64, i64* %53, i64 0 
-  %55 = load  i64, i64* %54 
-  %56 = icmp eq i64 %48, %55 
-  ret i1 %56 
+  %43 = add   i64 %"#right##0", -2 
+  %44 = inttoptr i64 %43 to i64* 
+  %45 = load  i64, i64* %44 
+  %46 = icmp eq i64 %39, %45 
+  ret i1 %46 
 if.else11:
   ret i1 0 
 }
@@ -1291,8 +1260,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"tb1##0", i64* %4 
+  store  i64 %"tb1##0", i64* %3 
   ret i64 %2 
 }
 
@@ -1306,20 +1274,19 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %11 = insertvalue {i64, i1} %10, i1 0, 1 
-  ret {i64, i1} %11 
+  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i1} %9, i1 0, 1 
+  ret {i64, i1} %10 
 if.then1:
   %3 = inttoptr i64 %"#result##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else1:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1332,20 +1299,19 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %11 = insertvalue {i64, i1} %10, i1 0, 1 
-  ret {i64, i1} %11 
+  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i1} %9, i1 0, 1 
+  ret {i64, i1} %10 
 if.then1:
   %3 = inttoptr i64 %"#rec##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else1:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1358,9 +1324,9 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -1370,15 +1336,14 @@ if.then1:
   %8 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %6, i8*  %7, i32  %8, i1  0)  
   %9 = inttoptr i64 %5 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"#field##0", i64* %10 
-  %11 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %12 = insertvalue {i64, i1} %11, i1 1, 1 
-  ret {i64, i1} %12 
+  store  i64 %"#field##0", i64* %9 
+  %10 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
 if.else1:
-  %13 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %14 = insertvalue {i64, i1} %13, i1 0, 1 
-  ret {i64, i1} %14 
+  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -1388,18 +1353,15 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"tc1##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"tc2##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"tc3##0", i64* %10 
-  %11 = or i64 %2, 1 
-  ret i64 %11 
+  store  i64 %"tc1##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"tc2##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"tc3##0", i64* %7 
+  %8 = or i64 %2, 1 
+  ret i64 %8 
 }
 
 
@@ -1412,35 +1374,32 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %23 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %24 = insertvalue {i64, i64, i64, i1} %23, i64 undef, 1 
-  %25 = insertvalue {i64, i64, i64, i1} %24, i64 undef, 2 
-  %26 = insertvalue {i64, i64, i64, i1} %25, i1 0, 3 
-  ret {i64, i64, i64, i1} %26 
+  %20 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %21 = insertvalue {i64, i64, i64, i1} %20, i64 undef, 1 
+  %22 = insertvalue {i64, i64, i64, i1} %21, i64 undef, 2 
+  %23 = insertvalue {i64, i64, i64, i1} %22, i1 0, 3 
+  ret {i64, i64, i64, i1} %23 
 if.then1:
   %3 = add   i64 %"#result##0", -1 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#result##0", 7 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = add   i64 %"#result##0", 15 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  %15 = insertvalue {i64, i64, i64, i1} undef, i64 %6, 0 
-  %16 = insertvalue {i64, i64, i64, i1} %15, i64 %10, 1 
-  %17 = insertvalue {i64, i64, i64, i1} %16, i64 %14, 2 
-  %18 = insertvalue {i64, i64, i64, i1} %17, i1 1, 3 
-  ret {i64, i64, i64, i1} %18 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 7 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#result##0", 15 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = insertvalue {i64, i64, i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i64, i64, i1} %12, i64 %8, 1 
+  %14 = insertvalue {i64, i64, i64, i1} %13, i64 %11, 2 
+  %15 = insertvalue {i64, i64, i64, i1} %14, i1 1, 3 
+  ret {i64, i64, i64, i1} %15 
 if.else1:
-  %19 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %20 = insertvalue {i64, i64, i64, i1} %19, i64 undef, 1 
-  %21 = insertvalue {i64, i64, i64, i1} %20, i64 undef, 2 
-  %22 = insertvalue {i64, i64, i64, i1} %21, i1 0, 3 
-  ret {i64, i64, i64, i1} %22 
+  %16 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %17 = insertvalue {i64, i64, i64, i1} %16, i64 undef, 1 
+  %18 = insertvalue {i64, i64, i64, i1} %17, i64 undef, 2 
+  %19 = insertvalue {i64, i64, i64, i1} %18, i1 0, 3 
+  ret {i64, i64, i64, i1} %19 
 }
 
 
@@ -1453,21 +1412,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -1 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -1480,9 +1438,9 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 24 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -1495,15 +1453,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -1 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -1516,21 +1473,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", 7 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -1543,9 +1499,9 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 24 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -1558,15 +1514,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, 7 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -1579,21 +1534,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", 15 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -1606,9 +1560,9 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 24 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -1621,15 +1575,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, 15 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -1639,10 +1592,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"td1##0", i64* %4 
-  %5 = or i64 %2, 2 
-  ret i64 %5 
+  store  i64 %"td1##0", i64* %3 
+  %4 = or i64 %2, 2 
+  ret i64 %4 
 }
 
 
@@ -1655,21 +1607,20 @@ if.then:
   %2 = icmp eq i64 %1, 2 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -2 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -1682,21 +1633,20 @@ if.then:
   %2 = icmp eq i64 %1, 2 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -2 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -1709,9 +1659,9 @@ if.then:
   %2 = icmp eq i64 %1, 2 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -1724,15 +1674,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -2 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -1875,19 +1824,17 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp ne i64 %"#right##0", 0 
-  br i1 %4, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = icmp ne i64 %"#right##0", 0 
+  br i1 %3, label %if.then1, label %if.else1 
 if.else:
-  %9 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %9 
+  %7 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %7 
 if.then1:
-  %5 = inttoptr i64 %"#right##0" to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, %7 
-  ret i1 %8 
+  %4 = inttoptr i64 %"#right##0" to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, %5 
+  ret i1 %6 
 if.else1:
   ret i1 0 
 }
@@ -1899,15 +1846,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -1924,15 +1870,14 @@ if.then:
   %6 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -1948,8 +1893,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"a##0", i64* %4 
+  store  i64 %"a##0", i64* %3 
   ret i64 %2 
 }
 
@@ -1960,15 +1904,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 

--- a/test-cases/final-dump/disjunction.exp
+++ b/test-cases/final-dump/disjunction.exp
@@ -109,21 +109,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp eq i64 %"e##0", %3 
-  br i1 %4, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = icmp eq i64 %"e##0", %2 
+  br i1 %3, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
   ret i1 1 
 if.else1:
-  %5 = add   i64 %"lst##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  %8 = load  i64, i64* %7 
-  %9 = musttail call fastcc  i1  @"disjunction.in<0>"(i64  %"e##0", i64  %8)  
-  ret i1 %9 
+  %4 = add   i64 %"lst##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  %7 = musttail call fastcc  i1  @"disjunction.in<0>"(i64  %"e##0", i64  %6)  
+  ret i1 %7 
 }
 
 
@@ -133,21 +131,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %"e##0", %3 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %"e##0", %2 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
   ret i1 1 
 if.else1:
-  %9 = musttail call fastcc  i1  @"disjunction.member<0>"(i64  %"e##0", i64  %7)  
-  ret i1 %9 
+  %7 = musttail call fastcc  i1  @"disjunction.member<0>"(i64  %"e##0", i64  %5)  
+  ret i1 %7 
 }
 
 
@@ -158,9 +154,8 @@ entry:
 if.then:
   %1 = add   i64 %"lst##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  ret i64 %4 
+  %3 = load  i64, i64* %2 
+  ret i64 %3 
 if.else:
   ret i64 0 
 }
@@ -173,9 +168,8 @@ entry:
 if.then:
   %1 = add   i64 %"lst##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  ret i64 %4 
+  %3 = load  i64, i64* %2 
+  ret i64 %3 
 if.else:
   ret i64 0 
 }

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -181,22 +181,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"x##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  store  i64 %10, i64* %"#result##0" 
-  musttail call fastcc  void  @"generic_list.append<0>"(i64  %7, i64  %"y##0", i64*  %14)  
+  store  i64 %8, i64* %"#result##0" 
+  musttail call fastcc  void  @"generic_list.append<0>"(i64  %5, i64  %"y##0", i64*  %11)  
   ret void 
 if.else:
   store  i64 %"y##0", i64* %"#result##0" 
@@ -210,15 +207,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -235,15 +231,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -254,15 +249,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -280,15 +274,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -298,12 +291,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"car##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"cdr##0", i64* %7 
+  store  i64 %"car##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"cdr##0", i64* %5 
   ret i64 %2 
 }
 
@@ -314,21 +305,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -346,11 +335,10 @@ entry:
 if.then:
   %1 = add   i64 %"x##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"acc##0", 1 
-  %6 = musttail call fastcc  i64  @"generic_list.length1<0>"(i64  %4, i64  %5)  
-  ret i64 %6 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"acc##0", 1 
+  %5 = musttail call fastcc  i64  @"generic_list.length1<0>"(i64  %3, i64  %4)  
+  ret i64 %5 
 if.else:
   ret i64 %"acc##0" 
 }

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -181,22 +181,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"x##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  store  i64 %10, i64* %"#result##0" 
-  musttail call fastcc  void  @"generic_list.append<0>"(i64  %7, i64  %"y##0", i64*  %14)  
+  store  i64 %8, i64* %"#result##0" 
+  musttail call fastcc  void  @"generic_list.append<0>"(i64  %5, i64  %"y##0", i64*  %11)  
   ret void 
 if.else:
   store  i64 %"y##0", i64* %"#result##0" 
@@ -210,15 +207,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -235,15 +231,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -254,15 +249,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -280,15 +274,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -298,12 +291,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"car##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"cdr##0", i64* %7 
+  store  i64 %"car##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"cdr##0", i64* %5 
   ret i64 %2 
 }
 
@@ -314,21 +305,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -346,11 +335,10 @@ entry:
 if.then:
   %1 = add   i64 %"x##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"acc##0", 1 
-  %6 = musttail call fastcc  i64  @"generic_list.length1<0>"(i64  %4, i64  %5)  
-  ret i64 %6 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"acc##0", 1 
+  %5 = musttail call fastcc  i64  @"generic_list.length1<0>"(i64  %3, i64  %4)  
+  ret i64 %5 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -664,22 +652,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"l1##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"l1##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"l1##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  store  i64 %10, i64* %"#result##0" 
-  musttail call fastcc  void  @"generic_use.concat<0>"(i64  %7, i64  %"l2##0", i64*  %14)  
+  store  i64 %8, i64* %"#result##0" 
+  musttail call fastcc  void  @"generic_use.concat<0>"(i64  %5, i64  %"l2##0", i64*  %11)  
   ret void 
 if.else:
   store  i64 %"l2##0", i64* %"#result##0" 
@@ -694,12 +679,11 @@ entry:
 if.then:
   %1 = add   i64 %"l1##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"l1##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"l1##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
   store  i64 %"l1##0", i64* %"#result##0" 
-  musttail call fastcc  void  @"generic_use.concat<0>[410bae77d3]"(i64  %4, i64  %"l2##0", i64*  %6)  
+  musttail call fastcc  void  @"generic_use.concat<0>[410bae77d3]"(i64  %3, i64  %"l2##0", i64*  %5)  
   ret void 
 if.else:
   store  i64 %"l2##0", i64* %"#result##0" 
@@ -724,14 +708,12 @@ if.then:
   %3 = tail call ccc  i8*  @wybe_malloc(i32  %2)  
   %4 = ptrtoint i8* %3 to i64 
   %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  store  i64 %"hi##0", i64* %6 
-  %7 = add   i64 %4, 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"sofar##0", i64* %9 
-  %10 = musttail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %1, i64  %4)  
-  ret i64 %10 
+  store  i64 %"hi##0", i64* %5 
+  %6 = add   i64 %4, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"sofar##0", i64* %7 
+  %8 = musttail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %1, i64  %4)  
+  ret i64 %8 
 if.else:
   ret i64 %"sofar##0" 
 }
@@ -750,27 +732,23 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = tail call fastcc  i64  @"generic_use.nrev<0>"(i64  %7)  
-  %9 = trunc i64 16 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = tail call fastcc  i64  @"generic_use.nrev<0>"(i64  %5)  
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i64* 
+  store  i64 %2, i64* %10 
+  %11 = add   i64 %9, 8 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %3, i64* %13 
-  %14 = add   i64 %11, 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 0, i64* %16 
-  %17 = alloca i64 
-   call fastcc  void  @"generic_use.concat<0>[410bae77d3]"(i64  %8, i64  %11, i64*  %17)  
-  %18 = load  i64, i64* %17 
-  ret i64 %18 
+  store  i64 0, i64* %12 
+  %13 = alloca i64 
+   call fastcc  void  @"generic_use.concat<0>[410bae77d3]"(i64  %6, i64  %9, i64*  %13)  
+  %14 = load  i64, i64* %13 
+  ret i64 %14 
 if.else:
   ret i64 0 
 }
@@ -783,17 +761,15 @@ entry:
 if.then:
   %1 = add   i64 %"lst##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %4)  
-  %6 = add   i64 %"lst##0", 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 0, i64* %8 
-  %9 = alloca i64 
-   call fastcc  void  @"generic_use.concat<0>[410bae77d3]"(i64  %5, i64  %"lst##0", i64*  %9)  
-  %10 = load  i64, i64* %9 
-  ret i64 %10 
+  %3 = load  i64, i64* %2 
+  %4 = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %3)  
+  %5 = add   i64 %"lst##0", 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 0, i64* %6 
+  %7 = alloca i64 
+   call fastcc  void  @"generic_use.concat<0>[410bae77d3]"(i64  %4, i64  %"lst##0", i64*  %7)  
+  %8 = load  i64, i64* %7 
+  ret i64 %8 
 if.else:
   ret i64 0 
 }
@@ -806,14 +782,12 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  tail call ccc  void  @print_int(i64  %3)  
-  tail call fastcc  void  @"generic_use.print_tail<0>"(i64  %7)  
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call fastcc  void  @"generic_use.print_tail<0>"(i64  %5)  
   tail call ccc  void  @putchar(i8  93)  
   ret void 
 if.else:
@@ -828,15 +802,13 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @generic_use.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %3)  
-  musttail call fastcc  void  @"generic_use.print_tail<0>"(i64  %7)  
+  tail call ccc  void  @print_int(i64  %2)  
+  musttail call fastcc  void  @"generic_use.print_tail<0>"(i64  %5)  
   ret void 
 if.else:
   ret void 
@@ -864,24 +836,20 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"suffix##0", i64* %15 
-  %16 = musttail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %7, i64  %10)  
-  ret i64 %16 
+  store  i64 %"suffix##0", i64* %11 
+  %12 = musttail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %5, i64  %8)  
+  ret i64 %12 
 if.else:
   ret i64 %"suffix##0" 
 }
@@ -894,14 +862,12 @@ entry:
 if.then:
   %1 = add   i64 %"lst##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"lst##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"suffix##0", i64* %7 
-  %8 = musttail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %4, i64  %"lst##0")  
-  ret i64 %8 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"lst##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"suffix##0", i64* %5 
+  %6 = musttail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %3, i64  %"lst##0")  
+  ret i64 %6 
 if.else:
   ret i64 %"suffix##0" 
 }

--- a/test-cases/final-dump/higher_order_append.exp
+++ b/test-cases/final-dump/higher_order_append.exp
@@ -160,95 +160,79 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 1, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 1, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 0, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 3, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
+  store  i64 0, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 3, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 0, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 %14, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
   store  i64 0, i64* %23 
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
   %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 %18, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 0, i64* %31 
-  %32 = trunc i64 16 to i32  
-  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
-  %34 = ptrtoint i8* %33 to i64 
+  store  i64 %8, i64* %27 
+  %28 = add   i64 %26, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  store  i64 %20, i64* %29 
+  %30 = trunc i64 16 to i32  
+  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
+  %32 = ptrtoint i8* %31 to i64 
+  %33 = inttoptr i64 %32 to i64* 
+  store  i64 %2, i64* %33 
+  %34 = add   i64 %32, 8 
   %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 %10, i64* %36 
-  %37 = add   i64 %34, 8 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %26, i64* %39 
-  %40 = trunc i64 16 to i32  
-  %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
-  %42 = ptrtoint i8* %41 to i64 
-  %43 = inttoptr i64 %42 to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  store  i64 %2, i64* %44 
-  %45 = add   i64 %42, 8 
-  %46 = inttoptr i64 %45 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %34, i64* %47 
+  store  i64 %26, i64* %35 
+  %36 = trunc i64 16 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i64* 
+  store  i64 6, i64* %39 
+  %40 = add   i64 %38, 8 
+  %41 = inttoptr i64 %40 to i64* 
+  store  i64 0, i64* %41 
+  %42 = trunc i64 16 to i32  
+  %43 = tail call ccc  i8*  @wybe_malloc(i32  %42)  
+  %44 = ptrtoint i8* %43 to i64 
+  %45 = inttoptr i64 %44 to i64* 
+  store  i64 4, i64* %45 
+  %46 = add   i64 %44, 8 
+  %47 = inttoptr i64 %46 to i64* 
+  store  i64 %38, i64* %47 
   %48 = trunc i64 16 to i32  
   %49 = tail call ccc  i8*  @wybe_malloc(i32  %48)  
   %50 = ptrtoint i8* %49 to i64 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 6, i64* %52 
-  %53 = add   i64 %50, 8 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 0, i64* %55 
-  %56 = trunc i64 16 to i32  
-  %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
-  %58 = ptrtoint i8* %57 to i64 
-  %59 = inttoptr i64 %58 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 4, i64* %60 
-  %61 = add   i64 %58, 8 
-  %62 = inttoptr i64 %61 to i64* 
-  %63 = getelementptr  i64, i64* %62, i64 0 
-  store  i64 %50, i64* %63 
-  %64 = trunc i64 16 to i32  
-  %65 = tail call ccc  i8*  @wybe_malloc(i32  %64)  
-  %66 = ptrtoint i8* %65 to i64 
-  %67 = inttoptr i64 %66 to i64* 
-  %68 = getelementptr  i64, i64* %67, i64 0 
-  store  i64 ptrtoint (i64 (i64, i64)* @"higher_order_append.gen#1<1>" to i64), i64* %68 
-  %69 = getelementptr  i64, i64* %67, i64 1 
-  store  i64 %58, i64* %69 
-  %70 = alloca i64 
-   call fastcc  void  @"wybe.list.map<1>"(i64  %66, i64  %42, i64*  %70)  
-  %71 = load  i64, i64* %70 
-  tail call fastcc  void  @"wybe.list.println<0>"(i64  %42, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.list.println<0>"(i64  %71, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64))  
+  store  i64 ptrtoint (i64 (i64, i64)* @"higher_order_append.gen#1<1>" to i64), i64* %52 
+  %53 = getelementptr  i64, i64* %51, i64 1 
+  store  i64 %44, i64* %53 
+  %54 = alloca i64 
+   call fastcc  void  @"wybe.list.map<1>"(i64  %50, i64  %32, i64*  %54)  
+  %55 = load  i64, i64* %54 
+  tail call fastcc  void  @"wybe.list.println<0>"(i64  %32, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.list.println<0>"(i64  %55, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64))  
   ret void 
 }
 
@@ -259,22 +243,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"front##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"front##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"front##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  store  i64 %10, i64* %"result##0" 
-  musttail call fastcc  void  @"higher_order_append.append<0>"(i64  %7, i64  %"back##0", i64*  %14)  
+  store  i64 %8, i64* %"result##0" 
+  musttail call fastcc  void  @"higher_order_append.append<0>"(i64  %5, i64  %"back##0", i64*  %11)  
   ret void 
 if.else:
   store  i64 %"back##0", i64* %"result##0" 
@@ -295,12 +276,11 @@ define external fastcc  i64 @"higher_order_append.gen#1<1>"(i64  %"#env##0", i64
 entry:
   %0 = add   i64 %"#env##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = alloca i64 
-   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %3, i64*  %4)  
-  %5 = load  i64, i64* %4 
-  ret i64 %5 
+  %2 = load  i64, i64* %1 
+  %3 = alloca i64 
+   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %2, i64*  %3)  
+  %4 = load  i64, i64* %3 
+  ret i64 %4 
 }
 
 

--- a/test-cases/final-dump/higher_order_append.exp
+++ b/test-cases/final-dump/higher_order_append.exp
@@ -2,12 +2,12 @@
 AFTER EVERYTHING:
  Module higher_order_append
   representation  : (not a type)
-  public submods  :
-  public resources:
+  public submods  : 
+  public resources: 
   public procs    : higher_order_append.<0>
   imports         : use wybe
-  resources       :
-  procs           :
+  resources       : 
+  procs           : 
 
 module top-level code > public {impure} (0 calls)
 0: higher_order_append.<0>
@@ -114,7 +114,7 @@ print_list_of_ints(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>
 ; ModuleID = 'higher_order_append'
 
 
-
+ 
 
 
 @higher_order_append.0 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_append.gen#2<0>" to i64)]
@@ -123,192 +123,172 @@ print_list_of_ints(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>
 @higher_order_append.1 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_append.gen#4<0>" to i64)]
 
 
-declare external fastcc  void @"wybe.list.print<0>"(i64, i64)
+declare external fastcc  void @"wybe.list.print<0>"(i64, i64)    
 
 
-declare external ccc  void @print_int(i64)
+declare external ccc  void @print_int(i64)    
 
 
-declare external ccc  void @putchar(i8)
+declare external ccc  void @putchar(i8)    
 
 
-declare external fastcc  void @"wybe.list.map<1>"(i64, i64, i64*)
+declare external fastcc  void @"wybe.list.map<1>"(i64, i64, i64*)    
 
 
-declare external ccc  i8* @wybe_malloc(i32)
+declare external ccc  i8* @wybe_malloc(i32)    
 
 
-declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
 define external fastcc  void @"higher_order_append.<0>"()    {
 entry:
-  %0 = trunc i64 16 to i32
-  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)
-  %2 = ptrtoint i8* %1 to i64
-  %3 = inttoptr i64 %2 to i64*
-  store  i64 1, i64* %3
-  %4 = add   i64 %2, 8
-  %5 = inttoptr i64 %4 to i64*
-  store  i64 0, i64* %5
-  %6 = trunc i64 16 to i32
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)
-  %8 = ptrtoint i8* %7 to i64
-  %9 = inttoptr i64 %8 to i64*
-  store  i64 2, i64* %9
-  %10 = add   i64 %8, 8
-  %11 = inttoptr i64 %10 to i64*
-  store  i64 0, i64* %11
-  %12 = trunc i64 16 to i32
-  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)
-  %14 = ptrtoint i8* %13 to i64
-  %15 = inttoptr i64 %14 to i64*
-  store  i64 3, i64* %15
-  %16 = add   i64 %14, 8
-  %17 = inttoptr i64 %16 to i64*
-  store  i64 0, i64* %17
-  %18 = trunc i64 16 to i32
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)
-  %20 = ptrtoint i8* %19 to i64
-  %21 = inttoptr i64 %20 to i64*
-  store  i64 %14, i64* %21
-  %22 = add   i64 %20, 8
-  %23 = inttoptr i64 %22 to i64*
-  store  i64 0, i64* %23
-  %24 = trunc i64 16 to i32
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)
-  %26 = ptrtoint i8* %25 to i64
-  %27 = inttoptr i64 %26 to i64*
-  store  i64 %8, i64* %27
-  %28 = add   i64 %26, 8
-  %29 = inttoptr i64 %28 to i64*
-  store  i64 %20, i64* %29
-  %30 = trunc i64 16 to i32
-  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)
-  %32 = ptrtoint i8* %31 to i64
-  %33 = inttoptr i64 %32 to i64*
-  store  i64 %2, i64* %33
-  %34 = add   i64 %32, 8
-  %35 = inttoptr i64 %34 to i64*
-  store  i64 %26, i64* %35
-  %36 = trunc i64 16 to i32
-  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)
-  %38 = ptrtoint i8* %37 to i64
-  %39 = inttoptr i64 %38 to i64*
-  store  i64 6, i64* %39
-  %40 = add   i64 %38, 8
-  %41 = inttoptr i64 %40 to i64*
-  store  i64 0, i64* %41
-  %42 = trunc i64 16 to i32
-  %43 = tail call ccc  i8*  @wybe_malloc(i32  %42)
-  %44 = ptrtoint i8* %43 to i64
-  %45 = inttoptr i64 %44 to i64*
-  store  i64 4, i64* %45
-  %46 = add   i64 %44, 8
-  %47 = inttoptr i64 %46 to i64*
-  store  i64 %38, i64* %47
-  %48 = trunc i64 16 to i32
-  %49 = tail call ccc  i8*  @wybe_malloc(i32  %48)
-  %50 = ptrtoint i8* %49 to i64
-  %51 = inttoptr i64 %50 to i64*
-  %52 = getelementptr  i64, i64* %51, i64 0
-  store  i64 6, i64* %52
-  %53 = add   i64 %50, 8
-  %54 = inttoptr i64 %53 to i64*
-  %55 = getelementptr  i64, i64* %54, i64 0
-  store  i64 0, i64* %55
-  %56 = trunc i64 16 to i32
-  %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)
-  %58 = ptrtoint i8* %57 to i64
-  %59 = inttoptr i64 %58 to i64*
-  %60 = getelementptr  i64, i64* %59, i64 0
-  store  i64 4, i64* %60
-  %61 = add   i64 %58, 8
-  %62 = inttoptr i64 %61 to i64*
-  %63 = getelementptr  i64, i64* %62, i64 0
-  store  i64 %50, i64* %63
-  %64 = trunc i64 16 to i32
-  %65 = tail call ccc  i8*  @wybe_malloc(i32  %64)
-  %66 = ptrtoint i8* %65 to i64
-  %67 = inttoptr i64 %66 to i64*
-  %68 = getelementptr  i64, i64* %67, i64 0
-  store  i64 ptrtoint (i64 (i64, i64)* @"higher_order_append.gen#1<1>" to i64), i64* %68
-  %69 = getelementptr  i64, i64* %67, i64 1
-  store  i64 %58, i64* %69
-  %70 = alloca i64
-   call fastcc  void  @"wybe.list.map<1>"(i64  %66, i64  %42, i64*  %70)
-  %71 = load  i64, i64* %70
-  tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64), i64  %42)
-  tail call ccc  void  @putchar(i8  10)
-  tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64), i64  %71)
-  tail call ccc  void  @putchar(i8  10)
-  ret void
+  %0 = trunc i64 16 to i32  
+  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
+  %2 = ptrtoint i8* %1 to i64 
+  %3 = inttoptr i64 %2 to i64* 
+  store  i64 1, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 0, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 3, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 0, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 %14, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 0, i64* %23 
+  %24 = trunc i64 16 to i32  
+  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
+  %26 = ptrtoint i8* %25 to i64 
+  %27 = inttoptr i64 %26 to i64* 
+  store  i64 %8, i64* %27 
+  %28 = add   i64 %26, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  store  i64 %20, i64* %29 
+  %30 = trunc i64 16 to i32  
+  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
+  %32 = ptrtoint i8* %31 to i64 
+  %33 = inttoptr i64 %32 to i64* 
+  store  i64 %2, i64* %33 
+  %34 = add   i64 %32, 8 
+  %35 = inttoptr i64 %34 to i64* 
+  store  i64 %26, i64* %35 
+  %36 = trunc i64 16 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i64* 
+  store  i64 6, i64* %39 
+  %40 = add   i64 %38, 8 
+  %41 = inttoptr i64 %40 to i64* 
+  store  i64 0, i64* %41 
+  %42 = trunc i64 16 to i32  
+  %43 = tail call ccc  i8*  @wybe_malloc(i32  %42)  
+  %44 = ptrtoint i8* %43 to i64 
+  %45 = inttoptr i64 %44 to i64* 
+  store  i64 4, i64* %45 
+  %46 = add   i64 %44, 8 
+  %47 = inttoptr i64 %46 to i64* 
+  store  i64 %38, i64* %47 
+  %48 = trunc i64 16 to i32  
+  %49 = tail call ccc  i8*  @wybe_malloc(i32  %48)  
+  %50 = ptrtoint i8* %49 to i64 
+  %51 = inttoptr i64 %50 to i64* 
+  %52 = getelementptr  i64, i64* %51, i64 0 
+  store  i64 ptrtoint (i64 (i64, i64)* @"higher_order_append.gen#1<1>" to i64), i64* %52 
+  %53 = getelementptr  i64, i64* %51, i64 1 
+  store  i64 %44, i64* %53 
+  %54 = alloca i64 
+   call fastcc  void  @"wybe.list.map<1>"(i64  %50, i64  %32, i64*  %54)  
+  %55 = load  i64, i64* %54 
+  tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64), i64  %32)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64), i64  %55)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_append.append<0>"(i64  %"front##0", i64  %"back##0", i64*  %"result##0")    {
 entry:
-  %0 = icmp ne i64 %"front##0", 0
-  br i1 %0, label %if.then, label %if.else
+  %0 = icmp ne i64 %"front##0", 0 
+  br i1 %0, label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"front##0" to i64*
-  %2 = load  i64, i64* %1
-  %3 = add   i64 %"front##0", 8
-  %4 = inttoptr i64 %3 to i64*
-  %5 = load  i64, i64* %4
-  %6 = trunc i64 16 to i32
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)
-  %8 = ptrtoint i8* %7 to i64
-  %9 = inttoptr i64 %8 to i64*
-  store  i64 %2, i64* %9
-  %10 = add   i64 %8, 8
-  %11 = inttoptr i64 %10 to i64*
-  store  i64 %8, i64* %"result##0"
-  musttail call fastcc  void  @"higher_order_append.append<0>"(i64  %5, i64  %"back##0", i64*  %11)
-  ret void
+  %1 = inttoptr i64 %"front##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"front##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 %8, i64* %"result##0" 
+  musttail call fastcc  void  @"higher_order_append.append<0>"(i64  %5, i64  %"back##0", i64*  %11)  
+  ret void 
 if.else:
-  store  i64 %"back##0", i64* %"result##0"
-  ret void
+  store  i64 %"back##0", i64* %"result##0" 
+  ret void 
 }
 
 
 define external fastcc  i64 @"higher_order_append.gen#1<0>"(i64  %"cons##0", i64  %"anon#1#1##0")    {
 entry:
-  %0 = alloca i64
-   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %"cons##0", i64*  %0)
-  %1 = load  i64, i64* %0
-  ret i64 %1
+  %0 = alloca i64 
+   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %"cons##0", i64*  %0)  
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
 define external fastcc  i64 @"higher_order_append.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0")    {
 entry:
-  %0 = add   i64 %"#env##0", 8
-  %1 = inttoptr i64 %0 to i64*
-  %2 = load  i64, i64* %1
-  %3 = alloca i64
-   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %2, i64*  %3)
-  %4 = load  i64, i64* %3
-  ret i64 %4
+  %0 = add   i64 %"#env##0", 8 
+  %1 = inttoptr i64 %0 to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = alloca i64 
+   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %2, i64*  %3)  
+  %4 = load  i64, i64* %3 
+  ret i64 %4 
 }
 
 
 define external fastcc  void @"higher_order_append.gen#2<0>"(i64  %"#env##0", i64  %"l##0")    {
 entry:
-  musttail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")
-  ret void
+  musttail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")  
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_append.gen#4<0>"(i64  %"#env##0", i64  %"x##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"x##0")
-  ret void
+  tail call ccc  void  @print_int(i64  %"x##0")  
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_append.print_list_of_ints<0>"(i64  %"l##0")    {
 entry:
-  tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")
-  ret void
+  tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")  
+  ret void 
 }

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -255,12 +255,11 @@ define external fastcc  i64 @"higher_order_refs.gen#3<1>"(i64  %"#env##0", i64  
 entry:
   %0 = add   i64 %"#env##0", 8 
   %1 = inttoptr i64 %0 to double* 
-  %2 = getelementptr  double, double* %1, i64 0 
-  %3 = load  double, double* %2 
-  %4 = bitcast i64 %"anon#3#1##0" to double 
-  %5 = fsub double %4, %3 
-  %6 = bitcast double %5 to i64 
-  ret i64 %6 
+  %2 = load  double, double* %1 
+  %3 = bitcast i64 %"anon#3#1##0" to double 
+  %4 = fsub double %3, %2 
+  %5 = bitcast double %4 to i64 
+  ret i64 %5 
 }
 
 

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -224,206 +224,168 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 3, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 1, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 0, i64* %23 
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
   %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 1, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 0, i64* %31 
-  %32 = trunc i64 16 to i32  
-  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
-  %34 = ptrtoint i8* %33 to i64 
+  store  i64 5, i64* %27 
+  %28 = add   i64 %26, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  store  i64 %20, i64* %29 
+  %30 = trunc i64 16 to i32  
+  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
+  %32 = ptrtoint i8* %31 to i64 
+  %33 = inttoptr i64 %32 to i64* 
+  store  i64 %26, i64* %33 
+  %34 = add   i64 %32, 8 
   %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 5, i64* %36 
-  %37 = add   i64 %34, 8 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %26, i64* %39 
-  %40 = trunc i64 16 to i32  
-  %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
-  %42 = ptrtoint i8* %41 to i64 
-  %43 = inttoptr i64 %42 to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  store  i64 %34, i64* %44 
-  %45 = add   i64 %42, 8 
-  %46 = inttoptr i64 %45 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 0, i64* %47 
-  %48 = trunc i64 16 to i32  
-  %49 = tail call ccc  i8*  @wybe_malloc(i32  %48)  
-  %50 = ptrtoint i8* %49 to i64 
-  %51 = inttoptr i64 %50 to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %18, i64* %52 
-  %53 = add   i64 %50, 8 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %42, i64* %55 
-  %56 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  store  i64 0, i64* %35 
+  %36 = trunc i64 16 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i64* 
+  store  i64 %14, i64* %39 
+  %40 = add   i64 %38, 8 
+  %41 = inttoptr i64 %40 to i64* 
+  store  i64 %32, i64* %41 
+  %42 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
-  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  %50, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.0, i32 0, i32 0) to i64), i64  %50)  
-  %57 = load  i64, i64* @"resource#higher_order_resources.maximum" 
-  tail call ccc  void  @print_int(i64  %57)  
+  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  %38, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.0, i32 0, i32 0) to i64), i64  %38)  
+  %43 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  tail call ccc  void  @print_int(i64  %43)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %58 = trunc i64 16 to i32  
-  %59 = tail call ccc  i8*  @wybe_malloc(i32  %58)  
-  %60 = ptrtoint i8* %59 to i64 
+  %44 = trunc i64 16 to i32  
+  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
+  %46 = ptrtoint i8* %45 to i64 
+  %47 = inttoptr i64 %46 to i64* 
+  store  i64 3, i64* %47 
+  %48 = add   i64 %46, 8 
+  %49 = inttoptr i64 %48 to i64* 
+  store  i64 0, i64* %49 
+  %50 = trunc i64 16 to i32  
+  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
+  %52 = ptrtoint i8* %51 to i64 
+  %53 = inttoptr i64 %52 to i64* 
+  store  i64 2, i64* %53 
+  %54 = add   i64 %52, 8 
+  %55 = inttoptr i64 %54 to i64* 
+  store  i64 %46, i64* %55 
+  %56 = trunc i64 16 to i32  
+  %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
+  %58 = ptrtoint i8* %57 to i64 
+  %59 = inttoptr i64 %58 to i64* 
+  store  i64 1, i64* %59 
+  %60 = add   i64 %58, 8 
   %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  store  i64 3, i64* %62 
-  %63 = add   i64 %60, 8 
-  %64 = inttoptr i64 %63 to i64* 
-  %65 = getelementptr  i64, i64* %64, i64 0 
-  store  i64 0, i64* %65 
-  %66 = trunc i64 16 to i32  
-  %67 = tail call ccc  i8*  @wybe_malloc(i32  %66)  
-  %68 = ptrtoint i8* %67 to i64 
-  %69 = inttoptr i64 %68 to i64* 
-  %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 2, i64* %70 
-  %71 = add   i64 %68, 8 
-  %72 = inttoptr i64 %71 to i64* 
-  %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %60, i64* %73 
+  store  i64 %52, i64* %61 
+  %62 = trunc i64 16 to i32  
+  %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
+  %64 = ptrtoint i8* %63 to i64 
+  %65 = inttoptr i64 %64 to i64* 
+  store  i64 2, i64* %65 
+  %66 = add   i64 %64, 8 
+  %67 = inttoptr i64 %66 to i64* 
+  store  i64 0, i64* %67 
+  %68 = trunc i64 16 to i32  
+  %69 = tail call ccc  i8*  @wybe_malloc(i32  %68)  
+  %70 = ptrtoint i8* %69 to i64 
+  %71 = inttoptr i64 %70 to i64* 
+  store  i64 1, i64* %71 
+  %72 = add   i64 %70, 8 
+  %73 = inttoptr i64 %72 to i64* 
+  store  i64 %64, i64* %73 
   %74 = trunc i64 16 to i32  
   %75 = tail call ccc  i8*  @wybe_malloc(i32  %74)  
   %76 = ptrtoint i8* %75 to i64 
   %77 = inttoptr i64 %76 to i64* 
-  %78 = getelementptr  i64, i64* %77, i64 0 
-  store  i64 1, i64* %78 
-  %79 = add   i64 %76, 8 
-  %80 = inttoptr i64 %79 to i64* 
-  %81 = getelementptr  i64, i64* %80, i64 0 
-  store  i64 %68, i64* %81 
-  %82 = trunc i64 16 to i32  
-  %83 = tail call ccc  i8*  @wybe_malloc(i32  %82)  
-  %84 = ptrtoint i8* %83 to i64 
+  store  i64 2, i64* %77 
+  %78 = add   i64 %76, 8 
+  %79 = inttoptr i64 %78 to i64* 
+  store  i64 %70, i64* %79 
+  %80 = trunc i64 16 to i32  
+  %81 = tail call ccc  i8*  @wybe_malloc(i32  %80)  
+  %82 = ptrtoint i8* %81 to i64 
+  %83 = inttoptr i64 %82 to i64* 
+  store  i64 1, i64* %83 
+  %84 = add   i64 %82, 8 
   %85 = inttoptr i64 %84 to i64* 
-  %86 = getelementptr  i64, i64* %85, i64 0 
-  store  i64 2, i64* %86 
-  %87 = add   i64 %84, 8 
-  %88 = inttoptr i64 %87 to i64* 
-  %89 = getelementptr  i64, i64* %88, i64 0 
-  store  i64 0, i64* %89 
-  %90 = trunc i64 16 to i32  
-  %91 = tail call ccc  i8*  @wybe_malloc(i32  %90)  
-  %92 = ptrtoint i8* %91 to i64 
-  %93 = inttoptr i64 %92 to i64* 
-  %94 = getelementptr  i64, i64* %93, i64 0 
-  store  i64 1, i64* %94 
-  %95 = add   i64 %92, 8 
-  %96 = inttoptr i64 %95 to i64* 
-  %97 = getelementptr  i64, i64* %96, i64 0 
-  store  i64 %84, i64* %97 
+  store  i64 %76, i64* %85 
+  %86 = trunc i64 16 to i32  
+  %87 = tail call ccc  i8*  @wybe_malloc(i32  %86)  
+  %88 = ptrtoint i8* %87 to i64 
+  %89 = inttoptr i64 %88 to i64* 
+  store  i64 1, i64* %89 
+  %90 = add   i64 %88, 8 
+  %91 = inttoptr i64 %90 to i64* 
+  store  i64 0, i64* %91 
+  %92 = trunc i64 16 to i32  
+  %93 = tail call ccc  i8*  @wybe_malloc(i32  %92)  
+  %94 = ptrtoint i8* %93 to i64 
+  %95 = inttoptr i64 %94 to i64* 
+  store  i64 5, i64* %95 
+  %96 = add   i64 %94, 8 
+  %97 = inttoptr i64 %96 to i64* 
+  store  i64 %88, i64* %97 
   %98 = trunc i64 16 to i32  
   %99 = tail call ccc  i8*  @wybe_malloc(i32  %98)  
   %100 = ptrtoint i8* %99 to i64 
   %101 = inttoptr i64 %100 to i64* 
-  %102 = getelementptr  i64, i64* %101, i64 0 
-  store  i64 2, i64* %102 
-  %103 = add   i64 %100, 8 
-  %104 = inttoptr i64 %103 to i64* 
-  %105 = getelementptr  i64, i64* %104, i64 0 
-  store  i64 %92, i64* %105 
-  %106 = trunc i64 16 to i32  
-  %107 = tail call ccc  i8*  @wybe_malloc(i32  %106)  
-  %108 = ptrtoint i8* %107 to i64 
+  store  i64 %94, i64* %101 
+  %102 = add   i64 %100, 8 
+  %103 = inttoptr i64 %102 to i64* 
+  store  i64 0, i64* %103 
+  %104 = trunc i64 16 to i32  
+  %105 = tail call ccc  i8*  @wybe_malloc(i32  %104)  
+  %106 = ptrtoint i8* %105 to i64 
+  %107 = inttoptr i64 %106 to i64* 
+  store  i64 %82, i64* %107 
+  %108 = add   i64 %106, 8 
   %109 = inttoptr i64 %108 to i64* 
-  %110 = getelementptr  i64, i64* %109, i64 0 
-  store  i64 1, i64* %110 
-  %111 = add   i64 %108, 8 
-  %112 = inttoptr i64 %111 to i64* 
-  %113 = getelementptr  i64, i64* %112, i64 0 
-  store  i64 %100, i64* %113 
-  %114 = trunc i64 16 to i32  
-  %115 = tail call ccc  i8*  @wybe_malloc(i32  %114)  
-  %116 = ptrtoint i8* %115 to i64 
-  %117 = inttoptr i64 %116 to i64* 
-  %118 = getelementptr  i64, i64* %117, i64 0 
-  store  i64 1, i64* %118 
-  %119 = add   i64 %116, 8 
-  %120 = inttoptr i64 %119 to i64* 
-  %121 = getelementptr  i64, i64* %120, i64 0 
-  store  i64 0, i64* %121 
-  %122 = trunc i64 16 to i32  
-  %123 = tail call ccc  i8*  @wybe_malloc(i32  %122)  
-  %124 = ptrtoint i8* %123 to i64 
-  %125 = inttoptr i64 %124 to i64* 
-  %126 = getelementptr  i64, i64* %125, i64 0 
-  store  i64 5, i64* %126 
-  %127 = add   i64 %124, 8 
-  %128 = inttoptr i64 %127 to i64* 
-  %129 = getelementptr  i64, i64* %128, i64 0 
-  store  i64 %116, i64* %129 
-  %130 = trunc i64 16 to i32  
-  %131 = tail call ccc  i8*  @wybe_malloc(i32  %130)  
-  %132 = ptrtoint i8* %131 to i64 
-  %133 = inttoptr i64 %132 to i64* 
-  %134 = getelementptr  i64, i64* %133, i64 0 
-  store  i64 %124, i64* %134 
-  %135 = add   i64 %132, 8 
-  %136 = inttoptr i64 %135 to i64* 
-  %137 = getelementptr  i64, i64* %136, i64 0 
-  store  i64 0, i64* %137 
-  %138 = trunc i64 16 to i32  
-  %139 = tail call ccc  i8*  @wybe_malloc(i32  %138)  
-  %140 = ptrtoint i8* %139 to i64 
-  %141 = inttoptr i64 %140 to i64* 
-  %142 = getelementptr  i64, i64* %141, i64 0 
-  store  i64 %108, i64* %142 
-  %143 = add   i64 %140, 8 
-  %144 = inttoptr i64 %143 to i64* 
-  %145 = getelementptr  i64, i64* %144, i64 0 
-  store  i64 %132, i64* %145 
-  %146 = trunc i64 16 to i32  
-  %147 = tail call ccc  i8*  @wybe_malloc(i32  %146)  
-  %148 = ptrtoint i8* %147 to i64 
-  %149 = inttoptr i64 %148 to i64* 
-  %150 = getelementptr  i64, i64* %149, i64 0 
-  store  i64 %76, i64* %150 
-  %151 = add   i64 %148, 8 
-  %152 = inttoptr i64 %151 to i64* 
-  %153 = getelementptr  i64, i64* %152, i64 0 
-  store  i64 %140, i64* %153 
+  store  i64 %100, i64* %109 
+  %110 = trunc i64 16 to i32  
+  %111 = tail call ccc  i8*  @wybe_malloc(i32  %110)  
+  %112 = ptrtoint i8* %111 to i64 
+  %113 = inttoptr i64 %112 to i64* 
+  store  i64 %58, i64* %113 
+  %114 = add   i64 %112, 8 
+  %115 = inttoptr i64 %114 to i64* 
+  store  i64 %106, i64* %115 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
-  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  %148, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.3, i32 0, i32 0) to i64), i64  %148)  
-  %154 = load  i64, i64* @"resource#higher_order_resources.maximum" 
-  tail call ccc  void  @print_int(i64  %154)  
+  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  %112, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.3, i32 0, i32 0) to i64), i64  %112)  
+  %116 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  tail call ccc  void  @print_int(i64  %116)  
   tail call ccc  void  @putchar(i8  10)  
-  store  i64 %56, i64* @"resource#higher_order_resources.maximum" 
+  store  i64 %42, i64* @"resource#higher_order_resources.maximum" 
   ret void 
 }
 

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -2,12 +2,12 @@
 AFTER EVERYTHING:
  Module higher_order_resources
   representation  : (not a type)
-  public submods  :
-  public resources:
+  public submods  : 
+  public resources: 
   public procs    : higher_order_resources.<0>
   imports         : use wybe
   resources       : maximum: fromList [(higher_order_resources.maximum,wybe.int @higher_order_resources:nn:nn)]
-  procs           :
+  procs           : 
 
 module top-level code > public {impure} (0 calls)
 0: higher_order_resources.<0>
@@ -167,7 +167,7 @@ take_max(i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_re
 ; ModuleID = 'higher_order_resources'
 
 
-
+ 
 
 
 @"resource#higher_order_resources.maximum" =    global i64 undef
@@ -194,261 +194,261 @@ take_max(i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_re
 @higher_order_resources.4 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#3<0>" to i64)]
 
 
-declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)
+declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)    
 
 
-declare external fastcc  i64 @"wybe.list.length1<0>"(i64, i64)
+declare external fastcc  i64 @"wybe.list.length1<0>"(i64, i64)    
 
 
-declare external ccc  void @putchar(i8)
+declare external ccc  void @putchar(i8)    
 
 
-declare external ccc  void @print_int(i64)
+declare external ccc  void @print_int(i64)    
 
 
-declare external fastcc  void @"wybe.string.print<0>"(i64)
+declare external fastcc  void @"wybe.string.print<0>"(i64)    
 
 
-declare external fastcc  void @"wybe.list.gen#4<0>"(i64, i64, i64)
+declare external fastcc  void @"wybe.list.gen#4<0>"(i64, i64, i64)    
 
 
-declare external ccc  i8* @wybe_malloc(i32)
+declare external ccc  i8* @wybe_malloc(i32)    
 
 
-declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
 define external fastcc  void @"higher_order_resources.<0>"()    {
 entry:
-  %0 = trunc i64 16 to i32
-  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)
-  %2 = ptrtoint i8* %1 to i64
-  %3 = inttoptr i64 %2 to i64*
-  store  i64 3, i64* %3
-  %4 = add   i64 %2, 8
-  %5 = inttoptr i64 %4 to i64*
-  store  i64 0, i64* %5
-  %6 = trunc i64 16 to i32
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)
-  %8 = ptrtoint i8* %7 to i64
-  %9 = inttoptr i64 %8 to i64*
-  store  i64 2, i64* %9
-  %10 = add   i64 %8, 8
-  %11 = inttoptr i64 %10 to i64*
-  store  i64 %2, i64* %11
-  %12 = trunc i64 16 to i32
-  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)
-  %14 = ptrtoint i8* %13 to i64
-  %15 = inttoptr i64 %14 to i64*
-  store  i64 1, i64* %15
-  %16 = add   i64 %14, 8
-  %17 = inttoptr i64 %16 to i64*
-  store  i64 %8, i64* %17
-  %18 = trunc i64 16 to i32
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)
-  %20 = ptrtoint i8* %19 to i64
-  %21 = inttoptr i64 %20 to i64*
-  store  i64 1, i64* %21
-  %22 = add   i64 %20, 8
-  %23 = inttoptr i64 %22 to i64*
-  store  i64 0, i64* %23
-  %24 = trunc i64 16 to i32
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)
-  %26 = ptrtoint i8* %25 to i64
-  %27 = inttoptr i64 %26 to i64*
-  store  i64 5, i64* %27
-  %28 = add   i64 %26, 8
-  %29 = inttoptr i64 %28 to i64*
-  store  i64 %20, i64* %29
-  %30 = trunc i64 16 to i32
-  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)
-  %32 = ptrtoint i8* %31 to i64
-  %33 = inttoptr i64 %32 to i64*
-  store  i64 %26, i64* %33
-  %34 = add   i64 %32, 8
-  %35 = inttoptr i64 %34 to i64*
-  store  i64 0, i64* %35
-  %36 = trunc i64 16 to i32
-  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)
-  %38 = ptrtoint i8* %37 to i64
-  %39 = inttoptr i64 %38 to i64*
-  store  i64 %14, i64* %39
-  %40 = add   i64 %38, 8
-  %41 = inttoptr i64 %40 to i64*
-  store  i64 %32, i64* %41
-  %42 = load  i64, i64* @"resource#higher_order_resources.maximum"
-  store  i64 -1000, i64* @"resource#higher_order_resources.maximum"
-  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.0, i32 0, i32 0) to i64), i64  %50, i64  %50)
-  %57 = load  i64, i64* @"resource#higher_order_resources.maximum"
-  tail call ccc  void  @print_int(i64  %57)
-  tail call ccc  void  @putchar(i8  10)
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.2, i32 0, i32 0) to i64))
-  tail call ccc  void  @putchar(i8  10)
-  %44 = trunc i64 16 to i32
-  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)
-  %46 = ptrtoint i8* %45 to i64
-  %47 = inttoptr i64 %46 to i64*
-  store  i64 3, i64* %47
-  %48 = add   i64 %46, 8
-  %49 = inttoptr i64 %48 to i64*
-  store  i64 0, i64* %49
-  %50 = trunc i64 16 to i32
-  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)
-  %52 = ptrtoint i8* %51 to i64
-  %53 = inttoptr i64 %52 to i64*
-  store  i64 2, i64* %53
-  %54 = add   i64 %52, 8
-  %55 = inttoptr i64 %54 to i64*
-  store  i64 %46, i64* %55
-  %56 = trunc i64 16 to i32
-  %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)
-  %58 = ptrtoint i8* %57 to i64
-  %59 = inttoptr i64 %58 to i64*
-  store  i64 1, i64* %59
-  %60 = add   i64 %58, 8
-  %61 = inttoptr i64 %60 to i64*
-  store  i64 %52, i64* %61
-  %62 = trunc i64 16 to i32
-  %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)
-  %64 = ptrtoint i8* %63 to i64
-  %65 = inttoptr i64 %64 to i64*
-  store  i64 2, i64* %65
-  %66 = add   i64 %64, 8
-  %67 = inttoptr i64 %66 to i64*
-  store  i64 0, i64* %67
-  %68 = trunc i64 16 to i32
-  %69 = tail call ccc  i8*  @wybe_malloc(i32  %68)
-  %70 = ptrtoint i8* %69 to i64
-  %71 = inttoptr i64 %70 to i64*
-  store  i64 1, i64* %71
-  %72 = add   i64 %70, 8
-  %73 = inttoptr i64 %72 to i64*
-  store  i64 %64, i64* %73
-  %74 = trunc i64 16 to i32
-  %75 = tail call ccc  i8*  @wybe_malloc(i32  %74)
-  %76 = ptrtoint i8* %75 to i64
-  %77 = inttoptr i64 %76 to i64*
-  store  i64 2, i64* %77
-  %78 = add   i64 %76, 8
-  %79 = inttoptr i64 %78 to i64*
-  store  i64 %70, i64* %79
-  %80 = trunc i64 16 to i32
-  %81 = tail call ccc  i8*  @wybe_malloc(i32  %80)
-  %82 = ptrtoint i8* %81 to i64
-  %83 = inttoptr i64 %82 to i64*
-  store  i64 1, i64* %83
-  %84 = add   i64 %82, 8
-  %85 = inttoptr i64 %84 to i64*
-  store  i64 %76, i64* %85
-  %86 = trunc i64 16 to i32
-  %87 = tail call ccc  i8*  @wybe_malloc(i32  %86)
-  %88 = ptrtoint i8* %87 to i64
-  %89 = inttoptr i64 %88 to i64*
-  store  i64 1, i64* %89
-  %90 = add   i64 %88, 8
-  %91 = inttoptr i64 %90 to i64*
-  store  i64 0, i64* %91
-  %92 = trunc i64 16 to i32
-  %93 = tail call ccc  i8*  @wybe_malloc(i32  %92)
-  %94 = ptrtoint i8* %93 to i64
-  %95 = inttoptr i64 %94 to i64*
-  store  i64 5, i64* %95
-  %96 = add   i64 %94, 8
-  %97 = inttoptr i64 %96 to i64*
-  store  i64 %88, i64* %97
-  %98 = trunc i64 16 to i32
-  %99 = tail call ccc  i8*  @wybe_malloc(i32  %98)
-  %100 = ptrtoint i8* %99 to i64
-  %101 = inttoptr i64 %100 to i64*
-  store  i64 %94, i64* %101
-  %102 = add   i64 %100, 8
-  %103 = inttoptr i64 %102 to i64*
-  store  i64 0, i64* %103
-  %104 = trunc i64 16 to i32
-  %105 = tail call ccc  i8*  @wybe_malloc(i32  %104)
-  %106 = ptrtoint i8* %105 to i64
-  %107 = inttoptr i64 %106 to i64*
-  store  i64 %82, i64* %107
-  %108 = add   i64 %106, 8
-  %109 = inttoptr i64 %108 to i64*
-  store  i64 %100, i64* %109
-  %110 = trunc i64 16 to i32
-  %111 = tail call ccc  i8*  @wybe_malloc(i32  %110)
-  %112 = ptrtoint i8* %111 to i64
-  %113 = inttoptr i64 %112 to i64*
-  store  i64 %58, i64* %113
-  %114 = add   i64 %112, 8
-  %115 = inttoptr i64 %114 to i64*
-  store  i64 %106, i64* %115
-  store  i64 -1000, i64* @"resource#higher_order_resources.maximum"
-  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.3, i32 0, i32 0) to i64), i64  %148, i64  %148)
-  %154 = load  i64, i64* @"resource#higher_order_resources.maximum"
-  tail call ccc  void  @print_int(i64  %154)
-  tail call ccc  void  @putchar(i8  10)
-  store  i64 %42, i64* @"resource#higher_order_resources.maximum"
-  ret void
+  %0 = trunc i64 16 to i32  
+  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
+  %2 = ptrtoint i8* %1 to i64 
+  %3 = inttoptr i64 %2 to i64* 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 0, i64* %23 
+  %24 = trunc i64 16 to i32  
+  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
+  %26 = ptrtoint i8* %25 to i64 
+  %27 = inttoptr i64 %26 to i64* 
+  store  i64 5, i64* %27 
+  %28 = add   i64 %26, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  store  i64 %20, i64* %29 
+  %30 = trunc i64 16 to i32  
+  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
+  %32 = ptrtoint i8* %31 to i64 
+  %33 = inttoptr i64 %32 to i64* 
+  store  i64 %26, i64* %33 
+  %34 = add   i64 %32, 8 
+  %35 = inttoptr i64 %34 to i64* 
+  store  i64 0, i64* %35 
+  %36 = trunc i64 16 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i64* 
+  store  i64 %14, i64* %39 
+  %40 = add   i64 %38, 8 
+  %41 = inttoptr i64 %40 to i64* 
+  store  i64 %32, i64* %41 
+  %42 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
+  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.0, i32 0, i32 0) to i64), i64  %38, i64  %38)  
+  %43 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  tail call ccc  void  @print_int(i64  %43)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.2, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  %44 = trunc i64 16 to i32  
+  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
+  %46 = ptrtoint i8* %45 to i64 
+  %47 = inttoptr i64 %46 to i64* 
+  store  i64 3, i64* %47 
+  %48 = add   i64 %46, 8 
+  %49 = inttoptr i64 %48 to i64* 
+  store  i64 0, i64* %49 
+  %50 = trunc i64 16 to i32  
+  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
+  %52 = ptrtoint i8* %51 to i64 
+  %53 = inttoptr i64 %52 to i64* 
+  store  i64 2, i64* %53 
+  %54 = add   i64 %52, 8 
+  %55 = inttoptr i64 %54 to i64* 
+  store  i64 %46, i64* %55 
+  %56 = trunc i64 16 to i32  
+  %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
+  %58 = ptrtoint i8* %57 to i64 
+  %59 = inttoptr i64 %58 to i64* 
+  store  i64 1, i64* %59 
+  %60 = add   i64 %58, 8 
+  %61 = inttoptr i64 %60 to i64* 
+  store  i64 %52, i64* %61 
+  %62 = trunc i64 16 to i32  
+  %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
+  %64 = ptrtoint i8* %63 to i64 
+  %65 = inttoptr i64 %64 to i64* 
+  store  i64 2, i64* %65 
+  %66 = add   i64 %64, 8 
+  %67 = inttoptr i64 %66 to i64* 
+  store  i64 0, i64* %67 
+  %68 = trunc i64 16 to i32  
+  %69 = tail call ccc  i8*  @wybe_malloc(i32  %68)  
+  %70 = ptrtoint i8* %69 to i64 
+  %71 = inttoptr i64 %70 to i64* 
+  store  i64 1, i64* %71 
+  %72 = add   i64 %70, 8 
+  %73 = inttoptr i64 %72 to i64* 
+  store  i64 %64, i64* %73 
+  %74 = trunc i64 16 to i32  
+  %75 = tail call ccc  i8*  @wybe_malloc(i32  %74)  
+  %76 = ptrtoint i8* %75 to i64 
+  %77 = inttoptr i64 %76 to i64* 
+  store  i64 2, i64* %77 
+  %78 = add   i64 %76, 8 
+  %79 = inttoptr i64 %78 to i64* 
+  store  i64 %70, i64* %79 
+  %80 = trunc i64 16 to i32  
+  %81 = tail call ccc  i8*  @wybe_malloc(i32  %80)  
+  %82 = ptrtoint i8* %81 to i64 
+  %83 = inttoptr i64 %82 to i64* 
+  store  i64 1, i64* %83 
+  %84 = add   i64 %82, 8 
+  %85 = inttoptr i64 %84 to i64* 
+  store  i64 %76, i64* %85 
+  %86 = trunc i64 16 to i32  
+  %87 = tail call ccc  i8*  @wybe_malloc(i32  %86)  
+  %88 = ptrtoint i8* %87 to i64 
+  %89 = inttoptr i64 %88 to i64* 
+  store  i64 1, i64* %89 
+  %90 = add   i64 %88, 8 
+  %91 = inttoptr i64 %90 to i64* 
+  store  i64 0, i64* %91 
+  %92 = trunc i64 16 to i32  
+  %93 = tail call ccc  i8*  @wybe_malloc(i32  %92)  
+  %94 = ptrtoint i8* %93 to i64 
+  %95 = inttoptr i64 %94 to i64* 
+  store  i64 5, i64* %95 
+  %96 = add   i64 %94, 8 
+  %97 = inttoptr i64 %96 to i64* 
+  store  i64 %88, i64* %97 
+  %98 = trunc i64 16 to i32  
+  %99 = tail call ccc  i8*  @wybe_malloc(i32  %98)  
+  %100 = ptrtoint i8* %99 to i64 
+  %101 = inttoptr i64 %100 to i64* 
+  store  i64 %94, i64* %101 
+  %102 = add   i64 %100, 8 
+  %103 = inttoptr i64 %102 to i64* 
+  store  i64 0, i64* %103 
+  %104 = trunc i64 16 to i32  
+  %105 = tail call ccc  i8*  @wybe_malloc(i32  %104)  
+  %106 = ptrtoint i8* %105 to i64 
+  %107 = inttoptr i64 %106 to i64* 
+  store  i64 %82, i64* %107 
+  %108 = add   i64 %106, 8 
+  %109 = inttoptr i64 %108 to i64* 
+  store  i64 %100, i64* %109 
+  %110 = trunc i64 16 to i32  
+  %111 = tail call ccc  i8*  @wybe_malloc(i32  %110)  
+  %112 = ptrtoint i8* %111 to i64 
+  %113 = inttoptr i64 %112 to i64* 
+  store  i64 %58, i64* %113 
+  %114 = add   i64 %112, 8 
+  %115 = inttoptr i64 %114 to i64* 
+  store  i64 %106, i64* %115 
+  store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
+  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.3, i32 0, i32 0) to i64), i64  %112, i64  %112)  
+  %116 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  tail call ccc  void  @print_int(i64  %116)  
+  tail call ccc  void  @putchar(i8  10)  
+  store  i64 %42, i64* @"resource#higher_order_resources.maximum" 
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_resources.gen#1<0>"(i64  %"anon#1#1##0")    {
 entry:
-  %0 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#1#1##0", i64  0)
-  musttail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %0)
-  ret void
+  %0 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#1#1##0", i64  0)  
+  musttail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %0)  
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_resources.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0")    {
 entry:
-  %0 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#1#1##0", i64  0)
-  tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %0)
-  ret void
+  %0 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#1#1##0", i64  0)  
+  tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %0)  
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_resources.gen#2<0>"(i64  %"anon#2#1##0")    {
 entry:
-  %0 = load  i64, i64* @"resource#higher_order_resources.maximum"
-  store  i64 -1000, i64* @"resource#higher_order_resources.maximum"
-  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.4, i32 0, i32 0) to i64), i64  %"anon#2#1##0", i64  %"anon#2#1##0")
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.6, i32 0, i32 0) to i64))
-  %1 = load  i64, i64* @"resource#higher_order_resources.maximum"
-  tail call ccc  void  @print_int(i64  %1)
-  tail call ccc  void  @putchar(i8  10)
-  store  i64 %0, i64* @"resource#higher_order_resources.maximum"
-  %2 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#2#1##0", i64  0)
-  musttail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %2)
-  ret void
+  %0 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
+  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.4, i32 0, i32 0) to i64), i64  %"anon#2#1##0", i64  %"anon#2#1##0")  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.6, i32 0, i32 0) to i64))  
+  %1 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  store  i64 %0, i64* @"resource#higher_order_resources.maximum" 
+  %2 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#2#1##0", i64  0)  
+  musttail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %2)  
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_resources.gen#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0")    {
 entry:
-  %0 = load  i64, i64* @"resource#higher_order_resources.maximum"
-  store  i64 -1000, i64* @"resource#higher_order_resources.maximum"
-  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.4, i32 0, i32 0) to i64), i64  %"anon#2#1##0", i64  %"anon#2#1##0")
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.6, i32 0, i32 0) to i64))
-  %1 = load  i64, i64* @"resource#higher_order_resources.maximum"
-  tail call ccc  void  @print_int(i64  %1)
-  tail call ccc  void  @putchar(i8  10)
-  store  i64 %0, i64* @"resource#higher_order_resources.maximum"
-  %2 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#2#1##0", i64  0)
-  tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %2)
-  ret void
+  %0 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
+  tail call fastcc  void  @"wybe.list.gen#4<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.4, i32 0, i32 0) to i64), i64  %"anon#2#1##0", i64  %"anon#2#1##0")  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.6, i32 0, i32 0) to i64))  
+  %1 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  store  i64 %0, i64* @"resource#higher_order_resources.maximum" 
+  %2 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#2#1##0", i64  0)  
+  tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %2)  
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_resources.gen#3<0>"(i64  %"#env##0", i64  %"i##0")    {
 entry:
-  tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %"i##0")
-  ret void
+  tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %"i##0")  
+  ret void 
 }
 
 
 define external fastcc  void @"higher_order_resources.take_max<0>"(i64  %"i##0")    {
 entry:
-  %0 = load  i64, i64* @"resource#higher_order_resources.maximum"
-  %1 = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %"i##0", i64  %0)
-  store  i64 %1, i64* @"resource#higher_order_resources.maximum"
-  ret void
+  %0 = load  i64, i64* @"resource#higher_order_resources.maximum" 
+  %1 = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %"i##0", i64  %0)  
+  store  i64 %1, i64* @"resource#higher_order_resources.maximum" 
+  ret void 
 }

--- a/test-cases/final-dump/higher_order_sort.exp
+++ b/test-cases/final-dump/higher_order_sort.exp
@@ -85,17 +85,15 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#1##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#1##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#1##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = alloca i64 
+   call fastcc  void  @"higher_order_sort.insert<0>"(i64  %"<=##0", i64  %2, i64  %"sorted##0", i64*  %6)  
   %7 = load  i64, i64* %6 
-  %8 = alloca i64 
-   call fastcc  void  @"higher_order_sort.insert<0>"(i64  %"<=##0", i64  %3, i64  %"sorted##0", i64*  %8)  
-  %9 = load  i64, i64* %8 
-  %10 = musttail call fastcc  i64  @"higher_order_sort.gen#1<0>"(i64  %"<=##0", i64  %9, i64  %"tmp#0##0", i64  %7, i64  %"xs##0")  
-  ret i64 %10 
+  %8 = musttail call fastcc  i64  @"higher_order_sort.gen#1<0>"(i64  %"<=##0", i64  %7, i64  %"tmp#0##0", i64  %5, i64  %"xs##0")  
+  ret i64 %8 
 if.else:
   ret i64 %"sorted##0" 
 }
@@ -107,55 +105,48 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"xs##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"xs##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"xs##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = inttoptr i64 %"<=##0" to i64* 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"<=##0" to i64* 
-  %9 = load  i64, i64* %8 
-  %10 = inttoptr i64 %9 to i64 (i64, i64, i64)* 
-  %11 = tail call fastcc  i64  %10(i64  %"<=##0", i64  %"x##0", i64  %3)  
-  %12 = trunc i64 %11 to i1  
-  br i1 %12, label %if.then1, label %if.else1 
+  %8 = inttoptr i64 %7 to i64 (i64, i64, i64)* 
+  %9 = tail call fastcc  i64  %8(i64  %"<=##0", i64  %"x##0", i64  %2)  
+  %10 = trunc i64 %9 to i1  
+  br i1 %10, label %if.then1, label %if.else1 
 if.else:
-  %28 = trunc i64 16 to i32  
-  %29 = tail call ccc  i8*  @wybe_malloc(i32  %28)  
-  %30 = ptrtoint i8* %29 to i64 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 %"x##0", i64* %32 
-  %33 = add   i64 %30, 8 
-  %34 = inttoptr i64 %33 to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  store  i64 0, i64* %35 
-  store  i64 %30, i64* %"xs##1" 
+  %23 = trunc i64 16 to i32  
+  %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
+  %25 = ptrtoint i8* %24 to i64 
+  %26 = inttoptr i64 %25 to i64* 
+  store  i64 %"x##0", i64* %26 
+  %27 = add   i64 %25, 8 
+  %28 = inttoptr i64 %27 to i64* 
+  store  i64 0, i64* %28 
+  store  i64 %25, i64* %"xs##1" 
   ret void 
 if.then1:
-  %13 = trunc i64 16 to i32  
-  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
-  %15 = ptrtoint i8* %14 to i64 
+  %11 = trunc i64 16 to i32  
+  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
+  %13 = ptrtoint i8* %12 to i64 
+  %14 = inttoptr i64 %13 to i64* 
+  store  i64 %"x##0", i64* %14 
+  %15 = add   i64 %13, 8 
   %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  store  i64 %"x##0", i64* %17 
-  %18 = add   i64 %15, 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 %"xs##0", i64* %20 
-  store  i64 %15, i64* %"xs##1" 
+  store  i64 %"xs##0", i64* %16 
+  store  i64 %13, i64* %"xs##1" 
   ret void 
 if.else1:
-  %21 = trunc i64 16 to i32  
-  %22 = tail call ccc  i8*  @wybe_malloc(i32  %21)  
-  %23 = ptrtoint i8* %22 to i64 
-  %24 = inttoptr i64 %23 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %3, i64* %25 
-  %26 = add   i64 %23, 8 
-  %27 = inttoptr i64 %26 to i64* 
-  store  i64 %23, i64* %"xs##1" 
-  musttail call fastcc  void  @"higher_order_sort.insert<0>"(i64  %"<=##0", i64  %"x##0", i64  %7, i64*  %27)  
+  %17 = trunc i64 16 to i32  
+  %18 = tail call ccc  i8*  @wybe_malloc(i32  %17)  
+  %19 = ptrtoint i8* %18 to i64 
+  %20 = inttoptr i64 %19 to i64* 
+  store  i64 %2, i64* %20 
+  %21 = add   i64 %19, 8 
+  %22 = inttoptr i64 %21 to i64* 
+  store  i64 %19, i64* %"xs##1" 
+  musttail call fastcc  void  @"higher_order_sort.insert<0>"(i64  %"<=##0", i64  %"x##0", i64  %5, i64*  %22)  
   ret void 
 }
 

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -77,24 +77,20 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 20, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 20, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 0, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 0, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 0, i64* %15 
-  %16 = tail call fastcc  i64  @"import.distance<0>"(i64  %2, i64  %10)  
-  tail call ccc  void  @print_int(i64  %16)  
+  store  i64 0, i64* %11 
+  %12 = tail call fastcc  i64  @"import.distance<0>"(i64  %2, i64  %8)  
+  tail call ccc  void  @print_int(i64  %12)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -103,26 +99,22 @@ entry:
 define external fastcc  i64 @"import.distance<0>"(i64  %"p1##0", i64  %"p2##0")    {
 entry:
   %0 = inttoptr i64 %"p2##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = inttoptr i64 %"p1##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = sub   i64 %2, %5 
-  %7 = tail call ccc  i64  @ipow(i64  %6, i64  2)  
-  %8 = add   i64 %"p2##0", 8 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %"p1##0" to i64* 
+  %3 = load  i64, i64* %2 
+  %4 = sub   i64 %1, %3 
+  %5 = tail call ccc  i64  @ipow(i64  %4, i64  2)  
+  %6 = add   i64 %"p2##0", 8 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"p1##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"p1##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = sub   i64 %11, %15 
-  %17 = tail call ccc  i64  @ipow(i64  %16, i64  2)  
-  %18 = add   i64 %7, %17 
-  %19 = tail call ccc  i64  @isqrt(i64  %18)  
-  ret i64 %19 
+  %12 = sub   i64 %8, %11 
+  %13 = tail call ccc  i64  @ipow(i64  %12, i64  2)  
+  %14 = add   i64 %5, %13 
+  %15 = tail call ccc  i64  @isqrt(i64  %14)  
+  ret i64 %15 
 }
 --------------------------------------------------
  Module position
@@ -209,15 +201,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -341,24 +331,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -370,12 +356,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -383,24 +367,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -414,8 +395,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -424,9 +404,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -441,8 +420,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -450,26 +428,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -98,33 +98,27 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 3, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 1, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  tail call fastcc  void  @"int_list.print<0>"(i64  %18)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  tail call fastcc  void  @"int_list.print<0>"(i64  %14)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -136,15 +130,13 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  tail call ccc  void  @print_int(i64  %3)  
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"x##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  32)  
-  musttail call fastcc  void  @"int_list.print<0>"(i64  %7)  
+  musttail call fastcc  void  @"int_list.print<0>"(i64  %5)  
   ret void 
 if.else:
   ret void 
@@ -336,32 +328,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"#right##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"#right##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
-  %18 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %18 
+  %14 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %14 
 if.then1:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"#right##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#right##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#right##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp eq i64 %3, %11 
-  br i1 %16, label %if.then2, label %if.else2 
+  %12 = icmp eq i64 %2, %8 
+  br i1 %12, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %17 = musttail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %15)  
-  ret i1 %17 
+  %13 = musttail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %5, i64  %11)  
+  ret i1 %13 
 if.else2:
   ret i1 0 
 }
@@ -373,12 +361,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"head##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"tail##0", i64* %7 
+  store  i64 %"head##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"tail##0", i64* %5 
   ret i64 %2 
 }
 
@@ -389,21 +375,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -413,15 +397,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -438,15 +421,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -463,15 +445,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -489,15 +470,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -211,12 +211,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 1, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 10, i64* %7 
+  store  i64 1, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 10, i64* %5 
   tail call fastcc  void  @"int_sequence.gen#1<0>"(i64  %2, i64  %2)  
   ret void 
 }
@@ -228,12 +226,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"lower##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"upper##0", i64* %7 
+  store  i64 %"lower##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"upper##0", i64* %5 
   ret i64 %2 
 }
 
@@ -241,39 +237,33 @@ entry:
 define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"int_sequence.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -282,67 +272,59 @@ if.else:
 define external fastcc  {i64, i64, i1} @"int_sequence.[|]<0>"(i64  %"seq##0")    {
 entry:
   %0 = inttoptr i64 %"seq##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"seq##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = icmp sle i64 %2, %6 
-  br i1 %7, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"seq##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = icmp sle i64 %1, %4 
+  br i1 %5, label %if.then, label %if.else 
 if.then:
-  %8 = add   i64 %2, 1 
-  %9 = trunc i64 16 to i32  
-  %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
-  %11 = ptrtoint i8* %10 to i64 
+  %6 = add   i64 %1, 1 
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i64* 
+  store  i64 %6, i64* %10 
+  %11 = add   i64 %9, 8 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %8, i64* %13 
-  %14 = add   i64 %11, 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 %6, i64* %16 
-  %17 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
-  %18 = insertvalue {i64, i64, i1} %17, i64 %11, 1 
-  %19 = insertvalue {i64, i64, i1} %18, i1 1, 2 
-  ret {i64, i64, i1} %19 
+  store  i64 %4, i64* %12 
+  %13 = insertvalue {i64, i64, i1} undef, i64 %1, 0 
+  %14 = insertvalue {i64, i64, i1} %13, i64 %9, 1 
+  %15 = insertvalue {i64, i64, i1} %14, i1 1, 2 
+  ret {i64, i64, i1} %15 
 if.else:
-  %20 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %21 = insertvalue {i64, i64, i1} %20, i64 undef, 1 
-  %22 = insertvalue {i64, i64, i1} %21, i1 0, 2 
-  ret {i64, i64, i1} %22 
+  %16 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %17 = insertvalue {i64, i64, i1} %16, i64 undef, 1 
+  %18 = insertvalue {i64, i64, i1} %17, i1 0, 2 
+  ret {i64, i64, i1} %18 
 }
 
 
 define external fastcc  {i64, i64, i1} @"int_sequence.[|]<0>[785a827a1b]"(i64  %"seq##0")    {
 entry:
   %0 = inttoptr i64 %"seq##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"seq##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = icmp sle i64 %2, %6 
-  br i1 %7, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"seq##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = icmp sle i64 %1, %4 
+  br i1 %5, label %if.then, label %if.else 
 if.then:
-  %8 = add   i64 %2, 1 
-  %9 = inttoptr i64 %"seq##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %8, i64* %10 
-  %11 = add   i64 %"seq##0", 8 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %6, i64* %13 
-  %14 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
-  %15 = insertvalue {i64, i64, i1} %14, i64 %"seq##0", 1 
-  %16 = insertvalue {i64, i64, i1} %15, i1 1, 2 
-  ret {i64, i64, i1} %16 
+  %6 = add   i64 %1, 1 
+  %7 = inttoptr i64 %"seq##0" to i64* 
+  store  i64 %6, i64* %7 
+  %8 = add   i64 %"seq##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %4, i64* %9 
+  %10 = insertvalue {i64, i64, i1} undef, i64 %1, 0 
+  %11 = insertvalue {i64, i64, i1} %10, i64 %"seq##0", 1 
+  %12 = insertvalue {i64, i64, i1} %11, i1 1, 2 
+  ret {i64, i64, i1} %12 
 if.else:
-  %17 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %18 = insertvalue {i64, i64, i1} %17, i64 undef, 1 
-  %19 = insertvalue {i64, i64, i1} %18, i1 0, 2 
-  ret {i64, i64, i1} %19 
+  %13 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %14 = insertvalue {i64, i64, i1} %13, i64 undef, 1 
+  %15 = insertvalue {i64, i64, i1} %14, i1 0, 2 
+  ret {i64, i64, i1} %15 
 }
 
 
@@ -383,9 +365,8 @@ if.else:
 define external fastcc  i64 @"int_sequence.lower<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -399,8 +380,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -409,9 +389,8 @@ define external fastcc  i64 @"int_sequence.upper<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -426,8 +405,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -435,26 +413,22 @@ entry:
 define external fastcc  i1 @"int_sequence.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -152,33 +152,27 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 3, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 1, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  tail call fastcc  void  @"list_loop.gen#1<0>"(i64  %18, i64  %18, i64  %10, i64  %2, i64  0, i64  %18)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  tail call fastcc  void  @"list_loop.gen#1<0>"(i64  %14, i64  %14, i64  %8, i64  %2, i64  0, i64  %14)  
   ret void 
 }
 
@@ -189,15 +183,13 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"l##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"l##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  tail call ccc  void  @print_int(i64  %3)  
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"l##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %3, i64  %7, i64  %"x##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %2, i64  %5, i64  %"x##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -219,18 +211,16 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"l2##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"l2##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"l2##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %7, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
+  musttail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %5, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
   ret void 
 if.else:
   tail call fastcc  void  @"list_loop.gen#1<0>"(i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
@@ -427,32 +417,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"#right##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"#right##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
-  %18 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %18 
+  %14 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %14 
 if.then1:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"#right##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#right##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#right##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp eq i64 %3, %11 
-  br i1 %16, label %if.then2, label %if.else2 
+  %12 = icmp eq i64 %2, %8 
+  br i1 %12, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %17 = musttail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %7, i64  %15)  
-  ret i1 %17 
+  %13 = musttail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %5, i64  %11)  
+  ret i1 %13 
 if.else2:
   ret i1 0 
 }
@@ -464,12 +450,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"head##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"tail##0", i64* %7 
+  store  i64 %"head##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"tail##0", i64* %5 
   ret i64 %2 
 }
 
@@ -480,21 +464,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -504,15 +486,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -529,15 +510,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -554,15 +534,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -580,15 +559,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -181,22 +181,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"x##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  store  i64 %10, i64* %"#result##0" 
-  musttail call fastcc  void  @"list_this.append<0>"(i64  %7, i64  %"y##0", i64*  %14)  
+  store  i64 %8, i64* %"#result##0" 
+  musttail call fastcc  void  @"list_this.append<0>"(i64  %5, i64  %"y##0", i64*  %11)  
   ret void 
 if.else:
   store  i64 %"y##0", i64* %"#result##0" 
@@ -210,15 +207,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -235,15 +231,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -254,15 +249,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -280,15 +274,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -298,12 +291,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"car##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"cdr##0", i64* %7 
+  store  i64 %"car##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"cdr##0", i64* %5 
   ret i64 %2 
 }
 
@@ -314,21 +305,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -346,11 +335,10 @@ entry:
 if.then:
   %1 = add   i64 %"x##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"acc##0", 1 
-  %6 = musttail call fastcc  i64  @"list_this.length1<0>"(i64  %4, i64  %5)  
-  ret i64 %6 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"acc##0", 1 
+  %5 = musttail call fastcc  i64  @"list_this.length1<0>"(i64  %3, i64  %4)  
+  ret i64 %5 
 if.else:
   ret i64 %"acc##0" 
 }

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -111,15 +111,13 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"t##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"t##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"t##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %3)  
-  musttail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %7)  
+  tail call ccc  void  @print_int(i64  %2)  
+  musttail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %5)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  
@@ -143,14 +141,12 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"lst##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"lst##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  tail call ccc  void  @print_int(i64  %3)  
-  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %7)  
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"lst##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %5)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  
@@ -335,32 +331,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"#right##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"#right##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
-  %18 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %18 
+  %14 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %14 
 if.then1:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"#right##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#right##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#right##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp eq i64 %3, %11 
-  br i1 %16, label %if.then2, label %if.else2 
+  %12 = icmp eq i64 %2, %8 
+  br i1 %12, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %17 = musttail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %7, i64  %15)  
-  ret i1 %17 
+  %13 = musttail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %5, i64  %11)  
+  ret i1 %13 
 if.else2:
   ret i1 0 
 }
@@ -372,12 +364,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"head##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"tail##0", i64* %7 
+  store  i64 %"head##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"tail##0", i64* %5 
   ret i64 %2 
 }
 
@@ -388,21 +378,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -412,15 +400,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -437,15 +424,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -462,15 +448,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -488,15 +473,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -102,22 +102,20 @@ entry:
   %3 = tail call ccc  i8*  @wybe_malloc(i32  %2)  
   %4 = ptrtoint i8* %3 to i64 
   %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  store  i64 %0, i64* %6 
-  %7 = add   i64 %4, 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %1, i64* %9 
+  store  i64 %0, i64* %5 
+  %6 = add   i64 %4, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %1, i64* %7 
   store  i64 %4, i64* @"resource#command_line.arguments" 
   store  i64 ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.0, i32 0, i32 0) to i64), i64* @"resource#command_line.command" 
-  %10 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
-  %11 = extractvalue {i64, i64, i1} %10, 0 
-  %12 = extractvalue {i64, i64, i1} %10, 1 
-  %13 = extractvalue {i64, i64, i1} %10, 2 
-  br i1 %13, label %if.then, label %if.else 
+  %8 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>[785a827a1b]"(i64  %4)  
+  %9 = extractvalue {i64, i64, i1} %8, 0 
+  %10 = extractvalue {i64, i64, i1} %8, 1 
+  %11 = extractvalue {i64, i64, i1} %8, 2 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  store  i64 %12, i64* @"resource#command_line.arguments" 
-  store  i64 %11, i64* @"resource#command_line.command" 
+  store  i64 %10, i64* @"resource#command_line.arguments" 
+  store  i64 %9, i64* @"resource#command_line.command" 
   store  i64 0, i64* @"resource#command_line.exit_code" 
   ret void 
 if.else:
@@ -208,9 +206,8 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %0 = load  i64, i64* @"resource#command_line.arguments" 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  tail call ccc  void  @print_int(i64  %3)  
+  %2 = load  i64, i64* %1 
+  tail call ccc  void  @print_int(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -271,28 +271,22 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i8* 
-  %4 = getelementptr  i8, i8* %3, i64 0 
-  store  i8 97, i8* %4 
-  %5 = add   i64 %2, 1 
-  %6 = inttoptr i64 %5 to i1* 
-  %7 = getelementptr  i1, i1* %6, i64 0 
-  store  i1 1, i1* %7 
-  %8 = add   i64 %2, 2 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = getelementptr  i8, i8* %9, i64 0 
-  store  i8 65, i8* %10 
-  %11 = add   i64 %2, 8 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 3, i64* %13 
-  %14 = add   i64 %2, 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 42, i64* %16 
-  %17 = add   i64 %2, 24 
-  %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 17, i64* %19 
+  store  i8 97, i8* %3 
+  %4 = add   i64 %2, 1 
+  %5 = inttoptr i64 %4 to i1* 
+  store  i1 1, i1* %5 
+  %6 = add   i64 %2, 2 
+  %7 = inttoptr i64 %6 to i8* 
+  store  i8 65, i8* %7 
+  %8 = add   i64 %2, 8 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 3, i64* %9 
+  %10 = add   i64 %2, 16 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 42, i64* %11 
+  %12 = add   i64 %2, 24 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 17, i64* %13 
   tail call fastcc  void  @"mixed_fields.printit<0>"(i64  %2)  
   ret void 
 }
@@ -301,76 +295,64 @@ entry:
 define external fastcc  i1 @"mixed_fields.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i8* 
-  %1 = getelementptr  i8, i8* %0, i64 0 
-  %2 = load  i8, i8* %1 
-  %3 = add   i64 %"#left##0", 1 
-  %4 = inttoptr i64 %3 to i1* 
-  %5 = getelementptr  i1, i1* %4, i64 0 
-  %6 = load  i1, i1* %5 
-  %7 = add   i64 %"#left##0", 2 
-  %8 = inttoptr i64 %7 to i8* 
-  %9 = getelementptr  i8, i8* %8, i64 0 
-  %10 = load  i8, i8* %9 
-  %11 = add   i64 %"#left##0", 8 
+  %1 = load  i8, i8* %0 
+  %2 = add   i64 %"#left##0", 1 
+  %3 = inttoptr i64 %2 to i1* 
+  %4 = load  i1, i1* %3 
+  %5 = add   i64 %"#left##0", 2 
+  %6 = inttoptr i64 %5 to i8* 
+  %7 = load  i8, i8* %6 
+  %8 = add   i64 %"#left##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = load  i64, i64* %9 
+  %11 = add   i64 %"#left##0", 16 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  %15 = add   i64 %"#left##0", 16 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  %18 = load  i64, i64* %17 
-  %19 = add   i64 %"#left##0", 24 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  %22 = load  i64, i64* %21 
-  %23 = inttoptr i64 %"#right##0" to i8* 
-  %24 = getelementptr  i8, i8* %23, i64 0 
-  %25 = load  i8, i8* %24 
-  %26 = add   i64 %"#right##0", 1 
-  %27 = inttoptr i64 %26 to i1* 
-  %28 = getelementptr  i1, i1* %27, i64 0 
-  %29 = load  i1, i1* %28 
-  %30 = add   i64 %"#right##0", 2 
-  %31 = inttoptr i64 %30 to i8* 
-  %32 = getelementptr  i8, i8* %31, i64 0 
-  %33 = load  i8, i8* %32 
-  %34 = add   i64 %"#right##0", 8 
-  %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %38 = add   i64 %"#right##0", 16 
-  %39 = inttoptr i64 %38 to i64* 
-  %40 = getelementptr  i64, i64* %39, i64 0 
-  %41 = load  i64, i64* %40 
-  %42 = add   i64 %"#right##0", 24 
-  %43 = inttoptr i64 %42 to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  %45 = load  i64, i64* %44 
-  %46 = icmp eq i64 %14, %37 
-  br i1 %46, label %if.then, label %if.else 
+  %13 = load  i64, i64* %12 
+  %14 = add   i64 %"#left##0", 24 
+  %15 = inttoptr i64 %14 to i64* 
+  %16 = load  i64, i64* %15 
+  %17 = inttoptr i64 %"#right##0" to i8* 
+  %18 = load  i8, i8* %17 
+  %19 = add   i64 %"#right##0", 1 
+  %20 = inttoptr i64 %19 to i1* 
+  %21 = load  i1, i1* %20 
+  %22 = add   i64 %"#right##0", 2 
+  %23 = inttoptr i64 %22 to i8* 
+  %24 = load  i8, i8* %23 
+  %25 = add   i64 %"#right##0", 8 
+  %26 = inttoptr i64 %25 to i64* 
+  %27 = load  i64, i64* %26 
+  %28 = add   i64 %"#right##0", 16 
+  %29 = inttoptr i64 %28 to i64* 
+  %30 = load  i64, i64* %29 
+  %31 = add   i64 %"#right##0", 24 
+  %32 = inttoptr i64 %31 to i64* 
+  %33 = load  i64, i64* %32 
+  %34 = icmp eq i64 %10, %27 
+  br i1 %34, label %if.then, label %if.else 
 if.then:
-  %47 = icmp eq i8 %2, %25 
-  br i1 %47, label %if.then1, label %if.else1 
+  %35 = icmp eq i8 %1, %18 
+  br i1 %35, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %48 = icmp eq i64 %18, %41 
-  br i1 %48, label %if.then2, label %if.else2 
+  %36 = icmp eq i64 %13, %30 
+  br i1 %36, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %49 = icmp eq i1 %6, %29 
-  br i1 %49, label %if.then3, label %if.else3 
+  %37 = icmp eq i1 %4, %21 
+  br i1 %37, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %50 = icmp eq i64 %22, %45 
-  br i1 %50, label %if.then4, label %if.else4 
+  %38 = icmp eq i64 %16, %33 
+  br i1 %38, label %if.then4, label %if.else4 
 if.else3:
   ret i1 0 
 if.then4:
-  %51 = icmp eq i8 %10, %33 
-  ret i1 %51 
+  %39 = icmp eq i8 %7, %24 
+  ret i1 %39 
 if.else4:
   ret i1 0 
 }
@@ -380,9 +362,8 @@ define external fastcc  i64 @"mixed_fields.f1<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -397,8 +378,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -406,9 +386,8 @@ entry:
 define external fastcc  i8 @"mixed_fields.f2<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i8* 
-  %1 = getelementptr  i8, i8* %0, i64 0 
-  %2 = load  i8, i8* %1 
-  ret i8 %2 
+  %1 = load  i8, i8* %0 
+  ret i8 %1 
 }
 
 
@@ -422,8 +401,7 @@ entry:
   %5 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i8* 
-  %7 = getelementptr  i8, i8* %6, i64 0 
-  store  i8 %"#field##0", i8* %7 
+  store  i8 %"#field##0", i8* %6 
   ret i64 %2 
 }
 
@@ -432,9 +410,8 @@ define external fastcc  i64 @"mixed_fields.f3<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -449,8 +426,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 16 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -459,9 +435,8 @@ define external fastcc  i1 @"mixed_fields.f4<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 1 
   %1 = inttoptr i64 %0 to i1* 
-  %2 = getelementptr  i1, i1* %1, i64 0 
-  %3 = load  i1, i1* %2 
-  ret i1 %3 
+  %2 = load  i1, i1* %1 
+  ret i1 %2 
 }
 
 
@@ -476,8 +451,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 1 
   %7 = inttoptr i64 %6 to i1* 
-  %8 = getelementptr  i1, i1* %7, i64 0 
-  store  i1 %"#field##0", i1* %8 
+  store  i1 %"#field##0", i1* %7 
   ret i64 %2 
 }
 
@@ -486,9 +460,8 @@ define external fastcc  i64 @"mixed_fields.f5<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 24 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -503,8 +476,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 24 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -513,9 +485,8 @@ define external fastcc  i8 @"mixed_fields.f6<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 2 
   %1 = inttoptr i64 %0 to i8* 
-  %2 = getelementptr  i8, i8* %1, i64 0 
-  %3 = load  i8, i8* %2 
-  ret i8 %3 
+  %2 = load  i8, i8* %1 
+  ret i8 %2 
 }
 
 
@@ -530,8 +501,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 2 
   %7 = inttoptr i64 %6 to i8* 
-  %8 = getelementptr  i8, i8* %7, i64 0 
-  store  i8 %"#field##0", i8* %8 
+  store  i8 %"#field##0", i8* %7 
   ret i64 %2 
 }
 
@@ -542,28 +512,22 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i8* 
-  %4 = getelementptr  i8, i8* %3, i64 0 
-  store  i8 %"f2##0", i8* %4 
-  %5 = add   i64 %2, 1 
-  %6 = inttoptr i64 %5 to i1* 
-  %7 = getelementptr  i1, i1* %6, i64 0 
-  store  i1 %"f4##0", i1* %7 
-  %8 = add   i64 %2, 2 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = getelementptr  i8, i8* %9, i64 0 
-  store  i8 %"f6##0", i8* %10 
-  %11 = add   i64 %2, 8 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"f1##0", i64* %13 
-  %14 = add   i64 %2, 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 %"f3##0", i64* %16 
-  %17 = add   i64 %2, 24 
-  %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"f5##0", i64* %19 
+  store  i8 %"f2##0", i8* %3 
+  %4 = add   i64 %2, 1 
+  %5 = inttoptr i64 %4 to i1* 
+  store  i1 %"f4##0", i1* %5 
+  %6 = add   i64 %2, 2 
+  %7 = inttoptr i64 %6 to i8* 
+  store  i8 %"f6##0", i8* %7 
+  %8 = add   i64 %2, 8 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %"f1##0", i64* %9 
+  %10 = add   i64 %2, 16 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 %"f3##0", i64* %11 
+  %12 = add   i64 %2, 24 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 %"f5##0", i64* %13 
   ret i64 %2 
 }
 
@@ -571,35 +535,29 @@ entry:
 define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i8* 
-  %1 = getelementptr  i8, i8* %0, i64 0 
-  %2 = load  i8, i8* %1 
-  %3 = add   i64 %"#result##0", 1 
-  %4 = inttoptr i64 %3 to i1* 
-  %5 = getelementptr  i1, i1* %4, i64 0 
-  %6 = load  i1, i1* %5 
-  %7 = add   i64 %"#result##0", 2 
-  %8 = inttoptr i64 %7 to i8* 
-  %9 = getelementptr  i8, i8* %8, i64 0 
-  %10 = load  i8, i8* %9 
-  %11 = add   i64 %"#result##0", 8 
+  %1 = load  i8, i8* %0 
+  %2 = add   i64 %"#result##0", 1 
+  %3 = inttoptr i64 %2 to i1* 
+  %4 = load  i1, i1* %3 
+  %5 = add   i64 %"#result##0", 2 
+  %6 = inttoptr i64 %5 to i8* 
+  %7 = load  i8, i8* %6 
+  %8 = add   i64 %"#result##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = load  i64, i64* %9 
+  %11 = add   i64 %"#result##0", 16 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  %15 = add   i64 %"#result##0", 16 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  %18 = load  i64, i64* %17 
-  %19 = add   i64 %"#result##0", 24 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  %22 = load  i64, i64* %21 
-  %23 = insertvalue {i64, i8, i64, i1, i64, i8} undef, i64 %14, 0 
-  %24 = insertvalue {i64, i8, i64, i1, i64, i8} %23, i8 %2, 1 
-  %25 = insertvalue {i64, i8, i64, i1, i64, i8} %24, i64 %18, 2 
-  %26 = insertvalue {i64, i8, i64, i1, i64, i8} %25, i1 %6, 3 
-  %27 = insertvalue {i64, i8, i64, i1, i64, i8} %26, i64 %22, 4 
-  %28 = insertvalue {i64, i8, i64, i1, i64, i8} %27, i8 %10, 5 
-  ret {i64, i8, i64, i1, i64, i8} %28 
+  %13 = load  i64, i64* %12 
+  %14 = add   i64 %"#result##0", 24 
+  %15 = inttoptr i64 %14 to i64* 
+  %16 = load  i64, i64* %15 
+  %17 = insertvalue {i64, i8, i64, i1, i64, i8} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i8, i64, i1, i64, i8} %17, i8 %1, 1 
+  %19 = insertvalue {i64, i8, i64, i1, i64, i8} %18, i64 %13, 2 
+  %20 = insertvalue {i64, i8, i64, i1, i64, i8} %19, i1 %4, 3 
+  %21 = insertvalue {i64, i8, i64, i1, i64, i8} %20, i64 %16, 4 
+  %22 = insertvalue {i64, i8, i64, i1, i64, i8} %21, i8 %7, 5 
+  ret {i64, i8, i64, i1, i64, i8} %22 
 }
 
 
@@ -607,38 +565,32 @@ define external fastcc  void @"mixed_fields.printit<0>"(i64  %"ob##0")    {
 entry:
   %0 = add   i64 %"ob##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  tail call ccc  void  @print_int(i64  %3)  
+  %2 = load  i64, i64* %1 
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  %4 = inttoptr i64 %"ob##0" to i8* 
-  %5 = getelementptr  i8, i8* %4, i64 0 
-  %6 = load  i8, i8* %5 
-  tail call ccc  void  @putchar(i8  %6)  
+  %3 = inttoptr i64 %"ob##0" to i8* 
+  %4 = load  i8, i8* %3 
+  tail call ccc  void  @putchar(i8  %4)  
   tail call ccc  void  @putchar(i8  10)  
-  %7 = add   i64 %"ob##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  tail call ccc  void  @print_int(i64  %10)  
+  %5 = add   i64 %"ob##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  tail call ccc  void  @print_int(i64  %7)  
   tail call ccc  void  @putchar(i8  10)  
-  %11 = add   i64 %"ob##0", 1 
-  %12 = inttoptr i64 %11 to i1* 
-  %13 = getelementptr  i1, i1* %12, i64 0 
-  %14 = load  i1, i1* %13 
-  tail call fastcc  void  @"wybe.bool.print<0>"(i1  %14)  
+  %8 = add   i64 %"ob##0", 1 
+  %9 = inttoptr i64 %8 to i1* 
+  %10 = load  i1, i1* %9 
+  tail call fastcc  void  @"wybe.bool.print<0>"(i1  %10)  
   tail call ccc  void  @putchar(i8  10)  
-  %15 = add   i64 %"ob##0", 24 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  %18 = load  i64, i64* %17 
-  tail call ccc  void  @print_int(i64  %18)  
+  %11 = add   i64 %"ob##0", 24 
+  %12 = inttoptr i64 %11 to i64* 
+  %13 = load  i64, i64* %12 
+  tail call ccc  void  @print_int(i64  %13)  
   tail call ccc  void  @putchar(i8  10)  
-  %19 = add   i64 %"ob##0", 2 
-  %20 = inttoptr i64 %19 to i8* 
-  %21 = getelementptr  i8, i8* %20, i64 0 
-  %22 = load  i8, i8* %21 
-  tail call ccc  void  @putchar(i8  %22)  
+  %14 = add   i64 %"ob##0", 2 
+  %15 = inttoptr i64 %14 to i8* 
+  %16 = load  i8, i8* %15 
+  tail call ccc  void  @putchar(i8  %16)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -171,49 +171,41 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 0, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 0, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 0, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 3, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 0, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 4, i64* %31 
+  store  i64 2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 0, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 3, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 0, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 4, i64* %23 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"multi_specz.foo<0>[7477e50a09]"(i64  %2, i64  %10, i64  %18, i64  %26)  
+  tail call fastcc  void  @"multi_specz.foo<0>[7477e50a09]"(i64  %2, i64  %8, i64  %14, i64  %20)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %18)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %26)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %14)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %20)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -226,51 +218,43 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 0, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 0, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 0, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 3, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 0, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 4, i64* %31 
+  store  i64 2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 0, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 3, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 0, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 4, i64* %23 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"multi_specz.foo<0>"(i64  %2, i64  %10, i64  %18, i64  %26)  
+  tail call fastcc  void  @"multi_specz.foo<0>"(i64  %2, i64  %8, i64  %14, i64  %20)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %18)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %26)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %14)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %20)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -307,8 +291,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"v##0", i64* %7 
+  store  i64 %"v##0", i64* %6 
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   ret void 
 }
@@ -317,8 +300,7 @@ entry:
 define external fastcc  void @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"pos##0", i64  %"v##0")    {
 entry:
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  store  i64 %"v##0", i64* %1 
+  store  i64 %"v##0", i64* %0 
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"pos##0")  
   ret void 
 }
@@ -407,15 +389,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -539,24 +519,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -568,12 +544,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -581,24 +555,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -612,8 +583,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -622,9 +592,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -639,8 +608,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -648,26 +616,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -104,49 +104,41 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 0, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 0, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 0, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 3, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 0, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 4, i64* %31 
+  store  i64 2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 0, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 3, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 0, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 4, i64* %23 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %2, i64  %10, i64  %18, i64  %26, i64  3)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %2, i64  %8, i64  %14, i64  %20, i64  3)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %18)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %26)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %14)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %20)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -364,8 +356,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"v##0", i64* %7 
+  store  i64 %"v##0", i64* %6 
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %2)  
   ret void 
 }
@@ -374,8 +365,7 @@ entry:
 define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"pos##0", i64  %"v##0")    {
 entry:
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  store  i64 %"v##0", i64* %1 
+  store  i64 %"v##0", i64* %0 
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos##0")  
   ret void 
 }
@@ -385,15 +375,13 @@ define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"p
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -517,24 +505,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -546,12 +530,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -559,24 +541,21 @@ entry:
 define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -590,8 +569,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -600,9 +578,8 @@ define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec#
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -617,8 +594,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -626,28 +602,24 @@ entry:
 define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -142,8 +142,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"v##0", i64* %7 
+  store  i64 %"v##0", i64* %6 
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %2)  
   ret void 
 }
@@ -153,15 +152,13 @@ define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"p
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -285,24 +282,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -314,12 +307,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -327,24 +318,21 @@ entry:
 define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -358,8 +346,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -368,9 +355,8 @@ define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec#
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -385,8 +371,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -394,28 +379,24 @@ entry:
 define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -142,8 +142,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"v##0", i64* %7 
+  store  i64 %"v##0", i64* %6 
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %2)  
   ret void 
 }
@@ -153,15 +152,13 @@ define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"p
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -285,24 +282,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -314,12 +307,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -327,24 +318,21 @@ entry:
 define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -358,8 +346,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -368,9 +355,8 @@ define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec#
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -385,8 +371,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -394,28 +379,24 @@ entry:
 define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -2728,527 +2728,482 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %276 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %276 
+  %231 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %231 
 if.then1:
   %3 = inttoptr i64 %"#left##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = icmp uge i64 %"#right##0", 4 
-  br i1 %6, label %if.then2, label %if.else2 
+  %4 = load  i64, i64* %3 
+  %5 = icmp uge i64 %"#right##0", 4 
+  br i1 %5, label %if.then2, label %if.else2 
 if.else1:
-  %13 = icmp eq i64 %1, 1 
-  br i1 %13, label %if.then4, label %if.else4 
+  %11 = icmp eq i64 %1, 1 
+  br i1 %11, label %if.then4, label %if.else4 
 if.then2:
-  %7 = and i64 %"#right##0", 7 
-  %8 = icmp eq i64 %7, 0 
-  br i1 %8, label %if.then3, label %if.else3 
+  %6 = and i64 %"#right##0", 7 
+  %7 = icmp eq i64 %6, 0 
+  br i1 %7, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp eq i64 %5, %11 
-  ret i1 %12 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = icmp eq i64 %4, %9 
+  ret i1 %10 
 if.else3:
   ret i1 0 
 if.then4:
-  %14 = add   i64 %"#left##0", -1 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = icmp uge i64 %"#right##0", 4 
-  br i1 %18, label %if.then5, label %if.else5 
+  %12 = add   i64 %"#left##0", -1 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = icmp uge i64 %"#right##0", 4 
+  br i1 %15, label %if.then5, label %if.else5 
 if.else4:
-  %26 = icmp eq i64 %1, 2 
-  br i1 %26, label %if.then7, label %if.else7 
+  %22 = icmp eq i64 %1, 2 
+  br i1 %22, label %if.then7, label %if.else7 
 if.then5:
-  %19 = and i64 %"#right##0", 7 
-  %20 = icmp eq i64 %19, 1 
-  br i1 %20, label %if.then6, label %if.else6 
+  %16 = and i64 %"#right##0", 7 
+  %17 = icmp eq i64 %16, 1 
+  br i1 %17, label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %21 = add   i64 %"#right##0", -1 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = icmp eq i64 %17, %24 
-  ret i1 %25 
+  %18 = add   i64 %"#right##0", -1 
+  %19 = inttoptr i64 %18 to i64* 
+  %20 = load  i64, i64* %19 
+  %21 = icmp eq i64 %14, %20 
+  ret i1 %21 
 if.else6:
   ret i1 0 
 if.then7:
-  %27 = add   i64 %"#left##0", -2 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  %30 = load  i64, i64* %29 
-  %31 = icmp uge i64 %"#right##0", 4 
-  br i1 %31, label %if.then8, label %if.else8 
+  %23 = add   i64 %"#left##0", -2 
+  %24 = inttoptr i64 %23 to i64* 
+  %25 = load  i64, i64* %24 
+  %26 = icmp uge i64 %"#right##0", 4 
+  br i1 %26, label %if.then8, label %if.else8 
 if.else7:
-  %39 = icmp eq i64 %1, 3 
-  br i1 %39, label %if.then10, label %if.else10 
+  %33 = icmp eq i64 %1, 3 
+  br i1 %33, label %if.then10, label %if.else10 
 if.then8:
-  %32 = and i64 %"#right##0", 7 
-  %33 = icmp eq i64 %32, 2 
-  br i1 %33, label %if.then9, label %if.else9 
+  %27 = and i64 %"#right##0", 7 
+  %28 = icmp eq i64 %27, 2 
+  br i1 %28, label %if.then9, label %if.else9 
 if.else8:
   ret i1 0 
 if.then9:
-  %34 = add   i64 %"#right##0", -2 
-  %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %38 = icmp eq i64 %30, %37 
-  ret i1 %38 
+  %29 = add   i64 %"#right##0", -2 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = load  i64, i64* %30 
+  %32 = icmp eq i64 %25, %31 
+  ret i1 %32 
 if.else9:
   ret i1 0 
 if.then10:
-  %40 = add   i64 %"#left##0", -3 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  %43 = load  i64, i64* %42 
-  %44 = icmp uge i64 %"#right##0", 4 
-  br i1 %44, label %if.then11, label %if.else11 
+  %34 = add   i64 %"#left##0", -3 
+  %35 = inttoptr i64 %34 to i64* 
+  %36 = load  i64, i64* %35 
+  %37 = icmp uge i64 %"#right##0", 4 
+  br i1 %37, label %if.then11, label %if.else11 
 if.else10:
-  %52 = icmp eq i64 %1, 4 
-  br i1 %52, label %if.then13, label %if.else13 
+  %44 = icmp eq i64 %1, 4 
+  br i1 %44, label %if.then13, label %if.else13 
 if.then11:
-  %45 = and i64 %"#right##0", 7 
-  %46 = icmp eq i64 %45, 3 
-  br i1 %46, label %if.then12, label %if.else12 
+  %38 = and i64 %"#right##0", 7 
+  %39 = icmp eq i64 %38, 3 
+  br i1 %39, label %if.then12, label %if.else12 
 if.else11:
   ret i1 0 
 if.then12:
-  %47 = add   i64 %"#right##0", -3 
-  %48 = inttoptr i64 %47 to i64* 
-  %49 = getelementptr  i64, i64* %48, i64 0 
-  %50 = load  i64, i64* %49 
-  %51 = icmp eq i64 %43, %50 
-  ret i1 %51 
+  %40 = add   i64 %"#right##0", -3 
+  %41 = inttoptr i64 %40 to i64* 
+  %42 = load  i64, i64* %41 
+  %43 = icmp eq i64 %36, %42 
+  ret i1 %43 
 if.else12:
   ret i1 0 
 if.then13:
-  %53 = add   i64 %"#left##0", -4 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  %56 = load  i64, i64* %55 
-  %57 = icmp uge i64 %"#right##0", 4 
-  br i1 %57, label %if.then14, label %if.else14 
+  %45 = add   i64 %"#left##0", -4 
+  %46 = inttoptr i64 %45 to i64* 
+  %47 = load  i64, i64* %46 
+  %48 = icmp uge i64 %"#right##0", 4 
+  br i1 %48, label %if.then14, label %if.else14 
 if.else13:
-  %65 = icmp eq i64 %1, 5 
-  br i1 %65, label %if.then16, label %if.else16 
+  %55 = icmp eq i64 %1, 5 
+  br i1 %55, label %if.then16, label %if.else16 
 if.then14:
-  %58 = and i64 %"#right##0", 7 
-  %59 = icmp eq i64 %58, 4 
-  br i1 %59, label %if.then15, label %if.else15 
+  %49 = and i64 %"#right##0", 7 
+  %50 = icmp eq i64 %49, 4 
+  br i1 %50, label %if.then15, label %if.else15 
 if.else14:
   ret i1 0 
 if.then15:
-  %60 = add   i64 %"#right##0", -4 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  %63 = load  i64, i64* %62 
-  %64 = icmp eq i64 %56, %63 
-  ret i1 %64 
+  %51 = add   i64 %"#right##0", -4 
+  %52 = inttoptr i64 %51 to i64* 
+  %53 = load  i64, i64* %52 
+  %54 = icmp eq i64 %47, %53 
+  ret i1 %54 
 if.else15:
   ret i1 0 
 if.then16:
-  %66 = add   i64 %"#left##0", -5 
-  %67 = inttoptr i64 %66 to i64* 
-  %68 = getelementptr  i64, i64* %67, i64 0 
-  %69 = load  i64, i64* %68 
-  %70 = icmp uge i64 %"#right##0", 4 
-  br i1 %70, label %if.then17, label %if.else17 
+  %56 = add   i64 %"#left##0", -5 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = load  i64, i64* %57 
+  %59 = icmp uge i64 %"#right##0", 4 
+  br i1 %59, label %if.then17, label %if.else17 
 if.else16:
-  %78 = icmp eq i64 %1, 6 
-  br i1 %78, label %if.then19, label %if.else19 
+  %66 = icmp eq i64 %1, 6 
+  br i1 %66, label %if.then19, label %if.else19 
 if.then17:
-  %71 = and i64 %"#right##0", 7 
-  %72 = icmp eq i64 %71, 5 
-  br i1 %72, label %if.then18, label %if.else18 
+  %60 = and i64 %"#right##0", 7 
+  %61 = icmp eq i64 %60, 5 
+  br i1 %61, label %if.then18, label %if.else18 
 if.else17:
   ret i1 0 
 if.then18:
-  %73 = add   i64 %"#right##0", -5 
-  %74 = inttoptr i64 %73 to i64* 
-  %75 = getelementptr  i64, i64* %74, i64 0 
-  %76 = load  i64, i64* %75 
-  %77 = icmp eq i64 %69, %76 
-  ret i1 %77 
+  %62 = add   i64 %"#right##0", -5 
+  %63 = inttoptr i64 %62 to i64* 
+  %64 = load  i64, i64* %63 
+  %65 = icmp eq i64 %58, %64 
+  ret i1 %65 
 if.else18:
   ret i1 0 
 if.then19:
-  %79 = add   i64 %"#left##0", -6 
-  %80 = inttoptr i64 %79 to i64* 
-  %81 = getelementptr  i64, i64* %80, i64 0 
-  %82 = load  i64, i64* %81 
-  %83 = icmp uge i64 %"#right##0", 4 
-  br i1 %83, label %if.then20, label %if.else20 
+  %67 = add   i64 %"#left##0", -6 
+  %68 = inttoptr i64 %67 to i64* 
+  %69 = load  i64, i64* %68 
+  %70 = icmp uge i64 %"#right##0", 4 
+  br i1 %70, label %if.then20, label %if.else20 
 if.else19:
-  %91 = icmp eq i64 %1, 7 
-  br i1 %91, label %if.then22, label %if.else22 
+  %77 = icmp eq i64 %1, 7 
+  br i1 %77, label %if.then22, label %if.else22 
 if.then20:
-  %84 = and i64 %"#right##0", 7 
-  %85 = icmp eq i64 %84, 6 
-  br i1 %85, label %if.then21, label %if.else21 
+  %71 = and i64 %"#right##0", 7 
+  %72 = icmp eq i64 %71, 6 
+  br i1 %72, label %if.then21, label %if.else21 
 if.else20:
   ret i1 0 
 if.then21:
-  %86 = add   i64 %"#right##0", -6 
-  %87 = inttoptr i64 %86 to i64* 
-  %88 = getelementptr  i64, i64* %87, i64 0 
-  %89 = load  i64, i64* %88 
-  %90 = icmp eq i64 %82, %89 
-  ret i1 %90 
+  %73 = add   i64 %"#right##0", -6 
+  %74 = inttoptr i64 %73 to i64* 
+  %75 = load  i64, i64* %74 
+  %76 = icmp eq i64 %69, %75 
+  ret i1 %76 
 if.else21:
   ret i1 0 
 if.then22:
-  %92 = add   i64 %"#left##0", -7 
-  %93 = inttoptr i64 %92 to i16* 
-  %94 = getelementptr  i16, i16* %93, i64 0 
-  %95 = load  i16, i16* %94 
-  %96 = icmp eq i16 %95, 7 
-  br i1 %96, label %if.then23, label %if.else23 
+  %78 = add   i64 %"#left##0", -7 
+  %79 = inttoptr i64 %78 to i16* 
+  %80 = load  i16, i16* %79 
+  %81 = icmp eq i16 %80, 7 
+  br i1 %81, label %if.then23, label %if.else23 
 if.else22:
   ret i1 0 
 if.then23:
-  %97 = add   i64 %"#left##0", 1 
-  %98 = inttoptr i64 %97 to i64* 
-  %99 = getelementptr  i64, i64* %98, i64 0 
-  %100 = load  i64, i64* %99 
-  %101 = icmp uge i64 %"#right##0", 4 
-  br i1 %101, label %if.then24, label %if.else24 
+  %82 = add   i64 %"#left##0", 1 
+  %83 = inttoptr i64 %82 to i64* 
+  %84 = load  i64, i64* %83 
+  %85 = icmp uge i64 %"#right##0", 4 
+  br i1 %85, label %if.then24, label %if.else24 
 if.else23:
-  %114 = icmp eq i16 %95, 8 
-  br i1 %114, label %if.then27, label %if.else27 
+  %96 = icmp eq i16 %80, 8 
+  br i1 %96, label %if.then27, label %if.else27 
 if.then24:
-  %102 = and i64 %"#right##0", 7 
-  %103 = icmp eq i64 %102, 7 
-  br i1 %103, label %if.then25, label %if.else25 
+  %86 = and i64 %"#right##0", 7 
+  %87 = icmp eq i64 %86, 7 
+  br i1 %87, label %if.then25, label %if.else25 
 if.else24:
   ret i1 0 
 if.then25:
-  %104 = add   i64 %"#right##0", -7 
-  %105 = inttoptr i64 %104 to i16* 
-  %106 = getelementptr  i16, i16* %105, i64 0 
-  %107 = load  i16, i16* %106 
-  %108 = icmp eq i16 %107, 7 
-  br i1 %108, label %if.then26, label %if.else26 
+  %88 = add   i64 %"#right##0", -7 
+  %89 = inttoptr i64 %88 to i16* 
+  %90 = load  i16, i16* %89 
+  %91 = icmp eq i16 %90, 7 
+  br i1 %91, label %if.then26, label %if.else26 
 if.else25:
   ret i1 0 
 if.then26:
-  %109 = add   i64 %"#right##0", 1 
-  %110 = inttoptr i64 %109 to i64* 
-  %111 = getelementptr  i64, i64* %110, i64 0 
-  %112 = load  i64, i64* %111 
-  %113 = icmp eq i64 %100, %112 
-  ret i1 %113 
+  %92 = add   i64 %"#right##0", 1 
+  %93 = inttoptr i64 %92 to i64* 
+  %94 = load  i64, i64* %93 
+  %95 = icmp eq i64 %84, %94 
+  ret i1 %95 
 if.else26:
   ret i1 0 
 if.then27:
-  %115 = add   i64 %"#left##0", 1 
-  %116 = inttoptr i64 %115 to i64* 
-  %117 = getelementptr  i64, i64* %116, i64 0 
-  %118 = load  i64, i64* %117 
-  %119 = icmp uge i64 %"#right##0", 4 
-  br i1 %119, label %if.then28, label %if.else28 
+  %97 = add   i64 %"#left##0", 1 
+  %98 = inttoptr i64 %97 to i64* 
+  %99 = load  i64, i64* %98 
+  %100 = icmp uge i64 %"#right##0", 4 
+  br i1 %100, label %if.then28, label %if.else28 
 if.else27:
-  %132 = icmp eq i16 %95, 9 
-  br i1 %132, label %if.then31, label %if.else31 
+  %111 = icmp eq i16 %80, 9 
+  br i1 %111, label %if.then31, label %if.else31 
 if.then28:
-  %120 = and i64 %"#right##0", 7 
-  %121 = icmp eq i64 %120, 7 
-  br i1 %121, label %if.then29, label %if.else29 
+  %101 = and i64 %"#right##0", 7 
+  %102 = icmp eq i64 %101, 7 
+  br i1 %102, label %if.then29, label %if.else29 
 if.else28:
   ret i1 0 
 if.then29:
-  %122 = add   i64 %"#right##0", -7 
-  %123 = inttoptr i64 %122 to i16* 
-  %124 = getelementptr  i16, i16* %123, i64 0 
-  %125 = load  i16, i16* %124 
-  %126 = icmp eq i16 %125, 8 
-  br i1 %126, label %if.then30, label %if.else30 
+  %103 = add   i64 %"#right##0", -7 
+  %104 = inttoptr i64 %103 to i16* 
+  %105 = load  i16, i16* %104 
+  %106 = icmp eq i16 %105, 8 
+  br i1 %106, label %if.then30, label %if.else30 
 if.else29:
   ret i1 0 
 if.then30:
-  %127 = add   i64 %"#right##0", 1 
-  %128 = inttoptr i64 %127 to i64* 
-  %129 = getelementptr  i64, i64* %128, i64 0 
-  %130 = load  i64, i64* %129 
-  %131 = icmp eq i64 %118, %130 
-  ret i1 %131 
+  %107 = add   i64 %"#right##0", 1 
+  %108 = inttoptr i64 %107 to i64* 
+  %109 = load  i64, i64* %108 
+  %110 = icmp eq i64 %99, %109 
+  ret i1 %110 
 if.else30:
   ret i1 0 
 if.then31:
-  %133 = add   i64 %"#left##0", 1 
-  %134 = inttoptr i64 %133 to i64* 
-  %135 = getelementptr  i64, i64* %134, i64 0 
-  %136 = load  i64, i64* %135 
-  %137 = icmp uge i64 %"#right##0", 4 
-  br i1 %137, label %if.then32, label %if.else32 
+  %112 = add   i64 %"#left##0", 1 
+  %113 = inttoptr i64 %112 to i64* 
+  %114 = load  i64, i64* %113 
+  %115 = icmp uge i64 %"#right##0", 4 
+  br i1 %115, label %if.then32, label %if.else32 
 if.else31:
-  %150 = icmp eq i16 %95, 10 
-  br i1 %150, label %if.then35, label %if.else35 
+  %126 = icmp eq i16 %80, 10 
+  br i1 %126, label %if.then35, label %if.else35 
 if.then32:
-  %138 = and i64 %"#right##0", 7 
-  %139 = icmp eq i64 %138, 7 
-  br i1 %139, label %if.then33, label %if.else33 
+  %116 = and i64 %"#right##0", 7 
+  %117 = icmp eq i64 %116, 7 
+  br i1 %117, label %if.then33, label %if.else33 
 if.else32:
   ret i1 0 
 if.then33:
-  %140 = add   i64 %"#right##0", -7 
-  %141 = inttoptr i64 %140 to i16* 
-  %142 = getelementptr  i16, i16* %141, i64 0 
-  %143 = load  i16, i16* %142 
-  %144 = icmp eq i16 %143, 9 
-  br i1 %144, label %if.then34, label %if.else34 
+  %118 = add   i64 %"#right##0", -7 
+  %119 = inttoptr i64 %118 to i16* 
+  %120 = load  i16, i16* %119 
+  %121 = icmp eq i16 %120, 9 
+  br i1 %121, label %if.then34, label %if.else34 
 if.else33:
   ret i1 0 
 if.then34:
-  %145 = add   i64 %"#right##0", 1 
-  %146 = inttoptr i64 %145 to i64* 
-  %147 = getelementptr  i64, i64* %146, i64 0 
-  %148 = load  i64, i64* %147 
-  %149 = icmp eq i64 %136, %148 
-  ret i1 %149 
+  %122 = add   i64 %"#right##0", 1 
+  %123 = inttoptr i64 %122 to i64* 
+  %124 = load  i64, i64* %123 
+  %125 = icmp eq i64 %114, %124 
+  ret i1 %125 
 if.else34:
   ret i1 0 
 if.then35:
-  %151 = add   i64 %"#left##0", 1 
-  %152 = inttoptr i64 %151 to i64* 
-  %153 = getelementptr  i64, i64* %152, i64 0 
-  %154 = load  i64, i64* %153 
-  %155 = icmp uge i64 %"#right##0", 4 
-  br i1 %155, label %if.then36, label %if.else36 
+  %127 = add   i64 %"#left##0", 1 
+  %128 = inttoptr i64 %127 to i64* 
+  %129 = load  i64, i64* %128 
+  %130 = icmp uge i64 %"#right##0", 4 
+  br i1 %130, label %if.then36, label %if.else36 
 if.else35:
-  %168 = icmp eq i16 %95, 11 
-  br i1 %168, label %if.then39, label %if.else39 
+  %141 = icmp eq i16 %80, 11 
+  br i1 %141, label %if.then39, label %if.else39 
 if.then36:
-  %156 = and i64 %"#right##0", 7 
-  %157 = icmp eq i64 %156, 7 
-  br i1 %157, label %if.then37, label %if.else37 
+  %131 = and i64 %"#right##0", 7 
+  %132 = icmp eq i64 %131, 7 
+  br i1 %132, label %if.then37, label %if.else37 
 if.else36:
   ret i1 0 
 if.then37:
-  %158 = add   i64 %"#right##0", -7 
-  %159 = inttoptr i64 %158 to i16* 
-  %160 = getelementptr  i16, i16* %159, i64 0 
-  %161 = load  i16, i16* %160 
-  %162 = icmp eq i16 %161, 10 
-  br i1 %162, label %if.then38, label %if.else38 
+  %133 = add   i64 %"#right##0", -7 
+  %134 = inttoptr i64 %133 to i16* 
+  %135 = load  i16, i16* %134 
+  %136 = icmp eq i16 %135, 10 
+  br i1 %136, label %if.then38, label %if.else38 
 if.else37:
   ret i1 0 
 if.then38:
-  %163 = add   i64 %"#right##0", 1 
-  %164 = inttoptr i64 %163 to i64* 
-  %165 = getelementptr  i64, i64* %164, i64 0 
-  %166 = load  i64, i64* %165 
-  %167 = icmp eq i64 %154, %166 
-  ret i1 %167 
+  %137 = add   i64 %"#right##0", 1 
+  %138 = inttoptr i64 %137 to i64* 
+  %139 = load  i64, i64* %138 
+  %140 = icmp eq i64 %129, %139 
+  ret i1 %140 
 if.else38:
   ret i1 0 
 if.then39:
-  %169 = add   i64 %"#left##0", 1 
-  %170 = inttoptr i64 %169 to i64* 
-  %171 = getelementptr  i64, i64* %170, i64 0 
-  %172 = load  i64, i64* %171 
-  %173 = icmp uge i64 %"#right##0", 4 
-  br i1 %173, label %if.then40, label %if.else40 
+  %142 = add   i64 %"#left##0", 1 
+  %143 = inttoptr i64 %142 to i64* 
+  %144 = load  i64, i64* %143 
+  %145 = icmp uge i64 %"#right##0", 4 
+  br i1 %145, label %if.then40, label %if.else40 
 if.else39:
-  %186 = icmp eq i16 %95, 12 
-  br i1 %186, label %if.then43, label %if.else43 
+  %156 = icmp eq i16 %80, 12 
+  br i1 %156, label %if.then43, label %if.else43 
 if.then40:
-  %174 = and i64 %"#right##0", 7 
-  %175 = icmp eq i64 %174, 7 
-  br i1 %175, label %if.then41, label %if.else41 
+  %146 = and i64 %"#right##0", 7 
+  %147 = icmp eq i64 %146, 7 
+  br i1 %147, label %if.then41, label %if.else41 
 if.else40:
   ret i1 0 
 if.then41:
-  %176 = add   i64 %"#right##0", -7 
-  %177 = inttoptr i64 %176 to i16* 
-  %178 = getelementptr  i16, i16* %177, i64 0 
-  %179 = load  i16, i16* %178 
-  %180 = icmp eq i16 %179, 11 
-  br i1 %180, label %if.then42, label %if.else42 
+  %148 = add   i64 %"#right##0", -7 
+  %149 = inttoptr i64 %148 to i16* 
+  %150 = load  i16, i16* %149 
+  %151 = icmp eq i16 %150, 11 
+  br i1 %151, label %if.then42, label %if.else42 
 if.else41:
   ret i1 0 
 if.then42:
-  %181 = add   i64 %"#right##0", 1 
-  %182 = inttoptr i64 %181 to i64* 
-  %183 = getelementptr  i64, i64* %182, i64 0 
-  %184 = load  i64, i64* %183 
-  %185 = icmp eq i64 %172, %184 
-  ret i1 %185 
+  %152 = add   i64 %"#right##0", 1 
+  %153 = inttoptr i64 %152 to i64* 
+  %154 = load  i64, i64* %153 
+  %155 = icmp eq i64 %144, %154 
+  ret i1 %155 
 if.else42:
   ret i1 0 
 if.then43:
-  %187 = add   i64 %"#left##0", 1 
-  %188 = inttoptr i64 %187 to i64* 
-  %189 = getelementptr  i64, i64* %188, i64 0 
-  %190 = load  i64, i64* %189 
-  %191 = icmp uge i64 %"#right##0", 4 
-  br i1 %191, label %if.then44, label %if.else44 
+  %157 = add   i64 %"#left##0", 1 
+  %158 = inttoptr i64 %157 to i64* 
+  %159 = load  i64, i64* %158 
+  %160 = icmp uge i64 %"#right##0", 4 
+  br i1 %160, label %if.then44, label %if.else44 
 if.else43:
-  %204 = icmp eq i16 %95, 13 
-  br i1 %204, label %if.then47, label %if.else47 
+  %171 = icmp eq i16 %80, 13 
+  br i1 %171, label %if.then47, label %if.else47 
 if.then44:
-  %192 = and i64 %"#right##0", 7 
-  %193 = icmp eq i64 %192, 7 
-  br i1 %193, label %if.then45, label %if.else45 
+  %161 = and i64 %"#right##0", 7 
+  %162 = icmp eq i64 %161, 7 
+  br i1 %162, label %if.then45, label %if.else45 
 if.else44:
   ret i1 0 
 if.then45:
-  %194 = add   i64 %"#right##0", -7 
-  %195 = inttoptr i64 %194 to i16* 
-  %196 = getelementptr  i16, i16* %195, i64 0 
-  %197 = load  i16, i16* %196 
-  %198 = icmp eq i16 %197, 12 
-  br i1 %198, label %if.then46, label %if.else46 
+  %163 = add   i64 %"#right##0", -7 
+  %164 = inttoptr i64 %163 to i16* 
+  %165 = load  i16, i16* %164 
+  %166 = icmp eq i16 %165, 12 
+  br i1 %166, label %if.then46, label %if.else46 
 if.else45:
   ret i1 0 
 if.then46:
-  %199 = add   i64 %"#right##0", 1 
-  %200 = inttoptr i64 %199 to i64* 
-  %201 = getelementptr  i64, i64* %200, i64 0 
-  %202 = load  i64, i64* %201 
-  %203 = icmp eq i64 %190, %202 
-  ret i1 %203 
+  %167 = add   i64 %"#right##0", 1 
+  %168 = inttoptr i64 %167 to i64* 
+  %169 = load  i64, i64* %168 
+  %170 = icmp eq i64 %159, %169 
+  ret i1 %170 
 if.else46:
   ret i1 0 
 if.then47:
-  %205 = add   i64 %"#left##0", 1 
-  %206 = inttoptr i64 %205 to i64* 
-  %207 = getelementptr  i64, i64* %206, i64 0 
-  %208 = load  i64, i64* %207 
-  %209 = icmp uge i64 %"#right##0", 4 
-  br i1 %209, label %if.then48, label %if.else48 
+  %172 = add   i64 %"#left##0", 1 
+  %173 = inttoptr i64 %172 to i64* 
+  %174 = load  i64, i64* %173 
+  %175 = icmp uge i64 %"#right##0", 4 
+  br i1 %175, label %if.then48, label %if.else48 
 if.else47:
-  %222 = icmp eq i16 %95, 14 
-  br i1 %222, label %if.then51, label %if.else51 
+  %186 = icmp eq i16 %80, 14 
+  br i1 %186, label %if.then51, label %if.else51 
 if.then48:
-  %210 = and i64 %"#right##0", 7 
-  %211 = icmp eq i64 %210, 7 
-  br i1 %211, label %if.then49, label %if.else49 
+  %176 = and i64 %"#right##0", 7 
+  %177 = icmp eq i64 %176, 7 
+  br i1 %177, label %if.then49, label %if.else49 
 if.else48:
   ret i1 0 
 if.then49:
-  %212 = add   i64 %"#right##0", -7 
-  %213 = inttoptr i64 %212 to i16* 
-  %214 = getelementptr  i16, i16* %213, i64 0 
-  %215 = load  i16, i16* %214 
-  %216 = icmp eq i16 %215, 13 
-  br i1 %216, label %if.then50, label %if.else50 
+  %178 = add   i64 %"#right##0", -7 
+  %179 = inttoptr i64 %178 to i16* 
+  %180 = load  i16, i16* %179 
+  %181 = icmp eq i16 %180, 13 
+  br i1 %181, label %if.then50, label %if.else50 
 if.else49:
   ret i1 0 
 if.then50:
-  %217 = add   i64 %"#right##0", 1 
-  %218 = inttoptr i64 %217 to i64* 
-  %219 = getelementptr  i64, i64* %218, i64 0 
-  %220 = load  i64, i64* %219 
-  %221 = icmp eq i64 %208, %220 
-  ret i1 %221 
+  %182 = add   i64 %"#right##0", 1 
+  %183 = inttoptr i64 %182 to i64* 
+  %184 = load  i64, i64* %183 
+  %185 = icmp eq i64 %174, %184 
+  ret i1 %185 
 if.else50:
   ret i1 0 
 if.then51:
-  %223 = add   i64 %"#left##0", 1 
-  %224 = inttoptr i64 %223 to i64* 
-  %225 = getelementptr  i64, i64* %224, i64 0 
-  %226 = load  i64, i64* %225 
-  %227 = icmp uge i64 %"#right##0", 4 
-  br i1 %227, label %if.then52, label %if.else52 
+  %187 = add   i64 %"#left##0", 1 
+  %188 = inttoptr i64 %187 to i64* 
+  %189 = load  i64, i64* %188 
+  %190 = icmp uge i64 %"#right##0", 4 
+  br i1 %190, label %if.then52, label %if.else52 
 if.else51:
-  %240 = icmp eq i16 %95, 15 
-  br i1 %240, label %if.then55, label %if.else55 
+  %201 = icmp eq i16 %80, 15 
+  br i1 %201, label %if.then55, label %if.else55 
 if.then52:
-  %228 = and i64 %"#right##0", 7 
-  %229 = icmp eq i64 %228, 7 
-  br i1 %229, label %if.then53, label %if.else53 
+  %191 = and i64 %"#right##0", 7 
+  %192 = icmp eq i64 %191, 7 
+  br i1 %192, label %if.then53, label %if.else53 
 if.else52:
   ret i1 0 
 if.then53:
-  %230 = add   i64 %"#right##0", -7 
-  %231 = inttoptr i64 %230 to i16* 
-  %232 = getelementptr  i16, i16* %231, i64 0 
-  %233 = load  i16, i16* %232 
-  %234 = icmp eq i16 %233, 14 
-  br i1 %234, label %if.then54, label %if.else54 
+  %193 = add   i64 %"#right##0", -7 
+  %194 = inttoptr i64 %193 to i16* 
+  %195 = load  i16, i16* %194 
+  %196 = icmp eq i16 %195, 14 
+  br i1 %196, label %if.then54, label %if.else54 
 if.else53:
   ret i1 0 
 if.then54:
-  %235 = add   i64 %"#right##0", 1 
-  %236 = inttoptr i64 %235 to i64* 
-  %237 = getelementptr  i64, i64* %236, i64 0 
-  %238 = load  i64, i64* %237 
-  %239 = icmp eq i64 %226, %238 
-  ret i1 %239 
+  %197 = add   i64 %"#right##0", 1 
+  %198 = inttoptr i64 %197 to i64* 
+  %199 = load  i64, i64* %198 
+  %200 = icmp eq i64 %189, %199 
+  ret i1 %200 
 if.else54:
   ret i1 0 
 if.then55:
-  %241 = add   i64 %"#left##0", 1 
-  %242 = inttoptr i64 %241 to i64* 
-  %243 = getelementptr  i64, i64* %242, i64 0 
-  %244 = load  i64, i64* %243 
-  %245 = icmp uge i64 %"#right##0", 4 
-  br i1 %245, label %if.then56, label %if.else56 
+  %202 = add   i64 %"#left##0", 1 
+  %203 = inttoptr i64 %202 to i64* 
+  %204 = load  i64, i64* %203 
+  %205 = icmp uge i64 %"#right##0", 4 
+  br i1 %205, label %if.then56, label %if.else56 
 if.else55:
-  %258 = icmp eq i16 %95, 16 
-  br i1 %258, label %if.then59, label %if.else59 
+  %216 = icmp eq i16 %80, 16 
+  br i1 %216, label %if.then59, label %if.else59 
 if.then56:
-  %246 = and i64 %"#right##0", 7 
-  %247 = icmp eq i64 %246, 7 
-  br i1 %247, label %if.then57, label %if.else57 
+  %206 = and i64 %"#right##0", 7 
+  %207 = icmp eq i64 %206, 7 
+  br i1 %207, label %if.then57, label %if.else57 
 if.else56:
   ret i1 0 
 if.then57:
-  %248 = add   i64 %"#right##0", -7 
-  %249 = inttoptr i64 %248 to i16* 
-  %250 = getelementptr  i16, i16* %249, i64 0 
-  %251 = load  i16, i16* %250 
-  %252 = icmp eq i16 %251, 15 
-  br i1 %252, label %if.then58, label %if.else58 
+  %208 = add   i64 %"#right##0", -7 
+  %209 = inttoptr i64 %208 to i16* 
+  %210 = load  i16, i16* %209 
+  %211 = icmp eq i16 %210, 15 
+  br i1 %211, label %if.then58, label %if.else58 
 if.else57:
   ret i1 0 
 if.then58:
-  %253 = add   i64 %"#right##0", 1 
-  %254 = inttoptr i64 %253 to i64* 
-  %255 = getelementptr  i64, i64* %254, i64 0 
-  %256 = load  i64, i64* %255 
-  %257 = icmp eq i64 %244, %256 
-  ret i1 %257 
+  %212 = add   i64 %"#right##0", 1 
+  %213 = inttoptr i64 %212 to i64* 
+  %214 = load  i64, i64* %213 
+  %215 = icmp eq i64 %204, %214 
+  ret i1 %215 
 if.else58:
   ret i1 0 
 if.then59:
-  %259 = add   i64 %"#left##0", 1 
-  %260 = inttoptr i64 %259 to i64* 
-  %261 = getelementptr  i64, i64* %260, i64 0 
-  %262 = load  i64, i64* %261 
-  %263 = icmp uge i64 %"#right##0", 4 
-  br i1 %263, label %if.then60, label %if.else60 
+  %217 = add   i64 %"#left##0", 1 
+  %218 = inttoptr i64 %217 to i64* 
+  %219 = load  i64, i64* %218 
+  %220 = icmp uge i64 %"#right##0", 4 
+  br i1 %220, label %if.then60, label %if.else60 
 if.else59:
   ret i1 0 
 if.then60:
-  %264 = and i64 %"#right##0", 7 
-  %265 = icmp eq i64 %264, 7 
-  br i1 %265, label %if.then61, label %if.else61 
+  %221 = and i64 %"#right##0", 7 
+  %222 = icmp eq i64 %221, 7 
+  br i1 %222, label %if.then61, label %if.else61 
 if.else60:
   ret i1 0 
 if.then61:
-  %266 = add   i64 %"#right##0", -7 
-  %267 = inttoptr i64 %266 to i16* 
-  %268 = getelementptr  i16, i16* %267, i64 0 
-  %269 = load  i16, i16* %268 
-  %270 = icmp eq i16 %269, 16 
-  br i1 %270, label %if.then62, label %if.else62 
+  %223 = add   i64 %"#right##0", -7 
+  %224 = inttoptr i64 %223 to i16* 
+  %225 = load  i16, i16* %224 
+  %226 = icmp eq i16 %225, 16 
+  br i1 %226, label %if.then62, label %if.else62 
 if.else61:
   ret i1 0 
 if.then62:
-  %271 = add   i64 %"#right##0", 1 
-  %272 = inttoptr i64 %271 to i64* 
-  %273 = getelementptr  i64, i64* %272, i64 0 
-  %274 = load  i64, i64* %273 
-  %275 = icmp eq i64 %262, %274 
-  ret i1 %275 
+  %227 = add   i64 %"#right##0", 1 
+  %228 = inttoptr i64 %227 to i64* 
+  %229 = load  i64, i64* %228 
+  %230 = icmp eq i64 %219, %229 
+  ret i1 %230 
 if.else62:
   ret i1 0 
 }
@@ -3266,8 +3221,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f01##0", i64* %4 
+  store  i64 %"f01##0", i64* %3 
   ret i64 %2 
 }
 
@@ -3281,20 +3235,19 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %11 = insertvalue {i64, i1} %10, i1 0, 1 
-  ret {i64, i1} %11 
+  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i1} %9, i1 0, 1 
+  ret {i64, i1} %10 
 if.then1:
   %3 = inttoptr i64 %"#result##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else1:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -3304,10 +3257,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f02##0", i64* %4 
-  %5 = or i64 %2, 1 
-  ret i64 %5 
+  store  i64 %"f02##0", i64* %3 
+  %4 = or i64 %2, 1 
+  ret i64 %4 
 }
 
 
@@ -3320,21 +3272,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -1 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -3344,10 +3295,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f03##0", i64* %4 
-  %5 = or i64 %2, 2 
-  ret i64 %5 
+  store  i64 %"f03##0", i64* %3 
+  %4 = or i64 %2, 2 
+  ret i64 %4 
 }
 
 
@@ -3360,21 +3310,20 @@ if.then:
   %2 = icmp eq i64 %1, 2 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -2 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -3384,10 +3333,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f04##0", i64* %4 
-  %5 = or i64 %2, 3 
-  ret i64 %5 
+  store  i64 %"f04##0", i64* %3 
+  %4 = or i64 %2, 3 
+  ret i64 %4 
 }
 
 
@@ -3400,21 +3348,20 @@ if.then:
   %2 = icmp eq i64 %1, 3 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -3 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -3424,10 +3371,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f05##0", i64* %4 
-  %5 = or i64 %2, 4 
-  ret i64 %5 
+  store  i64 %"f05##0", i64* %3 
+  %4 = or i64 %2, 4 
+  ret i64 %4 
 }
 
 
@@ -3440,21 +3386,20 @@ if.then:
   %2 = icmp eq i64 %1, 4 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -4 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -3464,10 +3409,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f06##0", i64* %4 
-  %5 = or i64 %2, 5 
-  ret i64 %5 
+  store  i64 %"f06##0", i64* %3 
+  %4 = or i64 %2, 5 
+  ret i64 %4 
 }
 
 
@@ -3480,21 +3424,20 @@ if.then:
   %2 = icmp eq i64 %1, 5 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -5 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -3504,10 +3447,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f07##0", i64* %4 
-  %5 = or i64 %2, 6 
-  ret i64 %5 
+  store  i64 %"f07##0", i64* %3 
+  %4 = or i64 %2, 6 
+  ret i64 %4 
 }
 
 
@@ -3520,21 +3462,20 @@ if.then:
   %2 = icmp eq i64 %1, 6 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#result##0", -6 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -3544,14 +3485,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 7, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f08##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 7, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f08##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -3564,32 +3503,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 7 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 7 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -3599,14 +3536,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 8, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f09##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 8, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f09##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -3619,32 +3554,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 8 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 8 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -3654,14 +3587,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 9, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f10##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 9, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f10##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -3674,32 +3605,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 9 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 9 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -3709,14 +3638,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 10, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f11##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 10, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f11##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -3729,32 +3656,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 10 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 10 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -3764,14 +3689,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 11, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f12##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 11, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f12##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -3784,32 +3707,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 11 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 11 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -3819,14 +3740,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 12, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f13##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 12, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f13##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -3839,32 +3758,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 12 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 12 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -3874,14 +3791,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 13, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f14##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 13, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f14##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -3894,32 +3809,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 13 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 13 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -3929,14 +3842,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 14, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f15##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 14, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f15##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -3949,32 +3860,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 14 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 14 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -3984,14 +3893,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 15, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f16##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 15, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f16##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -4004,32 +3911,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 15 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 15 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4039,14 +3944,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 16, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f17##0", i64* %7 
-  %8 = or i64 %2, 7 
-  ret i64 %8 
+  store  i64 16, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f17##0", i64* %5 
+  %6 = or i64 %2, 7 
+  ret i64 %6 
 }
 
 
@@ -4059,32 +3962,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#result##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 16 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#result##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#result##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 16 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#result##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4097,20 +3998,19 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %11 = insertvalue {i64, i1} %10, i1 0, 1 
-  ret {i64, i1} %11 
+  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i1} %9, i1 0, 1 
+  ret {i64, i1} %10 
 if.then1:
   %3 = inttoptr i64 %"#rec##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else1:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -4123,9 +4023,9 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -4135,15 +4035,14 @@ if.then1:
   %8 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %6, i8*  %7, i32  %8, i1  0)  
   %9 = inttoptr i64 %5 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"#field##0", i64* %10 
-  %11 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %12 = insertvalue {i64, i1} %11, i1 1, 1 
-  ret {i64, i1} %12 
+  store  i64 %"#field##0", i64* %9 
+  %10 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
 if.else1:
-  %13 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %14 = insertvalue {i64, i1} %13, i1 0, 1 
-  ret {i64, i1} %14 
+  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4156,21 +4055,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -1 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -4183,9 +4081,9 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -4198,15 +4096,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -1 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -4219,21 +4116,20 @@ if.then:
   %2 = icmp eq i64 %1, 2 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -2 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -4246,9 +4142,9 @@ if.then:
   %2 = icmp eq i64 %1, 2 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -4261,15 +4157,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -2 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -4282,21 +4177,20 @@ if.then:
   %2 = icmp eq i64 %1, 3 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -3 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -4309,9 +4203,9 @@ if.then:
   %2 = icmp eq i64 %1, 3 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -4324,15 +4218,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -3 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -4345,21 +4238,20 @@ if.then:
   %2 = icmp eq i64 %1, 4 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -4 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -4372,9 +4264,9 @@ if.then:
   %2 = icmp eq i64 %1, 4 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -4387,15 +4279,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -4 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -4408,21 +4299,20 @@ if.then:
   %2 = icmp eq i64 %1, 5 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -5 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -4435,9 +4325,9 @@ if.then:
   %2 = icmp eq i64 %1, 5 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -4450,15 +4340,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -5 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -4471,21 +4360,20 @@ if.then:
   %2 = icmp eq i64 %1, 6 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -6 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -4498,9 +4386,9 @@ if.then:
   %2 = icmp eq i64 %1, 6 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -4513,15 +4401,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -6 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -4534,32 +4421,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 7 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 7 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4572,41 +4457,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 7 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 7 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -4619,32 +4502,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 8 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 8 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4657,41 +4538,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 8 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 8 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -4704,32 +4583,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 9 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 9 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4742,41 +4619,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 9 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 9 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -4789,32 +4664,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 10 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 10 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4827,41 +4700,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 10 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 10 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -4874,32 +4745,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 11 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 11 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4912,41 +4781,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 11 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 11 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -4959,32 +4826,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 12 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 12 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -4997,41 +4862,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 12 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 12 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -5044,32 +4907,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 13 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 13 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -5082,41 +4943,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 13 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 13 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -5129,32 +4988,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 14 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 14 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -5167,41 +5024,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 14 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 14 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -5214,32 +5069,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 15 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 15 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -5252,41 +5105,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 15 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 15 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -5299,32 +5150,30 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 16 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %16 = insertvalue {i64, i1} undef, i64 undef, 0 
   %17 = insertvalue {i64, i1} %16, i1 0, 1 
   ret {i64, i1} %17 
-if.then2:
-  %8 = add   i64 %"#rec##0", 1 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 16 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %14 = insertvalue {i64, i1} undef, i64 undef, 0 
   %15 = insertvalue {i64, i1} %14, i1 0, 1 
   ret {i64, i1} %15 
+if.then2:
+  %7 = add   i64 %"#rec##0", 1 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else2:
+  %12 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -5337,41 +5186,39 @@ if.then:
   %2 = icmp eq i64 %1, 7 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %25 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %26 = insertvalue {i64, i1} %25, i1 0, 1 
-  ret {i64, i1} %26 
-if.then1:
-  %3 = add   i64 %"#rec##0", -7 
-  %4 = inttoptr i64 %3 to i16* 
-  %5 = getelementptr  i16, i16* %4, i64 0 
-  %6 = load  i16, i16* %5 
-  %7 = icmp eq i16 %6, 16 
-  br i1 %7, label %if.then2, label %if.else2 
-if.else1:
   %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
-if.then2:
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = add   i64 %10, 7 
-  %12 = sub   i64 %"#rec##0", 7 
-  %13 = inttoptr i64 %10 to i8* 
-  %14 = inttoptr i64 %12 to i8* 
-  %15 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
-  %16 = add   i64 %11, 1 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"#field##0", i64* %18 
-  %19 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %20 = insertvalue {i64, i1} %19, i1 1, 1 
-  ret {i64, i1} %20 
-if.else2:
+if.then1:
+  %3 = add   i64 %"#rec##0", -7 
+  %4 = inttoptr i64 %3 to i16* 
+  %5 = load  i16, i16* %4 
+  %6 = icmp eq i16 %5, 16 
+  br i1 %6, label %if.then2, label %if.else2 
+if.else1:
   %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
+if.then2:
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = add   i64 %9, 7 
+  %11 = sub   i64 %"#rec##0", 7 
+  %12 = inttoptr i64 %9 to i8* 
+  %13 = inttoptr i64 %11 to i8* 
+  %14 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %12, i8*  %13, i32  %14, i1  0)  
+  %15 = add   i64 %10, 1 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"#field##0", i64* %16 
+  %17 = insertvalue {i64, i1} undef, i64 %10, 0 
+  %18 = insertvalue {i64, i1} %17, i1 1, 1 
+  ret {i64, i1} %18 
+if.else2:
+  %19 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %20 = insertvalue {i64, i1} %19, i1 0, 1 
+  ret {i64, i1} %20 
 }
 
 
@@ -5647,19 +5494,17 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = icmp ne i64 %"#right##0", 0 
-  br i1 %4, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = icmp ne i64 %"#right##0", 0 
+  br i1 %3, label %if.then1, label %if.else1 
 if.else:
-  %9 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %9 
+  %7 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %7 
 if.then1:
-  %5 = inttoptr i64 %"#right##0" to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, %7 
-  ret i1 %8 
+  %4 = inttoptr i64 %"#right##0" to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, %5 
+  ret i1 %6 
 if.else1:
   ret i1 0 
 }
@@ -5671,8 +5516,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"value##0", i64* %4 
+  store  i64 %"value##0", i64* %3 
   ret i64 %2 
 }
 
@@ -5683,15 +5527,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -5707,15 +5550,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -5732,15 +5574,14 @@ if.then:
   %6 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -5961,39 +5802,35 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#left##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = and i64 %"#right##0", 1 
-  %6 = icmp eq i64 %5, 0 
-  br i1 %6, label %if.then1, label %if.else1 
+  %3 = load  i64, i64* %2 
+  %4 = and i64 %"#right##0", 1 
+  %5 = icmp eq i64 %4, 0 
+  br i1 %5, label %if.then1, label %if.else1 
 if.else:
-  %11 = icmp eq i64 %0, 1 
-  br i1 %11, label %if.then2, label %if.else2 
+  %9 = icmp eq i64 %0, 1 
+  br i1 %9, label %if.then2, label %if.else2 
 if.then1:
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = icmp eq i64 %4, %9 
-  ret i1 %10 
+  %6 = inttoptr i64 %"#right##0" to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = icmp eq i64 %3, %7 
+  ret i1 %8 
 if.else1:
   ret i1 0 
 if.then2:
-  %12 = add   i64 %"#left##0", -1 
-  %13 = inttoptr i64 %12 to double* 
-  %14 = getelementptr  double, double* %13, i64 0 
-  %15 = load  double, double* %14 
-  %16 = and i64 %"#right##0", 1 
-  %17 = icmp eq i64 %16, 1 
-  br i1 %17, label %if.then3, label %if.else3 
+  %10 = add   i64 %"#left##0", -1 
+  %11 = inttoptr i64 %10 to double* 
+  %12 = load  double, double* %11 
+  %13 = and i64 %"#right##0", 1 
+  %14 = icmp eq i64 %13, 1 
+  br i1 %14, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %18 = add   i64 %"#right##0", -1 
-  %19 = inttoptr i64 %18 to double* 
-  %20 = getelementptr  double, double* %19, i64 0 
-  %21 = load  double, double* %20 
-  %22 = fcmp oeq double %15, %21 
-  ret i1 %22 
+  %15 = add   i64 %"#right##0", -1 
+  %16 = inttoptr i64 %15 to double* 
+  %17 = load  double, double* %16 
+  %18 = fcmp oeq double %12, %17 
+  ret i1 %18 
 if.else3:
   ret i1 0 
 }
@@ -6005,10 +5842,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to double* 
-  %4 = getelementptr  double, double* %3, i64 0 
-  store  double %"float_value##0", double* %4 
-  %5 = or i64 %2, 1 
-  ret i64 %5 
+  store  double %"float_value##0", double* %3 
+  %4 = or i64 %2, 1 
+  ret i64 %4 
 }
 
 
@@ -6020,15 +5856,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -1 
   %3 = inttoptr i64 %2 to double* 
-  %4 = getelementptr  double, double* %3, i64 0 
-  %5 = load  double, double* %4 
-  %6 = insertvalue {double, i1} undef, double %5, 0 
-  %7 = insertvalue {double, i1} %6, i1 1, 1 
-  ret {double, i1} %7 
+  %4 = load  double, double* %3 
+  %5 = insertvalue {double, i1} undef, double %4, 0 
+  %6 = insertvalue {double, i1} %5, i1 1, 1 
+  ret {double, i1} %6 
 if.else:
-  %8 = insertvalue {double, i1} undef, double undef, 0 
-  %9 = insertvalue {double, i1} %8, i1 0, 1 
-  ret {double, i1} %9 
+  %7 = insertvalue {double, i1} undef, double undef, 0 
+  %8 = insertvalue {double, i1} %7, i1 0, 1 
+  ret {double, i1} %8 
 }
 
 
@@ -6040,15 +5875,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -1 
   %3 = inttoptr i64 %2 to double* 
-  %4 = getelementptr  double, double* %3, i64 0 
-  %5 = load  double, double* %4 
-  %6 = insertvalue {double, i1} undef, double %5, 0 
-  %7 = insertvalue {double, i1} %6, i1 1, 1 
-  ret {double, i1} %7 
+  %4 = load  double, double* %3 
+  %5 = insertvalue {double, i1} undef, double %4, 0 
+  %6 = insertvalue {double, i1} %5, i1 1, 1 
+  ret {double, i1} %6 
 if.else:
-  %8 = insertvalue {double, i1} undef, double undef, 0 
-  %9 = insertvalue {double, i1} %8, i1 0, 1 
-  ret {double, i1} %9 
+  %7 = insertvalue {double, i1} undef, double undef, 0 
+  %8 = insertvalue {double, i1} %7, i1 0, 1 
+  ret {double, i1} %8 
 }
 
 
@@ -6069,15 +5903,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -1 
   %11 = inttoptr i64 %10 to double* 
-  %12 = getelementptr  double, double* %11, i64 0 
-  store  double %"#field##0", double* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  double %"#field##0", double* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -6087,8 +5920,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"int_value##0", i64* %4 
+  store  i64 %"int_value##0", i64* %3 
   ret i64 %2 
 }
 
@@ -6100,15 +5932,14 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#result##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -6119,15 +5950,14 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#rec##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -6145,15 +5975,14 @@ if.then:
   %7 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %5, i8*  %6, i32  %7, i1  0)  
   %8 = inttoptr i64 %4 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -6880,66 +6709,60 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %35 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %35 
+  %29 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %29 
 if.then1:
   %3 = inttoptr i64 %"#left##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = icmp ne i64 %"#right##0", 0 
-  br i1 %6, label %if.then2, label %if.else2 
+  %4 = load  i64, i64* %3 
+  %5 = icmp ne i64 %"#right##0", 0 
+  br i1 %5, label %if.then2, label %if.else2 
 if.else1:
-  %13 = icmp eq i64 %1, 1 
-  br i1 %13, label %if.then4, label %if.else4 
+  %11 = icmp eq i64 %1, 1 
+  br i1 %11, label %if.then4, label %if.else4 
 if.then2:
-  %7 = and i64 %"#right##0", 1 
-  %8 = icmp eq i64 %7, 0 
-  br i1 %8, label %if.then3, label %if.else3 
+  %6 = and i64 %"#right##0", 1 
+  %7 = icmp eq i64 %6, 0 
+  br i1 %7, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp eq i64 %5, %11 
-  ret i1 %12 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = icmp eq i64 %4, %9 
+  ret i1 %10 
 if.else3:
   ret i1 0 
 if.then4:
-  %14 = add   i64 %"#left##0", -1 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
+  %12 = add   i64 %"#left##0", -1 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#left##0", 7 
+  %16 = inttoptr i64 %15 to i64* 
   %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#left##0", 7 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = icmp ne i64 %"#right##0", 0 
-  br i1 %22, label %if.then5, label %if.else5 
+  %18 = icmp ne i64 %"#right##0", 0 
+  br i1 %18, label %if.then5, label %if.else5 
 if.else4:
   ret i1 0 
 if.then5:
-  %23 = and i64 %"#right##0", 1 
-  %24 = icmp eq i64 %23, 1 
-  br i1 %24, label %if.then6, label %if.else6 
+  %19 = and i64 %"#right##0", 1 
+  %20 = icmp eq i64 %19, 1 
+  br i1 %20, label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %25 = add   i64 %"#right##0", -1 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %29 = add   i64 %"#right##0", 7 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  %32 = load  i64, i64* %31 
-  %33 = icmp eq i64 %17, %28 
-  br i1 %33, label %if.then7, label %if.else7 
+  %21 = add   i64 %"#right##0", -1 
+  %22 = inttoptr i64 %21 to i64* 
+  %23 = load  i64, i64* %22 
+  %24 = add   i64 %"#right##0", 7 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = load  i64, i64* %25 
+  %27 = icmp eq i64 %14, %23 
+  br i1 %27, label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %34 = icmp eq i64 %21, %32 
-  ret i1 %34 
+  %28 = icmp eq i64 %17, %26 
+  ret i1 %28 
 if.else7:
   ret i1 0 
 }
@@ -6951,8 +6774,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"one_field##0", i64* %4 
+  store  i64 %"one_field##0", i64* %3 
   ret i64 %2 
 }
 
@@ -6966,20 +6788,19 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %11 = insertvalue {i64, i1} %10, i1 0, 1 
-  ret {i64, i1} %11 
+  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i1} %9, i1 0, 1 
+  ret {i64, i1} %10 
 if.then1:
   %3 = inttoptr i64 %"#result##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else1:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -6992,20 +6813,19 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %11 = insertvalue {i64, i1} %10, i1 0, 1 
-  ret {i64, i1} %11 
+  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i1} %9, i1 0, 1 
+  ret {i64, i1} %10 
 if.then1:
   %3 = inttoptr i64 %"#rec##0" to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else1:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -7018,9 +6838,9 @@ if.then:
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 if.then1:
   %3 = trunc i64 8 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -7030,15 +6850,14 @@ if.then1:
   %8 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %6, i8*  %7, i32  %8, i1  0)  
   %9 = inttoptr i64 %5 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"#field##0", i64* %10 
-  %11 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %12 = insertvalue {i64, i1} %11, i1 1, 1 
-  ret {i64, i1} %12 
+  store  i64 %"#field##0", i64* %9 
+  %10 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
 if.else1:
-  %13 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %14 = insertvalue {i64, i1} %13, i1 0, 1 
-  ret {i64, i1} %14 
+  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %13 = insertvalue {i64, i1} %12, i1 0, 1 
+  ret {i64, i1} %13 
 }
 
 
@@ -7048,14 +6867,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"two_field1##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"two_field2##0", i64* %7 
-  %8 = or i64 %2, 1 
-  ret i64 %8 
+  store  i64 %"two_field1##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"two_field2##0", i64* %5 
+  %6 = or i64 %2, 1 
+  ret i64 %6 
 }
 
 
@@ -7068,28 +6885,26 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %17 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %18 = insertvalue {i64, i64, i1} %17, i64 undef, 1 
-  %19 = insertvalue {i64, i64, i1} %18, i1 0, 2 
-  ret {i64, i64, i1} %19 
+  %15 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %16 = insertvalue {i64, i64, i1} %15, i64 undef, 1 
+  %17 = insertvalue {i64, i64, i1} %16, i1 0, 2 
+  ret {i64, i64, i1} %17 
 if.then1:
   %3 = add   i64 %"#result##0", -1 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#result##0", 7 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = insertvalue {i64, i64, i1} undef, i64 %6, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 %10, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 1, 2 
-  ret {i64, i64, i1} %13 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 7 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = insertvalue {i64, i64, i1} undef, i64 %5, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 %8, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 1, 2 
+  ret {i64, i64, i1} %11 
 if.else1:
-  %14 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %15 = insertvalue {i64, i64, i1} %14, i64 undef, 1 
-  %16 = insertvalue {i64, i64, i1} %15, i1 0, 2 
-  ret {i64, i64, i1} %16 
+  %12 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %13 = insertvalue {i64, i64, i1} %12, i64 undef, 1 
+  %14 = insertvalue {i64, i64, i1} %13, i1 0, 2 
+  ret {i64, i64, i1} %14 
 }
 
 
@@ -7102,21 +6917,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", -1 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -7129,9 +6943,9 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 16 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -7144,15 +6958,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, -1 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 
@@ -7165,21 +6978,20 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 if.then1:
   %3 = add   i64 %"#rec##0", 7 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %8 = insertvalue {i64, i1} %7, i1 1, 1 
-  ret {i64, i1} %8 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %7 = insertvalue {i64, i1} %6, i1 1, 1 
+  ret {i64, i1} %7 
 if.else1:
-  %9 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %10 = insertvalue {i64, i1} %9, i1 0, 1 
-  ret {i64, i1} %10 
+  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %9 = insertvalue {i64, i1} %8, i1 0, 1 
+  ret {i64, i1} %9 
 }
 
 
@@ -7192,9 +7004,9 @@ if.then:
   %2 = icmp eq i64 %1, 1 
   br i1 %2, label %if.then1, label %if.else1 
 if.else:
-  %18 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %19 = insertvalue {i64, i1} %18, i1 0, 1 
-  ret {i64, i1} %19 
+  %17 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %18 = insertvalue {i64, i1} %17, i1 0, 1 
+  ret {i64, i1} %18 
 if.then1:
   %3 = trunc i64 16 to i32  
   %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
@@ -7207,15 +7019,14 @@ if.then1:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i1  0)  
   %11 = add   i64 %6, 7 
   %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"#field##0", i64* %13 
-  %14 = insertvalue {i64, i1} undef, i64 %6, 0 
-  %15 = insertvalue {i64, i1} %14, i1 1, 1 
-  ret {i64, i1} %15 
+  store  i64 %"#field##0", i64* %12 
+  %13 = insertvalue {i64, i1} undef, i64 %6, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
 if.else1:
-  %16 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %17 = insertvalue {i64, i1} %16, i1 0, 1 
-  ret {i64, i1} %17 
+  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
 }
 
 

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -276,113 +276,103 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"x##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
+  %3 = load  i64, i64* %2 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %4)  
+  tail call ccc  void  @print_int(i64  %3)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %5 = icmp eq i64 %0, 1 
-  br i1 %5, label %if.then1, label %if.else1 
+  %4 = icmp eq i64 %0, 1 
+  br i1 %4, label %if.then1, label %if.else1 
 if.then1:
-  %6 = add   i64 %"x##0", -1 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
+  %5 = add   i64 %"x##0", -1 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.5, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %9)  
+  tail call ccc  void  @print_int(i64  %7)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
-  %10 = icmp eq i64 %0, 2 
-  br i1 %10, label %if.then2, label %if.else2 
+  %8 = icmp eq i64 %0, 2 
+  br i1 %8, label %if.then2, label %if.else2 
 if.then2:
-  %11 = add   i64 %"x##0", -2 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
+  %9 = add   i64 %"x##0", -2 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = load  i64, i64* %10 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.5, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %14)  
+  tail call ccc  void  @print_int(i64  %11)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
-  %15 = icmp eq i64 %0, 3 
-  br i1 %15, label %if.then3, label %if.else3 
+  %12 = icmp eq i64 %0, 3 
+  br i1 %12, label %if.then3, label %if.else3 
 if.then3:
-  %16 = add   i64 %"x##0", -3 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
+  %13 = add   i64 %"x##0", -3 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %19)  
+  tail call ccc  void  @print_int(i64  %15)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
-  %20 = icmp eq i64 %0, 4 
-  br i1 %20, label %if.then4, label %if.else4 
+  %16 = icmp eq i64 %0, 4 
+  br i1 %16, label %if.then4, label %if.else4 
 if.then4:
-  %21 = add   i64 %"x##0", -4 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
+  %17 = add   i64 %"x##0", -4 
+  %18 = inttoptr i64 %17 to i64* 
+  %19 = load  i64, i64* %18 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.9, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %24)  
+  tail call ccc  void  @print_int(i64  %19)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else4:
-  %25 = icmp eq i64 %0, 5 
-  br i1 %25, label %if.then5, label %if.else5 
+  %20 = icmp eq i64 %0, 5 
+  br i1 %20, label %if.then5, label %if.else5 
 if.then5:
-  %26 = add   i64 %"x##0", -5 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  %29 = load  i64, i64* %28 
+  %21 = add   i64 %"x##0", -5 
+  %22 = inttoptr i64 %21 to i64* 
+  %23 = load  i64, i64* %22 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.11, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %29)  
+  tail call ccc  void  @print_int(i64  %23)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else5:
-  %30 = icmp eq i64 %0, 6 
-  br i1 %30, label %if.then6, label %if.else6 
+  %24 = icmp eq i64 %0, 6 
+  br i1 %24, label %if.then6, label %if.else6 
 if.then6:
-  %31 = add   i64 %"x##0", -6 
-  %32 = inttoptr i64 %31 to i64* 
-  %33 = getelementptr  i64, i64* %32, i64 0 
-  %34 = load  i64, i64* %33 
+  %25 = add   i64 %"x##0", -6 
+  %26 = inttoptr i64 %25 to i64* 
+  %27 = load  i64, i64* %26 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.13, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %34)  
+  tail call ccc  void  @print_int(i64  %27)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else6:
-  %35 = icmp eq i64 %0, 7 
-  br i1 %35, label %if.then7, label %if.else7 
+  %28 = icmp eq i64 %0, 7 
+  br i1 %28, label %if.then7, label %if.else7 
 if.then7:
-  %36 = add   i64 %"x##0", -7 
-  %37 = inttoptr i64 %36 to i64* 
-  %38 = getelementptr  i64, i64* %37, i64 0 
-  %39 = load  i64, i64* %38 
-  %40 = add   i64 %"x##0", 1 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  %43 = load  i64, i64* %42 
-  %44 = add   i64 %"x##0", 9 
-  %45 = inttoptr i64 %44 to double* 
-  %46 = getelementptr  double, double* %45, i64 0 
-  %47 = load  double, double* %46 
+  %29 = add   i64 %"x##0", -7 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = load  i64, i64* %30 
+  %32 = add   i64 %"x##0", 1 
+  %33 = inttoptr i64 %32 to i64* 
+  %34 = load  i64, i64* %33 
+  %35 = add   i64 %"x##0", 9 
+  %36 = inttoptr i64 %35 to double* 
+  %37 = load  double, double* %36 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.15, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %39)  
+  tail call ccc  void  @print_int(i64  %31)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.17, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %43)  
+  tail call ccc  void  @print_int(i64  %34)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.17, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_float(double  %47)  
+  tail call ccc  void  @print_float(double  %37)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -1183,185 +1173,165 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#left##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = and i64 %"#right##0", 7 
-  %6 = icmp eq i64 %5, 0 
-  br i1 %6, label %if.then1, label %if.else1 
+  %3 = load  i64, i64* %2 
+  %4 = and i64 %"#right##0", 7 
+  %5 = icmp eq i64 %4, 0 
+  br i1 %5, label %if.then1, label %if.else1 
 if.else:
-  %11 = icmp eq i64 %0, 1 
-  br i1 %11, label %if.then2, label %if.else2 
+  %9 = icmp eq i64 %0, 1 
+  br i1 %9, label %if.then2, label %if.else2 
 if.then1:
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = icmp eq i64 %4, %9 
-  ret i1 %10 
+  %6 = inttoptr i64 %"#right##0" to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = icmp eq i64 %3, %7 
+  ret i1 %8 
 if.else1:
   ret i1 0 
 if.then2:
-  %12 = add   i64 %"#left##0", -1 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = and i64 %"#right##0", 7 
-  %17 = icmp eq i64 %16, 1 
-  br i1 %17, label %if.then3, label %if.else3 
+  %10 = add   i64 %"#left##0", -1 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = and i64 %"#right##0", 7 
+  %14 = icmp eq i64 %13, 1 
+  br i1 %14, label %if.then3, label %if.else3 
 if.else2:
-  %23 = icmp eq i64 %0, 2 
-  br i1 %23, label %if.then4, label %if.else4 
+  %19 = icmp eq i64 %0, 2 
+  br i1 %19, label %if.then4, label %if.else4 
 if.then3:
-  %18 = add   i64 %"#right##0", -1 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = icmp eq i64 %15, %21 
-  ret i1 %22 
+  %15 = add   i64 %"#right##0", -1 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = icmp eq i64 %12, %17 
+  ret i1 %18 
 if.else3:
   ret i1 0 
 if.then4:
-  %24 = add   i64 %"#left##0", -2 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = and i64 %"#right##0", 7 
-  %29 = icmp eq i64 %28, 2 
-  br i1 %29, label %if.then5, label %if.else5 
+  %20 = add   i64 %"#left##0", -2 
+  %21 = inttoptr i64 %20 to i64* 
+  %22 = load  i64, i64* %21 
+  %23 = and i64 %"#right##0", 7 
+  %24 = icmp eq i64 %23, 2 
+  br i1 %24, label %if.then5, label %if.else5 
 if.else4:
-  %35 = icmp eq i64 %0, 3 
-  br i1 %35, label %if.then6, label %if.else6 
+  %29 = icmp eq i64 %0, 3 
+  br i1 %29, label %if.then6, label %if.else6 
 if.then5:
-  %30 = add   i64 %"#right##0", -2 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  %33 = load  i64, i64* %32 
-  %34 = icmp eq i64 %27, %33 
-  ret i1 %34 
+  %25 = add   i64 %"#right##0", -2 
+  %26 = inttoptr i64 %25 to i64* 
+  %27 = load  i64, i64* %26 
+  %28 = icmp eq i64 %22, %27 
+  ret i1 %28 
 if.else5:
   ret i1 0 
 if.then6:
-  %36 = add   i64 %"#left##0", -3 
-  %37 = inttoptr i64 %36 to i64* 
-  %38 = getelementptr  i64, i64* %37, i64 0 
-  %39 = load  i64, i64* %38 
-  %40 = and i64 %"#right##0", 7 
-  %41 = icmp eq i64 %40, 3 
-  br i1 %41, label %if.then7, label %if.else7 
+  %30 = add   i64 %"#left##0", -3 
+  %31 = inttoptr i64 %30 to i64* 
+  %32 = load  i64, i64* %31 
+  %33 = and i64 %"#right##0", 7 
+  %34 = icmp eq i64 %33, 3 
+  br i1 %34, label %if.then7, label %if.else7 
 if.else6:
-  %47 = icmp eq i64 %0, 4 
-  br i1 %47, label %if.then8, label %if.else8 
+  %39 = icmp eq i64 %0, 4 
+  br i1 %39, label %if.then8, label %if.else8 
 if.then7:
-  %42 = add   i64 %"#right##0", -3 
-  %43 = inttoptr i64 %42 to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  %45 = load  i64, i64* %44 
-  %46 = icmp eq i64 %39, %45 
-  ret i1 %46 
+  %35 = add   i64 %"#right##0", -3 
+  %36 = inttoptr i64 %35 to i64* 
+  %37 = load  i64, i64* %36 
+  %38 = icmp eq i64 %32, %37 
+  ret i1 %38 
 if.else7:
   ret i1 0 
 if.then8:
-  %48 = add   i64 %"#left##0", -4 
-  %49 = inttoptr i64 %48 to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  %51 = load  i64, i64* %50 
-  %52 = and i64 %"#right##0", 7 
-  %53 = icmp eq i64 %52, 4 
-  br i1 %53, label %if.then9, label %if.else9 
+  %40 = add   i64 %"#left##0", -4 
+  %41 = inttoptr i64 %40 to i64* 
+  %42 = load  i64, i64* %41 
+  %43 = and i64 %"#right##0", 7 
+  %44 = icmp eq i64 %43, 4 
+  br i1 %44, label %if.then9, label %if.else9 
 if.else8:
-  %59 = icmp eq i64 %0, 5 
-  br i1 %59, label %if.then10, label %if.else10 
+  %49 = icmp eq i64 %0, 5 
+  br i1 %49, label %if.then10, label %if.else10 
 if.then9:
-  %54 = add   i64 %"#right##0", -4 
-  %55 = inttoptr i64 %54 to i64* 
-  %56 = getelementptr  i64, i64* %55, i64 0 
-  %57 = load  i64, i64* %56 
-  %58 = icmp eq i64 %51, %57 
-  ret i1 %58 
+  %45 = add   i64 %"#right##0", -4 
+  %46 = inttoptr i64 %45 to i64* 
+  %47 = load  i64, i64* %46 
+  %48 = icmp eq i64 %42, %47 
+  ret i1 %48 
 if.else9:
   ret i1 0 
 if.then10:
-  %60 = add   i64 %"#left##0", -5 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  %63 = load  i64, i64* %62 
-  %64 = and i64 %"#right##0", 7 
-  %65 = icmp eq i64 %64, 5 
-  br i1 %65, label %if.then11, label %if.else11 
+  %50 = add   i64 %"#left##0", -5 
+  %51 = inttoptr i64 %50 to i64* 
+  %52 = load  i64, i64* %51 
+  %53 = and i64 %"#right##0", 7 
+  %54 = icmp eq i64 %53, 5 
+  br i1 %54, label %if.then11, label %if.else11 
 if.else10:
-  %71 = icmp eq i64 %0, 6 
-  br i1 %71, label %if.then12, label %if.else12 
+  %59 = icmp eq i64 %0, 6 
+  br i1 %59, label %if.then12, label %if.else12 
 if.then11:
-  %66 = add   i64 %"#right##0", -5 
-  %67 = inttoptr i64 %66 to i64* 
-  %68 = getelementptr  i64, i64* %67, i64 0 
-  %69 = load  i64, i64* %68 
-  %70 = icmp eq i64 %63, %69 
-  ret i1 %70 
+  %55 = add   i64 %"#right##0", -5 
+  %56 = inttoptr i64 %55 to i64* 
+  %57 = load  i64, i64* %56 
+  %58 = icmp eq i64 %52, %57 
+  ret i1 %58 
 if.else11:
   ret i1 0 
 if.then12:
-  %72 = add   i64 %"#left##0", -6 
-  %73 = inttoptr i64 %72 to i64* 
-  %74 = getelementptr  i64, i64* %73, i64 0 
-  %75 = load  i64, i64* %74 
-  %76 = and i64 %"#right##0", 7 
-  %77 = icmp eq i64 %76, 6 
-  br i1 %77, label %if.then13, label %if.else13 
+  %60 = add   i64 %"#left##0", -6 
+  %61 = inttoptr i64 %60 to i64* 
+  %62 = load  i64, i64* %61 
+  %63 = and i64 %"#right##0", 7 
+  %64 = icmp eq i64 %63, 6 
+  br i1 %64, label %if.then13, label %if.else13 
 if.else12:
-  %83 = icmp eq i64 %0, 7 
-  br i1 %83, label %if.then14, label %if.else14 
+  %69 = icmp eq i64 %0, 7 
+  br i1 %69, label %if.then14, label %if.else14 
 if.then13:
-  %78 = add   i64 %"#right##0", -6 
-  %79 = inttoptr i64 %78 to i64* 
-  %80 = getelementptr  i64, i64* %79, i64 0 
-  %81 = load  i64, i64* %80 
-  %82 = icmp eq i64 %75, %81 
-  ret i1 %82 
+  %65 = add   i64 %"#right##0", -6 
+  %66 = inttoptr i64 %65 to i64* 
+  %67 = load  i64, i64* %66 
+  %68 = icmp eq i64 %62, %67 
+  ret i1 %68 
 if.else13:
   ret i1 0 
 if.then14:
-  %84 = add   i64 %"#left##0", -7 
-  %85 = inttoptr i64 %84 to i64* 
-  %86 = getelementptr  i64, i64* %85, i64 0 
-  %87 = load  i64, i64* %86 
-  %88 = add   i64 %"#left##0", 1 
-  %89 = inttoptr i64 %88 to i64* 
-  %90 = getelementptr  i64, i64* %89, i64 0 
-  %91 = load  i64, i64* %90 
-  %92 = add   i64 %"#left##0", 9 
-  %93 = inttoptr i64 %92 to double* 
-  %94 = getelementptr  double, double* %93, i64 0 
-  %95 = load  double, double* %94 
-  %96 = and i64 %"#right##0", 7 
-  %97 = icmp eq i64 %96, 7 
-  br i1 %97, label %if.then15, label %if.else15 
+  %70 = add   i64 %"#left##0", -7 
+  %71 = inttoptr i64 %70 to i64* 
+  %72 = load  i64, i64* %71 
+  %73 = add   i64 %"#left##0", 1 
+  %74 = inttoptr i64 %73 to i64* 
+  %75 = load  i64, i64* %74 
+  %76 = add   i64 %"#left##0", 9 
+  %77 = inttoptr i64 %76 to double* 
+  %78 = load  double, double* %77 
+  %79 = and i64 %"#right##0", 7 
+  %80 = icmp eq i64 %79, 7 
+  br i1 %80, label %if.then15, label %if.else15 
 if.else14:
   ret i1 0 
 if.then15:
-  %98 = add   i64 %"#right##0", -7 
-  %99 = inttoptr i64 %98 to i64* 
-  %100 = getelementptr  i64, i64* %99, i64 0 
-  %101 = load  i64, i64* %100 
-  %102 = add   i64 %"#right##0", 1 
-  %103 = inttoptr i64 %102 to i64* 
-  %104 = getelementptr  i64, i64* %103, i64 0 
-  %105 = load  i64, i64* %104 
-  %106 = add   i64 %"#right##0", 9 
-  %107 = inttoptr i64 %106 to double* 
-  %108 = getelementptr  double, double* %107, i64 0 
-  %109 = load  double, double* %108 
-  %110 = icmp eq i64 %87, %101 
-  br i1 %110, label %if.then16, label %if.else16 
+  %81 = add   i64 %"#right##0", -7 
+  %82 = inttoptr i64 %81 to i64* 
+  %83 = load  i64, i64* %82 
+  %84 = add   i64 %"#right##0", 1 
+  %85 = inttoptr i64 %84 to i64* 
+  %86 = load  i64, i64* %85 
+  %87 = add   i64 %"#right##0", 9 
+  %88 = inttoptr i64 %87 to double* 
+  %89 = load  double, double* %88 
+  %90 = icmp eq i64 %72, %83 
+  br i1 %90, label %if.then16, label %if.else16 
 if.else15:
   ret i1 0 
 if.then16:
-  %111 = icmp eq i64 %91, %105 
-  br i1 %111, label %if.then17, label %if.else17 
+  %91 = icmp eq i64 %75, %86 
+  br i1 %91, label %if.then17, label %if.else17 
 if.else16:
   ret i1 0 
 if.then17:
-  %112 = fcmp oeq double %95, %109 
-  ret i1 %112 
+  %92 = fcmp oeq double %78, %89 
+  ret i1 %92 
 if.else17:
   ret i1 0 
 }
@@ -1373,8 +1343,7 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f01##0", i64* %4 
+  store  i64 %"f01##0", i64* %3 
   ret i64 %2 
 }
 
@@ -1386,15 +1355,14 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#result##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -1404,10 +1372,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f02##0", i64* %4 
-  %5 = or i64 %2, 1 
-  ret i64 %5 
+  store  i64 %"f02##0", i64* %3 
+  %4 = or i64 %2, 1 
+  ret i64 %4 
 }
 
 
@@ -1419,15 +1386,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -1 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1437,10 +1403,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f03##0", i64* %4 
-  %5 = or i64 %2, 2 
-  ret i64 %5 
+  store  i64 %"f03##0", i64* %3 
+  %4 = or i64 %2, 2 
+  ret i64 %4 
 }
 
 
@@ -1452,15 +1417,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -2 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1470,10 +1434,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f04##0", i64* %4 
-  %5 = or i64 %2, 3 
-  ret i64 %5 
+  store  i64 %"f04##0", i64* %3 
+  %4 = or i64 %2, 3 
+  ret i64 %4 
 }
 
 
@@ -1485,15 +1448,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -3 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1503,10 +1465,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f05##0", i64* %4 
-  %5 = or i64 %2, 4 
-  ret i64 %5 
+  store  i64 %"f05##0", i64* %3 
+  %4 = or i64 %2, 4 
+  ret i64 %4 
 }
 
 
@@ -1518,15 +1479,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -4 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1536,10 +1496,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f06##0", i64* %4 
-  %5 = or i64 %2, 5 
-  ret i64 %5 
+  store  i64 %"f06##0", i64* %3 
+  %4 = or i64 %2, 5 
+  ret i64 %4 
 }
 
 
@@ -1551,15 +1510,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -5 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1569,10 +1527,9 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f07##0", i64* %4 
-  %5 = or i64 %2, 6 
-  ret i64 %5 
+  store  i64 %"f07##0", i64* %3 
+  %4 = or i64 %2, 6 
+  ret i64 %4 
 }
 
 
@@ -1584,15 +1541,14 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -6 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1602,18 +1558,15 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"f08_a##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"f08_b##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to double* 
-  %10 = getelementptr  double, double* %9, i64 0 
-  store  double %"f08_c##0", double* %10 
-  %11 = or i64 %2, 7 
-  ret i64 %11 
+  store  i64 %"f08_a##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"f08_b##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to double* 
+  store  double %"f08_c##0", double* %7 
+  %8 = or i64 %2, 7 
+  ret i64 %8 
 }
 
 
@@ -1625,27 +1578,24 @@ entry:
 if.then:
   %2 = add   i64 %"#result##0", -7 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = add   i64 %"#result##0", 1 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#result##0", 9 
-  %11 = inttoptr i64 %10 to double* 
-  %12 = getelementptr  double, double* %11, i64 0 
-  %13 = load  double, double* %12 
-  %14 = insertvalue {i64, i64, double, i1} undef, i64 %5, 0 
-  %15 = insertvalue {i64, i64, double, i1} %14, i64 %9, 1 
-  %16 = insertvalue {i64, i64, double, i1} %15, double %13, 2 
-  %17 = insertvalue {i64, i64, double, i1} %16, i1 1, 3 
-  ret {i64, i64, double, i1} %17 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#result##0", 1 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"#result##0", 9 
+  %9 = inttoptr i64 %8 to double* 
+  %10 = load  double, double* %9 
+  %11 = insertvalue {i64, i64, double, i1} undef, i64 %4, 0 
+  %12 = insertvalue {i64, i64, double, i1} %11, i64 %7, 1 
+  %13 = insertvalue {i64, i64, double, i1} %12, double %10, 2 
+  %14 = insertvalue {i64, i64, double, i1} %13, i1 1, 3 
+  ret {i64, i64, double, i1} %14 
 if.else:
-  %18 = insertvalue {i64, i64, double, i1} undef, i64 undef, 0 
-  %19 = insertvalue {i64, i64, double, i1} %18, i64 undef, 1 
-  %20 = insertvalue {i64, i64, double, i1} %19, double undef, 2 
-  %21 = insertvalue {i64, i64, double, i1} %20, i1 0, 3 
-  ret {i64, i64, double, i1} %21 
+  %15 = insertvalue {i64, i64, double, i1} undef, i64 undef, 0 
+  %16 = insertvalue {i64, i64, double, i1} %15, i64 undef, 1 
+  %17 = insertvalue {i64, i64, double, i1} %16, double undef, 2 
+  %18 = insertvalue {i64, i64, double, i1} %17, i1 0, 3 
+  ret {i64, i64, double, i1} %18 
 }
 
 
@@ -1656,15 +1606,14 @@ entry:
   br i1 %1, label %if.then, label %if.else 
 if.then:
   %2 = inttoptr i64 %"#rec##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -1682,15 +1631,14 @@ if.then:
   %7 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %5, i8*  %6, i32  %7, i1  0)  
   %8 = inttoptr i64 %4 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -1702,15 +1650,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -1 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1731,15 +1678,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -1 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -1751,15 +1697,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -2 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1780,15 +1725,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -2 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -1800,15 +1744,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -3 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1829,15 +1772,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -3 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -1849,15 +1791,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -4 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1878,15 +1819,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -4 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -1898,15 +1838,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -5 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1927,15 +1866,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -5 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -1947,15 +1885,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -6 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -1976,15 +1913,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -6 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -1996,15 +1932,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", -7 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -2025,15 +1960,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, -7 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -2045,15 +1979,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", 1 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  %5 = load  i64, i64* %4 
-  %6 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %7 = insertvalue {i64, i1} %6, i1 1, 1 
-  ret {i64, i1} %7 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
+  %6 = insertvalue {i64, i1} %5, i1 1, 1 
+  ret {i64, i1} %6 
 if.else:
-  %8 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %9 = insertvalue {i64, i1} %8, i1 0, 1 
-  ret {i64, i1} %9 
+  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %8 = insertvalue {i64, i1} %7, i1 0, 1 
+  ret {i64, i1} %8 
 }
 
 
@@ -2074,15 +2007,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, 1 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %"#field##0", i64* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  i64 %"#field##0", i64* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 
@@ -2094,15 +2026,14 @@ entry:
 if.then:
   %2 = add   i64 %"#rec##0", 9 
   %3 = inttoptr i64 %2 to double* 
-  %4 = getelementptr  double, double* %3, i64 0 
-  %5 = load  double, double* %4 
-  %6 = insertvalue {double, i1} undef, double %5, 0 
-  %7 = insertvalue {double, i1} %6, i1 1, 1 
-  ret {double, i1} %7 
+  %4 = load  double, double* %3 
+  %5 = insertvalue {double, i1} undef, double %4, 0 
+  %6 = insertvalue {double, i1} %5, i1 1, 1 
+  ret {double, i1} %6 
 if.else:
-  %8 = insertvalue {double, i1} undef, double undef, 0 
-  %9 = insertvalue {double, i1} %8, i1 0, 1 
-  ret {double, i1} %9 
+  %7 = insertvalue {double, i1} undef, double undef, 0 
+  %8 = insertvalue {double, i1} %7, i1 0, 1 
+  ret {double, i1} %8 
 }
 
 
@@ -2123,15 +2054,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %7, i8*  %8, i32  %9, i1  0)  
   %10 = add   i64 %5, 9 
   %11 = inttoptr i64 %10 to double* 
-  %12 = getelementptr  double, double* %11, i64 0 
-  store  double %"#field##0", double* %12 
-  %13 = insertvalue {i64, i1} undef, i64 %5, 0 
-  %14 = insertvalue {i64, i1} %13, i1 1, 1 
-  ret {i64, i1} %14 
+  store  double %"#field##0", double* %11 
+  %12 = insertvalue {i64, i1} undef, i64 %5, 0 
+  %13 = insertvalue {i64, i1} %12, i1 1, 1 
+  ret {i64, i1} %13 
 if.else:
-  %15 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %16 = insertvalue {i64, i1} %15, i1 0, 1 
-  ret {i64, i1} %16 
+  %14 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %15 = insertvalue {i64, i1} %14, i1 0, 1 
+  ret {i64, i1} %15 
 }
 
 

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -204,32 +204,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"#right##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"#right##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
-  %18 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %18 
+  %14 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %14 
 if.then1:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"#right##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#right##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#right##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp eq i64 %3, %11 
-  br i1 %16, label %if.then2, label %if.else2 
+  %12 = icmp eq i64 %2, %8 
+  br i1 %12, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %17 = musttail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %7, i64  %15)  
-  ret i1 %17 
+  %13 = musttail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %5, i64  %11)  
+  ret i1 %13 
 if.else2:
   ret i1 0 
 }
@@ -241,12 +237,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"ahead##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"atail##0", i64* %7 
+  store  i64 %"ahead##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"atail##0", i64* %5 
   ret i64 %2 
 }
 
@@ -257,21 +251,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -281,15 +273,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -306,15 +297,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -325,15 +315,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -351,15 +340,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -554,32 +542,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"#right##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"#right##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
-  %18 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %18 
+  %14 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %14 
 if.then1:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"#right##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#right##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#right##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp eq i64 %3, %11 
-  br i1 %16, label %if.then2, label %if.else2 
+  %12 = icmp eq i64 %2, %8 
+  br i1 %12, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %17 = musttail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %7, i64  %15)  
-  ret i1 %17 
+  %13 = musttail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %5, i64  %11)  
+  ret i1 %13 
 if.else2:
   ret i1 0 
 }
@@ -591,12 +575,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"bhead##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"btail##0", i64* %7 
+  store  i64 %"bhead##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"btail##0", i64* %5 
   ret i64 %2 
 }
 
@@ -607,21 +589,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -631,15 +611,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -656,15 +635,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -675,15 +653,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -701,15 +678,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -106,21 +106,18 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"t##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"t##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"t##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %3, i64  %"prefix##0")  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %12)  
-  tail call ccc  void  @print_int(i64  %7)  
-  %13 = musttail call fastcc  i64  @"mytree.printTree1<0>"(i64  %11, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64))  
-  ret i64 %13 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"t##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"t##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %2, i64  %"prefix##0")  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  %9)  
+  tail call ccc  void  @print_int(i64  %5)  
+  %10 = musttail call fastcc  i64  @"mytree.printTree1<0>"(i64  %8, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64))  
+  ret i64 %10 
 if.else:
   ret i64 %"prefix##0" 
 }
@@ -349,45 +346,39 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#left##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp ne i64 %"#right##0", 0 
-  br i1 %12, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#left##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = icmp ne i64 %"#right##0", 0 
+  br i1 %9, label %if.then1, label %if.else1 
 if.else:
-  %27 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %27 
+  %21 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %21 
 if.then1:
-  %13 = inttoptr i64 %"#right##0" to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = add   i64 %"#right##0", 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
-  %20 = add   i64 %"#right##0", 16 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %15)  
-  br i1 %24, label %if.then2, label %if.else2 
+  %10 = inttoptr i64 %"#right##0" to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"#right##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#right##0", 16 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %2, i64  %11)  
+  br i1 %18, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %25 = icmp eq i64 %7, %19 
-  br i1 %25, label %if.then3, label %if.else3 
+  %19 = icmp eq i64 %5, %14 
+  br i1 %19, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %26 = musttail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %23)  
-  ret i1 %26 
+  %20 = musttail call fastcc  i1  @"mytree.tree.=<0>"(i64  %8, i64  %17)  
+  ret i1 %20 
 if.else3:
   ret i1 0 
 }
@@ -406,15 +397,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -432,15 +422,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -450,15 +439,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -475,15 +463,14 @@ if.then:
   %6 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -493,16 +480,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"left##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"key##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"right##0", i64* %10 
+  store  i64 %"left##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"key##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"right##0", i64* %7 
   ret i64 %2 
 }
 
@@ -513,27 +497,24 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#result##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i64, i64, i1} undef, i64 %3, 0 
-  %13 = insertvalue {i64, i64, i64, i1} %12, i64 %7, 1 
-  %14 = insertvalue {i64, i64, i64, i1} %13, i64 %11, 2 
-  %15 = insertvalue {i64, i64, i64, i1} %14, i1 1, 3 
-  ret {i64, i64, i64, i1} %15 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = insertvalue {i64, i64, i64, i1} undef, i64 %2, 0 
+  %10 = insertvalue {i64, i64, i64, i1} %9, i64 %5, 1 
+  %11 = insertvalue {i64, i64, i64, i1} %10, i64 %8, 2 
+  %12 = insertvalue {i64, i64, i64, i1} %11, i1 1, 3 
+  ret {i64, i64, i64, i1} %12 
 if.else:
-  %16 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %17 = insertvalue {i64, i64, i64, i1} %16, i64 undef, 1 
-  %18 = insertvalue {i64, i64, i64, i1} %17, i64 undef, 2 
-  %19 = insertvalue {i64, i64, i64, i1} %18, i1 0, 3 
-  ret {i64, i64, i64, i1} %19 
+  %13 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %14 = insertvalue {i64, i64, i64, i1} %13, i64 undef, 1 
+  %15 = insertvalue {i64, i64, i64, i1} %14, i64 undef, 2 
+  %16 = insertvalue {i64, i64, i64, i1} %15, i1 0, 3 
+  ret {i64, i64, i64, i1} %16 
 }
 
 
@@ -544,15 +525,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 16 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -570,15 +550,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 16 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -176,24 +176,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"person1.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  ret i1 %15 
+  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -202,9 +198,8 @@ if.else:
 define external fastcc  i64 @"person1.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -218,8 +213,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -228,9 +222,8 @@ define external fastcc  i64 @"person1.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -245,8 +238,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -257,12 +249,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"firstname##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"lastname##0", i64* %7 
+  store  i64 %"firstname##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"lastname##0", i64* %5 
   ret i64 %2 
 }
 
@@ -270,41 +260,35 @@ entry:
 define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"person1.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -178,24 +178,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"person2.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  ret i1 %15 
+  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -204,9 +200,8 @@ if.else:
 define external fastcc  i64 @"person2.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -220,8 +215,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -230,9 +224,8 @@ define external fastcc  i64 @"person2.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -247,8 +240,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -259,12 +251,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"firstname##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"lastname##0", i64* %7 
+  store  i64 %"firstname##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"lastname##0", i64* %5 
   ret i64 %2 
 }
 
@@ -272,41 +262,35 @@ entry:
 define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"person2.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -184,24 +184,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"person3.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  ret i1 %15 
+  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -210,9 +206,8 @@ if.else:
 define external fastcc  i64 @"person3.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -226,8 +221,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -236,9 +230,8 @@ define external fastcc  i64 @"person3.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -253,8 +246,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -265,12 +257,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"firstname##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"lastname##0", i64* %7 
+  store  i64 %"firstname##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"lastname##0", i64* %5 
   ret i64 %2 
 }
 
@@ -278,41 +268,35 @@ entry:
 define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"person3.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -184,24 +184,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"person4.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  ret i1 %15 
+  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -210,9 +206,8 @@ if.else:
 define external fastcc  i64 @"person4.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -226,8 +221,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -236,9 +230,8 @@ define external fastcc  i64 @"person4.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -253,8 +246,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -265,12 +257,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"firstname##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"lastname##0", i64* %7 
+  store  i64 %"firstname##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"lastname##0", i64* %5 
   ret i64 %2 
 }
 
@@ -278,41 +268,35 @@ entry:
 define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"person4.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -83,21 +83,19 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.1, i32 0, i32 0) to i64), i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = inttoptr i64 %10 to i8* 
-  %12 = inttoptr i64 %"p2##0" to i8* 
-  %13 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %11, i8*  %12, i32  %13, i1  0)  
-  %14 = inttoptr i64 %10 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.3, i32 0, i32 0) to i64), i64* %15 
-  %16 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %17 = insertvalue {i64, i64} %16, i64 %10, 1 
-  ret {i64, i64} %17 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.1, i32 0, i32 0) to i64), i64* %6 
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i8* 
+  %11 = inttoptr i64 %"p2##0" to i8* 
+  %12 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %10, i8*  %11, i32  %12, i1  0)  
+  %13 = inttoptr i64 %9 to i64* 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.3, i32 0, i32 0) to i64), i64* %13 
+  %14 = insertvalue {i64, i64} undef, i64 %2, 0 
+  %15 = insertvalue {i64, i64} %14, i64 %9, 1 
+  ret {i64, i64} %15 
 }
 --------------------------------------------------
  Module person5.person
@@ -221,24 +219,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"person5.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  ret i1 %15 
+  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -247,9 +241,8 @@ if.else:
 define external fastcc  i64 @"person5.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -263,8 +256,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -273,9 +265,8 @@ define external fastcc  i64 @"person5.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -290,8 +281,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -302,12 +292,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"firstname##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"lastname##0", i64* %7 
+  store  i64 %"firstname##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"lastname##0", i64* %5 
   ret i64 %2 
 }
 
@@ -315,41 +303,35 @@ entry:
 define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"person5.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %2, i64  %9)  
-  br i1 %14, label %if.then, label %if.else 
+  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -84,15 +84,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -216,24 +214,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -245,12 +239,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -258,24 +250,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -289,8 +278,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -299,9 +287,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -316,8 +303,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -325,26 +311,22 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -84,15 +84,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -216,24 +214,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -245,12 +239,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -258,24 +250,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -289,8 +278,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -299,9 +287,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -316,8 +303,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -325,28 +311,24 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module position1
@@ -403,16 +385,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 111, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 222, i64* %7 
-  %8 = add   i64 %2, 8 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 112, i64* %10 
+  store  i64 111, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 222, i64* %5 
+  %6 = add   i64 %2, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 112, i64* %7 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position1.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   ret void 

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -84,15 +84,13 @@ define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.1, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.3, i32 0, i32 0) to i64))  
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -216,24 +214,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  ret i1 %15 
+  %11 = icmp eq i64 %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -245,12 +239,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -258,24 +250,21 @@ entry:
 define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -289,8 +278,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -299,9 +287,8 @@ define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -316,8 +303,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -325,28 +311,24 @@ entry:
 define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = icmp eq i64 %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = icmp eq i64 %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module position2
@@ -422,31 +404,26 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 111, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 222, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 111, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 222, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 333, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 333, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 222, i64* %15 
+  store  i64 222, i64* %11 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
-  %16 = add   i64 %2, 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 20000, i64* %18 
+  %12 = add   i64 %2, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 20000, i64* %13 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.3, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.5, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
   ret void 
 }

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -150,24 +150,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"position_float.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to double* 
-  %1 = getelementptr  double, double* %0, i64 0 
-  %2 = load  double, double* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to double* 
-  %5 = getelementptr  double, double* %4, i64 0 
+  %1 = load  double, double* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to double* 
+  %4 = load  double, double* %3 
+  %5 = inttoptr i64 %"#right##0" to double* 
   %6 = load  double, double* %5 
-  %7 = inttoptr i64 %"#right##0" to double* 
-  %8 = getelementptr  double, double* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to double* 
   %9 = load  double, double* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to double* 
-  %12 = getelementptr  double, double* %11, i64 0 
-  %13 = load  double, double* %12 
-  %14 = fcmp oeq double %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = fcmp oeq double %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = fcmp oeq double %6, %13 
-  ret i1 %15 
+  %11 = fcmp oeq double %4, %9 
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -179,12 +175,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to double* 
-  %4 = getelementptr  double, double* %3, i64 0 
-  store  double %"x##0", double* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to double* 
-  %7 = getelementptr  double, double* %6, i64 0 
-  store  double %"y##0", double* %7 
+  store  double %"x##0", double* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to double* 
+  store  double %"y##0", double* %5 
   ret i64 %2 
 }
 
@@ -192,24 +186,21 @@ entry:
 define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to double* 
-  %1 = getelementptr  double, double* %0, i64 0 
-  %2 = load  double, double* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to double* 
-  %5 = getelementptr  double, double* %4, i64 0 
-  %6 = load  double, double* %5 
-  %7 = insertvalue {double, double} undef, double %2, 0 
-  %8 = insertvalue {double, double} %7, double %6, 1 
-  ret {double, double} %8 
+  %1 = load  double, double* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to double* 
+  %4 = load  double, double* %3 
+  %5 = insertvalue {double, double} undef, double %1, 0 
+  %6 = insertvalue {double, double} %5, double %4, 1 
+  ret {double, double} %6 
 }
 
 
 define external fastcc  double @"position_float.position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to double* 
-  %1 = getelementptr  double, double* %0, i64 0 
-  %2 = load  double, double* %1 
-  ret double %2 
+  %1 = load  double, double* %0 
+  ret double %1 
 }
 
 
@@ -223,8 +214,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to double* 
-  %7 = getelementptr  double, double* %6, i64 0 
-  store  double %"#field##0", double* %7 
+  store  double %"#field##0", double* %6 
   ret i64 %2 
 }
 
@@ -233,9 +223,8 @@ define external fastcc  double @"position_float.position.y<0>"(i64  %"#rec##0") 
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to double* 
-  %2 = getelementptr  double, double* %1, i64 0 
-  %3 = load  double, double* %2 
-  ret double %3 
+  %2 = load  double, double* %1 
+  ret double %2 
 }
 
 
@@ -250,8 +239,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to double* 
-  %8 = getelementptr  double, double* %7, i64 0 
-  store  double %"#field##0", double* %8 
+  store  double %"#field##0", double* %7 
   ret i64 %2 
 }
 
@@ -259,26 +247,22 @@ entry:
 define external fastcc  i1 @"position_float.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to double* 
-  %1 = getelementptr  double, double* %0, i64 0 
-  %2 = load  double, double* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to double* 
-  %5 = getelementptr  double, double* %4, i64 0 
+  %1 = load  double, double* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to double* 
+  %4 = load  double, double* %3 
+  %5 = inttoptr i64 %"#right##0" to double* 
   %6 = load  double, double* %5 
-  %7 = inttoptr i64 %"#right##0" to double* 
-  %8 = getelementptr  double, double* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to double* 
   %9 = load  double, double* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to double* 
-  %12 = getelementptr  double, double* %11, i64 0 
-  %13 = load  double, double* %12 
-  %14 = fcmp oeq double %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = fcmp oeq double %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = fcmp oeq double %6, %13 
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = fcmp oeq double %4, %9 
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -862,29 +862,25 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#8##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#8##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"tmp#9##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#8##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"tmp#9##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
-  %9 = inttoptr i64 %"tmp#9##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"tmp#9##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"tmp#9##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"tmp#9##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %11)  
+  tail call ccc  void  @print_int(i64  %8)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %7, i64  %15, i64  %"x##0", i64  %"y##0")  
+  musttail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %5, i64  %11, i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else1:
   ret void 
@@ -897,22 +893,20 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#5##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, 3 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
   ret void 
 if.else1:
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 }
 
@@ -923,23 +917,21 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#5##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp slt i64 %3, 3 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp slt i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 if.else1:
-  musttail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 }
 
@@ -950,20 +942,18 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#5##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp slt i64 %3, 3 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp slt i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 if.else1:
   ret void 
@@ -1030,29 +1020,25 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#8##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#8##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"tmp#9##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#8##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"tmp#9##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
-  %9 = inttoptr i64 %"tmp#9##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"tmp#9##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"tmp#9##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"tmp#9##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %11)  
+  tail call ccc  void  @print_int(i64  %8)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#3<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %7, i64  %15, i64  %"x##0", i64  %"y##0")  
+  musttail call fastcc  void  @"stmt_for.gen#3<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %5, i64  %11, i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else1:
   ret void 
@@ -1065,15 +1051,13 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#4##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#4##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  tail call ccc  void  @print_int(i64  %3)  
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#4##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %5, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -1086,22 +1070,20 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#5##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, 3 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
   ret void 
 if.else1:
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#5<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#5<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 }
 
@@ -1146,23 +1128,21 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#5##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp eq i64 %3, 3 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
-  musttail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 if.else1:
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 }
 
@@ -1173,23 +1153,21 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tmp#5##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp slt i64 %3, 3 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp slt i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
-  musttail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 if.else1:
-  tail call ccc  void  @print_int(i64  %3)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %7, i64  %"x##0")  
+  musttail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
   ret void 
 }
 
@@ -1204,34 +1182,28 @@ if.then:
   %3 = tail call ccc  i8*  @wybe_malloc(i32  %2)  
   %4 = ptrtoint i8* %3 to i64 
   %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  store  i64 %"start##0", i64* %6 
-  %7 = add   i64 %4, 8 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"stride##0", i64* %9 
-  %10 = add   i64 %4, 16 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %1, i64* %12 
+  store  i64 %"start##0", i64* %5 
+  %6 = add   i64 %4, 8 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"stride##0", i64* %7 
+  %8 = add   i64 %4, 16 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %1, i64* %9 
   ret i64 %4 
 if.else:
-  %13 = add   i64 %"end##0", 1 
-  %14 = trunc i64 24 to i32  
-  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
-  %16 = ptrtoint i8* %15 to i64 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"start##0", i64* %18 
-  %19 = add   i64 %16, 8 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 %"stride##0", i64* %21 
-  %22 = add   i64 %16, 16 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  store  i64 %13, i64* %24 
-  ret i64 %16 
+  %10 = add   i64 %"end##0", 1 
+  %11 = trunc i64 24 to i32  
+  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
+  %13 = ptrtoint i8* %12 to i64 
+  %14 = inttoptr i64 %13 to i64* 
+  store  i64 %"start##0", i64* %14 
+  %15 = add   i64 %13, 8 
+  %16 = inttoptr i64 %15 to i64* 
+  store  i64 %"stride##0", i64* %16 
+  %17 = add   i64 %13, 16 
+  %18 = inttoptr i64 %17 to i64* 
+  store  i64 %10, i64* %18 
+  ret i64 %13 
 }
 
 
@@ -1241,63 +1213,51 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 3, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 1, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 6, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 0, i64* %23 
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
   %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 6, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 0, i64* %31 
-  %32 = trunc i64 16 to i32  
-  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
-  %34 = ptrtoint i8* %33 to i64 
+  store  i64 5, i64* %27 
+  %28 = add   i64 %26, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  store  i64 %20, i64* %29 
+  %30 = trunc i64 16 to i32  
+  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
+  %32 = ptrtoint i8* %31 to i64 
+  %33 = inttoptr i64 %32 to i64* 
+  store  i64 4, i64* %33 
+  %34 = add   i64 %32, 8 
   %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 5, i64* %36 
-  %37 = add   i64 %34, 8 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %26, i64* %39 
-  %40 = trunc i64 16 to i32  
-  %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
-  %42 = ptrtoint i8* %41 to i64 
-  %43 = inttoptr i64 %42 to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  store  i64 4, i64* %44 
-  %45 = add   i64 %42, 8 
-  %46 = inttoptr i64 %45 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %34, i64* %47 
-  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %18, i64  %10, i64  %2, i64  0, i64  %42, i64  %34, i64  %26, i64  0, i64  %18, i64  %42, i64  %18, i64  %42)  
+  store  i64 %26, i64* %35 
+  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %14, i64  %8, i64  %2, i64  0, i64  %32, i64  %26, i64  %20, i64  0, i64  %14, i64  %32, i64  %14, i64  %32)  
   ret void 
 }
 
@@ -1316,63 +1276,51 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 4, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 4, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 3, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 %14, i64* %23 
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
   %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 1, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %18, i64* %31 
-  %32 = trunc i64 16 to i32  
-  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
-  %34 = ptrtoint i8* %33 to i64 
+  store  i64 5, i64* %27 
+  %28 = add   i64 %26, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  store  i64 0, i64* %29 
+  %30 = trunc i64 16 to i32  
+  %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
+  %32 = ptrtoint i8* %31 to i64 
+  %33 = inttoptr i64 %32 to i64* 
+  store  i64 4, i64* %33 
+  %34 = add   i64 %32, 8 
   %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 5, i64* %36 
-  %37 = add   i64 %34, 8 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 0, i64* %39 
-  %40 = trunc i64 16 to i32  
-  %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
-  %42 = ptrtoint i8* %41 to i64 
-  %43 = inttoptr i64 %42 to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  store  i64 4, i64* %44 
-  %45 = add   i64 %42, 8 
-  %46 = inttoptr i64 %45 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %34, i64* %47 
-  tail call fastcc  void  @"stmt_for.gen#3<0>"(i64  %26, i64  %18, i64  %10, i64  %2, i64  0, i64  %42, i64  %34, i64  0, i64  %26, i64  %42, i64  %26, i64  %42)  
+  store  i64 %26, i64* %35 
+  tail call fastcc  void  @"stmt_for.gen#3<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %32, i64  %26, i64  0, i64  %20, i64  %32, i64  %20, i64  %32)  
   ret void 
 }
 
@@ -1383,33 +1331,27 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 3, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 1, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  tail call fastcc  void  @"stmt_for.gen#4<0>"(i64  %18, i64  %10, i64  %2, i64  0, i64  %18, i64  %18)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  tail call fastcc  void  @"stmt_for.gen#4<0>"(i64  %14, i64  %8, i64  %2, i64  0, i64  %14, i64  %14)  
   ret void 
 }
 
@@ -1420,43 +1362,35 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 4, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 4, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 3, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 1, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %18, i64* %31 
-  tail call fastcc  void  @"stmt_for.gen#5<0>"(i64  %26, i64  %18, i64  %10, i64  %2, i64  0, i64  %26, i64  %26)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 %14, i64* %23 
+  tail call fastcc  void  @"stmt_for.gen#5<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
   ret void 
 }
 
@@ -1483,43 +1417,35 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 4, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 4, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 3, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 1, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %18, i64* %31 
-  tail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %26, i64  %18, i64  %10, i64  %2, i64  0, i64  %26, i64  %26)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 %14, i64* %23 
+  tail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
   ret void 
 }
 
@@ -1530,43 +1456,35 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 4, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 4, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 3, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 1, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %18, i64* %31 
-  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %26, i64  %18, i64  %10, i64  %2, i64  0, i64  %26, i64  %26)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 %14, i64* %23 
+  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
   ret void 
 }
 
@@ -1577,43 +1495,35 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 4, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 4, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 3, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 1, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %18, i64* %31 
-  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %26, i64  %18, i64  %10, i64  %2, i64  0, i64  %26, i64  %26)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 %14, i64* %23 
+  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
   ret void 
 }
 
@@ -1624,43 +1534,35 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 4, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 4, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 3, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 1, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %18, i64* %31 
-  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %26, i64  %18, i64  %10, i64  %2, i64  0, i64  %26, i64  %26)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 %14, i64* %23 
+  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
   ret void 
 }
 
@@ -1671,43 +1573,35 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 4, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 4, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 3, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 2, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 1, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %18, i64* %31 
-  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %26, i64  %18, i64  %10, i64  %2, i64  0, i64  %26, i64  %26)  
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 2, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 1, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 %14, i64* %23 
+  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
   ret void 
 }
 
@@ -1734,16 +1628,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"start##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"stride##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"end##0", i64* %10 
+  store  i64 %"start##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"stride##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"end##0", i64* %7 
   ret i64 %2 
 }
 --------------------------------------------------
@@ -1953,37 +1844,31 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"stmt_for.int_sequence.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#left##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %"#right##0" to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"#right##0", 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#right##0", 16 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = icmp eq i64 %2, %13 
-  br i1 %22, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#left##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %"#right##0", 8 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"#right##0", 16 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = icmp eq i64 %1, %9 
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  %23 = icmp eq i64 %6, %17 
-  br i1 %23, label %if.then1, label %if.else1 
+  %17 = icmp eq i64 %4, %12 
+  br i1 %17, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %24 = icmp eq i64 %10, %21 
-  ret i1 %24 
+  %18 = icmp eq i64 %7, %15 
+  ret i1 %18 
 if.else1:
   ret i1 0 
 }
@@ -1992,52 +1877,49 @@ if.else1:
 define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.[|]<0>"(i64  %"current##0")    {
 entry:
   %0 = inttoptr i64 %"current##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"current##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"current##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = icmp slt i64 %6, 0 
-  br i1 %11, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"current##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"current##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = icmp slt i64 %4, 0 
+  br i1 %8, label %if.then, label %if.else 
 if.then:
-  %12 = icmp slt i64 %10, %2 
-  br i1 %12, label %if.then1, label %if.else1 
+  %9 = icmp slt i64 %7, %1 
+  br i1 %9, label %if.then1, label %if.else1 
 if.else:
-  %23 = icmp sgt i64 %10, %2 
-  br i1 %23, label %if.then2, label %if.else2 
+  %20 = icmp sgt i64 %7, %1 
+  br i1 %20, label %if.then2, label %if.else2 
 if.then1:
-  %13 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen#1<0>"(i64  %10, i64  %2, i64  %6)  
-  %14 = extractvalue {i64, i64, i1} %13, 0 
-  %15 = extractvalue {i64, i64, i1} %13, 1 
-  %16 = extractvalue {i64, i64, i1} %13, 2 
-  %17 = insertvalue {i64, i64, i1} undef, i64 %14, 0 
-  %18 = insertvalue {i64, i64, i1} %17, i64 %15, 1 
-  %19 = insertvalue {i64, i64, i1} %18, i1 %16, 2 
-  ret {i64, i64, i1} %19 
+  %10 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen#1<0>"(i64  %7, i64  %1, i64  %4)  
+  %11 = extractvalue {i64, i64, i1} %10, 0 
+  %12 = extractvalue {i64, i64, i1} %10, 1 
+  %13 = extractvalue {i64, i64, i1} %10, 2 
+  %14 = insertvalue {i64, i64, i1} undef, i64 %11, 0 
+  %15 = insertvalue {i64, i64, i1} %14, i64 %12, 1 
+  %16 = insertvalue {i64, i64, i1} %15, i1 %13, 2 
+  ret {i64, i64, i1} %16 
 if.else1:
-  %20 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %21 = insertvalue {i64, i64, i1} %20, i64 undef, 1 
-  %22 = insertvalue {i64, i64, i1} %21, i1 0, 2 
-  ret {i64, i64, i1} %22 
+  %17 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %18 = insertvalue {i64, i64, i1} %17, i64 undef, 1 
+  %19 = insertvalue {i64, i64, i1} %18, i1 0, 2 
+  ret {i64, i64, i1} %19 
 if.then2:
-  %24 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen#1<0>"(i64  %10, i64  %2, i64  %6)  
-  %25 = extractvalue {i64, i64, i1} %24, 0 
-  %26 = extractvalue {i64, i64, i1} %24, 1 
-  %27 = extractvalue {i64, i64, i1} %24, 2 
-  %28 = insertvalue {i64, i64, i1} undef, i64 %25, 0 
-  %29 = insertvalue {i64, i64, i1} %28, i64 %26, 1 
-  %30 = insertvalue {i64, i64, i1} %29, i1 %27, 2 
-  ret {i64, i64, i1} %30 
+  %21 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen#1<0>"(i64  %7, i64  %1, i64  %4)  
+  %22 = extractvalue {i64, i64, i1} %21, 0 
+  %23 = extractvalue {i64, i64, i1} %21, 1 
+  %24 = extractvalue {i64, i64, i1} %21, 2 
+  %25 = insertvalue {i64, i64, i1} undef, i64 %22, 0 
+  %26 = insertvalue {i64, i64, i1} %25, i64 %23, 1 
+  %27 = insertvalue {i64, i64, i1} %26, i1 %24, 2 
+  ret {i64, i64, i1} %27 
 if.else2:
-  %31 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %32 = insertvalue {i64, i64, i1} %31, i64 undef, 1 
-  %33 = insertvalue {i64, i64, i1} %32, i1 0, 2 
-  ret {i64, i64, i1} %33 
+  %28 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %29 = insertvalue {i64, i64, i1} %28, i64 undef, 1 
+  %30 = insertvalue {i64, i64, i1} %29, i1 0, 2 
+  ret {i64, i64, i1} %30 
 }
 
 
@@ -2045,9 +1927,8 @@ define external fastcc  i64 @"stmt_for.int_sequence.end<0>"(i64  %"#rec##0")    
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -2062,8 +1943,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 16 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -2075,20 +1955,17 @@ entry:
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %0, i64* %5 
-  %6 = add   i64 %3, 8 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"st##0", i64* %8 
-  %9 = add   i64 %3, 16 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 %"en##0", i64* %11 
-  %12 = insertvalue {i64, i64, i1} undef, i64 %"s##0", 0 
-  %13 = insertvalue {i64, i64, i1} %12, i64 %3, 1 
-  %14 = insertvalue {i64, i64, i1} %13, i1 1, 2 
-  ret {i64, i64, i1} %14 
+  store  i64 %0, i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %"st##0", i64* %6 
+  %7 = add   i64 %3, 16 
+  %8 = inttoptr i64 %7 to i64* 
+  store  i64 %"en##0", i64* %8 
+  %9 = insertvalue {i64, i64, i1} undef, i64 %"s##0", 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 %3, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 1, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -2098,16 +1975,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"start##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"stride##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"end##0", i64* %10 
+  store  i64 %"start##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"stride##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"end##0", i64* %7 
   ret i64 %2 
 }
 
@@ -2115,29 +1989,25 @@ entry:
 define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#result##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = insertvalue {i64, i64, i64} undef, i64 %2, 0 
-  %12 = insertvalue {i64, i64, i64} %11, i64 %6, 1 
-  %13 = insertvalue {i64, i64, i64} %12, i64 %10, 2 
-  ret {i64, i64, i64} %13 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#result##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = insertvalue {i64, i64, i64} undef, i64 %1, 0 
+  %9 = insertvalue {i64, i64, i64} %8, i64 %4, 1 
+  %10 = insertvalue {i64, i64, i64} %9, i64 %7, 2 
+  ret {i64, i64, i64} %10 
 }
 
 
 define external fastcc  i64 @"stmt_for.int_sequence.start<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -2151,8 +2021,7 @@ entry:
   %5 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -2161,9 +2030,8 @@ define external fastcc  i64 @"stmt_for.int_sequence.stride<0>"(i64  %"#rec##0") 
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -2178,8 +2046,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -2187,40 +2054,34 @@ entry:
 define external fastcc  i1 @"stmt_for.int_sequence.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#left##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %"#right##0" to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"#right##0", 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#right##0", 16 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = icmp eq i64 %2, %13 
-  br i1 %22, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#left##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %"#right##0", 8 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"#right##0", 16 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = icmp eq i64 %1, %9 
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  %23 = icmp eq i64 %6, %17 
-  br i1 %23, label %if.then1, label %if.else1 
+  %17 = icmp eq i64 %4, %12 
+  br i1 %17, label %if.then1, label %if.else1 
 if.else:
-  %27 = xor i1 0, 1 
-  ret i1 %27 
+  %21 = xor i1 0, 1 
+  ret i1 %21 
 if.then1:
-  %24 = icmp eq i64 %10, %21 
-  %25 = xor i1 %24, 1 
-  ret i1 %25 
+  %18 = icmp eq i64 %7, %15 
+  %19 = xor i1 %18, 1 
+  ret i1 %19 
 if.else1:
-  %26 = xor i1 0, 1 
-  ret i1 %26 
+  %20 = xor i1 0, 1 
+  ret i1 %20 
 }

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -151,18 +151,15 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 0, i64* %10 
-  %11 = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  1, i64  %2)  
-  br i1 %11, label %if.then, label %if.else 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 0, i64* %7 
+  %8 = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  1, i64  %2)  
+  br i1 %8, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -197,31 +194,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"tree##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"tree##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"tree##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp eq i64 %"key##0", %7 
-  br i1 %12, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tree##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"tree##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = icmp eq i64 %"key##0", %5 
+  br i1 %9, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
   ret i1 1 
 if.else1:
-  %13 = icmp slt i64 %"key##0", %7 
-  br i1 %13, label %if.then2, label %if.else2 
+  %10 = icmp slt i64 %"key##0", %5 
+  br i1 %10, label %if.then2, label %if.else2 
 if.then2:
-  %14 = musttail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %3)  
-  ret i1 %14 
+  %11 = musttail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %2)  
+  ret i1 %11 
 if.else2:
-  %15 = musttail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %11)  
-  ret i1 %15 
+  %12 = musttail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %8)  
+  ret i1 %12 
 }
 --------------------------------------------------
  Module stmt_if.tree
@@ -448,45 +442,39 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#left##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp ne i64 %"#right##0", 0 
-  br i1 %12, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#left##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = icmp ne i64 %"#right##0", 0 
+  br i1 %9, label %if.then1, label %if.else1 
 if.else:
-  %27 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %27 
+  %21 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %21 
 if.then1:
-  %13 = inttoptr i64 %"#right##0" to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = add   i64 %"#right##0", 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
-  %20 = add   i64 %"#right##0", 16 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %3, i64  %15)  
-  br i1 %24, label %if.then2, label %if.else2 
+  %10 = inttoptr i64 %"#right##0" to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"#right##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#right##0", 16 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %2, i64  %11)  
+  br i1 %18, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %25 = icmp eq i64 %7, %19 
-  br i1 %25, label %if.then3, label %if.else3 
+  %19 = icmp eq i64 %5, %14 
+  br i1 %19, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %26 = musttail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %11, i64  %23)  
-  ret i1 %26 
+  %20 = musttail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %8, i64  %17)  
+  ret i1 %20 
 if.else3:
   ret i1 0 
 }
@@ -505,15 +493,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -531,15 +518,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -549,15 +535,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -574,15 +559,14 @@ if.then:
   %6 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -592,16 +576,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"left##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"key##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"right##0", i64* %10 
+  store  i64 %"left##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"key##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"right##0", i64* %7 
   ret i64 %2 
 }
 
@@ -612,27 +593,24 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#result##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i64, i64, i1} undef, i64 %3, 0 
-  %13 = insertvalue {i64, i64, i64, i1} %12, i64 %7, 1 
-  %14 = insertvalue {i64, i64, i64, i1} %13, i64 %11, 2 
-  %15 = insertvalue {i64, i64, i64, i1} %14, i1 1, 3 
-  ret {i64, i64, i64, i1} %15 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = insertvalue {i64, i64, i64, i1} undef, i64 %2, 0 
+  %10 = insertvalue {i64, i64, i64, i1} %9, i64 %5, 1 
+  %11 = insertvalue {i64, i64, i64, i1} %10, i64 %8, 2 
+  %12 = insertvalue {i64, i64, i64, i1} %11, i1 1, 3 
+  ret {i64, i64, i64, i1} %12 
 if.else:
-  %16 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %17 = insertvalue {i64, i64, i64, i1} %16, i64 undef, 1 
-  %18 = insertvalue {i64, i64, i64, i1} %17, i64 undef, 2 
-  %19 = insertvalue {i64, i64, i64, i1} %18, i1 0, 3 
-  ret {i64, i64, i64, i1} %19 
+  %13 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %14 = insertvalue {i64, i64, i64, i1} %13, i64 undef, 1 
+  %15 = insertvalue {i64, i64, i64, i1} %14, i64 undef, 2 
+  %16 = insertvalue {i64, i64, i64, i1} %15, i1 0, 3 
+  ret {i64, i64, i64, i1} %16 
 }
 
 
@@ -643,15 +621,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 16 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -669,15 +646,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 16 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -116,18 +116,15 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 0, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 1, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 0, i64* %10 
-  %11 = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  1, i64  %2)  
-  br i1 %11, label %if.then, label %if.else 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 0, i64* %7 
+  %8 = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  1, i64  %2)  
+  br i1 %8, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if2.1, i32 0, i32 0) to i64))  
   ret void 
@@ -153,31 +150,28 @@ if.else:
   br i1 %1, label %if.then1, label %if.else1 
 if.then1:
   %2 = inttoptr i64 %"tree##0" to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"tree##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  %8 = load  i64, i64* %7 
-  %9 = add   i64 %"tree##0", 16 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  %12 = load  i64, i64* %11 
-  %13 = icmp eq i64 %8, %"key##0" 
-  br i1 %13, label %if.then2, label %if.else2 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"tree##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  %7 = add   i64 %"tree##0", 16 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = icmp eq i64 %6, %"key##0" 
+  br i1 %10, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
   ret i1 1 
 if.else2:
-  %14 = icmp sgt i64 %8, %"key##0" 
-  br i1 %14, label %if.then3, label %if.else3 
+  %11 = icmp sgt i64 %6, %"key##0" 
+  br i1 %11, label %if.then3, label %if.else3 
 if.then3:
-  %15 = musttail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %4)  
-  ret i1 %15 
+  %12 = musttail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %3)  
+  ret i1 %12 
 if.else3:
-  %16 = musttail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %12)  
-  ret i1 %16 
+  %13 = musttail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %9)  
+  ret i1 %13 
 }
 --------------------------------------------------
  Module stmt_if2.tree
@@ -404,45 +398,39 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#left##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = icmp ne i64 %"#right##0", 0 
-  br i1 %12, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#left##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = icmp ne i64 %"#right##0", 0 
+  br i1 %9, label %if.then1, label %if.else1 
 if.else:
-  %27 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %27 
+  %21 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %21 
 if.then1:
-  %13 = inttoptr i64 %"#right##0" to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = add   i64 %"#right##0", 8 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
-  %20 = add   i64 %"#right##0", 16 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %24 = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %3, i64  %15)  
-  br i1 %24, label %if.then2, label %if.else2 
+  %10 = inttoptr i64 %"#right##0" to i64* 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"#right##0", 8 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#right##0", 16 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %2, i64  %11)  
+  br i1 %18, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %25 = icmp eq i64 %7, %19 
-  br i1 %25, label %if.then3, label %if.else3 
+  %19 = icmp eq i64 %5, %14 
+  br i1 %19, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %26 = musttail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %11, i64  %23)  
-  ret i1 %26 
+  %20 = musttail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %8, i64  %17)  
+  ret i1 %20 
 if.else3:
   ret i1 0 
 }
@@ -461,15 +449,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -487,15 +474,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -505,15 +491,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -530,15 +515,14 @@ if.then:
   %6 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -548,16 +532,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"left##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"key##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"right##0", i64* %10 
+  store  i64 %"left##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"key##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"right##0", i64* %7 
   ret i64 %2 
 }
 
@@ -568,27 +549,24 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#result##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i64, i64, i1} undef, i64 %3, 0 
-  %13 = insertvalue {i64, i64, i64, i1} %12, i64 %7, 1 
-  %14 = insertvalue {i64, i64, i64, i1} %13, i64 %11, 2 
-  %15 = insertvalue {i64, i64, i64, i1} %14, i1 1, 3 
-  ret {i64, i64, i64, i1} %15 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = insertvalue {i64, i64, i64, i1} undef, i64 %2, 0 
+  %10 = insertvalue {i64, i64, i64, i1} %9, i64 %5, 1 
+  %11 = insertvalue {i64, i64, i64, i1} %10, i64 %8, 2 
+  %12 = insertvalue {i64, i64, i64, i1} %11, i1 1, 3 
+  ret {i64, i64, i64, i1} %12 
 if.else:
-  %16 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
-  %17 = insertvalue {i64, i64, i64, i1} %16, i64 undef, 1 
-  %18 = insertvalue {i64, i64, i64, i1} %17, i64 undef, 2 
-  %19 = insertvalue {i64, i64, i64, i1} %18, i1 0, 3 
-  ret {i64, i64, i64, i1} %19 
+  %13 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
+  %14 = insertvalue {i64, i64, i64, i1} %13, i64 undef, 1 
+  %15 = insertvalue {i64, i64, i64, i1} %14, i64 undef, 2 
+  %16 = insertvalue {i64, i64, i64, i1} %15, i1 0, 3 
+  ret {i64, i64, i64, i1} %16 
 }
 
 
@@ -599,15 +577,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 16 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -625,15 +602,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 16 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -122,23 +122,19 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 90048, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.1, i32 0, i32 0) to i64), i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 90048, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.1, i32 0, i32 0) to i64), i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 12345, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 12345, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %10)  
+  store  i64 %2, i64* %11 
+  tail call fastcc  void  @"student.printStudent<0>"(i64  %8)  
   ret void 
 }
 
@@ -147,26 +143,22 @@ define external fastcc  void @"student.printStudent<0>"(i64  %"stu##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.3, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"stu##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  tail call ccc  void  @print_int(i64  %2)  
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
   tail call ccc  void  @putchar(i8  10)  
-  %3 = add   i64 %"stu##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
+  %2 = add   i64 %"stu##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.5, i32 0, i32 0) to i64))  
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  tail call ccc  void  @print_int(i64  %9)  
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  tail call ccc  void  @print_int(i64  %6)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.7, i32 0, i32 0) to i64))  
-  %10 = add   i64 %6, 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %13)  
+  %7 = add   i64 %4, 8 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  %9)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -292,24 +284,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"student.course.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  ret i1 %15 
+  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  ret i1 %11 
 if.else:
   ret i1 0 
 }
@@ -318,9 +306,8 @@ if.else:
 define external fastcc  i64 @"student.course.code<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -334,8 +321,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -346,12 +332,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"code##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"name##0", i64* %7 
+  store  i64 %"code##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"name##0", i64* %5 
   ret i64 %2 
 }
 
@@ -359,15 +343,13 @@ entry:
 define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
@@ -375,9 +357,8 @@ define external fastcc  i64 @"student.course.name<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -392,8 +373,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -401,28 +381,24 @@ entry:
 define external fastcc  i1 @"student.course.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %6, i64  %13)  
-  %16 = xor i1 %15, 1 
-  ret i1 %16 
+  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
+  %12 = xor i1 %11, 1 
+  ret i1 %12 
 if.else:
-  %17 = xor i1 0, 1 
-  ret i1 %17 
+  %13 = xor i1 0, 1 
+  ret i1 %13 
 }
 --------------------------------------------------
  Module student.student
@@ -569,43 +545,35 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"student.student.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = inttoptr i64 %6 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
+  %11 = inttoptr i64 %4 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %4, 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = inttoptr i64 %9 to i64* 
   %17 = load  i64, i64* %16 
-  %18 = add   i64 %6, 8 
+  %18 = add   i64 %9, 8 
   %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = inttoptr i64 %13 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = add   i64 %13, 8 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %29 = icmp eq i64 %24, %17 
-  br i1 %29, label %if.then1, label %if.else1 
+  %20 = load  i64, i64* %19 
+  %21 = icmp eq i64 %17, %12 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %30 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %21, i64  %28)  
-  ret i1 %30 
+  %22 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %15, i64  %20)  
+  ret i1 %22 
 if.else1:
   ret i1 0 
 }
@@ -614,9 +582,8 @@ if.else1:
 define external fastcc  i64 @"student.student.id<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -630,8 +597,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -640,9 +606,8 @@ define external fastcc  i64 @"student.student.major<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -657,8 +622,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -669,12 +633,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"id##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"major##0", i64* %7 
+  store  i64 %"id##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"major##0", i64* %5 
   ret i64 %2 
 }
 
@@ -682,61 +644,51 @@ entry:
 define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i1 @"student.student.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = inttoptr i64 %"#right##0" to i64* 
   %6 = load  i64, i64* %5 
-  %7 = inttoptr i64 %"#right##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
+  %7 = add   i64 %"#right##0", 8 
+  %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = add   i64 %"#right##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = icmp eq i64 %2, %9 
-  br i1 %14, label %if.then, label %if.else 
+  %10 = icmp eq i64 %1, %6 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
-  %15 = inttoptr i64 %6 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
+  %11 = inttoptr i64 %4 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %4, 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = inttoptr i64 %9 to i64* 
   %17 = load  i64, i64* %16 
-  %18 = add   i64 %6, 8 
+  %18 = add   i64 %9, 8 
   %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = inttoptr i64 %13 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = add   i64 %13, 8 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %29 = icmp eq i64 %24, %17 
-  br i1 %29, label %if.then1, label %if.else1 
+  %20 = load  i64, i64* %19 
+  %21 = icmp eq i64 %17, %12 
+  br i1 %21, label %if.then1, label %if.else1 
 if.else:
-  %33 = xor i1 0, 1 
-  ret i1 %33 
+  %25 = xor i1 0, 1 
+  ret i1 %25 
 if.then1:
-  %30 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %21, i64  %28)  
-  %31 = xor i1 %30, 1 
-  ret i1 %31 
+  %22 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %15, i64  %20)  
+  %23 = xor i1 %22, 1 
+  ret i1 %23 
 if.else1:
-  %32 = xor i1 0, 1 
-  ret i1 %32 
+  %24 = xor i1 0, 1 
+  ret i1 %24 
 }

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -181,25 +181,22 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 2, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 2, i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 10, i64* %10 
-  %11 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %2)  
-  %12 = extractvalue {i64, i1} %11, 0 
-  %13 = extractvalue {i64, i1} %11, 1 
-  br i1 %13, label %if.then, label %if.else 
+  store  i64 2, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 2, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 10, i64* %7 
+  %8 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %2)  
+  %9 = extractvalue {i64, i1} %8, 0 
+  %10 = extractvalue {i64, i1} %8, 1 
+  br i1 %10, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"modulus##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %12)  
+  tail call ccc  void  @print_int(i64  %9)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
@@ -459,37 +456,31 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  i1 @"test_loop.int_seq.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#left##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %"#right##0" to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"#right##0", 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#right##0", 16 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = icmp eq i64 %2, %13 
-  br i1 %22, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#left##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %"#right##0", 8 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"#right##0", 16 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = icmp eq i64 %1, %9 
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  %23 = icmp eq i64 %6, %17 
-  br i1 %23, label %if.then1, label %if.else1 
+  %17 = icmp eq i64 %4, %12 
+  br i1 %17, label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %24 = icmp eq i64 %10, %21 
-  ret i1 %24 
+  %18 = icmp eq i64 %7, %15 
+  ret i1 %18 
 if.else1:
   ret i1 0 
 }
@@ -499,9 +490,8 @@ define external fastcc  i64 @"test_loop.int_seq.high<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -516,8 +506,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 16 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -528,16 +517,13 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"low##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"step##0", i64* %7 
-  %8 = add   i64 %2, 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"high##0", i64* %10 
+  store  i64 %"low##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"step##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"high##0", i64* %7 
   ret i64 %2 
 }
 
@@ -545,29 +531,25 @@ entry:
 define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#result##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = insertvalue {i64, i64, i64} undef, i64 %2, 0 
-  %12 = insertvalue {i64, i64, i64} %11, i64 %6, 1 
-  %13 = insertvalue {i64, i64, i64} %12, i64 %10, 2 
-  ret {i64, i64, i64} %13 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#result##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = insertvalue {i64, i64, i64} undef, i64 %1, 0 
+  %9 = insertvalue {i64, i64, i64} %8, i64 %4, 1 
+  %10 = insertvalue {i64, i64, i64} %9, i64 %7, 2 
+  ret {i64, i64, i64} %10 
 }
 
 
 define external fastcc  i64 @"test_loop.int_seq.low<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -581,8 +563,7 @@ entry:
   %5 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -590,71 +571,63 @@ entry:
 define external fastcc  {i64, i64, i1} @"test_loop.int_seq.seq_next<0>"(i64  %"seq##0")    {
 entry:
   %0 = inttoptr i64 %"seq##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"seq##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"seq##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = icmp sle i64 %2, %10 
-  br i1 %11, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"seq##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"seq##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = icmp sle i64 %1, %7 
+  br i1 %8, label %if.then, label %if.else 
 if.then:
-  %12 = add   i64 %2, %6 
-  %13 = trunc i64 24 to i32  
-  %14 = tail call ccc  i8*  @wybe_malloc(i32  %13)  
-  %15 = ptrtoint i8* %14 to i64 
-  %16 = inttoptr i64 %15 to i8* 
-  %17 = inttoptr i64 %"seq##0" to i8* 
-  %18 = trunc i64 24 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %16, i8*  %17, i32  %18, i1  0)  
-  %19 = inttoptr i64 %15 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 %12, i64* %20 
-  %21 = insertvalue {i64, i64, i1} undef, i64 %15, 0 
-  %22 = insertvalue {i64, i64, i1} %21, i64 %2, 1 
-  %23 = insertvalue {i64, i64, i1} %22, i1 1, 2 
-  ret {i64, i64, i1} %23 
+  %9 = add   i64 %1, %4 
+  %10 = trunc i64 24 to i32  
+  %11 = tail call ccc  i8*  @wybe_malloc(i32  %10)  
+  %12 = ptrtoint i8* %11 to i64 
+  %13 = inttoptr i64 %12 to i8* 
+  %14 = inttoptr i64 %"seq##0" to i8* 
+  %15 = trunc i64 24 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %13, i8*  %14, i32  %15, i1  0)  
+  %16 = inttoptr i64 %12 to i64* 
+  store  i64 %9, i64* %16 
+  %17 = insertvalue {i64, i64, i1} undef, i64 %12, 0 
+  %18 = insertvalue {i64, i64, i1} %17, i64 %1, 1 
+  %19 = insertvalue {i64, i64, i1} %18, i1 1, 2 
+  ret {i64, i64, i1} %19 
 if.else:
-  %24 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
-  %25 = insertvalue {i64, i64, i1} %24, i64 %2, 1 
-  %26 = insertvalue {i64, i64, i1} %25, i1 0, 2 
-  ret {i64, i64, i1} %26 
+  %20 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
+  %21 = insertvalue {i64, i64, i1} %20, i64 %1, 1 
+  %22 = insertvalue {i64, i64, i1} %21, i1 0, 2 
+  ret {i64, i64, i1} %22 
 }
 
 
 define external fastcc  {i64, i64, i1} @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq##0")    {
 entry:
   %0 = inttoptr i64 %"seq##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"seq##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"seq##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = icmp sle i64 %2, %10 
-  br i1 %11, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"seq##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"seq##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = icmp sle i64 %1, %7 
+  br i1 %8, label %if.then, label %if.else 
 if.then:
-  %12 = add   i64 %2, %6 
-  %13 = inttoptr i64 %"seq##0" to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 %12, i64* %14 
-  %15 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
-  %16 = insertvalue {i64, i64, i1} %15, i64 %2, 1 
-  %17 = insertvalue {i64, i64, i1} %16, i1 1, 2 
-  ret {i64, i64, i1} %17 
+  %9 = add   i64 %1, %4 
+  %10 = inttoptr i64 %"seq##0" to i64* 
+  store  i64 %9, i64* %10 
+  %11 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
+  %12 = insertvalue {i64, i64, i1} %11, i64 %1, 1 
+  %13 = insertvalue {i64, i64, i1} %12, i1 1, 2 
+  ret {i64, i64, i1} %13 
 if.else:
-  %18 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
-  %19 = insertvalue {i64, i64, i1} %18, i64 %2, 1 
-  %20 = insertvalue {i64, i64, i1} %19, i1 0, 2 
-  ret {i64, i64, i1} %20 
+  %14 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
+  %15 = insertvalue {i64, i64, i1} %14, i64 %1, 1 
+  %16 = insertvalue {i64, i64, i1} %15, i1 0, 2 
+  ret {i64, i64, i1} %16 
 }
 
 
@@ -662,9 +635,8 @@ define external fastcc  i64 @"test_loop.int_seq.step<0>"(i64  %"#rec##0")    {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -679,8 +651,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }
 
@@ -688,40 +659,34 @@ entry:
 define external fastcc  i1 @"test_loop.int_seq.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#left##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = add   i64 %"#left##0", 16 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  %10 = load  i64, i64* %9 
-  %11 = inttoptr i64 %"#right##0" to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"#right##0", 8 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"#right##0", 16 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = icmp eq i64 %2, %13 
-  br i1 %22, label %if.then, label %if.else 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#left##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %"#left##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = inttoptr i64 %"#right##0" to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %"#right##0", 8 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = add   i64 %"#right##0", 16 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = icmp eq i64 %1, %9 
+  br i1 %16, label %if.then, label %if.else 
 if.then:
-  %23 = icmp eq i64 %6, %17 
-  br i1 %23, label %if.then1, label %if.else1 
+  %17 = icmp eq i64 %4, %12 
+  br i1 %17, label %if.then1, label %if.else1 
 if.else:
-  %27 = xor i1 0, 1 
-  ret i1 %27 
+  %21 = xor i1 0, 1 
+  ret i1 %21 
 if.then1:
-  %24 = icmp eq i64 %10, %21 
-  %25 = xor i1 %24, 1 
-  ret i1 %25 
+  %18 = icmp eq i64 %7, %15 
+  %19 = xor i1 %18, 1 
+  ret i1 %19 
 if.else1:
-  %26 = xor i1 0, 1 
-  ret i1 %26 
+  %20 = xor i1 0, 1 
+  ret i1 %20 
 }

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -112,46 +112,42 @@ entry:
 if.then:
   %1 = add   i64 %"map##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = icmp eq i64 %"key##0", %4 
-  br i1 %5, label %if.then1, label %if.else1 
+  %3 = load  i64, i64* %2 
+  %4 = icmp eq i64 %"key##0", %3 
+  br i1 %4, label %if.then1, label %if.else1 
 if.else:
-  %30 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %31 = insertvalue {i64, i1} %30, i1 0, 1 
-  ret {i64, i1} %31 
+  %26 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %27 = insertvalue {i64, i1} %26, i1 0, 1 
+  ret {i64, i1} %27 
 if.then1:
-  %6 = add   i64 %"map##0", 16 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = insertvalue {i64, i1} undef, i64 %9, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  %5 = add   i64 %"map##0", 16 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = load  i64, i64* %6 
+  %8 = insertvalue {i64, i1} undef, i64 %7, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else1:
-  %12 = icmp slt i64 %"key##0", %4 
-  br i1 %12, label %if.then2, label %if.else2 
+  %10 = icmp slt i64 %"key##0", %3 
+  br i1 %10, label %if.then2, label %if.else2 
 if.then2:
-  %13 = inttoptr i64 %"map##0" to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = tail call fastcc  {i64, i1}  @"tests.lookup<0>"(i64  %"key##0", i64  %15)  
-  %17 = extractvalue {i64, i1} %16, 0 
-  %18 = extractvalue {i64, i1} %16, 1 
-  %19 = insertvalue {i64, i1} undef, i64 %17, 0 
-  %20 = insertvalue {i64, i1} %19, i1 %18, 1 
-  ret {i64, i1} %20 
+  %11 = inttoptr i64 %"map##0" to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = tail call fastcc  {i64, i1}  @"tests.lookup<0>"(i64  %"key##0", i64  %12)  
+  %14 = extractvalue {i64, i1} %13, 0 
+  %15 = extractvalue {i64, i1} %13, 1 
+  %16 = insertvalue {i64, i1} undef, i64 %14, 0 
+  %17 = insertvalue {i64, i1} %16, i1 %15, 1 
+  ret {i64, i1} %17 
 if.else2:
-  %21 = add   i64 %"map##0", 24 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = tail call fastcc  {i64, i1}  @"tests.lookup<0>"(i64  %"key##0", i64  %24)  
-  %26 = extractvalue {i64, i1} %25, 0 
-  %27 = extractvalue {i64, i1} %25, 1 
-  %28 = insertvalue {i64, i1} undef, i64 %26, 0 
-  %29 = insertvalue {i64, i1} %28, i1 %27, 1 
-  ret {i64, i1} %29 
+  %18 = add   i64 %"map##0", 24 
+  %19 = inttoptr i64 %18 to i64* 
+  %20 = load  i64, i64* %19 
+  %21 = tail call fastcc  {i64, i1}  @"tests.lookup<0>"(i64  %"key##0", i64  %20)  
+  %22 = extractvalue {i64, i1} %21, 0 
+  %23 = extractvalue {i64, i1} %21, 1 
+  %24 = insertvalue {i64, i1} undef, i64 %22, 0 
+  %25 = insertvalue {i64, i1} %24, i1 %23, 1 
+  ret {i64, i1} %25 
 }
 
 
@@ -449,58 +445,50 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#left##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#left##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#left##0", 24 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#left##0", 24 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp ne i64 %"#right##0", 0 
-  br i1 %16, label %if.then1, label %if.else1 
+  %12 = icmp ne i64 %"#right##0", 0 
+  br i1 %12, label %if.then1, label %if.else1 
 if.else:
-  %36 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %36 
+  %28 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %28 
 if.then1:
-  %17 = inttoptr i64 %"#right##0" to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  %19 = load  i64, i64* %18 
-  %20 = add   i64 %"#right##0", 8 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
+  %13 = inttoptr i64 %"#right##0" to i64* 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"#right##0", 8 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = load  i64, i64* %16 
+  %18 = add   i64 %"#right##0", 16 
+  %19 = inttoptr i64 %18 to i64* 
+  %20 = load  i64, i64* %19 
+  %21 = add   i64 %"#right##0", 24 
+  %22 = inttoptr i64 %21 to i64* 
   %23 = load  i64, i64* %22 
-  %24 = add   i64 %"#right##0", 16 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %28 = add   i64 %"#right##0", 24 
-  %29 = inttoptr i64 %28 to i64* 
-  %30 = getelementptr  i64, i64* %29, i64 0 
-  %31 = load  i64, i64* %30 
-  %32 = tail call fastcc  i1  @"tests.map.=<0>"(i64  %3, i64  %19)  
-  br i1 %32, label %if.then2, label %if.else2 
+  %24 = tail call fastcc  i1  @"tests.map.=<0>"(i64  %2, i64  %14)  
+  br i1 %24, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %33 = icmp eq i64 %7, %23 
-  br i1 %33, label %if.then3, label %if.else3 
+  %25 = icmp eq i64 %5, %17 
+  br i1 %25, label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %34 = icmp eq i64 %11, %27 
-  br i1 %34, label %if.then4, label %if.else4 
+  %26 = icmp eq i64 %8, %20 
+  br i1 %26, label %if.then4, label %if.else4 
 if.else3:
   ret i1 0 
 if.then4:
-  %35 = musttail call fastcc  i1  @"tests.map.=<0>"(i64  %15, i64  %31)  
-  ret i1 %35 
+  %27 = musttail call fastcc  i1  @"tests.map.=<0>"(i64  %11, i64  %23)  
+  ret i1 %27 
 if.else4:
   ret i1 0 
 }
@@ -519,15 +507,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -545,15 +532,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -563,15 +549,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -588,15 +573,14 @@ if.then:
   %6 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -606,20 +590,16 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"left##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"key##0", i64* %7 
-  %8 = add   i64 %2, 16 
+  store  i64 %"left##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"key##0", i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 %"value##0", i64* %7 
+  %8 = add   i64 %2, 24 
   %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"value##0", i64* %10 
-  %11 = add   i64 %2, 24 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"right##0", i64* %13 
+  store  i64 %"right##0", i64* %9 
   ret i64 %2 
 }
 
@@ -630,33 +610,29 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = add   i64 %"#result##0", 16 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = add   i64 %"#result##0", 16 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#result##0", 24 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#result##0", 24 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = insertvalue {i64, i64, i64, i64, i1} undef, i64 %3, 0 
-  %17 = insertvalue {i64, i64, i64, i64, i1} %16, i64 %7, 1 
-  %18 = insertvalue {i64, i64, i64, i64, i1} %17, i64 %11, 2 
-  %19 = insertvalue {i64, i64, i64, i64, i1} %18, i64 %15, 3 
-  %20 = insertvalue {i64, i64, i64, i64, i1} %19, i1 1, 4 
-  ret {i64, i64, i64, i64, i1} %20 
+  %12 = insertvalue {i64, i64, i64, i64, i1} undef, i64 %2, 0 
+  %13 = insertvalue {i64, i64, i64, i64, i1} %12, i64 %5, 1 
+  %14 = insertvalue {i64, i64, i64, i64, i1} %13, i64 %8, 2 
+  %15 = insertvalue {i64, i64, i64, i64, i1} %14, i64 %11, 3 
+  %16 = insertvalue {i64, i64, i64, i64, i1} %15, i1 1, 4 
+  ret {i64, i64, i64, i64, i1} %16 
 if.else:
-  %21 = insertvalue {i64, i64, i64, i64, i1} undef, i64 undef, 0 
-  %22 = insertvalue {i64, i64, i64, i64, i1} %21, i64 undef, 1 
-  %23 = insertvalue {i64, i64, i64, i64, i1} %22, i64 undef, 2 
-  %24 = insertvalue {i64, i64, i64, i64, i1} %23, i64 undef, 3 
-  %25 = insertvalue {i64, i64, i64, i64, i1} %24, i1 0, 4 
-  ret {i64, i64, i64, i64, i1} %25 
+  %17 = insertvalue {i64, i64, i64, i64, i1} undef, i64 undef, 0 
+  %18 = insertvalue {i64, i64, i64, i64, i1} %17, i64 undef, 1 
+  %19 = insertvalue {i64, i64, i64, i64, i1} %18, i64 undef, 2 
+  %20 = insertvalue {i64, i64, i64, i64, i1} %19, i64 undef, 3 
+  %21 = insertvalue {i64, i64, i64, i64, i1} %20, i1 0, 4 
+  ret {i64, i64, i64, i64, i1} %21 
 }
 
 
@@ -667,15 +643,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 24 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -693,15 +668,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 24 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 
@@ -712,15 +686,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 16 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -738,15 +711,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 16 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -264,57 +264,47 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 3, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 1, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 200, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 0, i64* %23 
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
   %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 200, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 0, i64* %31 
-  %32 = trunc i64 16 to i32  
-  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
-  %34 = ptrtoint i8* %33 to i64 
-  %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 100, i64* %36 
-  %37 = add   i64 %34, 8 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %26, i64* %39 
-  %40 = alloca i64 
-   call fastcc  void  @"thistype.concat<0>[410bae77d3]"(i64  %18, i64  %34, i64*  %40)  
-  %41 = load  i64, i64* %40 
-  %42 = tail call fastcc  i64  @"thistype.length<0>"(i64  %41)  
-  tail call ccc  void  @print_int(i64  %42)  
+  store  i64 100, i64* %27 
+  %28 = add   i64 %26, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  store  i64 %20, i64* %29 
+  %30 = alloca i64 
+   call fastcc  void  @"thistype.concat<0>[410bae77d3]"(i64  %14, i64  %26, i64*  %30)  
+  %31 = load  i64, i64* %30 
+  %32 = tail call fastcc  i64  @"thistype.length<0>"(i64  %31)  
+  tail call ccc  void  @print_int(i64  %32)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -326,32 +316,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"#right##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"#right##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
-  %18 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %18 
+  %14 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %14 
 if.then1:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"#right##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#right##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#right##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp eq i64 %3, %11 
-  br i1 %16, label %if.then2, label %if.else2 
+  %12 = icmp eq i64 %2, %8 
+  br i1 %12, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %17 = musttail call fastcc  i1  @"thistype.=<0>"(i64  %7, i64  %15)  
-  ret i1 %17 
+  %13 = musttail call fastcc  i1  @"thistype.=<0>"(i64  %5, i64  %11)  
+  ret i1 %13 
 if.else2:
   ret i1 0 
 }
@@ -363,22 +349,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"x##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  store  i64 %10, i64* %"#result##0" 
-  musttail call fastcc  void  @"thistype.concat<0>"(i64  %7, i64  %"y##0", i64*  %14)  
+  store  i64 %8, i64* %"#result##0" 
+  musttail call fastcc  void  @"thistype.concat<0>"(i64  %5, i64  %"y##0", i64*  %11)  
   ret void 
 if.else:
   store  i64 %"y##0", i64* %"#result##0" 
@@ -393,12 +376,11 @@ entry:
 if.then:
   %1 = add   i64 %"x##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"x##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"x##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
   store  i64 %"x##0", i64* %"#result##0" 
-  musttail call fastcc  void  @"thistype.concat<0>[410bae77d3]"(i64  %4, i64  %"y##0", i64*  %6)  
+  musttail call fastcc  void  @"thistype.concat<0>[410bae77d3]"(i64  %3, i64  %"y##0", i64*  %5)  
   ret void 
 if.else:
   store  i64 %"y##0", i64* %"#result##0" 
@@ -412,12 +394,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"head##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"tail##0", i64* %7 
+  store  i64 %"head##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"tail##0", i64* %5 
   ret i64 %2 
 }
 
@@ -428,21 +408,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -452,15 +430,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -477,15 +454,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -496,11 +472,10 @@ entry:
 if.then:
   %1 = add   i64 %"x##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = tail call fastcc  i64  @"thistype.length<0>"(i64  %4)  
-  %6 = add   i64 %5, 1 
-  ret i64 %6 
+  %3 = load  i64, i64* %2 
+  %4 = tail call fastcc  i64  @"thistype.length<0>"(i64  %3)  
+  %5 = add   i64 %4, 1 
+  ret i64 %5 
 if.else:
   ret i64 0 
 }
@@ -519,15 +494,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -545,15 +519,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -215,14 +215,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %2, i64  0)  
-  tail call ccc  void  @print_int(i64  %8)  
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %2, i64  0)  
+  tail call ccc  void  @print_int(i64  %6)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -234,25 +232,22 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = icmp ne i64 %2, 0 
-  br i1 %8, label %if.then, label %if.else 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = icmp ne i64 %2, 0 
+  br i1 %6, label %if.then, label %if.else 
 if.then:
-  %9 = inttoptr i64 %2 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  %11 = load  i64, i64* %10 
-  %12 = insertvalue {i64, i1} undef, i64 %11, 0 
-  %13 = insertvalue {i64, i1} %12, i1 1, 1 
-  ret {i64, i1} %13 
+  %7 = inttoptr i64 %2 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = insertvalue {i64, i1} undef, i64 %8, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %14 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %15 = insertvalue {i64, i1} %14, i1 0, 1 
-  ret {i64, i1} %15 
+  %11 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -121,57 +121,47 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 3, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 0, i64* %7 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 2, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %2, i64* %15 
-  %16 = trunc i64 16 to i32  
-  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
-  %18 = ptrtoint i8* %17 to i64 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 1, i64* %20 
-  %21 = add   i64 %18, 8 
-  %22 = inttoptr i64 %21 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %10, i64* %23 
+  store  i64 %2, i64* %11 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = add   i64 %14, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  store  i64 %8, i64* %17 
+  %18 = trunc i64 16 to i32  
+  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
+  %20 = ptrtoint i8* %19 to i64 
+  %21 = inttoptr i64 %20 to i64* 
+  store  i64 200, i64* %21 
+  %22 = add   i64 %20, 8 
+  %23 = inttoptr i64 %22 to i64* 
+  store  i64 0, i64* %23 
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
   %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 200, i64* %28 
-  %29 = add   i64 %26, 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 0, i64* %31 
-  %32 = trunc i64 16 to i32  
-  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
-  %34 = ptrtoint i8* %33 to i64 
-  %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 100, i64* %36 
-  %37 = add   i64 %34, 8 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %26, i64* %39 
-  %40 = alloca i64 
-   call fastcc  void  @"type_list.,,<0>[410bae77d3]"(i64  %18, i64  %34, i64*  %40)  
-  %41 = load  i64, i64* %40 
-  %42 = tail call fastcc  i64  @"type_list.length<0>"(i64  %41)  
-  tail call ccc  void  @print_int(i64  %42)  
+  store  i64 100, i64* %27 
+  %28 = add   i64 %26, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  store  i64 %20, i64* %29 
+  %30 = alloca i64 
+   call fastcc  void  @"type_list.,,<0>[410bae77d3]"(i64  %14, i64  %26, i64*  %30)  
+  %31 = load  i64, i64* %30 
+  %32 = tail call fastcc  i64  @"type_list.length<0>"(i64  %31)  
+  tail call ccc  void  @print_int(i64  %32)  
   ret void 
 }
 
@@ -182,22 +172,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = trunc i64 16 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"x##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 %2, i64* %9 
+  %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  store  i64 %3, i64* %12 
-  %13 = add   i64 %10, 8 
-  %14 = inttoptr i64 %13 to i64* 
-  store  i64 %10, i64* %"#result##0" 
-  musttail call fastcc  void  @"type_list.,,<0>"(i64  %7, i64  %"y##0", i64*  %14)  
+  store  i64 %8, i64* %"#result##0" 
+  musttail call fastcc  void  @"type_list.,,<0>"(i64  %5, i64  %"y##0", i64*  %11)  
   ret void 
 if.else:
   store  i64 %"y##0", i64* %"#result##0" 
@@ -212,12 +199,11 @@ entry:
 if.then:
   %1 = add   i64 %"x##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %"x##0", 8 
-  %6 = inttoptr i64 %5 to i64* 
+  %3 = load  i64, i64* %2 
+  %4 = add   i64 %"x##0", 8 
+  %5 = inttoptr i64 %4 to i64* 
   store  i64 %"x##0", i64* %"#result##0" 
-  musttail call fastcc  void  @"type_list.,,<0>[410bae77d3]"(i64  %4, i64  %"y##0", i64*  %6)  
+  musttail call fastcc  void  @"type_list.,,<0>[410bae77d3]"(i64  %3, i64  %"y##0", i64*  %5)  
   ret void 
 if.else:
   store  i64 %"y##0", i64* %"#result##0" 
@@ -232,11 +218,10 @@ entry:
 if.then:
   %1 = add   i64 %"x##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = tail call fastcc  i64  @"type_list.length<0>"(i64  %4)  
-  %6 = add   i64 %5, 1 
-  ret i64 %6 
+  %3 = load  i64, i64* %2 
+  %4 = tail call fastcc  i64  @"type_list.length<0>"(i64  %3)  
+  %5 = add   i64 %4, 1 
+  ret i64 %5 
 if.else:
   ret i64 0 
 }
@@ -419,32 +404,28 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#left##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#left##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = icmp ne i64 %"#right##0", 0 
-  br i1 %8, label %if.then1, label %if.else1 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#left##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"#right##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
 if.else:
-  %18 = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %18 
+  %14 = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %14 
 if.then1:
-  %9 = inttoptr i64 %"#right##0" to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
+  %7 = inttoptr i64 %"#right##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"#right##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"#right##0", 8 
-  %13 = inttoptr i64 %12 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %15 = load  i64, i64* %14 
-  %16 = icmp eq i64 %3, %11 
-  br i1 %16, label %if.then2, label %if.else2 
+  %12 = icmp eq i64 %2, %8 
+  br i1 %12, label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %17 = musttail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %7, i64  %15)  
-  ret i1 %17 
+  %13 = musttail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %5, i64  %11)  
+  ret i1 %13 
 if.else2:
   ret i1 0 
 }
@@ -456,12 +437,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"head##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"tail##0", i64* %7 
+  store  i64 %"head##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"tail##0", i64* %5 
   ret i64 %2 
 }
 
@@ -472,21 +451,19 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#result##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = add   i64 %"#result##0", 8 
-  %5 = inttoptr i64 %4 to i64* 
-  %6 = getelementptr  i64, i64* %5, i64 0 
-  %7 = load  i64, i64* %6 
-  %8 = insertvalue {i64, i64, i1} undef, i64 %3, 0 
-  %9 = insertvalue {i64, i64, i1} %8, i64 %7, 1 
-  %10 = insertvalue {i64, i64, i1} %9, i1 1, 2 
-  ret {i64, i64, i1} %10 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"#result##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = insertvalue {i64, i64, i1} undef, i64 %2, 0 
+  %7 = insertvalue {i64, i64, i1} %6, i64 %5, 1 
+  %8 = insertvalue {i64, i64, i1} %7, i1 1, 2 
+  ret {i64, i64, i1} %8 
 if.else:
-  %11 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
-  %12 = insertvalue {i64, i64, i1} %11, i64 undef, 1 
-  %13 = insertvalue {i64, i64, i1} %12, i1 0, 2 
-  ret {i64, i64, i1} %13 
+  %9 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 undef, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 0, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -496,15 +473,14 @@ entry:
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"#rec##0" to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %5 = insertvalue {i64, i1} %4, i1 1, 1 
-  ret {i64, i1} %5 
+  %2 = load  i64, i64* %1 
+  %3 = insertvalue {i64, i1} undef, i64 %2, 0 
+  %4 = insertvalue {i64, i1} %3, i1 1, 1 
+  ret {i64, i1} %4 
 if.else:
-  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %7 = insertvalue {i64, i1} %6, i1 0, 1 
-  ret {i64, i1} %7 
+  %5 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %6 = insertvalue {i64, i1} %5, i1 0, 1 
+  ret {i64, i1} %6 
 }
 
 
@@ -521,15 +497,14 @@ if.then:
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
-  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %10 = insertvalue {i64, i1} %9, i1 1, 1 
-  ret {i64, i1} %10 
+  store  i64 %"#field##0", i64* %7 
+  %8 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %9 = insertvalue {i64, i1} %8, i1 1, 1 
+  ret {i64, i1} %9 
 if.else:
-  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %12 = insertvalue {i64, i1} %11, i1 0, 1 
-  ret {i64, i1} %12 
+  %10 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %11 = insertvalue {i64, i1} %10, i1 0, 1 
+  ret {i64, i1} %11 
 }
 
 
@@ -546,15 +521,14 @@ entry:
 if.then:
   %1 = add   i64 %"#rec##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  %5 = insertvalue {i64, i1} undef, i64 %4, 0 
-  %6 = insertvalue {i64, i1} %5, i1 1, 1 
-  ret {i64, i1} %6 
+  %3 = load  i64, i64* %2 
+  %4 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
 if.else:
-  %7 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %8 = insertvalue {i64, i1} %7, i1 0, 1 
-  ret {i64, i1} %8 
+  %6 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %7 = insertvalue {i64, i1} %6, i1 0, 1 
+  ret {i64, i1} %7 
 }
 
 
@@ -572,15 +546,14 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i1  0)  
   %7 = add   i64 %3, 8 
   %8 = inttoptr i64 %7 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 %"#field##0", i64* %9 
-  %10 = insertvalue {i64, i1} undef, i64 %3, 0 
-  %11 = insertvalue {i64, i1} %10, i1 1, 1 
-  ret {i64, i1} %11 
+  store  i64 %"#field##0", i64* %8 
+  %9 = insertvalue {i64, i1} undef, i64 %3, 0 
+  %10 = insertvalue {i64, i1} %9, i1 1, 1 
+  ret {i64, i1} %10 
 if.else:
-  %12 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %13 = insertvalue {i64, i1} %12, i1 0, 1 
-  ret {i64, i1} %13 
+  %11 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %12 = insertvalue {i64, i1} %11, i1 0, 1 
+  ret {i64, i1} %12 
 }
 
 

--- a/test-cases/final-dump/unbranch_bug.exp
+++ b/test-cases/final-dump/unbranch_bug.exp
@@ -85,9 +85,8 @@ entry:
 if.then:
   %1 = add   i64 %"tmp#0##0", 8 
   %2 = inttoptr i64 %1 to i64* 
-  %3 = getelementptr  i64, i64* %2, i64 0 
-  %4 = load  i64, i64* %3 
-  musttail call fastcc  void  @"unbranch_bug.gen#3<0>"(i64  %4, i64  %"tmp#1##0")  
+  %3 = load  i64, i64* %2 
+  musttail call fastcc  void  @"unbranch_bug.gen#3<0>"(i64  %3, i64  %"tmp#1##0")  
   ret void 
 if.else:
   ret void 

--- a/test-cases/final-dump/unique_position.exp
+++ b/test-cases/final-dump/unique_position.exp
@@ -97,15 +97,12 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 3, i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 4, i64* %7 
-  %8 = inttoptr i64 %2 to i64* 
-  %9 = getelementptr  i64, i64* %8, i64 0 
-  store  i64 5, i64* %9 
+  store  i64 3, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 4, i64* %5 
+  %6 = inttoptr i64 %2 to i64* 
+  store  i64 5, i64* %6 
   tail call fastcc  void  @"unique_position.printPosition<0>"(i64  %2)  
   ret void 
 }
@@ -114,16 +111,14 @@ entry:
 define external fastcc  void @"unique_position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"pos##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @unique_position.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @print_int(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @unique_position.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %6)  
+  tail call ccc  void  @print_int(i64  %4)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @unique_position.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -209,12 +204,10 @@ entry:
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
-  %4 = getelementptr  i64, i64* %3, i64 0 
-  store  i64 %"x##0", i64* %4 
-  %5 = add   i64 %2, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"y##0", i64* %7 
+  store  i64 %"x##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"y##0", i64* %5 
   ret i64 %2 
 }
 
@@ -222,24 +215,21 @@ entry:
 define external fastcc  {i64, i64} @"unique_position.unique_position.unique_position<1>"(i64  %"#result##0")    {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"#result##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  %7 = insertvalue {i64, i64} undef, i64 %2, 0 
-  %8 = insertvalue {i64, i64} %7, i64 %6, 1 
-  ret {i64, i64} %8 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"#result##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = insertvalue {i64, i64} undef, i64 %1, 0 
+  %6 = insertvalue {i64, i64} %5, i64 %4, 1 
+  ret {i64, i64} %6 
 }
 
 
 define external fastcc  i64 @"unique_position.unique_position.x<0>"(i64  %"#rec##0")    {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
-  %1 = getelementptr  i64, i64* %0, i64 0 
-  %2 = load  i64, i64* %1 
-  ret i64 %2 
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
 }
 
 
@@ -253,8 +243,7 @@ entry:
   %5 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = inttoptr i64 %2 to i64* 
-  %7 = getelementptr  i64, i64* %6, i64 0 
-  store  i64 %"#field##0", i64* %7 
+  store  i64 %"#field##0", i64* %6 
   ret i64 %2 
 }
 
@@ -263,9 +252,8 @@ define external fastcc  i64 @"unique_position.unique_position.y<0>"(i64  %"#rec#
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
-  %2 = getelementptr  i64, i64* %1, i64 0 
-  %3 = load  i64, i64* %2 
-  ret i64 %3 
+  %2 = load  i64, i64* %1 
+  ret i64 %2 
 }
 
 
@@ -280,7 +268,6 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %3, i8*  %4, i32  %5, i1  0)  
   %6 = add   i64 %2, 8 
   %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"#field##0", i64* %8 
+  store  i64 %"#field##0", i64* %7 
   ret i64 %2 
 }


### PR DESCRIPTION
Putting this PR up as a draft so I don't forget. I will try to get it merged after I've finished writing my report.

Consider the following excerpt of LLVM IR:
```
  %5 = add   i64 %2, 8 
  %6 = inttoptr i64 %5 to i64* 
  %7 = getelementptr  i64, i64* %6, i64 0 
  store  i64 0, i64* %7 
```

I believe `getelementptr` here is redundant. We are offset a pointer `%6`, selecting the 0-th field, which returns the exact same pointer as we just passed in.