### PR TITLE
Added LLVM FunctionAttributes to defined functions

### DIFF
--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -78,6 +78,7 @@ import LLVM.AST.Typed (Typed(typeOf))
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Short as BS
 import Data.ByteString.Char8 hiding (cons, map)
+import LLVM.AST.FunctionAttribute (FunctionAttribute)
 
 ----------------------------------------------------------------------------
 -- Types                                                                  --
@@ -284,17 +285,17 @@ emptyModule label = defaultModule { moduleName = fromString label }
 -- function will be called from foreign code, so it should use C calling
 -- conventions.
 globalDefine :: Bool -> Type -> String -> [(Type, Name)]
-             -> [BasicBlock] -> Definition
-globalDefine isForeign rettype label argtypes body
-             = GlobalDefinition $ functionDefaults {
-                 G.callingConvention = if isForeign then CC.C else CC.Fast
-               , name = Name $ fromString label
-               , parameters = ([Parameter ty nm [] | (ty, nm) <- argtypes],
-                               False)
-               , returnType = rettype
-               , basicBlocks = body
-               , section = fromString <$> functionDefSection label
-               }
+             -> [FunctionAttribute] -> [BasicBlock] -> Definition
+globalDefine isForeign rettype label argtypes attrs body
+    = GlobalDefinition $ functionDefaults {
+        G.callingConvention = if isForeign then CC.C else CC.Fast
+      , name = Name $ fromString label
+      , parameters = ([Parameter ty nm [] | (ty, nm) <- argtypes], False)
+      , returnType = rettype
+      , G.functionAttributes = Right <$> attrs
+      , basicBlocks = body
+      , section = fromString <$> functionDefSection label
+      }
 
 
 -- | create a global declaration of an external function for the specified

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -192,7 +192,7 @@ if.else:
 }
 
 
-define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0")    {
+define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0") alwaysinline   {
 entry:
   store  i64 %"code##0", i64* @"resource#command_line.exit_code" 
   ret void 
@@ -722,7 +722,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external ccc  i64 @main(i64  %"argc##0", i64  %"argv##0")    {
+define external ccc  i64 @main(i64  %"argc##0", i64  %"argv##0") alwaysinline   {
 entry:
   store  i64 %"argc##0", i64* @"resource#command_line.argc" 
   store  i64 %"argv##0", i64* @"resource#command_line.argv" 
@@ -858,7 +858,7 @@ if.else:
 }
 
 
-define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0")    {
+define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0") alwaysinline   {
 entry:
   store  i64 %"code##0", i64* @"resource#command_line.exit_code" 
   ret void 
@@ -1604,7 +1604,7 @@ entry:
 }
 
 
-define external fastcc  void @"drone.gen#1<0>"()    {
+define external fastcc  void @"drone.gen#1<0>"() alwaysinline   {
 entry:
   %0 = tail call ccc  i64  @malloc_count()  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.1, i32 0, i32 0) to i64))  
@@ -1785,7 +1785,7 @@ if.else2:
 }
 
 
-define external fastcc  void @"drone.print_info<0>"(i64  %"d##0")    {
+define external fastcc  void @"drone.print_info<0>"(i64  %"d##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.3, i32 0, i32 0) to i64))  
   %0 = inttoptr i64 %"d##0" to i64* 
@@ -1999,7 +1999,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"drone.drone_info.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"drone.drone_info.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -2043,7 +2043,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.count<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"drone.drone_info.count<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 24 
   %1 = inttoptr i64 %0 to i64* 
@@ -2052,7 +2052,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.count<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"drone.drone_info.count<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -2068,7 +2068,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.drone_info<0>"(i64  %"x##0", i64  %"y##0", i64  %"z##0", i64  %"count##0")    {
+define external fastcc  i64 @"drone.drone_info.drone_info<0>"(i64  %"x##0", i64  %"y##0", i64  %"z##0", i64  %"count##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -2088,7 +2088,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -2109,7 +2109,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"drone.drone_info.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -2117,7 +2117,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"drone.drone_info.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -2132,7 +2132,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"drone.drone_info.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -2141,7 +2141,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"drone.drone_info.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -2157,7 +2157,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.z<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"drone.drone_info.z<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
@@ -2166,7 +2166,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.z<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"drone.drone_info.z<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -2182,7 +2182,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"drone.drone_info.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"drone.drone_info.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -261,7 +261,7 @@ if.else:
 }
 
 
-define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0")    {
+define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0") alwaysinline   {
 entry:
   store  i64 %"code##0", i64* @"resource#command_line.exit_code" 
   ret void 
@@ -1072,7 +1072,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external ccc  i64 @main(i64  %"argc##0", i64  %"argv##0")    {
+define external ccc  i64 @main(i64  %"argc##0", i64  %"argv##0") alwaysinline   {
 entry:
   store  i64 %"argc##0", i64* @"resource#command_line.argc" 
   store  i64 %"argv##0", i64* @"resource#command_line.argv" 
@@ -1208,7 +1208,7 @@ if.else:
 }
 
 
-define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0")    {
+define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0") alwaysinline   {
 entry:
   store  i64 %"code##0", i64* @"resource#command_line.exit_code" 
   ret void 
@@ -1870,7 +1870,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"int_list.gen#1<0>"(i64  %"tmp#2##0", i64  %"tmp#3##0")    {
+define external fastcc  i64 @"int_list.gen#1<0>"(i64  %"tmp#2##0", i64  %"tmp#3##0") alwaysinline   {
 entry:
   %0 = add   i64 %"tmp#2##0", %"tmp#3##0" 
   ret i64 %0 
@@ -1921,7 +1921,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"int_list.gen#3<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")    {
+define external fastcc  i64 @"int_list.gen#3<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1996,7 +1996,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"int_list.index<0>"(i64  %"lst##0", i64  %"x##0")    {
+define external fastcc  i64 @"int_list.index<0>"(i64  %"lst##0", i64  %"x##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %"lst##0", i64  0, i64  %"x##0")  
   ret i64 %0 
@@ -2213,7 +2213,7 @@ if.else:
 }
 
 
-define external fastcc  void @"int_list.println<0>"(i64  %"x##0")    {
+define external fastcc  void @"int_list.println<0>"(i64  %"x##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"int_list.print<0>"(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -2221,7 +2221,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"int_list.range<0>"(i64  %"start##0", i64  %"stop##0", i64  %"step##0")    {
+define external fastcc  i64 @"int_list.range<0>"(i64  %"start##0", i64  %"stop##0", i64  %"step##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"int_list.gen#2<0>"(i64  0, i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  0)  
   ret i64 %0 
@@ -2287,7 +2287,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"int_list.reverse<0>"(i64  %"lst##0")    {
+define external fastcc  i64 @"int_list.reverse<0>"(i64  %"lst##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"lst##0", i64  0)  
   ret i64 %0 
@@ -2606,7 +2606,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"int_list.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
+define external fastcc  i64 @"int_list.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -2620,7 +2620,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -2642,7 +2642,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -2659,7 +2659,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -2683,13 +2683,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"int_list.int_list.nil<0>"()    {
+define external fastcc  i64 @"int_list.int_list.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -2707,7 +2707,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -2732,7 +2732,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/aaa.exp
+++ b/test-cases/final-dump/aaa.exp
@@ -47,7 +47,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"aaa.<0>"()    {
+define external fastcc  void @"aaa.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @aaa.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -100,7 +100,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"bbb.<0>"()    {
+define external fastcc  void @"bbb.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bbb.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -153,7 +153,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"ccc.<0>"()    {
+define external fastcc  void @"ccc.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ccc.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -205,7 +205,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"ddd.<0>"()    {
+define external fastcc  void @"ddd.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/afterbreak.exp
+++ b/test-cases/final-dump/afterbreak.exp
@@ -67,7 +67,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"afterbreak.<0>"()    {
+define external fastcc  void @"afterbreak.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"afterbreak.gen#1<0>"(i64  1)  
   ret void 
@@ -89,7 +89,7 @@ if.else:
 }
 
 
-define external fastcc  void @"afterbreak.gen#2<0>"(i64  %"y##0")    {
+define external fastcc  void @"afterbreak.gen#2<0>"(i64  %"y##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"y##0")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -627,7 +627,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -649,7 +649,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -663,7 +663,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -676,7 +676,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -684,7 +684,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -699,7 +699,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -708,7 +708,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -724,7 +724,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -402,7 +402,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -424,7 +424,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -438,7 +438,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -451,7 +451,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -459,7 +459,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -474,7 +474,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -483,7 +483,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -499,7 +499,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -125,7 +125,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"alias3.<0>"()    {
+define external fastcc  void @"alias3.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"alias3.bar<0>"()  
   ret void 
@@ -397,7 +397,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -419,7 +419,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -433,7 +433,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -446,7 +446,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -454,7 +454,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -469,7 +469,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -478,7 +478,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -494,7 +494,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -129,7 +129,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"alias4.<0>"()    {
+define external fastcc  void @"alias4.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"alias4.bar<0>"()  
   ret void 
@@ -402,7 +402,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -424,7 +424,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -438,7 +438,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -451,7 +451,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -459,7 +459,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -474,7 +474,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -483,7 +483,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -499,7 +499,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias5.exp
+++ b/test-cases/final-dump/alias5.exp
@@ -116,7 +116,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"alias5.<0>"()    {
+define external fastcc  void @"alias5.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"alias5.bar<0>"()  
   ret void 

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -129,7 +129,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"alias_cyclic.<0>"()    {
+define external fastcc  void @"alias_cyclic.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"alias_cyclic.bar<0>"()  
   ret void 
@@ -451,7 +451,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -473,7 +473,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -487,7 +487,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -500,7 +500,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -508,7 +508,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -523,7 +523,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -532,7 +532,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -548,7 +548,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -91,14 +91,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"alias_data.<0>"()    {
+define external fastcc  void @"alias_data.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"alias_data.bar<0>"()  
   ret void 
 }
 
 
-define external fastcc  i64 @"alias_data.backup<0>"(i64  %"student1##0")    {
+define external fastcc  i64 @"alias_data.backup<0>"(i64  %"student1##0") alwaysinline   {
 entry:
   ret i64 %"student1##0" 
 }
@@ -412,7 +412,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"student.course.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"student.course.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -434,7 +434,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"student.course.code<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"student.course.code<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -442,7 +442,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.code<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"student.course.code<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -457,7 +457,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.course<0>"(i64  %"code##0", i64  %"name##0")    {
+define external fastcc  i64 @"student.course.course<0>"(i64  %"code##0", i64  %"name##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -471,7 +471,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -484,7 +484,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"student.course.name<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -493,7 +493,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"student.course.name<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -509,7 +509,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"student.course.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"student.course.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -673,7 +673,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"student.student.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"student.student.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -710,7 +710,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"student.student.id<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"student.student.id<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -718,7 +718,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.id<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"student.student.id<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -733,7 +733,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.major<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"student.student.major<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -742,7 +742,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.major<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"student.student.major<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -758,7 +758,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.student<0>"(i64  %"id##0", i64  %"major##0")    {
+define external fastcc  i64 @"student.student.student<0>"(i64  %"id##0", i64  %"major##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -772,7 +772,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -785,7 +785,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"student.student.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"student.student.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -90,7 +90,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"alias_des.<0>"()    {
+define external fastcc  void @"alias_des.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"alias_des.foo<0>"()  
   ret void 
@@ -355,7 +355,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -377,7 +377,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -391,7 +391,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -404,7 +404,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -412,7 +412,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -427,7 +427,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -436,7 +436,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -452,7 +452,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -276,7 +276,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -298,7 +298,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -312,7 +312,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -325,7 +325,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -333,7 +333,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -348,7 +348,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -357,7 +357,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -373,7 +373,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -151,7 +151,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_fork1.gen#1<0>"(i64  %"tmp#2##0")    {
+define external fastcc  i64 @"alias_fork1.gen#1<0>"(i64  %"tmp#2##0") alwaysinline   {
 entry:
   ret i64 %"tmp#2##0" 
 }
@@ -325,7 +325,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
+define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.1, i32 0, i32 0) to i64))  
   musttail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.3, i32 0, i32 0) to i64))  
@@ -617,13 +617,13 @@ if.else3:
 }
 
 
-define external fastcc  i64 @"mytree.tree.empty<0>"()    {
+define external fastcc  i64 @"mytree.tree.empty<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -641,7 +641,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -666,7 +666,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -683,7 +683,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -707,7 +707,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
+define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -724,7 +724,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -751,7 +751,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -769,7 +769,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -794,7 +794,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -312,7 +312,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
+define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.1, i32 0, i32 0) to i64))  
   musttail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.3, i32 0, i32 0) to i64))  
@@ -604,13 +604,13 @@ if.else3:
 }
 
 
-define external fastcc  i64 @"mytree.tree.empty<0>"()    {
+define external fastcc  i64 @"mytree.tree.empty<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -628,7 +628,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -653,7 +653,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -670,7 +670,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -694,7 +694,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
+define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -711,7 +711,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -738,7 +738,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -756,7 +756,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -781,7 +781,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -251,7 +251,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
+define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.1, i32 0, i32 0) to i64))  
   musttail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.3, i32 0, i32 0) to i64))  
@@ -543,13 +543,13 @@ if.else3:
 }
 
 
-define external fastcc  i64 @"mytree.tree.empty<0>"()    {
+define external fastcc  i64 @"mytree.tree.empty<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -567,7 +567,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -592,7 +592,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -609,7 +609,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -633,7 +633,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
+define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -650,7 +650,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -677,7 +677,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -695,7 +695,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -720,7 +720,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -579,7 +579,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -601,7 +601,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -615,7 +615,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -628,7 +628,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -636,7 +636,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -651,7 +651,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -660,7 +660,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -676,7 +676,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -489,7 +489,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -511,7 +511,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -525,7 +525,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -538,7 +538,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -546,7 +546,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -561,7 +561,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -570,7 +570,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -586,7 +586,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -489,7 +489,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -511,7 +511,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -525,7 +525,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -538,7 +538,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -546,7 +546,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -561,7 +561,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -570,7 +570,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -586,7 +586,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -309,7 +309,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -331,7 +331,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -345,7 +345,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -358,7 +358,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -366,7 +366,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -381,7 +381,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -390,7 +390,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -406,7 +406,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -161,7 +161,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"alias_multifunc.<0>"()    {
+define external fastcc  void @"alias_multifunc.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"alias_multifunc.bar<0>"()  
   ret void 
@@ -461,7 +461,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -483,7 +483,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -497,7 +497,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -510,7 +510,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -518,7 +518,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -533,7 +533,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -542,7 +542,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -558,7 +558,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -449,7 +449,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -471,7 +471,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -485,7 +485,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -498,7 +498,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -506,7 +506,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -521,7 +521,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -530,7 +530,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -546,7 +546,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -428,7 +428,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -450,7 +450,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -464,7 +464,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -477,7 +477,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -485,7 +485,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -500,7 +500,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -509,7 +509,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -525,7 +525,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -393,7 +393,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -415,7 +415,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -429,7 +429,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -442,7 +442,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -450,7 +450,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -465,7 +465,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -474,7 +474,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -490,7 +490,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -517,7 +517,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -539,7 +539,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -553,7 +553,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -566,7 +566,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -574,7 +574,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -589,7 +589,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -598,7 +598,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -614,7 +614,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -426,7 +426,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -448,7 +448,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -462,7 +462,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -475,7 +475,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -483,7 +483,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -498,7 +498,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -507,7 +507,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -523,7 +523,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -534,7 +534,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -556,7 +556,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -570,7 +570,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -583,7 +583,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -591,7 +591,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -606,7 +606,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -615,7 +615,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -631,7 +631,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -223,7 +223,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type1.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type1.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -245,7 +245,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"alias_type1.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -259,7 +259,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -272,7 +272,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type1.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -280,7 +280,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type1.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -295,7 +295,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type1.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -304,7 +304,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type1.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -320,7 +320,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type1.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type1.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -481,7 +481,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type1.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type1.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -518,7 +518,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.a<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type1.posrec.a<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -526,7 +526,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type1.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -541,7 +541,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.p<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type1.posrec.p<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -550,7 +550,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type1.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -566,7 +566,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.posrec<0>"(i64  %"a##0", i64  %"p##0")    {
+define external fastcc  i64 @"alias_type1.posrec.posrec<0>"(i64  %"a##0", i64  %"p##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -580,7 +580,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -593,7 +593,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type1.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type1.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -237,7 +237,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type2.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type2.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -259,7 +259,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"alias_type2.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -273,7 +273,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -286,7 +286,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type2.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -294,7 +294,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type2.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -309,7 +309,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type2.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -318,7 +318,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type2.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -334,7 +334,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type2.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type2.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -495,7 +495,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type2.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type2.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -532,7 +532,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.a<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type2.posrec.a<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -541,7 +541,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type2.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -557,7 +557,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.p<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type2.posrec.p<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -565,7 +565,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type2.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -580,7 +580,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0")    {
+define external fastcc  i64 @"alias_type2.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -594,7 +594,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -607,7 +607,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type2.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type2.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -240,7 +240,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type3.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type3.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -262,7 +262,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"alias_type3.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -276,7 +276,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -289,7 +289,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type3.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -297,7 +297,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type3.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -312,7 +312,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type3.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -321,7 +321,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type3.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -337,7 +337,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type3.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type3.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -498,7 +498,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type3.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type3.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -535,7 +535,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.a<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type3.posrec.a<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -544,7 +544,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type3.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -560,7 +560,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.p<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type3.posrec.p<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -568,7 +568,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type3.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -583,7 +583,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0")    {
+define external fastcc  i64 @"alias_type3.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -597,7 +597,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -610,7 +610,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type3.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type3.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -258,7 +258,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type4.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type4.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -280,7 +280,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"alias_type4.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -294,7 +294,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -307,7 +307,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type4.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -315,7 +315,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type4.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -330,7 +330,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type4.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -339,7 +339,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type4.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -355,7 +355,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type4.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type4.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -516,7 +516,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type4.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type4.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -553,7 +553,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.a<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type4.posrec.a<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -562,7 +562,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type4.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -578,7 +578,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.p<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"alias_type4.posrec.p<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -586,7 +586,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"alias_type4.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -601,7 +601,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0")    {
+define external fastcc  i64 @"alias_type4.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -615,7 +615,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -628,7 +628,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type4.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"alias_type4.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/alloc_args.exp
+++ b/test-cases/final-dump/alloc_args.exp
@@ -49,14 +49,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"alloc_args.<0>"()    {
+define external fastcc  void @"alloc_args.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"alloc_args.foo<0>"(i64  1)  
   ret void 
 }
 
 
-define external fastcc  void @"alloc_args.foo<0>"(i64  %"size##0")    {
+define external fastcc  void @"alloc_args.foo<0>"(i64  %"size##0") noinline   {
 entry:
   %0 = trunc i64 %"size##0" to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -524,7 +524,7 @@ if.else7:
 }
 
 
-define external fastcc  i64 @"anon_field.bar<0>"(i64  %"bar#1##0")    {
+define external fastcc  i64 @"anon_field.bar<0>"(i64  %"bar#1##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -536,7 +536,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.bar<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"anon_field.bar<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 3 
   %1 = icmp eq i64 %0, 1 
@@ -555,7 +555,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"anon_field.baz<0>"(i64  %"field##0")    {
+define external fastcc  i64 @"anon_field.baz<0>"(i64  %"field##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -567,7 +567,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.baz<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"anon_field.baz<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 3 
   %1 = icmp eq i64 %0, 2 
@@ -586,7 +586,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.field<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"anon_field.field<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 3 
   %1 = icmp eq i64 %0, 2 
@@ -605,7 +605,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.field<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"anon_field.field<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 3 
   %1 = icmp eq i64 %0, 2 
@@ -633,7 +633,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"anon_field.foo<0>"(i64  %"foo#1##0", i1  %"foo#2##0", i64  %"i##0")    {
+define external fastcc  i64 @"anon_field.foo<0>"(i64  %"foo#1##0", i1  %"foo#2##0", i64  %"i##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -650,7 +650,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1, i64, i1} @"anon_field.foo<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1, i64, i1} @"anon_field.foo<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 3 
   %1 = icmp eq i64 %0, 0 
@@ -770,7 +770,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.i<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"anon_field.i<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 3 
   %1 = icmp eq i64 %0, 0 
@@ -789,7 +789,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.i<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"anon_field.i<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 3 
   %1 = icmp eq i64 %0, 0 
@@ -815,7 +815,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"anon_field.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"anon_field.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"anon_field.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 
@@ -921,7 +921,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"anon_field.quux.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"anon_field.quux.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -943,7 +943,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"anon_field.quux.j<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"anon_field.quux.j<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -952,7 +952,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"anon_field.quux.j<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"anon_field.quux.j<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -968,7 +968,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"anon_field.quux.quuz<0>"(i64  %"quuz#1##0", i64  %"j##0")    {
+define external fastcc  i64 @"anon_field.quux.quuz<0>"(i64  %"quuz#1##0", i64  %"j##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -982,7 +982,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"anon_field.quux.quuz<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"anon_field.quux.quuz<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -995,7 +995,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"anon_field.quux.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"anon_field.quux.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/anon_field_variable.exp
+++ b/test-cases/final-dump/anon_field_variable.exp
@@ -168,7 +168,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"anon_field_variable.bar<0>"(i64  %"bar#1##0", i64  %"field##0", i64  %"bar#3##0")    {
+define external fastcc  i64 @"anon_field_variable.bar<0>"(i64  %"bar#1##0", i64  %"field##0", i64  %"bar#3##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -186,7 +186,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"anon_field_variable.bar<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i1} @"anon_field_variable.bar<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 1 
   %1 = icmp eq i64 %0, 1 
@@ -215,7 +215,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field_variable.field<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"anon_field_variable.field<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 1 
   %1 = icmp eq i64 %0, 1 
@@ -234,7 +234,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field_variable.field<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"anon_field_variable.field<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 1 
   %1 = icmp eq i64 %0, 1 
@@ -262,7 +262,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"anon_field_variable.foo<0>"(i64  %"foo#1##0")    {
+define external fastcc  i64 @"anon_field_variable.foo<0>"(i64  %"foo#1##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -273,7 +273,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field_variable.foo<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"anon_field_variable.foo<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 1 
   %1 = icmp eq i64 %0, 0 

--- a/test-cases/final-dump/backquote_OK.exp
+++ b/test-cases/final-dump/backquote_OK.exp
@@ -30,7 +30,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"backquote_OK.OK backquote use!<0>"()    {
+define external fastcc  i64 @"backquote_OK.OK backquote use!<0>"() alwaysinline   {
 entry:
   ret i64 1 
 }

--- a/test-cases/final-dump/backwards_assign.exp
+++ b/test-cases/final-dump/backwards_assign.exp
@@ -63,14 +63,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"backwards_assign.<0>"()    {
+define external fastcc  void @"backwards_assign.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"backwards_assign.gen#1<0>"(i64  0)  
   ret void 
 }
 
 
-define external fastcc  i64 @"backwards_assign.backwards_assign<0>"(i64  %"input##0")    {
+define external fastcc  i64 @"backwards_assign.backwards_assign<0>"(i64  %"input##0") alwaysinline   {
 entry:
   %0 = add   i64 %"input##0", 1 
   ret i64 %0 

--- a/test-cases/final-dump/bar.exp
+++ b/test-cases/final-dump/bar.exp
@@ -132,7 +132,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"numbers.<0>"()    {
+define external fastcc  void @"numbers.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @numbers.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -154,7 +154,7 @@ if.else:
 }
 
 
-define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0") alwaysinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 

--- a/test-cases/final-dump/bbb.exp
+++ b/test-cases/final-dump/bbb.exp
@@ -46,7 +46,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"bbb.<0>"()    {
+define external fastcc  void @"bbb.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bbb.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -98,7 +98,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"ddd.<0>"()    {
+define external fastcc  void @"ddd.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/break_in_loop_in_do.exp
+++ b/test-cases/final-dump/break_in_loop_in_do.exp
@@ -76,7 +76,7 @@ entry:
 }
 
 
-define external fastcc  void @"break_in_loop_in_do.gen#1<0>"()    {
+define external fastcc  void @"break_in_loop_in_do.gen#1<0>"() alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#break_in_loop_in_do.counter" 
   tail call ccc  void  @print_int(i64  %0)  
@@ -85,7 +85,7 @@ entry:
 }
 
 
-define external fastcc  void @"break_in_loop_in_do.gen#2<0>"(i64  %"tmp#0##0")    {
+define external fastcc  void @"break_in_loop_in_do.gen#2<0>"(i64  %"tmp#0##0") alwaysinline   {
 entry:
   store  i64 %"tmp#0##0", i64* @"resource#break_in_loop_in_do.counter" 
   tail call ccc  void  @print_int(i64  %"tmp#0##0")  

--- a/test-cases/final-dump/bug214.exp
+++ b/test-cases/final-dump/bug214.exp
@@ -324,7 +324,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"bug214.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"bug214.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -357,7 +357,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"bug214.aim<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"bug214.aim<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -366,7 +366,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"bug214.aim<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"bug214.aim<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -382,7 +382,7 @@ entry:
 }
 
 
-define external fastcc  void @"bug214.gen#1<0>"(i64  %"pos##0", i64  %"sub##0")    {
+define external fastcc  void @"bug214.gen#1<0>"(i64  %"pos##0", i64  %"sub##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"bug214.position.print<0>"(i64  %"pos##0")  
@@ -588,7 +588,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"bug214.sub_pos<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"bug214.sub_pos<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -596,7 +596,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"bug214.sub_pos<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"bug214.sub_pos<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -611,7 +611,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"bug214.submarine<0>"(i64  %"sub_pos##0", i64  %"aim##0")    {
+define external fastcc  i64 @"bug214.submarine<0>"(i64  %"sub_pos##0", i64  %"aim##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -625,7 +625,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"bug214.submarine<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"bug214.submarine<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -638,7 +638,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"bug214.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"bug214.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -796,20 +796,20 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"bug214.direction.=<0>"(i2  %"#left##0", i2  %"#right##0")    {
+define external fastcc  i1 @"bug214.direction.=<0>"(i2  %"#left##0", i2  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i2 %"#left##0", %"#right##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i2 @"bug214.direction.down<0>"()    {
+define external fastcc  i2 @"bug214.direction.down<0>"() alwaysinline   {
 entry:
   ret i2 1 
 }
 
 
-define external fastcc  i2 @"bug214.direction.fwd<0>"()    {
+define external fastcc  i2 @"bug214.direction.fwd<0>"() alwaysinline   {
 entry:
   ret i2 0 
 }
@@ -844,13 +844,13 @@ if.else2:
 }
 
 
-define external fastcc  i2 @"bug214.direction.up<0>"()    {
+define external fastcc  i2 @"bug214.direction.up<0>"() alwaysinline   {
 entry:
   ret i2 2 
 }
 
 
-define external fastcc  i1 @"bug214.direction.~=<0>"(i2  %"#left##0", i2  %"#right##0")    {
+define external fastcc  i1 @"bug214.direction.~=<0>"(i2  %"#left##0", i2  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i2 %"#left##0", %"#right##0" 
   %1 = xor i1 %0, 1 
@@ -1026,7 +1026,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"bug214.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"bug214.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -1062,7 +1062,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"bug214.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"bug214.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1076,7 +1076,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"bug214.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"bug214.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -1105,7 +1105,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"bug214.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"bug214.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -1113,7 +1113,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"bug214.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"bug214.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1128,7 +1128,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"bug214.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"bug214.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -1137,7 +1137,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"bug214.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"bug214.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1153,7 +1153,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"bug214.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"bug214.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/bug217.exp
+++ b/test-cases/final-dump/bug217.exp
@@ -75,19 +75,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"bug217.foo.=<0>"()    {
+define external fastcc  i1 @"bug217.foo.=<0>"() alwaysinline   {
 entry:
   ret i1 1 
 }
 
 
-define external fastcc  void @"bug217.foo.foo<0>"()    {
+define external fastcc  void @"bug217.foo.foo<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  i1 @"bug217.foo.~=<0>"()    {
+define external fastcc  i1 @"bug217.foo.~=<0>"() alwaysinline   {
 entry:
   ret i1 0 
 }
@@ -140,19 +140,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"bug217.foo.bar.=<0>"()    {
+define external fastcc  i1 @"bug217.foo.bar.=<0>"() alwaysinline   {
 entry:
   ret i1 1 
 }
 
 
-define external fastcc  void @"bug217.foo.bar.bar<0>"()    {
+define external fastcc  void @"bug217.foo.bar.bar<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  i1 @"bug217.foo.bar.~=<0>"()    {
+define external fastcc  i1 @"bug217.foo.bar.~=<0>"() alwaysinline   {
 entry:
   ret i1 0 
 }

--- a/test-cases/final-dump/bug228-okay.exp
+++ b/test-cases/final-dump/bug228-okay.exp
@@ -73,7 +73,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"bug228-okay.bar<0>"()    {
+define external fastcc  {i64, i64} @"bug228-okay.bar<0>"() alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#bug228-okay.res" 
   store  i64 %0, i64* @"resource#bug228-okay.res" 
@@ -83,7 +83,7 @@ entry:
 }
 
 
-define external fastcc  void @"bug228-okay.init_res<0>"()    {
+define external fastcc  void @"bug228-okay.init_res<0>"() alwaysinline   {
 entry:
   store  i64 2, i64* @"resource#bug228-okay.res" 
   ret void 

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -140,7 +140,7 @@ if.else2:
 }
 
 
-define external fastcc  void @"call_site_id.bar<0>"(i64  %"x##0")    {
+define external fastcc  void @"call_site_id.bar<0>"(i64  %"x##0") alwaysinline   {
 entry:
   musttail call fastcc  void  @"call_site_id.foo<0>"(i64  %"x##0")  
   ret void 

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -479,7 +479,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"caret.region.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"caret.region.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -531,7 +531,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"caret.region.lower_left<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"caret.region.lower_left<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -539,7 +539,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.region.lower_left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"caret.region.lower_left<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -554,7 +554,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.region.region<0>"(i64  %"lower_left##0", i64  %"upper_right##0")    {
+define external fastcc  i64 @"caret.region.region<0>"(i64  %"lower_left##0", i64  %"upper_right##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -568,7 +568,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -581,7 +581,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.region.upper_right<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"caret.region.upper_right<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -590,7 +590,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.region.upper_right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"caret.region.upper_right<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -606,7 +606,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"caret.region.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"caret.region.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -872,7 +872,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -894,7 +894,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -908,7 +908,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -921,7 +921,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -929,7 +929,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -944,7 +944,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -953,7 +953,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -969,7 +969,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/ccc.exp
+++ b/test-cases/final-dump/ccc.exp
@@ -46,7 +46,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"ccc.<0>"()    {
+define external fastcc  void @"ccc.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ccc.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -98,7 +98,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"ddd.<0>"()    {
+define external fastcc  void @"ddd.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/chain_assign.exp
+++ b/test-cases/final-dump/chain_assign.exp
@@ -30,7 +30,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"chain_assign.chain<0>"()    {
+define external fastcc  i64 @"chain_assign.chain<0>"() alwaysinline   {
 entry:
   ret i64 1 
 }

--- a/test-cases/final-dump/commonsubexpr.exp
+++ b/test-cases/final-dump/commonsubexpr.exp
@@ -74,7 +74,7 @@ entry:
 }
 
 
-define external fastcc  void @"commonsubexpr.common_subexpr<0>"(i64  %"x##0")    {
+define external fastcc  void @"commonsubexpr.common_subexpr<0>"(i64  %"x##0") alwaysinline   {
 entry:
   %0 = add   i64 %"x##0", 1 
   %1 = sub   i64 %"x##0", 1 

--- a/test-cases/final-dump/compute.exp
+++ b/test-cases/final-dump/compute.exp
@@ -119,7 +119,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0") alwaysinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 
@@ -189,7 +189,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"math.utils.<0>"()    {
+define external fastcc  void @"math.utils.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @math.utils.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/constfold.exp
+++ b/test-cases/final-dump/constfold.exp
@@ -57,25 +57,25 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"constfold.fold_add<0>"()    {
+define external fastcc  i64 @"constfold.fold_add<0>"() alwaysinline   {
 entry:
   ret i64 42 
 }
 
 
-define external fastcc  i64 @"constfold.fold_mult<0>"()    {
+define external fastcc  i64 @"constfold.fold_mult<0>"() alwaysinline   {
 entry:
   ret i64 42 
 }
 
 
-define external fastcc  i64 @"constfold.fold_test<0>"()    {
+define external fastcc  i64 @"constfold.fold_test<0>"() alwaysinline   {
 entry:
   ret i64 42 
 }
 
 
-define external fastcc  i64 @"constfold.fortytwo<0>"()    {
+define external fastcc  i64 @"constfold.fortytwo<0>"() alwaysinline   {
 entry:
   ret i64 42 
 }

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -147,7 +147,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"constructors.just<0>"(i64  %"value##0")    {
+define external fastcc  i64 @"constructors.just<0>"(i64  %"value##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -158,7 +158,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"constructors.just<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"constructors.just<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -175,13 +175,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"constructors.nothing<0>"()    {
+define external fastcc  i64 @"constructors.nothing<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"constructors.value<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"constructors.value<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -198,7 +198,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"constructors.value<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"constructors.value<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -222,7 +222,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"constructors.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"constructors.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"constructors.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -116,7 +116,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.fcopy<0>"(i64  %"crd1##0")    {
+define external fastcc  i64 @"coordinate.fcopy<0>"(i64  %"crd1##0") alwaysinline   {
 entry:
   ret i64 %"crd1##0" 
 }
@@ -273,7 +273,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"coordinate.Coordinate.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"coordinate.Coordinate.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -306,7 +306,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.Coordinate<0>"(i64  %"x##0", i64  %"y##0", i64  %"z##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.Coordinate<0>"(i64  %"x##0", i64  %"y##0", i64  %"z##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -323,7 +323,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -340,7 +340,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -348,7 +348,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -363,7 +363,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -372,7 +372,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -388,7 +388,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.z<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.z<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
@@ -397,7 +397,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.z<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.z<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -413,7 +413,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"coordinate.Coordinate.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"coordinate.Coordinate.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -346,7 +346,7 @@ if.else6:
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char.c<0>"(i64  %"#rec##0")    {
+define external fastcc  {i8, i1} @"ctor_char.c<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -372,7 +372,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char.c<1>"(i64  %"#rec##0", i8  %"#field##0")    {
+define external fastcc  {i64, i1} @"ctor_char.c<1>"(i64  %"#rec##0", i8  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -399,13 +399,13 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"ctor_char.const<0>"()    {
+define external fastcc  i64 @"ctor_char.const<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  i64 @"ctor_char.ctor<0>"(i8  %"c##0")    {
+define external fastcc  i64 @"ctor_char.ctor<0>"(i8  %"c##0") alwaysinline   {
 entry:
   %0 = zext i8 %"c##0" to i64  
   %1 = shl   i64 %0, 1 
@@ -414,7 +414,7 @@ entry:
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char.ctor<1>"(i64  %"#result##0")    {
+define external fastcc  {i8, i1} @"ctor_char.ctor<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -460,7 +460,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"ctor_char.other_ctor<0>"(i64  %"other_ctor#1##0")    {
+define external fastcc  i64 @"ctor_char.other_ctor<0>"(i64  %"other_ctor#1##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -472,7 +472,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char.other_ctor<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"ctor_char.other_ctor<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -498,7 +498,7 @@ if.else1:
 }
 
 
-define external fastcc  i1 @"ctor_char.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"ctor_char.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -429,7 +429,7 @@ if.else9:
 }
 
 
-define external fastcc  i64 @"ctor_char2.another_ctor<0>"(i64  %"another_ctor#1##0")    {
+define external fastcc  i64 @"ctor_char2.another_ctor<0>"(i64  %"another_ctor#1##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -441,7 +441,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.another_ctor<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"ctor_char2.another_ctor<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -467,7 +467,7 @@ if.else1:
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char2.c<0>"(i64  %"#rec##0")    {
+define external fastcc  {i8, i1} @"ctor_char2.c<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -493,7 +493,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.c<1>"(i64  %"#rec##0", i8  %"#field##0")    {
+define external fastcc  {i64, i1} @"ctor_char2.c<1>"(i64  %"#rec##0", i8  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -520,13 +520,13 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"ctor_char2.const<0>"()    {
+define external fastcc  i64 @"ctor_char2.const<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  i64 @"ctor_char2.ctor<0>"(i8  %"c##0")    {
+define external fastcc  i64 @"ctor_char2.ctor<0>"(i8  %"c##0") alwaysinline   {
 entry:
   %0 = zext i8 %"c##0" to i64  
   %1 = shl   i64 %0, 2 
@@ -535,7 +535,7 @@ entry:
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char2.ctor<1>"(i64  %"#result##0")    {
+define external fastcc  {i8, i1} @"ctor_char2.ctor<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -581,7 +581,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"ctor_char2.other_ctor<0>"(i64  %"other_ctor#1##0")    {
+define external fastcc  i64 @"ctor_char2.other_ctor<0>"(i64  %"other_ctor#1##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -593,7 +593,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.other_ctor<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"ctor_char2.other_ctor<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -619,7 +619,7 @@ if.else1:
 }
 
 
-define external fastcc  i1 @"ctor_char2.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"ctor_char2.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/current_module_alias.exp
+++ b/test-cases/final-dump/current_module_alias.exp
@@ -60,7 +60,7 @@ entry:
 }
 
 
-define external fastcc  double @"current_module_alias.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"current_module_alias.toCelsius<0>"(double  %"f##0") noinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 
@@ -98,7 +98,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0") alwaysinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 

--- a/test-cases/final-dump/current_module_alias_fail.exp
+++ b/test-cases/final-dump/current_module_alias_fail.exp
@@ -60,7 +60,7 @@ entry:
 }
 
 
-define external fastcc  double @"current_module_alias_fail.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"current_module_alias_fail.toCelsius<0>"(double  %"f##0") noinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 
@@ -98,7 +98,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0") alwaysinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 

--- a/test-cases/final-dump/current_module_alias_warning.exp
+++ b/test-cases/final-dump/current_module_alias_warning.exp
@@ -68,7 +68,7 @@ entry:
 }
 
 
-define external fastcc  double @"current_module_alias_warning.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"current_module_alias_warning.toCelsius<0>"(double  %"f##0") noinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 
@@ -76,7 +76,7 @@ entry:
 }
 
 
-define external fastcc  double @"current_module_alias_warning.toCelsius<1>"(double  %"f##0")    {
+define external fastcc  double @"current_module_alias_warning.toCelsius<1>"(double  %"f##0") noinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 
@@ -114,7 +114,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0") alwaysinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 

--- a/test-cases/final-dump/ddd.exp
+++ b/test-cases/final-dump/ddd.exp
@@ -45,7 +45,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"ddd.<0>"()    {
+define external fastcc  void @"ddd.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -1248,13 +1248,13 @@ if.else11:
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t.ta<0>"()    {
+define external fastcc  i64 @"dead_cell_size.t.ta<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t.tb<0>"(i64  %"tb1##0")    {
+define external fastcc  i64 @"dead_cell_size.t.tb<0>"(i64  %"tb1##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1265,7 +1265,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1290,7 +1290,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1315,7 +1315,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1347,7 +1347,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t.tc<0>"(i64  %"tc1##0", i64  %"tc2##0", i64  %"tc3##0")    {
+define external fastcc  i64 @"dead_cell_size.t.tc<0>"(i64  %"tc1##0", i64  %"tc2##0", i64  %"tc3##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1365,7 +1365,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"dead_cell_size.t.tc<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i1} @"dead_cell_size.t.tc<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1403,7 +1403,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1429,7 +1429,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1464,7 +1464,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1490,7 +1490,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1525,7 +1525,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1551,7 +1551,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1586,7 +1586,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t.td<0>"(i64  %"td1##0")    {
+define external fastcc  i64 @"dead_cell_size.t.td<0>"(i64  %"td1##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1598,7 +1598,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1624,7 +1624,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td1<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td1<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1650,7 +1650,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td1<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1685,7 +1685,7 @@ if.else1:
 }
 
 
-define external fastcc  i1 @"dead_cell_size.t.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"dead_cell_size.t.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 
@@ -1840,7 +1840,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.a<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.a<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1857,7 +1857,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.a<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1881,13 +1881,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t2.t2a<0>"()    {
+define external fastcc  i64 @"dead_cell_size.t2.t2a<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t2.t2b<0>"(i64  %"a##0")    {
+define external fastcc  i64 @"dead_cell_size.t2.t2b<0>"(i64  %"a##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1898,7 +1898,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.t2b<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.t2b<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -1915,7 +1915,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"dead_cell_size.t2.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"dead_cell_size.t2.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/det_for.exp
+++ b/test-cases/final-dump/det_for.exp
@@ -58,14 +58,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"det_for.<0>"()    {
+define external fastcc  void @"det_for.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"det_for.gen#1<0>"(i64  0)  
   ret void 
 }
 
 
-define external fastcc  {i64, i64} @"det_for.[|]<0>"(i64  %"current##0")    {
+define external fastcc  {i64, i64} @"det_for.[|]<0>"(i64  %"current##0") alwaysinline   {
 entry:
   %0 = add   i64 %"current##0", 1 
   %1 = insertvalue {i64, i64} undef, i64 %"current##0", 0 

--- a/test-cases/final-dump/dont_care_constraint.exp
+++ b/test-cases/final-dump/dont_care_constraint.exp
@@ -35,7 +35,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"dont_care_constraint.<0>"()    {
+define external fastcc  void @"dont_care_constraint.<0>"() alwaysinline   {
 entry:
   %0 = tail call ccc  i64  @read_line()  
   ret void 

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -78,7 +78,7 @@ entry:
 }
 
 
-define external fastcc  void @"early_error.my_error<0>"(i64  %"msg##0")    {
+define external fastcc  void @"early_error.my_error<0>"(i64  %"msg##0") alwaysinline   {
 entry:
   tail call ccc  void  @puts(i64  %"msg##0")  
   tail call ccc  void  @exit(i64  1)  

--- a/test-cases/final-dump/early_exit2.exp
+++ b/test-cases/final-dump/early_exit2.exp
@@ -66,7 +66,7 @@ entry:
 }
 
 
-define external fastcc  void @"early_exit2.my_exit<0>"(i64  %"code##0")    {
+define external fastcc  void @"early_exit2.my_exit<0>"(i64  %"code##0") alwaysinline   {
 entry:
   tail call ccc  void  @exit(i64  %"code##0")  
   ret void 

--- a/test-cases/final-dump/eof_comment.exp
+++ b/test-cases/final-dump/eof_comment.exp
@@ -45,7 +45,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"eof_comment.<0>"()    {
+define external fastcc  void @"eof_comment.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @eof_comment.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -69,7 +69,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"exp_if.<0>"()    {
+define external fastcc  void @"exp_if.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_if.1, i32 0, i32 0) to i64))  
   %0 = tail call fastcc  i64  @"exp_if.if_test<0>"(i64  3)  

--- a/test-cases/final-dump/exp_simple.exp
+++ b/test-cases/final-dump/exp_simple.exp
@@ -89,7 +89,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"exp_simple.foreign_add<0>"()    {
+define external fastcc  i64 @"exp_simple.foreign_add<0>"() alwaysinline   {
 entry:
   ret i64 3 
 }

--- a/test-cases/final-dump/failure_in_cond_test.exp
+++ b/test-cases/final-dump/failure_in_cond_test.exp
@@ -44,14 +44,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"failure_in_cond_test.<0>"()    {
+define external fastcc  void @"failure_in_cond_test.<0>"() alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  1)  
   ret void 
 }
 
 
-define external fastcc  {i64, i1} @"failure_in_cond_test.foo<0>"()    {
+define external fastcc  {i64, i1} @"failure_in_cond_test.foo<0>"() alwaysinline   {
 entry:
   %0 = insertvalue {i64, i1} undef, i64 1, 0 
   %1 = insertvalue {i64, i1} %0, i1 1, 1 

--- a/test-cases/final-dump/func_let.exp
+++ b/test-cases/final-dump/func_let.exp
@@ -45,14 +45,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"func_let.<0>"()    {
+define external fastcc  void @"func_let.<0>"() alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  40)  
   ret void 
 }
 
 
-define external fastcc  i64 @"func_let.quad<0>"(i64  %"x##0")    {
+define external fastcc  i64 @"func_let.quad<0>"(i64  %"x##0") alwaysinline   {
 entry:
   %0 = add   i64 %"x##0", %"x##0" 
   %1 = add   i64 %0, %0 

--- a/test-cases/final-dump/func_quadruple.exp
+++ b/test-cases/final-dump/func_quadruple.exp
@@ -40,14 +40,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"func_quadruple.double<0>"(i64  %"a##0")    {
+define external fastcc  i64 @"func_quadruple.double<0>"(i64  %"a##0") alwaysinline   {
 entry:
   %0 = add   i64 %"a##0", %"a##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"func_quadruple.quadruple<0>"(i64  %"a##0")    {
+define external fastcc  i64 @"func_quadruple.quadruple<0>"(i64  %"a##0") alwaysinline   {
 entry:
   %0 = add   i64 %"a##0", %"a##0" 
   %1 = add   i64 %0, %0 

--- a/test-cases/final-dump/func_typed.exp
+++ b/test-cases/final-dump/func_typed.exp
@@ -30,7 +30,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"func_typed.plus<0>"(i64  %"a##0", i64  %"b##0")    {
+define external fastcc  i64 @"func_typed.plus<0>"(i64  %"a##0", i64  %"b##0") alwaysinline   {
 entry:
   %0 = add   i64 %"a##0", %"b##0" 
   ret i64 %0 

--- a/test-cases/final-dump/func_untyped.exp
+++ b/test-cases/final-dump/func_untyped.exp
@@ -30,7 +30,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"func_untyped.incr<0>"(i64  %"a##0")    {
+define external fastcc  i64 @"func_untyped.incr<0>"(i64  %"a##0") alwaysinline   {
 entry:
   %0 = add   i64 %"a##0", 1 
   ret i64 %0 

--- a/test-cases/final-dump/func_where.exp
+++ b/test-cases/final-dump/func_where.exp
@@ -31,7 +31,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"func_where.quad<0>"(i64  %"x##0")    {
+define external fastcc  i64 @"func_where.quad<0>"(i64  %"x##0") alwaysinline   {
 entry:
   %0 = add   i64 %"x##0", %"x##0" 
   %1 = add   i64 %0, %0 

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -201,7 +201,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -218,7 +218,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -242,7 +242,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -260,7 +260,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -285,7 +285,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_list.cons<0>"(i64  %"car##0", i64  %"cdr##0")    {
+define external fastcc  i64 @"generic_list.cons<0>"(i64  %"car##0", i64  %"cdr##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -299,7 +299,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -321,7 +321,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0")    {
+define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
   ret i64 %0 
@@ -344,7 +344,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_list.nil<0>"()    {
+define external fastcc  i64 @"generic_list.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -201,7 +201,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -218,7 +218,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -242,7 +242,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -260,7 +260,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -285,7 +285,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_list.cons<0>"(i64  %"car##0", i64  %"cdr##0")    {
+define external fastcc  i64 @"generic_list.cons<0>"(i64  %"car##0", i64  %"cdr##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -299,7 +299,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -321,7 +321,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0")    {
+define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
   ret i64 %0 
@@ -344,7 +344,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_list.nil<0>"()    {
+define external fastcc  i64 @"generic_list.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
@@ -691,7 +691,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_use.fromto<0>"(i64  %"lo##0", i64  %"hi##0")    {
+define external fastcc  i64 @"generic_use.fromto<0>"(i64  %"lo##0", i64  %"hi##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"hi##0", i64  0)  
   ret i64 %0 
@@ -719,7 +719,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_use.iota<0>"(i64  %"n##0")    {
+define external fastcc  i64 @"generic_use.iota<0>"(i64  %"n##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  %"n##0", i64  0)  
   ret i64 %0 
@@ -815,7 +815,7 @@ if.else:
 }
 
 
-define external fastcc  void @"generic_use.println<0>"(i64  %"lst##0")    {
+define external fastcc  void @"generic_use.println<0>"(i64  %"lst##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"generic_use.print<0>"(i64  %"lst##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -823,7 +823,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"generic_use.reverse<0>"(i64  %"lst##0")    {
+define external fastcc  i64 @"generic_use.reverse<0>"(i64  %"lst##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %"lst##0", i64  0)  
   ret i64 %0 

--- a/test-cases/final-dump/global_flow_inference.exp
+++ b/test-cases/final-dump/global_flow_inference.exp
@@ -114,14 +114,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"global_flow_inference.<0>"()    {
+define external fastcc  void @"global_flow_inference.<0>"() alwaysinline   {
 entry:
   store  i64 1, i64* @"resource#global_flow_inference.res" 
   ret void 
 }
 
 
-define external fastcc  void @"global_flow_inference.inout<0>"(i1  %"b##0")    {
+define external fastcc  void @"global_flow_inference.inout<0>"(i1  %"b##0") noinline   {
 entry:
   br i1 %"b##0", label %if.then, label %if.else 
 if.then:
@@ -132,14 +132,14 @@ if.else:
 }
 
 
-define external fastcc  i64 @"global_flow_inference.only_in<0>"()    {
+define external fastcc  i64 @"global_flow_inference.only_in<0>"() noinline   {
 entry:
   %0 = load  i64, i64* @"resource#global_flow_inference.res" 
   ret i64 %0 
 }
 
 
-define external fastcc  void @"global_flow_inference.only_out<0>"(i1  %"b##0")    {
+define external fastcc  void @"global_flow_inference.only_out<0>"(i1  %"b##0") noinline   {
 entry:
   br i1 %"b##0", label %if.then, label %if.else 
 if.then:
@@ -151,35 +151,35 @@ if.else:
 }
 
 
-define external fastcc  void @"global_flow_inference.rec_out_only1<0>"()    {
+define external fastcc  void @"global_flow_inference.rec_out_only1<0>"() noinline   {
 entry:
   musttail call fastcc  void  @"global_flow_inference.rec_out_only2<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"global_flow_inference.rec_out_only2<0>"()    {
+define external fastcc  void @"global_flow_inference.rec_out_only2<0>"() noinline   {
 entry:
   musttail call fastcc  void  @"global_flow_inference.rec_out_only1<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"global_flow_inference.rec_out_only_notail1<0>"()    {
+define external fastcc  void @"global_flow_inference.rec_out_only_notail1<0>"() noinline   {
 entry:
   store  i64 1, i64* @"resource#global_flow_inference.res" 
   ret void 
 }
 
 
-define external fastcc  void @"global_flow_inference.rec_out_only_notail2<0>"()    {
+define external fastcc  void @"global_flow_inference.rec_out_only_notail2<0>"() noinline   {
 entry:
   store  i64 1, i64* @"resource#global_flow_inference.res" 
   ret void 
 }
 
 
-define external fastcc  i64 @"global_flow_inference.still_only_in<0>"(i1  %"b##0")    {
+define external fastcc  i64 @"global_flow_inference.still_only_in<0>"(i1  %"b##0") noinline   {
 entry:
   br i1 %"b##0", label %if.then, label %if.else 
 if.then:

--- a/test-cases/final-dump/higher_order_append.exp
+++ b/test-cases/final-dump/higher_order_append.exp
@@ -252,7 +252,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"higher_order_append.gen#1<0>"(i64  %"cons##0", i64  %"anon#1#1##0")    {
+define external fastcc  i64 @"higher_order_append.gen#1<0>"(i64  %"cons##0", i64  %"anon#1#1##0") alwaysinline   {
 entry:
   %0 = alloca i64 
    call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %"cons##0", i64*  %0)  
@@ -261,7 +261,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"higher_order_append.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0")    {
+define external fastcc  i64 @"higher_order_append.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#env##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -273,21 +273,21 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_append.gen#2<0>"(i64  %"#env##0", i64  %"l##0")    {
+define external fastcc  void @"higher_order_append.gen#2<0>"(i64  %"#env##0", i64  %"l##0") alwaysinline   {
 entry:
   musttail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")  
   ret void 
 }
 
 
-define external fastcc  void @"higher_order_append.gen#4<0>"(i64  %"#env##0", i64  %"x##0")    {
+define external fastcc  void @"higher_order_append.gen#4<0>"(i64  %"#env##0", i64  %"x##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"higher_order_append.print_list_of_ints<0>"(i64  %"l##0")    {
+define external fastcc  void @"higher_order_append.print_list_of_ints<0>"(i64  %"l##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")  
   ret void 

--- a/test-cases/final-dump/higher_order_impure.exp
+++ b/test-cases/final-dump/higher_order_impure.exp
@@ -62,7 +62,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"higher_order_impure.<0>"()    {
+define external fastcc  void @"higher_order_impure.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"higher_order_impure.gen#1<0>"()  
   tail call ccc  void  @print_float(double  3.000000e0)  
@@ -71,19 +71,19 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_impure.gen#1<0>"()    {
+define external fastcc  void @"higher_order_impure.gen#1<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"higher_order_impure.gen#1<1>"(i64  %"#env##0")    {
+define external fastcc  void @"higher_order_impure.gen#1<1>"(i64  %"#env##0") alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  double @"higher_order_impure.measure<0>"(i64  %"func##0")    {
+define external fastcc  double @"higher_order_impure.measure<0>"(i64  %"func##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"func##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/higher_order_inline.exp
+++ b/test-cases/final-dump/higher_order_inline.exp
@@ -47,7 +47,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"higher_order_inline.<0>"()    {
+define external fastcc  void @"higher_order_inline.<0>"() alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  1)  
   tail call ccc  void  @putchar(i8  10)  
@@ -55,7 +55,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"higher_order_inline.gen#1<0>"(i64  %"#env##0", i64  %"a##0")    {
+define external fastcc  i64 @"higher_order_inline.gen#1<0>"(i64  %"#env##0", i64  %"a##0") alwaysinline   {
 entry:
   ret i64 %"a##0" 
 }

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -192,21 +192,21 @@ entry:
 }
 
 
-define external fastcc  i64 @"higher_order_refs.add_one<0>"(i64  %"i##0")    {
+define external fastcc  i64 @"higher_order_refs.add_one<0>"(i64  %"i##0") alwaysinline   {
 entry:
   %0 = add   i64 %"i##0", 1 
   ret i64 %0 
 }
 
 
-define external fastcc  double @"higher_order_refs.add_one<1>"(double  %"f##0")    {
+define external fastcc  double @"higher_order_refs.add_one<1>"(double  %"f##0") alwaysinline   {
 entry:
   %0 = fadd double %"f##0", 1.000000e0 
   ret double %0 
 }
 
 
-define external fastcc  i64 @"higher_order_refs.app<0>"(i64  %"f##0", i64  %"i##0")    {
+define external fastcc  i64 @"higher_order_refs.app<0>"(i64  %"f##0", i64  %"i##0") noinline   {
 entry:
   %0 = inttoptr i64 %"f##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -216,13 +216,13 @@ entry:
 }
 
 
-define external fastcc  double @"higher_order_refs.gen#1<0>"(double  %"anon#1#1##0")    {
+define external fastcc  double @"higher_order_refs.gen#1<0>"(double  %"anon#1#1##0") alwaysinline   {
 entry:
   ret double %"anon#1#1##0" 
 }
 
 
-define external fastcc  i64 @"higher_order_refs.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0")    {
+define external fastcc  i64 @"higher_order_refs.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
 entry:
   %0 = bitcast i64 %"anon#1#1##0" to double 
   %1 = bitcast double %0 to i64 
@@ -230,13 +230,13 @@ entry:
 }
 
 
-define external fastcc  double @"higher_order_refs.gen#2<0>"(double  %"anon#2#1##0")    {
+define external fastcc  double @"higher_order_refs.gen#2<0>"(double  %"anon#2#1##0") alwaysinline   {
 entry:
   ret double %"anon#2#1##0" 
 }
 
 
-define external fastcc  i64 @"higher_order_refs.gen#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0")    {
+define external fastcc  i64 @"higher_order_refs.gen#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
 entry:
   %0 = bitcast i64 %"anon#2#1##0" to double 
   %1 = bitcast double %0 to i64 
@@ -244,14 +244,14 @@ entry:
 }
 
 
-define external fastcc  double @"higher_order_refs.gen#3<0>"(double  %"y##0", double  %"anon#3#1##0")    {
+define external fastcc  double @"higher_order_refs.gen#3<0>"(double  %"y##0", double  %"anon#3#1##0") alwaysinline   {
 entry:
   %0 = fsub double %"anon#3#1##0", %"y##0" 
   ret double %0 
 }
 
 
-define external fastcc  i64 @"higher_order_refs.gen#3<1>"(i64  %"#env##0", i64  %"anon#3#1##0")    {
+define external fastcc  i64 @"higher_order_refs.gen#3<1>"(i64  %"#env##0", i64  %"anon#3#1##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#env##0", 8 
   %1 = inttoptr i64 %0 to double* 
@@ -263,20 +263,20 @@ entry:
 }
 
 
-define external fastcc  i64 @"higher_order_refs.gen#4<0>"(i64  %"#env##0", i64  %"a##0")    {
+define external fastcc  i64 @"higher_order_refs.gen#4<0>"(i64  %"#env##0", i64  %"a##0") alwaysinline   {
 entry:
   ret i64 %"a##0" 
 }
 
 
-define external fastcc  i64 @"higher_order_refs.gen#5<0>"(i64  %"#env##0", i64  %"i##0")    {
+define external fastcc  i64 @"higher_order_refs.gen#5<0>"(i64  %"#env##0", i64  %"i##0") alwaysinline   {
 entry:
   %0 = add   i64 %"i##0", 1 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"higher_order_refs.gen#6<0>"(i64  %"#env##0", i64  %"y##0")    {
+define external fastcc  i64 @"higher_order_refs.gen#6<0>"(i64  %"#env##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = add   i64 %"y##0", 10 
   ret i64 %0 

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -390,7 +390,7 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#1<0>"(i64  %"anon#1#1##0")    {
+define external fastcc  void @"higher_order_resources.gen#1<0>"(i64  %"anon#1#1##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#1#1##0", i64  0)  
   musttail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %0)  
@@ -398,7 +398,7 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0")    {
+define external fastcc  void @"higher_order_resources.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#1#1##0", i64  0)  
   tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %0)  
@@ -406,7 +406,7 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#2<0>"(i64  %"anon#2#1##0")    {
+define external fastcc  void @"higher_order_resources.gen#2<0>"(i64  %"anon#2#1##0") alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
@@ -422,7 +422,7 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0")    {
+define external fastcc  void @"higher_order_resources.gen#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
@@ -438,7 +438,7 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#3<0>"(i64  %"#env##0", i64  %"i##0")    {
+define external fastcc  void @"higher_order_resources.gen#3<0>"(i64  %"#env##0", i64  %"i##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %"i##0")  
   ret void 

--- a/test-cases/final-dump/higher_order_sort.exp
+++ b/test-cases/final-dump/higher_order_sort.exp
@@ -151,7 +151,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"higher_order_sort.sort<0>"(i64  %"<=##0", i64  %"xs##0")    {
+define external fastcc  i64 @"higher_order_sort.sort<0>"(i64  %"<=##0", i64  %"xs##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"higher_order_sort.gen#1<0>"(i64  %"<=##0", i64  0, i64  0, i64  %"xs##0", i64  %"xs##0")  
   ret i64 %0 

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -277,7 +277,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"higher_order_tests.do_test<0>"(i64  %"f##0", i64  %"i##0")    {
+define external fastcc  i1 @"higher_order_tests.do_test<0>"(i64  %"f##0", i64  %"i##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"f##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -288,7 +288,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"higher_order_tests.do_test2<0>"(i64  %"f##0", i64  %"i##0")    {
+define external fastcc  i1 @"higher_order_tests.do_test2<0>"(i64  %"f##0", i64  %"i##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"f##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -299,13 +299,13 @@ entry:
 }
 
 
-define external fastcc  i1 @"higher_order_tests.gen#1<0>"()    {
+define external fastcc  i1 @"higher_order_tests.gen#1<0>"() alwaysinline   {
 entry:
   ret i1 1 
 }
 
 
-define external fastcc  i64 @"higher_order_tests.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0")    {
+define external fastcc  i64 @"higher_order_tests.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
 entry:
   %0 = zext i1 1 to i64  
   ret i64 %0 
@@ -386,14 +386,14 @@ if.else:
 }
 
 
-define external fastcc  i1 @"higher_order_tests.gen#6<0>"(i64  %"anon#2#1##0")    {
+define external fastcc  i1 @"higher_order_tests.gen#6<0>"(i64  %"anon#2#1##0") alwaysinline   {
 entry:
   %0 = icmp eq i64 %"anon#2#1##0", 1 
   ret i1 %0 
 }
 
 
-define external fastcc  i64 @"higher_order_tests.gen#6<1>"(i64  %"#env##0", i64  %"anon#2#1##0")    {
+define external fastcc  i64 @"higher_order_tests.gen#6<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
 entry:
   %0 = icmp eq i64 %"anon#2#1##0", 1 
   %1 = zext i1 %0 to i64  

--- a/test-cases/final-dump/hypot.exp
+++ b/test-cases/final-dump/hypot.exp
@@ -331,7 +331,7 @@ entry:
 }
 
 
-define external fastcc  double @"hypot.area<0>"(double  %"r##0")    {
+define external fastcc  double @"hypot.area<0>"(double  %"r##0") alwaysinline   {
 entry:
   %0 = fmul double %"r##0", %"r##0" 
   %1 = fmul double 3.141593e0, %0 
@@ -339,7 +339,7 @@ entry:
 }
 
 
-define external fastcc  double @"hypot.hypot<0>"(double  %"s1##0", double  %"s2##0")    {
+define external fastcc  double @"hypot.hypot<0>"(double  %"s1##0", double  %"s2##0") alwaysinline   {
 entry:
   %0 = fmul double %"s1##0", %"s1##0" 
   %1 = fmul double %"s2##0", %"s2##0" 

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -328,7 +328,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -350,7 +350,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -364,7 +364,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -377,7 +377,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -385,7 +385,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -400,7 +400,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -409,7 +409,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -425,7 +425,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/import_in_sub_mod_lib.exp
+++ b/test-cases/final-dump/import_in_sub_mod_lib.exp
@@ -39,7 +39,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"import_in_sub_mod_lib.foo<0>"(i64  %"v##0")    {
+define external fastcc  void @"import_in_sub_mod_lib.foo<0>"(i64  %"v##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"v##0")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/import_in_sub_mod_main.exp
+++ b/test-cases/final-dump/import_in_sub_mod_main.exp
@@ -39,7 +39,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"import_in_sub_mod_lib.foo<0>"(i64  %"v##0")    {
+define external fastcc  void @"import_in_sub_mod_lib.foo<0>"(i64  %"v##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"v##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -87,7 +87,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"import_in_sub_mod_main.<0>"()    {
+define external fastcc  void @"import_in_sub_mod_main.<0>"() alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  10)  
   tail call ccc  void  @putchar(i8  10)  
@@ -135,7 +135,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"import_in_sub_mod_main.sub.bar<0>"(i64  %"v##0")    {
+define external fastcc  void @"import_in_sub_mod_main.sub.bar<0>"(i64  %"v##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"v##0")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/inline_decl.exp
+++ b/test-cases/final-dump/inline_decl.exp
@@ -100,14 +100,14 @@ entry:
 }
 
 
-define external fastcc  void @"inline_decl.finish<0>"()    {
+define external fastcc  void @"inline_decl.finish<0>"() noinline   {
 entry:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"inline_decl.long<0>"()    {
+define external fastcc  void @"inline_decl.long<0>"() alwaysinline   {
 entry:
   tail call ccc  void  @putchar(i8  104)  
   tail call ccc  void  @putchar(i8  101)  

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -143,7 +143,7 @@ if.else:
 }
 
 
-define external fastcc  void @"int_list.println<0>"(i64  %"x##0")    {
+define external fastcc  void @"int_list.println<0>"(i64  %"x##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"int_list.print<0>"(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -355,7 +355,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"int_list.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
+define external fastcc  i64 @"int_list.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -369,7 +369,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -391,7 +391,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -408,7 +408,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -432,13 +432,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"int_list.int_list.nil<0>"()    {
+define external fastcc  i64 @"int_list.int_list.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -456,7 +456,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -481,7 +481,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -220,7 +220,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"int_sequence...<0>"(i64  %"lower##0", i64  %"upper##0")    {
+define external fastcc  i64 @"int_sequence...<0>"(i64  %"lower##0", i64  %"upper##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -234,7 +234,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -247,7 +247,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"int_sequence.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"int_sequence.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -362,7 +362,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"int_sequence.lower<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"int_sequence.lower<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -370,7 +370,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"int_sequence.lower<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"int_sequence.lower<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -385,7 +385,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"int_sequence.upper<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"int_sequence.upper<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -394,7 +394,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"int_sequence.upper<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"int_sequence.upper<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -410,7 +410,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"int_sequence.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"int_sequence.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/io.exp
+++ b/test-cases/final-dump/io.exp
@@ -76,7 +76,7 @@ entry:
 }
 
 
-define external fastcc  void @"io.myprint_a<0>"(i64  %"x##0")    {
+define external fastcc  void @"io.myprint_a<0>"(i64  %"x##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -84,7 +84,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"io.myprint_b<0>"(i64  %"x##0")    {
+define external fastcc  i64 @"io.myprint_b<0>"(i64  %"x##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/io_flow_ok.exp
+++ b/test-cases/final-dump/io_flow_ok.exp
@@ -119,7 +119,7 @@ if.else:
 }
 
 
-define external fastcc  void @"io_flow_ok.aok<0>"()    {
+define external fastcc  void @"io_flow_ok.aok<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @io_flow_ok.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -127,7 +127,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"io_flow_ok.unknown<0>"()    {
+define external fastcc  i1 @"io_flow_ok.unknown<0>"() noinline   {
 entry:
   ret i1 1 
 }

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -196,7 +196,7 @@ if.else:
 }
 
 
-define external fastcc  void @"list_loop.gen#2<0>"(i64  %"h##0", i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
+define external fastcc  void @"list_loop.gen#2<0>"(i64  %"h##0", i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"h##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -228,7 +228,7 @@ if.else:
 }
 
 
-define external fastcc  void @"list_loop.gen#4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
+define external fastcc  void @"list_loop.gen#4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
@@ -444,7 +444,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"list_loop.intlist.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
+define external fastcc  i64 @"list_loop.intlist.cons<0>"(i64  %"head##0", i64  %"tail##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -458,7 +458,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"list_loop.intlist.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"list_loop.intlist.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -480,7 +480,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.head<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.head<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -497,7 +497,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.head<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -521,13 +521,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"list_loop.intlist.nil<0>"()    {
+define external fastcc  i64 @"list_loop.intlist.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.tail<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.tail<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -545,7 +545,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.tail<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -570,7 +570,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"list_loop.intlist.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"list_loop.intlist.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -201,7 +201,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_this.car<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"list_this.car<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -218,7 +218,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_this.car<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"list_this.car<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -242,7 +242,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_this.cdr<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"list_this.cdr<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -260,7 +260,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_this.cdr<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"list_this.cdr<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -285,7 +285,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"list_this.cons<0>"(i64  %"car##0", i64  %"cdr##0")    {
+define external fastcc  i64 @"list_this.cons<0>"(i64  %"car##0", i64  %"cdr##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -299,7 +299,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"list_this.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"list_this.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -321,7 +321,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"list_this.length<0>"(i64  %"x##0")    {
+define external fastcc  i64 @"list_this.length<0>"(i64  %"x##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"list_this.length1<0>"(i64  %"x##0", i64  0)  
   ret i64 %0 
@@ -344,7 +344,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"list_this.nil<0>"()    {
+define external fastcc  i64 @"list_this.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -125,7 +125,7 @@ if.else:
 }
 
 
-define external fastcc  void @"loop_bug.gen#2<0>"(i64  %"h##0", i64  %"lst##0", i64  %"t##0")    {
+define external fastcc  void @"loop_bug.gen#2<0>"(i64  %"h##0", i64  %"lst##0", i64  %"t##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
@@ -358,7 +358,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"loop_bug.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
+define external fastcc  i64 @"loop_bug.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -372,7 +372,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"loop_bug.int_list.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"loop_bug.int_list.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -394,7 +394,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.head<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.head<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -411,7 +411,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -435,13 +435,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"loop_bug.int_list.nil<0>"()    {
+define external fastcc  i64 @"loop_bug.int_list.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.tail<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.tail<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -459,7 +459,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -484,7 +484,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"loop_bug.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"loop_bug.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/loop_terminators.exp
+++ b/test-cases/final-dump/loop_terminators.exp
@@ -97,25 +97,25 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"loop_terminators.gen#1<0>"()    {
+define external fastcc  void @"loop_terminators.gen#1<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"loop_terminators.gen#2<0>"()    {
+define external fastcc  void @"loop_terminators.gen#2<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"loop_terminators.gen#3<0>"()    {
+define external fastcc  void @"loop_terminators.gen#3<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"loop_terminators.gen#4<0>"()    {
+define external fastcc  void @"loop_terminators.gen#4<0>"() alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_terminators.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_terminators.2, i32 0, i32 0) to i64), i64  %0)  
@@ -123,25 +123,25 @@ entry:
 }
 
 
-define external fastcc  void @"loop_terminators.loop0<0>"()    {
+define external fastcc  void @"loop_terminators.loop0<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"loop_terminators.loop1<0>"()    {
+define external fastcc  void @"loop_terminators.loop1<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"loop_terminators.loop2<0>"()    {
+define external fastcc  void @"loop_terminators.loop2<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"loop_terminators.loop3<0>"()    {
+define external fastcc  void @"loop_terminators.loop3<0>"() alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_terminators.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_terminators.2, i32 0, i32 0) to i64), i64  %0)  

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -124,7 +124,7 @@ if.else:
 }
 
 
-define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0")    {
+define external fastcc  void @"command_line.set_exit_code<0>"(i64  %"code##0") alwaysinline   {
 entry:
   store  i64 %"code##0", i64* @"resource#command_line.exit_code" 
   ret void 

--- a/test-cases/final-dump/mainless.exp
+++ b/test-cases/final-dump/mainless.exp
@@ -30,7 +30,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"mainless.nothing_interesting<0>"()    {
+define external fastcc  i64 @"mainless.nothing_interesting<0>"() alwaysinline   {
 entry:
   ret i64 7 
 }

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -358,7 +358,7 @@ if.else4:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f1<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"mixed_fields.f1<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -367,7 +367,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"mixed_fields.f1<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -383,7 +383,7 @@ entry:
 }
 
 
-define external fastcc  i8 @"mixed_fields.f2<0>"(i64  %"#rec##0")    {
+define external fastcc  i8 @"mixed_fields.f2<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i8* 
   %1 = load  i8, i8* %0 
@@ -391,7 +391,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f2<1>"(i64  %"#rec##0", i8  %"#field##0")    {
+define external fastcc  i64 @"mixed_fields.f2<1>"(i64  %"#rec##0", i8  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -406,7 +406,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f3<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"mixed_fields.f3<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
@@ -415,7 +415,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f3<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"mixed_fields.f3<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -431,7 +431,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"mixed_fields.f4<0>"(i64  %"#rec##0")    {
+define external fastcc  i1 @"mixed_fields.f4<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 1 
   %1 = inttoptr i64 %0 to i1* 
@@ -440,7 +440,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f4<1>"(i64  %"#rec##0", i1  %"#field##0")    {
+define external fastcc  i64 @"mixed_fields.f4<1>"(i64  %"#rec##0", i1  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -456,7 +456,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f5<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"mixed_fields.f5<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 24 
   %1 = inttoptr i64 %0 to i64* 
@@ -465,7 +465,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f5<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"mixed_fields.f5<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -481,7 +481,7 @@ entry:
 }
 
 
-define external fastcc  i8 @"mixed_fields.f6<0>"(i64  %"#rec##0")    {
+define external fastcc  i8 @"mixed_fields.f6<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 2 
   %1 = inttoptr i64 %0 to i8* 
@@ -490,7 +490,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f6<1>"(i64  %"#rec##0", i8  %"#field##0")    {
+define external fastcc  i64 @"mixed_fields.f6<1>"(i64  %"#rec##0", i8  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -506,7 +506,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.mixed<0>"(i64  %"f1##0", i8  %"f2##0", i64  %"f3##0", i1  %"f4##0", i64  %"f5##0", i8  %"f6##0")    {
+define external fastcc  i64 @"mixed_fields.mixed<0>"(i64  %"f1##0", i8  %"f2##0", i64  %"f3##0", i1  %"f4##0", i64  %"f5##0", i8  %"f6##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -532,7 +532,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i8* 
   %1 = load  i8, i8* %0 
@@ -596,7 +596,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"mixed_fields.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"mixed_fields.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"mixed_fields.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/multi_out.exp
+++ b/test-cases/final-dump/multi_out.exp
@@ -40,13 +40,13 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"multi_out.<0>"()    {
+define external fastcc  void @"multi_out.<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  {i64, i64, i64} @"multi_out.onetwothree<0>"()    {
+define external fastcc  {i64, i64, i64} @"multi_out.onetwothree<0>"() alwaysinline   {
 entry:
   %0 = insertvalue {i64, i64, i64} undef, i64 1, 0 
   %1 = insertvalue {i64, i64, i64} %0, i64 2, 1 

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -157,7 +157,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"multi_specz.<0>"()    {
+define external fastcc  void @"multi_specz.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"multi_specz.bar1<0>"()  
   musttail call fastcc  void  @"multi_specz.bar2<0>"()  
@@ -516,7 +516,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -538,7 +538,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -552,7 +552,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -565,7 +565,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -573,7 +573,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -588,7 +588,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -597,7 +597,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -613,7 +613,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -91,7 +91,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"multi_specz_cyclic_exe.<0>"()    {
+define external fastcc  void @"multi_specz_cyclic_exe.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"multi_specz_cyclic_exe.main<0>"()  
   ret void 
@@ -502,7 +502,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -524,7 +524,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -538,7 +538,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -551,7 +551,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -559,7 +559,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -574,7 +574,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -583,7 +583,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -599,7 +599,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -279,7 +279,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -301,7 +301,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -315,7 +315,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -328,7 +328,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -336,7 +336,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -351,7 +351,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -360,7 +360,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -376,7 +376,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -279,7 +279,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -301,7 +301,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -315,7 +315,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -328,7 +328,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -336,7 +336,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -351,7 +351,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -360,7 +360,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -376,7 +376,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -290,14 +290,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.card.=<0>"(i6  %"#left##0", i6  %"#right##0")    {
+define external fastcc  i1 @"multictr.card.=<0>"(i6  %"#left##0", i6  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i6 %"#left##0", %"#right##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i6 @"multictr.card.card<0>"(i4  %"rank##0", i2  %"suit##0")    {
+define external fastcc  i6 @"multictr.card.card<0>"(i4  %"rank##0", i2  %"suit##0") alwaysinline   {
 entry:
   %0 = zext i4 %"rank##0" to i6  
   %1 = shl   i6 %0, 2 
@@ -307,7 +307,7 @@ entry:
 }
 
 
-define external fastcc  {i4, i2} @"multictr.card.card<1>"(i6  %"#result##0")    {
+define external fastcc  {i4, i2} @"multictr.card.card<1>"(i6  %"#result##0") alwaysinline   {
 entry:
   %0 = lshr  i6 %"#result##0", 2 
   %1 = and i6 %0, 15 
@@ -320,7 +320,7 @@ entry:
 }
 
 
-define external fastcc  i4 @"multictr.card.rank<0>"(i6  %"#rec##0")    {
+define external fastcc  i4 @"multictr.card.rank<0>"(i6  %"#rec##0") alwaysinline   {
 entry:
   %0 = lshr  i6 %"#rec##0", 2 
   %1 = and i6 %0, 15 
@@ -329,7 +329,7 @@ entry:
 }
 
 
-define external fastcc  i6 @"multictr.card.rank<1>"(i6  %"#rec##0", i4  %"#field##0")    {
+define external fastcc  i6 @"multictr.card.rank<1>"(i6  %"#rec##0", i4  %"#field##0") alwaysinline   {
 entry:
   %0 = and i6 %"#rec##0", -61 
   %1 = zext i4 %"#field##0" to i6  
@@ -339,7 +339,7 @@ entry:
 }
 
 
-define external fastcc  i2 @"multictr.card.suit<0>"(i6  %"#rec##0")    {
+define external fastcc  i2 @"multictr.card.suit<0>"(i6  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i6 %"#rec##0", 3 
   %1 = trunc i6 %0 to i2  
@@ -347,7 +347,7 @@ entry:
 }
 
 
-define external fastcc  i6 @"multictr.card.suit<1>"(i6  %"#rec##0", i2  %"#field##0")    {
+define external fastcc  i6 @"multictr.card.suit<1>"(i6  %"#rec##0", i2  %"#field##0") alwaysinline   {
 entry:
   %0 = and i6 %"#rec##0", -4 
   %1 = zext i2 %"#field##0" to i6  
@@ -356,7 +356,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.card.~=<0>"(i6  %"#left##0", i6  %"#right##0")    {
+define external fastcc  i1 @"multictr.card.~=<0>"(i6  %"#left##0", i6  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i6 %"#left##0", %"#right##0" 
   %1 = xor i1 %0, 1 
@@ -3209,13 +3209,13 @@ if.else62:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.autumn<0>"()    {
+define external fastcc  i64 @"multictr.complicated.autumn<0>"() alwaysinline   {
 entry:
   ret i64 3 
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c01<0>"(i64  %"f01##0")    {
+define external fastcc  i64 @"multictr.complicated.c01<0>"(i64  %"f01##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3226,7 +3226,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c01<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c01<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3251,7 +3251,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c02<0>"(i64  %"f02##0")    {
+define external fastcc  i64 @"multictr.complicated.c02<0>"(i64  %"f02##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3263,7 +3263,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c02<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c02<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3289,7 +3289,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c03<0>"(i64  %"f03##0")    {
+define external fastcc  i64 @"multictr.complicated.c03<0>"(i64  %"f03##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3301,7 +3301,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c03<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c03<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3327,7 +3327,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c04<0>"(i64  %"f04##0")    {
+define external fastcc  i64 @"multictr.complicated.c04<0>"(i64  %"f04##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3339,7 +3339,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c04<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c04<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3365,7 +3365,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c05<0>"(i64  %"f05##0")    {
+define external fastcc  i64 @"multictr.complicated.c05<0>"(i64  %"f05##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3377,7 +3377,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c05<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c05<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3403,7 +3403,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c06<0>"(i64  %"f06##0")    {
+define external fastcc  i64 @"multictr.complicated.c06<0>"(i64  %"f06##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3415,7 +3415,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c06<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c06<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3441,7 +3441,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c07<0>"(i64  %"f07##0")    {
+define external fastcc  i64 @"multictr.complicated.c07<0>"(i64  %"f07##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3453,7 +3453,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c07<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c07<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3479,7 +3479,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c08<0>"(i64  %"f08##0")    {
+define external fastcc  i64 @"multictr.complicated.c08<0>"(i64  %"f08##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3494,7 +3494,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c08<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c08<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3530,7 +3530,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c09<0>"(i64  %"f09##0")    {
+define external fastcc  i64 @"multictr.complicated.c09<0>"(i64  %"f09##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3545,7 +3545,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c09<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c09<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3581,7 +3581,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c10<0>"(i64  %"f10##0")    {
+define external fastcc  i64 @"multictr.complicated.c10<0>"(i64  %"f10##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3596,7 +3596,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c10<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c10<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3632,7 +3632,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c11<0>"(i64  %"f11##0")    {
+define external fastcc  i64 @"multictr.complicated.c11<0>"(i64  %"f11##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3647,7 +3647,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c11<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c11<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3683,7 +3683,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c12<0>"(i64  %"f12##0")    {
+define external fastcc  i64 @"multictr.complicated.c12<0>"(i64  %"f12##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3698,7 +3698,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c12<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c12<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3734,7 +3734,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c13<0>"(i64  %"f13##0")    {
+define external fastcc  i64 @"multictr.complicated.c13<0>"(i64  %"f13##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3749,7 +3749,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c13<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c13<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3785,7 +3785,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c14<0>"(i64  %"f14##0")    {
+define external fastcc  i64 @"multictr.complicated.c14<0>"(i64  %"f14##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3800,7 +3800,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c14<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c14<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3836,7 +3836,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c15<0>"(i64  %"f15##0")    {
+define external fastcc  i64 @"multictr.complicated.c15<0>"(i64  %"f15##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3851,7 +3851,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c15<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c15<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3887,7 +3887,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c16<0>"(i64  %"f16##0")    {
+define external fastcc  i64 @"multictr.complicated.c16<0>"(i64  %"f16##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3902,7 +3902,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c16<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c16<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3938,7 +3938,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c17<0>"(i64  %"f17##0")    {
+define external fastcc  i64 @"multictr.complicated.c17<0>"(i64  %"f17##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -3953,7 +3953,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c17<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c17<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#result##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -3989,7 +3989,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f01<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f01<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4014,7 +4014,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f01<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f01<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4046,7 +4046,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f02<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f02<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4072,7 +4072,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f02<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f02<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4107,7 +4107,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f03<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f03<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4133,7 +4133,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f03<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f03<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4168,7 +4168,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f04<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f04<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4194,7 +4194,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f04<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f04<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4229,7 +4229,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f05<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f05<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4255,7 +4255,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f05<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f05<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4290,7 +4290,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f06<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f06<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4316,7 +4316,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f06<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f06<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4351,7 +4351,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f07<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f07<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4377,7 +4377,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f07<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f07<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4412,7 +4412,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f08<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f08<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4448,7 +4448,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f08<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f08<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4493,7 +4493,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f09<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f09<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4529,7 +4529,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f09<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f09<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4574,7 +4574,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f10<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f10<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4610,7 +4610,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f10<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f10<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4655,7 +4655,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f11<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f11<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4691,7 +4691,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f11<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f11<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4736,7 +4736,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f12<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f12<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4772,7 +4772,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f12<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f12<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4817,7 +4817,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f13<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f13<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4853,7 +4853,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f13<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f13<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4898,7 +4898,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f14<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f14<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4934,7 +4934,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f14<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f14<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -4979,7 +4979,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f15<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f15<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -5015,7 +5015,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f15<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f15<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -5060,7 +5060,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f16<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f16<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -5096,7 +5096,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f16<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f16<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -5141,7 +5141,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f17<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f17<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -5177,7 +5177,7 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f17<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f17<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp uge i64 %"#rec##0", 4 
   br i1 %0, label %if.then, label %if.else 
@@ -5222,25 +5222,25 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.spring<0>"()    {
+define external fastcc  i64 @"multictr.complicated.spring<0>"() alwaysinline   {
 entry:
   ret i64 1 
 }
 
 
-define external fastcc  i64 @"multictr.complicated.summer<0>"()    {
+define external fastcc  i64 @"multictr.complicated.summer<0>"() alwaysinline   {
 entry:
   ret i64 2 
 }
 
 
-define external fastcc  i64 @"multictr.complicated.winter<0>"()    {
+define external fastcc  i64 @"multictr.complicated.winter<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  i1 @"multictr.complicated.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr.complicated.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"multictr.complicated.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 
@@ -5320,42 +5320,42 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.length.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr.length.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i64 %"#left##0", %"#right##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i64 @"multictr.length.metres<0>"(double  %"value##0")    {
+define external fastcc  i64 @"multictr.length.metres<0>"(double  %"value##0") alwaysinline   {
 entry:
   %0 = bitcast double %"value##0" to i64 
   ret i64 %0 
 }
 
 
-define external fastcc  double @"multictr.length.metres<1>"(i64  %"#result##0")    {
+define external fastcc  double @"multictr.length.metres<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = bitcast i64 %"#result##0" to double 
   ret double %0 
 }
 
 
-define external fastcc  double @"multictr.length.value<0>"(i64  %"#rec##0")    {
+define external fastcc  double @"multictr.length.value<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = bitcast i64 %"#rec##0" to double 
   ret double %0 
 }
 
 
-define external fastcc  i64 @"multictr.length.value<1>"(double  %"#field##0")    {
+define external fastcc  i64 @"multictr.length.value<1>"(double  %"#field##0") alwaysinline   {
 entry:
   %0 = bitcast double %"#field##0" to i64 
   ret i64 %0 
 }
 
 
-define external fastcc  i1 @"multictr.length.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr.length.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i64 %"#left##0", %"#right##0" 
   %1 = xor i1 %0, 1 
@@ -5510,7 +5510,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.maybe_int.just<0>"(i64  %"value##0")    {
+define external fastcc  i64 @"multictr.maybe_int.just<0>"(i64  %"value##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -5521,7 +5521,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.just<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.just<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -5538,13 +5538,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr.maybe_int.nothing<0>"()    {
+define external fastcc  i64 @"multictr.maybe_int.nothing<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.value<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.value<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -5561,7 +5561,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.value<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.value<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -5585,7 +5585,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"multictr.maybe_int.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr.maybe_int.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"multictr.maybe_int.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 
@@ -5836,7 +5836,7 @@ if.else3:
 }
 
 
-define external fastcc  i64 @"multictr.number.float<0>"(double  %"float_value##0")    {
+define external fastcc  i64 @"multictr.number.float<0>"(double  %"float_value##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -5848,7 +5848,7 @@ entry:
 }
 
 
-define external fastcc  {double, i1} @"multictr.number.float<1>"(i64  %"#result##0")    {
+define external fastcc  {double, i1} @"multictr.number.float<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 1 
   %1 = icmp eq i64 %0, 1 
@@ -5867,7 +5867,7 @@ if.else:
 }
 
 
-define external fastcc  {double, i1} @"multictr.number.float_value<0>"(i64  %"#rec##0")    {
+define external fastcc  {double, i1} @"multictr.number.float_value<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 1 
   %1 = icmp eq i64 %0, 1 
@@ -5886,7 +5886,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.float_value<1>"(i64  %"#rec##0", double  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.number.float_value<1>"(i64  %"#rec##0", double  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 1 
   %1 = icmp eq i64 %0, 1 
@@ -5914,7 +5914,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr.number.int<0>"(i64  %"int_value##0")    {
+define external fastcc  i64 @"multictr.number.int<0>"(i64  %"int_value##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -5925,7 +5925,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.number.int<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 1 
   %1 = icmp eq i64 %0, 0 
@@ -5943,7 +5943,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int_value<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.number.int_value<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 1 
   %1 = icmp eq i64 %0, 0 
@@ -5961,7 +5961,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int_value<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.number.int_value<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 1 
   %1 = icmp eq i64 %0, 0 
@@ -5986,7 +5986,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"multictr.number.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr.number.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"multictr.number.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 
@@ -6066,38 +6066,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.perhaps.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr.perhaps.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i64 %"#left##0", %"#right##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.content<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"multictr.perhaps.content<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   ret i64 %"#rec##0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.content<1>"(i64  %"#field##0")    {
+define external fastcc  i64 @"multictr.perhaps.content<1>"(i64  %"#field##0") alwaysinline   {
 entry:
   ret i64 %"#field##0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.perhaps<0>"(i64  %"content##0")    {
+define external fastcc  i64 @"multictr.perhaps.perhaps<0>"(i64  %"content##0") alwaysinline   {
 entry:
   ret i64 %"content##0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.perhaps<1>"(i64  %"#result##0")    {
+define external fastcc  i64 @"multictr.perhaps.perhaps<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   ret i64 %"#result##0" 
 }
 
 
-define external fastcc  i1 @"multictr.perhaps.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr.perhaps.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i64 %"#left##0", %"#right##0" 
   %1 = xor i1 %0, 1 
@@ -6262,92 +6262,92 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.rank.=<0>"(i4  %"#left##0", i4  %"#right##0")    {
+define external fastcc  i1 @"multictr.rank.=<0>"(i4  %"#left##0", i4  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i4 %"#left##0", %"#right##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i4 @"multictr.rank.ace<0>"()    {
+define external fastcc  i4 @"multictr.rank.ace<0>"() alwaysinline   {
 entry:
   ret i4 12 
 }
 
 
-define external fastcc  i4 @"multictr.rank.jack<0>"()    {
+define external fastcc  i4 @"multictr.rank.jack<0>"() alwaysinline   {
 entry:
   ret i4 9 
 }
 
 
-define external fastcc  i4 @"multictr.rank.king<0>"()    {
+define external fastcc  i4 @"multictr.rank.king<0>"() alwaysinline   {
 entry:
   ret i4 11 
 }
 
 
-define external fastcc  i4 @"multictr.rank.queen<0>"()    {
+define external fastcc  i4 @"multictr.rank.queen<0>"() alwaysinline   {
 entry:
   ret i4 10 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r10<0>"()    {
+define external fastcc  i4 @"multictr.rank.r10<0>"() alwaysinline   {
 entry:
   ret i4 8 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r2<0>"()    {
+define external fastcc  i4 @"multictr.rank.r2<0>"() alwaysinline   {
 entry:
   ret i4 0 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r3<0>"()    {
+define external fastcc  i4 @"multictr.rank.r3<0>"() alwaysinline   {
 entry:
   ret i4 1 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r4<0>"()    {
+define external fastcc  i4 @"multictr.rank.r4<0>"() alwaysinline   {
 entry:
   ret i4 2 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r5<0>"()    {
+define external fastcc  i4 @"multictr.rank.r5<0>"() alwaysinline   {
 entry:
   ret i4 3 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r6<0>"()    {
+define external fastcc  i4 @"multictr.rank.r6<0>"() alwaysinline   {
 entry:
   ret i4 4 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r7<0>"()    {
+define external fastcc  i4 @"multictr.rank.r7<0>"() alwaysinline   {
 entry:
   ret i4 5 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r8<0>"()    {
+define external fastcc  i4 @"multictr.rank.r8<0>"() alwaysinline   {
 entry:
   ret i4 6 
 }
 
 
-define external fastcc  i4 @"multictr.rank.r9<0>"()    {
+define external fastcc  i4 @"multictr.rank.r9<0>"() alwaysinline   {
 entry:
   ret i4 7 
 }
 
 
-define external fastcc  i1 @"multictr.rank.~=<0>"(i4  %"#left##0", i4  %"#right##0")    {
+define external fastcc  i1 @"multictr.rank.~=<0>"(i4  %"#left##0", i4  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i4 %"#left##0", %"#right##0" 
   %1 = xor i1 %0, 1 
@@ -6768,7 +6768,7 @@ if.else7:
 }
 
 
-define external fastcc  i64 @"multictr.simple.one<0>"(i64  %"one_field##0")    {
+define external fastcc  i64 @"multictr.simple.one<0>"(i64  %"one_field##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -6779,7 +6779,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -6804,7 +6804,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one_field<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one_field<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -6829,7 +6829,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one_field<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one_field<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -6861,7 +6861,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.simple.two<0>"(i64  %"two_field1##0", i64  %"two_field2##0")    {
+define external fastcc  i64 @"multictr.simple.two<0>"(i64  %"two_field1##0", i64  %"two_field2##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -6876,7 +6876,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"multictr.simple.two<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"multictr.simple.two<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -6908,7 +6908,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field1<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field1<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -6934,7 +6934,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field1<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -6969,7 +6969,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field2<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field2<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -6995,7 +6995,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field2<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field2<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -7030,13 +7030,13 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.simple.zero<0>"()    {
+define external fastcc  i64 @"multictr.simple.zero<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  i1 @"multictr.simple.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr.simple.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"multictr.simple.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 
@@ -7120,38 +7120,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.suit.=<0>"(i2  %"#left##0", i2  %"#right##0")    {
+define external fastcc  i1 @"multictr.suit.=<0>"(i2  %"#left##0", i2  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i2 %"#left##0", %"#right##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i2 @"multictr.suit.clubs<0>"()    {
+define external fastcc  i2 @"multictr.suit.clubs<0>"() alwaysinline   {
 entry:
   ret i2 0 
 }
 
 
-define external fastcc  i2 @"multictr.suit.diamonds<0>"()    {
+define external fastcc  i2 @"multictr.suit.diamonds<0>"() alwaysinline   {
 entry:
   ret i2 1 
 }
 
 
-define external fastcc  i2 @"multictr.suit.hearts<0>"()    {
+define external fastcc  i2 @"multictr.suit.hearts<0>"() alwaysinline   {
 entry:
   ret i2 2 
 }
 
 
-define external fastcc  i2 @"multictr.suit.spades<0>"()    {
+define external fastcc  i2 @"multictr.suit.spades<0>"() alwaysinline   {
 entry:
   ret i2 3 
 }
 
 
-define external fastcc  i1 @"multictr.suit.~=<0>"(i2  %"#left##0", i2  %"#right##0")    {
+define external fastcc  i1 @"multictr.suit.~=<0>"(i2  %"#left##0", i2  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i2 %"#left##0", %"#right##0" 
   %1 = xor i1 %0, 1 
@@ -7207,19 +7207,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.unit.=<0>"()    {
+define external fastcc  i1 @"multictr.unit.=<0>"() alwaysinline   {
 entry:
   ret i1 1 
 }
 
 
-define external fastcc  void @"multictr.unit.unit<0>"()    {
+define external fastcc  void @"multictr.unit.unit<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  i1 @"multictr.unit.~=<0>"()    {
+define external fastcc  i1 @"multictr.unit.~=<0>"() alwaysinline   {
 entry:
   ret i1 0 
 }

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -1337,7 +1337,7 @@ if.else17:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c01<0>"(i64  %"f01##0")    {
+define external fastcc  i64 @"multictr2.t.c01<0>"(i64  %"f01##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1348,7 +1348,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c01<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c01<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 7 
   %1 = icmp eq i64 %0, 0 
@@ -1366,7 +1366,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c02<0>"(i64  %"f02##0")    {
+define external fastcc  i64 @"multictr2.t.c02<0>"(i64  %"f02##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1378,7 +1378,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c02<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c02<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 7 
   %1 = icmp eq i64 %0, 1 
@@ -1397,7 +1397,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c03<0>"(i64  %"f03##0")    {
+define external fastcc  i64 @"multictr2.t.c03<0>"(i64  %"f03##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1409,7 +1409,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c03<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c03<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 7 
   %1 = icmp eq i64 %0, 2 
@@ -1428,7 +1428,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c04<0>"(i64  %"f04##0")    {
+define external fastcc  i64 @"multictr2.t.c04<0>"(i64  %"f04##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1440,7 +1440,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c04<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c04<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 7 
   %1 = icmp eq i64 %0, 3 
@@ -1459,7 +1459,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c05<0>"(i64  %"f05##0")    {
+define external fastcc  i64 @"multictr2.t.c05<0>"(i64  %"f05##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1471,7 +1471,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c05<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c05<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 7 
   %1 = icmp eq i64 %0, 4 
@@ -1490,7 +1490,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c06<0>"(i64  %"f06##0")    {
+define external fastcc  i64 @"multictr2.t.c06<0>"(i64  %"f06##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1502,7 +1502,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c06<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c06<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 7 
   %1 = icmp eq i64 %0, 5 
@@ -1521,7 +1521,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c07<0>"(i64  %"f07##0")    {
+define external fastcc  i64 @"multictr2.t.c07<0>"(i64  %"f07##0") alwaysinline   {
 entry:
   %0 = trunc i64 8 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1533,7 +1533,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c07<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c07<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 7 
   %1 = icmp eq i64 %0, 6 
@@ -1552,7 +1552,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c08<0>"(i64  %"f08_a##0", i64  %"f08_b##0", double  %"f08_c##0")    {
+define external fastcc  i64 @"multictr2.t.c08<0>"(i64  %"f08_a##0", i64  %"f08_b##0", double  %"f08_c##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1570,7 +1570,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, double, i1} @"multictr2.t.c08<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, double, i1} @"multictr2.t.c08<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = and i64 %"#result##0", 7 
   %1 = icmp eq i64 %0, 7 
@@ -1599,7 +1599,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f01<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f01<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 0 
@@ -1617,7 +1617,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f01<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f01<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 0 
@@ -1642,7 +1642,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f02<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f02<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 1 
@@ -1661,7 +1661,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f02<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f02<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 1 
@@ -1689,7 +1689,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f03<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f03<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 2 
@@ -1708,7 +1708,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f03<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f03<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 2 
@@ -1736,7 +1736,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f04<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f04<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 3 
@@ -1755,7 +1755,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f04<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f04<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 3 
@@ -1783,7 +1783,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f05<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f05<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 4 
@@ -1802,7 +1802,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f05<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f05<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 4 
@@ -1830,7 +1830,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f06<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f06<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 5 
@@ -1849,7 +1849,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f06<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f06<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 5 
@@ -1877,7 +1877,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f07<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f07<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 6 
@@ -1896,7 +1896,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f07<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f07<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 6 
@@ -1924,7 +1924,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_a<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_a<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 7 
@@ -1943,7 +1943,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_a<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 7 
@@ -1971,7 +1971,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_b<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_b<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 7 
@@ -1990,7 +1990,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_b<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_b<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 7 
@@ -2018,7 +2018,7 @@ if.else:
 }
 
 
-define external fastcc  {double, i1} @"multictr2.t.f08_c<0>"(i64  %"#rec##0")    {
+define external fastcc  {double, i1} @"multictr2.t.f08_c<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 7 
@@ -2037,7 +2037,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_c<1>"(i64  %"#rec##0", double  %"#field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_c<1>"(i64  %"#rec##0", double  %"#field##0") alwaysinline   {
 entry:
   %0 = and i64 %"#rec##0", 7 
   %1 = icmp eq i64 %0, 7 
@@ -2065,7 +2065,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"multictr2.t.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"multictr2.t.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"multictr2.t.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -231,7 +231,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"mutual_type.a.a<0>"(i64  %"ahead##0", i64  %"atail##0")    {
+define external fastcc  i64 @"mutual_type.a.a<0>"(i64  %"ahead##0", i64  %"atail##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -245,7 +245,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"mutual_type.a.a<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"mutual_type.a.a<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -267,7 +267,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.ahead<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.ahead<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -284,7 +284,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.ahead<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.ahead<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -308,7 +308,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.atail<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.atail<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -326,7 +326,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.atail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.atail<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -351,13 +351,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"mutual_type.a.no_a<0>"()    {
+define external fastcc  i64 @"mutual_type.a.no_a<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  i1 @"mutual_type.a.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"mutual_type.a.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 
@@ -569,7 +569,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"mutual_type.b.b<0>"(i64  %"bhead##0", i64  %"btail##0")    {
+define external fastcc  i64 @"mutual_type.b.b<0>"(i64  %"bhead##0", i64  %"btail##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -583,7 +583,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"mutual_type.b.b<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"mutual_type.b.b<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -605,7 +605,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.bhead<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.bhead<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -622,7 +622,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.bhead<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.bhead<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -646,7 +646,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.btail<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.btail<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -664,7 +664,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.btail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.btail<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -689,13 +689,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"mutual_type.b.no_b<0>"()    {
+define external fastcc  i64 @"mutual_type.b.no_b<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  i1 @"mutual_type.b.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"mutual_type.b.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -92,7 +92,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
+define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.1, i32 0, i32 0) to i64))  
   musttail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.3, i32 0, i32 0) to i64))  
@@ -384,13 +384,13 @@ if.else3:
 }
 
 
-define external fastcc  i64 @"mytree.tree.empty<0>"()    {
+define external fastcc  i64 @"mytree.tree.empty<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -408,7 +408,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -433,7 +433,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -450,7 +450,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -474,7 +474,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
+define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -491,7 +491,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -518,7 +518,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -536,7 +536,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -561,7 +561,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -95,7 +95,7 @@ entry:
 }
 
 
-define external fastcc  void @"nested_loop.gen#1<0>"()    {
+define external fastcc  void @"nested_loop.gen#1<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -106,7 +106,7 @@ entry:
 }
 
 
-define external fastcc  void @"nested_loop.gen#2<0>"()    {
+define external fastcc  void @"nested_loop.gen#2<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/numbers.exp
+++ b/test-cases/final-dump/numbers.exp
@@ -73,7 +73,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"numbers.<0>"()    {
+define external fastcc  void @"numbers.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @numbers.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -95,7 +95,7 @@ if.else:
 }
 
 
-define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0")    {
+define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0") alwaysinline   {
 entry:
   %0 = fsub double %"f##0", 3.200000e1 
   %1 = fdiv double %0, 1.800000e0 

--- a/test-cases/final-dump/out_global_overwritten.exp
+++ b/test-cases/final-dump/out_global_overwritten.exp
@@ -58,7 +58,7 @@ entry:
 }
 
 
-define external fastcc  void @"out_global_overwritten.out<0>"()    {
+define external fastcc  void @"out_global_overwritten.out<0>"() noinline   {
 entry:
   store  i64 11, i64* @"resource#out_global_overwritten.res" 
   ret void 

--- a/test-cases/final-dump/out_only_global_flow.exp
+++ b/test-cases/final-dump/out_only_global_flow.exp
@@ -66,7 +66,7 @@ entry:
 }
 
 
-define external fastcc  void @"out_only_global_flow.out<0>"()    {
+define external fastcc  void @"out_only_global_flow.out<0>"() noinline   {
 entry:
   store  i64 11, i64* @"resource#out_only_global_flow.res" 
   ret void 

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -49,7 +49,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"person1.<0>"()    {
+define external fastcc  void @"person1.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person1.1, i32 0, i32 0) to i64))  
   ret void 
@@ -173,7 +173,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"person1.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person1.person.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -195,7 +195,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"person1.person.firstname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person1.person.firstname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -203,7 +203,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person1.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person1.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -218,7 +218,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person1.person.lastname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person1.person.lastname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -227,7 +227,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person1.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person1.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -243,7 +243,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person1.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
+define external fastcc  i64 @"person1.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -257,7 +257,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -270,7 +270,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"person1.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person1.person.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -50,7 +50,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"person2.<0>"()    {
+define external fastcc  void @"person2.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.1, i32 0, i32 0) to i64))  
@@ -175,7 +175,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"person2.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person2.person.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -197,7 +197,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"person2.person.firstname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person2.person.firstname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -205,7 +205,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person2.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person2.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -220,7 +220,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person2.person.lastname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person2.person.lastname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -229,7 +229,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person2.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person2.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -245,7 +245,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person2.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
+define external fastcc  i64 @"person2.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -259,7 +259,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -272,7 +272,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"person2.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person2.person.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -56,7 +56,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"person3.<0>"()    {
+define external fastcc  void @"person3.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person3.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person3.3, i32 0, i32 0) to i64))  
@@ -181,7 +181,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"person3.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person3.person.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -203,7 +203,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"person3.person.firstname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person3.person.firstname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -211,7 +211,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person3.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person3.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -226,7 +226,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person3.person.lastname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person3.person.lastname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -235,7 +235,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person3.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person3.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -251,7 +251,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person3.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
+define external fastcc  i64 @"person3.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -265,7 +265,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -278,7 +278,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"person3.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person3.person.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -56,7 +56,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"person4.<0>"()    {
+define external fastcc  void @"person4.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person4.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person4.3, i32 0, i32 0) to i64))  
@@ -181,7 +181,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"person4.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person4.person.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -203,7 +203,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"person4.person.firstname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person4.person.firstname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -211,7 +211,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person4.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person4.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -226,7 +226,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person4.person.lastname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person4.person.lastname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -235,7 +235,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person4.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person4.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -251,7 +251,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person4.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
+define external fastcc  i64 @"person4.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -265,7 +265,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -278,7 +278,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"person4.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person4.person.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -65,7 +65,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"person5.<0>"()    {
+define external fastcc  void @"person5.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.3, i32 0, i32 0) to i64))  
@@ -73,7 +73,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person5.update_both<0>"(i64  %"p1##0", i64  %"p2##0")    {
+define external fastcc  {i64, i64} @"person5.update_both<0>"(i64  %"p1##0", i64  %"p2##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -216,7 +216,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"person5.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person5.person.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -238,7 +238,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"person5.person.firstname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person5.person.firstname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -246,7 +246,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person5.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person5.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -261,7 +261,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person5.person.lastname<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"person5.person.lastname<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -270,7 +270,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person5.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"person5.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -286,7 +286,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"person5.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
+define external fastcc  i64 @"person5.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -300,7 +300,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -313,7 +313,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"person5.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"person5.person.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -211,7 +211,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -233,7 +233,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -247,7 +247,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -260,7 +260,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -268,7 +268,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -283,7 +283,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -292,7 +292,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -308,7 +308,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -211,7 +211,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -233,7 +233,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -247,7 +247,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -260,7 +260,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -268,7 +268,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -283,7 +283,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -292,7 +292,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -308,7 +308,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -211,7 +211,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -233,7 +233,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -247,7 +247,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -260,7 +260,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -268,7 +268,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -283,7 +283,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -292,7 +292,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -308,7 +308,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -147,7 +147,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"position_float.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position_float.position.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to double* 
   %1 = load  double, double* %0 
@@ -169,7 +169,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"position_float.position.position<0>"(double  %"x##0", double  %"y##0")    {
+define external fastcc  i64 @"position_float.position.position<0>"(double  %"x##0", double  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -183,7 +183,7 @@ entry:
 }
 
 
-define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"#result##0")    {
+define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to double* 
   %1 = load  double, double* %0 
@@ -196,7 +196,7 @@ entry:
 }
 
 
-define external fastcc  double @"position_float.position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  double @"position_float.position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to double* 
   %1 = load  double, double* %0 
@@ -204,7 +204,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position_float.position.x<1>"(i64  %"#rec##0", double  %"#field##0")    {
+define external fastcc  i64 @"position_float.position.x<1>"(i64  %"#rec##0", double  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -219,7 +219,7 @@ entry:
 }
 
 
-define external fastcc  double @"position_float.position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  double @"position_float.position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to double* 
@@ -228,7 +228,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"position_float.position.y<1>"(i64  %"#rec##0", double  %"#field##0")    {
+define external fastcc  i64 @"position_float.position.y<1>"(i64  %"#rec##0", double  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -244,7 +244,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"position_float.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"position_float.position.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to double* 
   %1 = load  double, double* %0 

--- a/test-cases/final-dump/proc_allin.exp
+++ b/test-cases/final-dump/proc_allin.exp
@@ -29,7 +29,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"proc_allin.nada<0>"()    {
+define external fastcc  void @"proc_allin.nada<0>"() alwaysinline   {
 entry:
   ret void 
 }

--- a/test-cases/final-dump/proc_beer.exp
+++ b/test-cases/final-dump/proc_beer.exp
@@ -92,14 +92,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"proc_beer.<0>"()    {
+define external fastcc  void @"proc_beer.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  99)  
   ret void 
 }
 
 
-define external fastcc  void @"proc_beer.beer99<0>"()    {
+define external fastcc  void @"proc_beer.beer99<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  99)  
   ret void 
@@ -122,7 +122,7 @@ if.else:
 }
 
 
-define external fastcc  void @"proc_beer.gen#2<0>"(i64  %"count##0")    {
+define external fastcc  void @"proc_beer.gen#2<0>"(i64  %"count##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"count##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.1, i32 0, i32 0) to i64))  

--- a/test-cases/final-dump/proc_factorial.exp
+++ b/test-cases/final-dump/proc_factorial.exp
@@ -85,7 +85,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"proc_factorial.factorial<0>"(i64  %"n##0")    {
+define external fastcc  i64 @"proc_factorial.factorial<0>"(i64  %"n##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  %"n##0", i64  1)  
   ret i64 %0 
@@ -106,7 +106,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"proc_factorial.gen#2<0>"(i64  %"n##0", i64  %"result##0")    {
+define external fastcc  i64 @"proc_factorial.gen#2<0>"(i64  %"n##0", i64  %"result##0") alwaysinline   {
 entry:
   %0 = mul   i64 %"n##0", %"result##0" 
   %1 = sub   i64 %"n##0", 1 

--- a/test-cases/final-dump/proc_gcd.exp
+++ b/test-cases/final-dump/proc_gcd.exp
@@ -98,7 +98,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"proc_gcd.gcd<0>"(i64  %"a##0", i64  %"b##0")    {
+define external fastcc  i64 @"proc_gcd.gcd<0>"(i64  %"a##0", i64  %"b##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"a##0", i64  %"b##0")  
   ret i64 %0 
@@ -118,7 +118,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"proc_gcd.gen#2<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"proc_gcd.gen#2<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
   %1 = musttail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %0)  

--- a/test-cases/final-dump/proc_hello.exp
+++ b/test-cases/final-dump/proc_hello.exp
@@ -45,7 +45,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"proc_hello.print2<0>"()    {
+define external fastcc  void @"proc_hello.print2<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_hello.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/proc_print2.exp
+++ b/test-cases/final-dump/proc_print2.exp
@@ -36,7 +36,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"proc_print2.print2<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"proc_print2.print2<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"x##0")  
   tail call ccc  void  @print_int(i64  %"y##0")  

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -157,7 +157,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"proc_yorn.is_yes<0>"(i8  %"ch##0")    {
+define external fastcc  i1 @"proc_yorn.is_yes<0>"(i8  %"ch##0") alwaysinline   {
 entry:
   %0 = icmp ne i8 %"ch##0", 121 
   %1 = icmp ne i8 %"ch##0", 89 
@@ -181,7 +181,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"proc_yorn.yorn<0>"(i64  %"prompt##0")    {
+define external fastcc  i1 @"proc_yorn.yorn<0>"(i64  %"prompt##0") alwaysinline   {
 entry:
   %0 = musttail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  %"prompt##0")  
   ret i1 %0 

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -96,7 +96,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"proc_yorn2.yorn<0>"(i64  %"prompt##0")    {
+define external fastcc  i1 @"proc_yorn2.yorn<0>"(i64  %"prompt##0") alwaysinline   {
 entry:
   %0 = musttail call fastcc  i1  @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")  
   ret i1 %0 

--- a/test-cases/final-dump/purity_warning.exp
+++ b/test-cases/final-dump/purity_warning.exp
@@ -29,7 +29,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"purity_warning.<0>"()    {
+define external fastcc  void @"purity_warning.<0>"() alwaysinline   {
 entry:
   ret void 
 }

--- a/test-cases/final-dump/representation.exp
+++ b/test-cases/final-dump/representation.exp
@@ -30,7 +30,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i16 @"representation.+<0>"(i16  %"x##0", i16  %"y##0")    {
+define external fastcc  i16 @"representation.+<0>"(i16  %"x##0", i16  %"y##0") alwaysinline   {
 entry:
   %0 = add   i16 %"x##0", %"y##0" 
   ret i16 %0 

--- a/test-cases/final-dump/resource_rollback.exp
+++ b/test-cases/final-dump/resource_rollback.exp
@@ -112,7 +112,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"resource_rollback.foo<0>"(i64  %"call_source_location##0")    {
+define external fastcc  {i64, i1} @"resource_rollback.foo<0>"(i64  %"call_source_location##0") noinline   {
 entry:
   %0 = insertvalue {i64, i1} undef, i64 %"call_source_location##0", 0 
   %1 = insertvalue {i64, i1} %0, i1 0, 1 

--- a/test-cases/final-dump/resource_tmp_vars.exp
+++ b/test-cases/final-dump/resource_tmp_vars.exp
@@ -70,7 +70,7 @@ entry:
 }
 
 
-define external fastcc  void @"resource_tmp_vars.gen#1<0>"(i64  %"tmp#0##0")    {
+define external fastcc  void @"resource_tmp_vars.gen#1<0>"(i64  %"tmp#0##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  1)  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/simple_loop.exp
+++ b/test-cases/final-dump/simple_loop.exp
@@ -55,7 +55,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"simple_loop.<0>"()    {
+define external fastcc  void @"simple_loop.<0>"() alwaysinline   {
 entry:
   musttail call fastcc  void  @"simple_loop.gen#1<0>"()  
   ret void 

--- a/test-cases/final-dump/sister_module.exp
+++ b/test-cases/final-dump/sister_module.exp
@@ -41,14 +41,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"sister_module.baz<0>"(i64  %"i##0")    {
+define external fastcc  i64 @"sister_module.baz<0>"(i64  %"i##0") alwaysinline   {
 entry:
   %0 = musttail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"i##0")  
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"sister_module.buzz<0>"(i64  %"i##0")    {
+define external fastcc  i64 @"sister_module.buzz<0>"(i64  %"i##0") alwaysinline   {
 entry:
   %0 = musttail call fastcc  i64  @"sister_module.m2.bar<0>"(i64  %"i##0")  
   ret i64 %0 
@@ -85,7 +85,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"sister_module.m1.foo<0>"(i64  %"i##0")    {
+define external fastcc  i64 @"sister_module.m1.foo<0>"(i64  %"i##0") alwaysinline   {
 entry:
   %0 = add   i64 %"i##0", 1 
   ret i64 %0 
@@ -123,7 +123,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"sister_module.m2.bar<0>"(i64  %"i##0")    {
+define external fastcc  i64 @"sister_module.m2.bar<0>"(i64  %"i##0") alwaysinline   {
 entry:
   %0 = add   i64 %"i##0", 1 
   %1 = musttail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %0)  

--- a/test-cases/final-dump/specials.exp
+++ b/test-cases/final-dump/specials.exp
@@ -102,7 +102,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"specials.show_column<0>"(i64  %"call_source_column_number##0")    {
+define external fastcc  void @"specials.show_column<0>"(i64  %"call_source_column_number##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"call_source_column_number##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -110,7 +110,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_file<0>"(i64  %"call_source_file_name##0")    {
+define external fastcc  void @"specials.show_file<0>"(i64  %"call_source_file_name##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_file_name##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -118,7 +118,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_full_file<0>"(i64  %"call_source_file_full_name##0")    {
+define external fastcc  void @"specials.show_full_file<0>"(i64  %"call_source_file_full_name##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_file_full_name##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -126,7 +126,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_full_location<0>"(i64  %"call_source_full_location##0")    {
+define external fastcc  void @"specials.show_full_location<0>"(i64  %"call_source_full_location##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_full_location##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -134,7 +134,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_line<0>"(i64  %"call_source_line_number##0")    {
+define external fastcc  void @"specials.show_line<0>"(i64  %"call_source_line_number##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"call_source_line_number##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -142,7 +142,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_location<0>"(i64  %"call_source_location##0")    {
+define external fastcc  void @"specials.show_location<0>"(i64  %"call_source_location##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_location##0")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/specials_one_module.exp
+++ b/test-cases/final-dump/specials_one_module.exp
@@ -144,7 +144,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials_one_module.show_column<0>"(i64  %"call_source_column_number##0")    {
+define external fastcc  void @"specials_one_module.show_column<0>"(i64  %"call_source_column_number##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"call_source_column_number##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -152,7 +152,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials_one_module.show_file<0>"(i64  %"call_source_file_name##0")    {
+define external fastcc  void @"specials_one_module.show_file<0>"(i64  %"call_source_file_name##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_file_name##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -160,7 +160,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials_one_module.show_line<0>"(i64  %"call_source_line_number##0")    {
+define external fastcc  void @"specials_one_module.show_line<0>"(i64  %"call_source_line_number##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"call_source_line_number##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -168,7 +168,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials_one_module.show_location<0>"(i64  %"call_source_location##0")    {
+define external fastcc  void @"specials_one_module.show_location<0>"(i64  %"call_source_location##0") alwaysinline   {
 entry:
   musttail call fastcc  void  @"specials_one_module.indirect_call_location<0>"(i64  %"call_source_location##0")  
   ret void 

--- a/test-cases/final-dump/specials_use.exp
+++ b/test-cases/final-dump/specials_use.exp
@@ -102,7 +102,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"specials.show_column<0>"(i64  %"call_source_column_number##0")    {
+define external fastcc  void @"specials.show_column<0>"(i64  %"call_source_column_number##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"call_source_column_number##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -110,7 +110,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_file<0>"(i64  %"call_source_file_name##0")    {
+define external fastcc  void @"specials.show_file<0>"(i64  %"call_source_file_name##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_file_name##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -118,7 +118,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_full_file<0>"(i64  %"call_source_file_full_name##0")    {
+define external fastcc  void @"specials.show_full_file<0>"(i64  %"call_source_file_full_name##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_file_full_name##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -126,7 +126,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_full_location<0>"(i64  %"call_source_full_location##0")    {
+define external fastcc  void @"specials.show_full_location<0>"(i64  %"call_source_full_location##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_full_location##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -134,7 +134,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_line<0>"(i64  %"call_source_line_number##0")    {
+define external fastcc  void @"specials.show_line<0>"(i64  %"call_source_line_number##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"call_source_line_number##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -142,7 +142,7 @@ entry:
 }
 
 
-define external fastcc  void @"specials.show_location<0>"(i64  %"call_source_location##0")    {
+define external fastcc  void @"specials.show_location<0>"(i64  %"call_source_location##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_location##0")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -1841,7 +1841,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"stmt_for.int_sequence.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"stmt_for.int_sequence.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -1923,7 +1923,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.end<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.end<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
@@ -1932,7 +1932,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.end<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.end<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1969,7 +1969,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.int_sequence<0>"(i64  %"start##0", i64  %"stride##0", i64  %"end##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.int_sequence<0>"(i64  %"start##0", i64  %"stride##0", i64  %"end##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -1986,7 +1986,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -2003,7 +2003,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.start<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.start<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -2011,7 +2011,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.start<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.start<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -2026,7 +2026,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.stride<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.stride<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -2035,7 +2035,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.stride<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.stride<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -2051,7 +2051,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"stmt_for.int_sequence.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"stmt_for.int_sequence.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -480,13 +480,13 @@ if.else3:
 }
 
 
-define external fastcc  i64 @"stmt_if.tree.empty<0>"()    {
+define external fastcc  i64 @"stmt_if.tree.empty<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.key<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.key<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -504,7 +504,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -529,7 +529,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.left<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.left<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -546,7 +546,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -570,7 +570,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"stmt_if.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
+define external fastcc  i64 @"stmt_if.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -587,7 +587,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"stmt_if.tree.node<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i1} @"stmt_if.tree.node<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -614,7 +614,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.right<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.right<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -632,7 +632,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -657,7 +657,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"stmt_if.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"stmt_if.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -133,7 +133,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"stmt_if2.gen#1<0>"(i1  %"tmp#4##0")    {
+define external fastcc  i1 @"stmt_if2.gen#1<0>"(i1  %"tmp#4##0") alwaysinline   {
 entry:
   ret i1 %"tmp#4##0" 
 }
@@ -436,13 +436,13 @@ if.else3:
 }
 
 
-define external fastcc  i64 @"stmt_if2.tree.empty<0>"()    {
+define external fastcc  i64 @"stmt_if2.tree.empty<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.key<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.key<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -460,7 +460,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -485,7 +485,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.left<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.left<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -502,7 +502,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -526,7 +526,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"stmt_if2.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
+define external fastcc  i64 @"stmt_if2.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -543,7 +543,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"stmt_if2.tree.node<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i1} @"stmt_if2.tree.node<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -570,7 +570,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.right<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.right<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -588,7 +588,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -613,7 +613,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"stmt_if2.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"stmt_if2.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/stmt_nop.exp
+++ b/test-cases/final-dump/stmt_nop.exp
@@ -29,7 +29,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"stmt_nop.<0>"()    {
+define external fastcc  void @"stmt_nop.<0>"() alwaysinline   {
 entry:
   ret void 
 }

--- a/test-cases/final-dump/stmt_unless.exp
+++ b/test-cases/final-dump/stmt_unless.exp
@@ -80,7 +80,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"stmt_unless.<0>"()    {
+define external fastcc  void @"stmt_unless.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"stmt_unless.gen#1<0>"(i64  10)  
   ret void 
@@ -116,7 +116,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"stmt_unless.mod<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"stmt_unless.mod<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = urem i64 %"x##0", %"y##0" 
   ret i64 %0 

--- a/test-cases/final-dump/stmt_until.exp
+++ b/test-cases/final-dump/stmt_until.exp
@@ -68,7 +68,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"stmt_until.<0>"()    {
+define external fastcc  void @"stmt_until.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"stmt_until.gen#1<0>"(i64  10)  
   ret void 
@@ -90,7 +90,7 @@ if.else:
 }
 
 
-define external fastcc  void @"stmt_until.gen#2<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_until.gen#2<0>"(i64  %"n##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"n##0", 1 
   tail call ccc  void  @print_int(i64  %0)  

--- a/test-cases/final-dump/stmt_when.exp
+++ b/test-cases/final-dump/stmt_when.exp
@@ -80,7 +80,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"stmt_when.<0>"()    {
+define external fastcc  void @"stmt_when.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"stmt_when.gen#1<0>"(i64  10)  
   ret void 
@@ -116,7 +116,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"stmt_when.mod<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"stmt_when.mod<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = urem i64 %"x##0", %"y##0" 
   ret i64 %0 

--- a/test-cases/final-dump/stmt_while.exp
+++ b/test-cases/final-dump/stmt_while.exp
@@ -68,7 +68,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"stmt_while.<0>"()    {
+define external fastcc  void @"stmt_while.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"stmt_while.gen#1<0>"(i64  10)  
   ret void 
@@ -90,7 +90,7 @@ if.else:
 }
 
 
-define external fastcc  void @"stmt_while.gen#2<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_while.gen#2<0>"(i64  %"n##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"n##0", 1 
   tail call ccc  void  @print_int(i64  %0)  

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -412,7 +412,7 @@ if.else:
 }
 
 
-define external fastcc  void @"string.print_loop<0>"(i64  %"s##0")    {
+define external fastcc  void @"string.print_loop<0>"(i64  %"s##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"string.gen#1<0>"(i64  %"s##0", i64  %"s##0")  
   ret void 

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -281,7 +281,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"student.course.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"student.course.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -303,7 +303,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"student.course.code<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"student.course.code<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -311,7 +311,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.code<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"student.course.code<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -326,7 +326,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.course<0>"(i64  %"code##0", i64  %"name##0")    {
+define external fastcc  i64 @"student.course.course<0>"(i64  %"code##0", i64  %"name##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -340,7 +340,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -353,7 +353,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"student.course.name<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -362,7 +362,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"student.course.name<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -378,7 +378,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"student.course.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"student.course.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -542,7 +542,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"student.student.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"student.student.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -579,7 +579,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"student.student.id<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"student.student.id<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -587,7 +587,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.id<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"student.student.id<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -602,7 +602,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.major<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"student.student.major<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -611,7 +611,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.major<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"student.student.major<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -627,7 +627,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.student<0>"(i64  %"id##0", i64  %"major##0")    {
+define external fastcc  i64 @"student.student.student<0>"(i64  %"id##0", i64  %"major##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -641,7 +641,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -654,7 +654,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"student.student.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"student.student.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/submodule.exp
+++ b/test-cases/final-dump/submodule.exp
@@ -80,14 +80,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"submodule.privatetest.hidden<0>"()    {
+define external fastcc  void @"submodule.privatetest.hidden<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.privatetest.1, i32 0, i32 0) to i64))  
   ret void 
 }
 
 
-define external fastcc  void @"submodule.privatetest.semi_hidden<0>"()    {
+define external fastcc  void @"submodule.privatetest.semi_hidden<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.privatetest.3, i32 0, i32 0) to i64))  
   ret void 
@@ -147,14 +147,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"submodule.publictest.semi_visible<0>"()    {
+define external fastcc  void @"submodule.publictest.semi_visible<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.publictest.1, i32 0, i32 0) to i64))  
   ret void 
 }
 
 
-define external fastcc  void @"submodule.publictest.visible<0>"()    {
+define external fastcc  void @"submodule.publictest.visible<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.publictest.3, i32 0, i32 0) to i64))  
   ret void 

--- a/test-cases/final-dump/terminal_ok.exp
+++ b/test-cases/final-dump/terminal_ok.exp
@@ -47,7 +47,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"terminal_ok.<0>"()    {
+define external fastcc  void @"terminal_ok.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"terminal_ok.exit_bool<0>"(i1  0)  
   ret void 

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -156,7 +156,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"test_loop.<0>"()    {
+define external fastcc  void @"test_loop.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"test_loop.find_test<0>"(i64  3)  
   tail call fastcc  void  @"test_loop.find_test<0>"(i64  7)  
@@ -164,7 +164,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"test_loop.find_modulo<0>"(i64  %"seq##0", i64  %"modulus##0")    {
+define external fastcc  {i64, i1} @"test_loop.find_modulo<0>"(i64  %"seq##0", i64  %"modulus##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %"seq##0")  
   %1 = extractvalue {i64, i1} %0, 0 
@@ -453,7 +453,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"test_loop.int_seq.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"test_loop.int_seq.=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -486,7 +486,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.high<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"test_loop.int_seq.high<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 16 
   %1 = inttoptr i64 %0 to i64* 
@@ -495,7 +495,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.high<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"test_loop.int_seq.high<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -511,7 +511,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.int_seq<0>"(i64  %"low##0", i64  %"step##0", i64  %"high##0")    {
+define external fastcc  i64 @"test_loop.int_seq.int_seq<0>"(i64  %"low##0", i64  %"step##0", i64  %"high##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -528,7 +528,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -545,7 +545,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.low<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"test_loop.int_seq.low<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -553,7 +553,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.low<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"test_loop.int_seq.low<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -631,7 +631,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.step<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"test_loop.int_seq.step<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -640,7 +640,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.step<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"test_loop.int_seq.step<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 24 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -656,7 +656,7 @@ entry:
 }
 
 
-define external fastcc  i1 @"test_loop.int_seq.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"test_loop.int_seq.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#left##0" to i64* 
   %1 = load  i64, i64* %0 

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -162,14 +162,14 @@ if.else:
 }
 
 
-define external fastcc  i1 @"tests.lt2<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i1 @"tests.lt2<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = musttail call fastcc  i1  @"tests.lt<0>"(i64  %"x##0", i64  %"y##0")  
   ret i1 %0 
 }
 
 
-define external fastcc  i1 @"tests.lt3<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i1 @"tests.lt3<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = musttail call fastcc  i1  @"tests.lt<0>"(i64  %"y##0", i64  %"x##0")  
   ret i1 %0 
@@ -494,13 +494,13 @@ if.else4:
 }
 
 
-define external fastcc  i64 @"tests.map.empty<0>"()    {
+define external fastcc  i64 @"tests.map.empty<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.key<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"tests.map.key<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -518,7 +518,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"tests.map.key<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -543,7 +543,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.left<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"tests.map.left<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -560,7 +560,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"tests.map.left<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -584,7 +584,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"tests.map.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"value##0", i64  %"right##0")    {
+define external fastcc  i64 @"tests.map.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"value##0", i64  %"right##0") alwaysinline   {
 entry:
   %0 = trunc i64 32 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -604,7 +604,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i64, i1} @"tests.map.node<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i64, i64, i1} @"tests.map.node<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -636,7 +636,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.right<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"tests.map.right<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -654,7 +654,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"tests.map.right<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -679,7 +679,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.value<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"tests.map.value<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -697,7 +697,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.value<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"tests.map.value<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -722,7 +722,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"tests.map.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"tests.map.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"tests.map.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -388,7 +388,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"thistype.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
+define external fastcc  i64 @"thistype.cons<0>"(i64  %"head##0", i64  %"tail##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -402,7 +402,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"thistype.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"thistype.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -424,7 +424,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.head<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"thistype.head<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -441,7 +441,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"thistype.head<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -481,13 +481,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"thistype.nil<0>"()    {
+define external fastcc  i64 @"thistype.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"thistype.tail<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"thistype.tail<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -505,7 +505,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"thistype.tail<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -530,7 +530,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"thistype.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"thistype.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"thistype.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/type_enum.exp
+++ b/test-cases/final-dump/type_enum.exp
@@ -107,38 +107,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"type_enum.season.=<0>"(i2  %"#left##0", i2  %"#right##0")    {
+define external fastcc  i1 @"type_enum.season.=<0>"(i2  %"#left##0", i2  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i2 %"#left##0", %"#right##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i2 @"type_enum.season.autumn<0>"()    {
+define external fastcc  i2 @"type_enum.season.autumn<0>"() alwaysinline   {
 entry:
   ret i2 3 
 }
 
 
-define external fastcc  i2 @"type_enum.season.spring<0>"()    {
+define external fastcc  i2 @"type_enum.season.spring<0>"() alwaysinline   {
 entry:
   ret i2 1 
 }
 
 
-define external fastcc  i2 @"type_enum.season.summer<0>"()    {
+define external fastcc  i2 @"type_enum.season.summer<0>"() alwaysinline   {
 entry:
   ret i2 2 
 }
 
 
-define external fastcc  i2 @"type_enum.season.winter<0>"()    {
+define external fastcc  i2 @"type_enum.season.winter<0>"() alwaysinline   {
 entry:
   ret i2 0 
 }
 
 
-define external fastcc  i1 @"type_enum.season.~=<0>"(i2  %"#left##0", i2  %"#right##0")    {
+define external fastcc  i1 @"type_enum.season.~=<0>"(i2  %"#left##0", i2  %"#right##0") alwaysinline   {
 entry:
   %0 = icmp eq i2 %"#left##0", %"#right##0" 
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/type_int.exp
+++ b/test-cases/final-dump/type_int.exp
@@ -178,98 +178,98 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"type_int.myint.*<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"type_int.myint.*<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = mul   i64 %"x##0", %"y##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"type_int.myint.+<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"type_int.myint.+<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = add   i64 %"x##0", %"y##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"type_int.myint.+<1>"(i64  %"y##0", i64  %"z##0")    {
+define external fastcc  i64 @"type_int.myint.+<1>"(i64  %"y##0", i64  %"z##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"z##0", %"y##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"type_int.myint.+<2>"(i64  %"x##0", i64  %"z##0")    {
+define external fastcc  i64 @"type_int.myint.+<2>"(i64  %"x##0", i64  %"z##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"z##0", %"x##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"type_int.myint.-<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"type_int.myint.-<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"x##0", %"y##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"type_int.myint.-<1>"(i64  %"y##0", i64  %"z##0")    {
+define external fastcc  i64 @"type_int.myint.-<1>"(i64  %"y##0", i64  %"z##0") alwaysinline   {
 entry:
   %0 = add   i64 %"y##0", %"z##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"type_int.myint.-<2>"(i64  %"x##0", i64  %"z##0")    {
+define external fastcc  i64 @"type_int.myint.-<2>"(i64  %"x##0", i64  %"z##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"z##0", %"x##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"type_int.myint./<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"type_int.myint./<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = sdiv exact i64 %"x##0", %"y##0" 
   ret i64 %0 
 }
 
 
-define external fastcc  i1 @"type_int.myint.<<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i1 @"type_int.myint.<<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = icmp slt i64 %"x##0", %"y##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i1 @"type_int.myint.<=<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i1 @"type_int.myint.<=<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = icmp sle i64 %"x##0", %"y##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i1 @"type_int.myint.=<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i1 @"type_int.myint.=<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = icmp eq i64 %"x##0", %"y##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i1 @"type_int.myint.><0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i1 @"type_int.myint.><0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = icmp sgt i64 %"x##0", %"y##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i1 @"type_int.myint.>=<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i1 @"type_int.myint.>=<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = icmp sge i64 %"x##0", %"y##0" 
   ret i1 %0 
 }
 
 
-define external fastcc  i1 @"type_int.myint.~=<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i1 @"type_int.myint.~=<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"x##0", %"y##0" 
   ret i1 %0 

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -431,7 +431,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"type_list.intlist.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
+define external fastcc  i64 @"type_list.intlist.cons<0>"(i64  %"head##0", i64  %"tail##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -445,7 +445,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"type_list.intlist.cons<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64, i1} @"type_list.intlist.cons<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#result##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -467,7 +467,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.head<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.head<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -484,7 +484,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.head<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -508,13 +508,13 @@ if.else:
 }
 
 
-define external fastcc  i64 @"type_list.intlist.nil<0>"()    {
+define external fastcc  i64 @"type_list.intlist.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.tail<0>"(i64  %"#rec##0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.tail<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -532,7 +532,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.tail<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = icmp ne i64 %"#rec##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -557,7 +557,7 @@ if.else:
 }
 
 
-define external fastcc  i1 @"type_list.intlist.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
+define external fastcc  i1 @"type_list.intlist.~=<0>"(i64  %"#left##0", i64  %"#right##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")  
   %1 = xor i1 %0, 1 

--- a/test-cases/final-dump/unbranch_bug.exp
+++ b/test-cases/final-dump/unbranch_bug.exp
@@ -59,20 +59,20 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"unbranch_bug.<0>"()    {
+define external fastcc  void @"unbranch_bug.<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"unbranch_bug.gen#3<0>"(i64  0, i64  0)  
   ret void 
 }
 
 
-define external fastcc  void @"unbranch_bug.gen#1<0>"()    {
+define external fastcc  void @"unbranch_bug.gen#1<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"unbranch_bug.gen#2<0>"()    {
+define external fastcc  void @"unbranch_bug.gen#2<0>"() alwaysinline   {
 entry:
   ret void 
 }

--- a/test-cases/final-dump/uneeded_closure_args.exp
+++ b/test-cases/final-dump/uneeded_closure_args.exp
@@ -71,7 +71,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"uneeded_closure_args.call<0>"(i64  %"f##0", i64  %"a##0")    {
+define external fastcc  i64 @"uneeded_closure_args.call<0>"(i64  %"f##0", i64  %"a##0") noinline   {
 entry:
   %0 = inttoptr i64 %"f##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -81,13 +81,13 @@ entry:
 }
 
 
-define external fastcc  i64 @"uneeded_closure_args.gen#1<0>"(i64  %"#env##0", i64  %"b##0")    {
+define external fastcc  i64 @"uneeded_closure_args.gen#1<0>"(i64  %"#env##0", i64  %"b##0") alwaysinline   {
 entry:
   ret i64 %"b##0" 
 }
 
 
-define external fastcc  i64 @"uneeded_closure_args.second<0>"(i64  %"b##0")    {
+define external fastcc  i64 @"uneeded_closure_args.second<0>"(i64  %"b##0") alwaysinline   {
 entry:
   ret i64 %"b##0" 
 }

--- a/test-cases/final-dump/unique_conditional.exp
+++ b/test-cases/final-dump/unique_conditional.exp
@@ -50,13 +50,13 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"unique_conditional.bar<0>"()    {
+define external fastcc  void @"unique_conditional.bar<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"unique_conditional.baz<0>"()    {
+define external fastcc  void @"unique_conditional.baz<0>"() alwaysinline   {
 entry:
   ret void 
 }

--- a/test-cases/final-dump/unique_position.exp
+++ b/test-cases/final-dump/unique_position.exp
@@ -198,7 +198,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"unique_position.unique_position.unique_position<0>"(i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"unique_position.unique_position.unique_position<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -212,7 +212,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"unique_position.unique_position.unique_position<1>"(i64  %"#result##0")    {
+define external fastcc  {i64, i64} @"unique_position.unique_position.unique_position<1>"(i64  %"#result##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#result##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -225,7 +225,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"unique_position.unique_position.x<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"unique_position.unique_position.x<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = inttoptr i64 %"#rec##0" to i64* 
   %1 = load  i64, i64* %0 
@@ -233,7 +233,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"unique_position.unique_position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"unique_position.unique_position.x<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
@@ -248,7 +248,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"unique_position.unique_position.y<0>"(i64  %"#rec##0")    {
+define external fastcc  i64 @"unique_position.unique_position.y<0>"(i64  %"#rec##0") alwaysinline   {
 entry:
   %0 = add   i64 %"#rec##0", 8 
   %1 = inttoptr i64 %0 to i64* 
@@ -257,7 +257,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"unique_position.unique_position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
+define external fastcc  i64 @"unique_position.unique_position.y<1>"(i64  %"#rec##0", i64  %"#field##0") alwaysinline   {
 entry:
   %0 = trunc i64 16 to i32  
   %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  

--- a/test-cases/final-dump/unneeded.exp
+++ b/test-cases/final-dump/unneeded.exp
@@ -30,7 +30,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"unneeded.unneeded<0>"(i64  %"x##0", i64  %"q##0")    {
+define external fastcc  i64 @"unneeded.unneeded<0>"(i64  %"x##0", i64  %"q##0") alwaysinline   {
 entry:
   %0 = add   i64 %"x##0", 1 
   ret i64 %0 

--- a/test-cases/final-dump/update.exp
+++ b/test-cases/final-dump/update.exp
@@ -39,7 +39,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i64 @"update.inc2<0>"(i64  %"x##0")    {
+define external fastcc  i64 @"update.inc2<0>"(i64  %"x##0") alwaysinline   {
 entry:
   %0 = add   i64 %"x##0", 1 
   %1 = add   i64 %0, 1 
@@ -47,7 +47,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"update.inc2<1>"(i64  %"y##0")    {
+define external fastcc  i64 @"update.inc2<1>"(i64  %"y##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"y##0", 1 
   %1 = sub   i64 %0, 1 

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -110,7 +110,7 @@ entry:
 }
 
 
-define external fastcc  void @"use_resource.inc_count<0>"()    {
+define external fastcc  void @"use_resource.inc_count<0>"() alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#use_resource.count" 
   %1 = add   i64 %0, 1 
@@ -119,7 +119,7 @@ entry:
 }
 
 
-define external fastcc  void @"use_resource.use_test<0>"()    {
+define external fastcc  void @"use_resource.use_test<0>"() alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#use_resource.count" 
   %1 = add   i64 %0, 1 

--- a/test-cases/final-dump/void_instr.exp
+++ b/test-cases/final-dump/void_instr.exp
@@ -1,0 +1,123 @@
+======================================================================
+AFTER EVERYTHING:
+ Module void_instr
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : void_instr.<0>
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+module top-level code > public {inline,impure} (0 calls)
+0: void_instr.<0>
+()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    void_instr.complex_computation<0>(?tmp#0##0:wybe.int) #0 @void_instr:nn:nn
+    foreign lpvm {impure} void(~tmp#0##0:wybe.int) @void_instr:nn:nn
+
+
+complex_computation > {noinline} (1 calls)
+0: void_instr.complex_computation<0>
+complex_computation(?x##1:wybe.int)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.range...<0>(0:wybe.int, 100:wybe.int, ?tmp#1##0:wybe.range) #0 @void_instr:nn:nn
+    void_instr.gen#1<0>(~tmp#1##0:wybe.range, ~tmp#1##0:wybe.range, 0:wybe.int, ?x##1:wybe.int) #1 @void_instr:nn:nn
+
+
+gen#1 > (2 calls)
+0: void_instr.gen#1<0>[410bae77d3]
+gen#1(tmp#0##0:wybe.range, tmp#1##0:wybe.range, x##0:wybe.int, ?x##2:wybe.int)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: [InterestingUnaliased 0]
+  MultiSpeczDepInfo: [(0,(wybe.range.[|]<0>,fromList [NonAliasedParamCond 2 [0]])),(2,(void_instr.gen#1<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.range.[|]<0>(?i##0:wybe.int, ?tmp#0##1:wybe.range, ~tmp#0##0:wybe.range, ?tmp#2##0:wybe.bool) #0 @void_instr:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+        foreign llvm move(~x##0:wybe.int, ?x##2:wybe.int)
+
+    1:
+        foreign llvm add(~i##0:wybe.int, ~x##0:wybe.int, ?x##1:wybe.int) @int:nn:nn
+        void_instr.gen#1<0>[410bae77d3](~tmp#0##1:wybe.range, ~tmp#1##0:wybe.range, ~x##1:wybe.int, ?x##2:wybe.int) #2 @void_instr:nn:nn
+
+ [410bae77d3] [NonAliasedParam 0] :
+    wybe.range.[|]<0>[785a827a1b](?i##0:wybe.int, ?tmp#0##1:wybe.range, ~tmp#0##0:wybe.range, ?tmp#2##0:wybe.bool) #0 @void_instr:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+        foreign llvm move(~x##0:wybe.int, ?x##2:wybe.int)
+
+    1:
+        foreign llvm add(~i##0:wybe.int, ~x##0:wybe.int, ?x##1:wybe.int) @int:nn:nn
+        void_instr.gen#1<0>[410bae77d3](~tmp#0##1:wybe.range, ~tmp#1##0:wybe.range, ~x##1:wybe.int, ?x##2:wybe.int) #2 @void_instr:nn:nn
+
+
+  LLVM code       :
+
+; ModuleID = 'void_instr'
+
+
+ 
+
+
+declare external fastcc  {i64, i64, i1} @"wybe.range.[|]<0>[785a827a1b]"(i64)    
+
+
+declare external fastcc  {i64, i64, i1} @"wybe.range.[|]<0>"(i64)    
+
+
+declare external fastcc  i64 @"wybe.range...<0>"(i64, i64)    
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"void_instr.<0>"() alwaysinline   {
+entry:
+  %0 = tail call fastcc  i64  @"void_instr.complex_computation<0>"()  
+  ret void 
+}
+
+
+define external fastcc  i64 @"void_instr.complex_computation<0>"() noinline   {
+entry:
+  %0 = tail call fastcc  i64  @"wybe.range...<0>"(i64  0, i64  100)  
+  %1 = tail call fastcc  i64  @"void_instr.gen#1<0>"(i64  %0, i64  %0, i64  0)  
+  ret i64 %1 
+}
+
+
+define external fastcc  i64 @"void_instr.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"x##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"wybe.range.[|]<0>"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  %4 = add   i64 %1, %"x##0" 
+  %5 = musttail call fastcc  i64  @"void_instr.gen#1<0>[410bae77d3]"(i64  %2, i64  %"tmp#1##0", i64  %4)  
+  ret i64 %5 
+if.else:
+  ret i64 %"x##0" 
+}
+
+
+define external fastcc  i64 @"void_instr.gen#1<0>[410bae77d3]"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"x##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"wybe.range.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  %4 = add   i64 %1, %"x##0" 
+  %5 = musttail call fastcc  i64  @"void_instr.gen#1<0>[410bae77d3]"(i64  %2, i64  %"tmp#1##0", i64  %4)  
+  ret i64 %5 
+if.else:
+  ret i64 %"x##0" 
+}


### PR DESCRIPTION
Closes #327 

Note: May be more appropriate to use the `InlineHint` attribute over the `AlwaysInline` hint. `AlwaysInline` is a much stronger attribute, and may be an issue for recursive procs