### PR TITLE
Improve `array` type

### DIFF
--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -422,10 +422,9 @@ limitedTerm precedence = termFirst >>= termRest precedence
 -- Valid suffixes include parenthesised argument lists or square bracketed
 -- indices.  If both prefix and suffix are present, the suffix binds tighter.
 termFirst :: Parser Term
-termFirst = (do
-             op <- prefixOp
-             termFirst >>= applyPrefixOp op)
-         <|> (primaryTerm >>= termSuffix)
+termFirst = 
+    ((prefixOp >>= (primaryTerm >>=) . applyPrefixOp) <|> primaryTerm) 
+        >>= termSuffix
 
 
 -- |Apply zero or more parenthesised or square bracketed suffixes to the

--- a/test-cases/final-dump/unbranch_bug.exp
+++ b/test-cases/final-dump/unbranch_bug.exp
@@ -14,26 +14,26 @@ module top-level code > public {inline,impure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    unbranch_bug.gen#3<0>(0:wybe.list(4), 0:wybe.list(4))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
+    unbranch_bug.gen#3<0>(0:wybe.list(5), 0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
 
 
 gen#1 > {inline} (1 calls)
 0: unbranch_bug.gen#1<0>
-gen#1([tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)])<{}; {}>:
+gen#1([tmp#0##0:wybe.list(5)], [tmp#1##0:wybe.list(5)])<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
 gen#2 > {inline} (1 calls)
 0: unbranch_bug.gen#2<0>
-gen#2([tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)])<{}; {}>:
+gen#2([tmp#0##0:wybe.list(5)], [tmp#1##0:wybe.list(5)])<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
 gen#3 > (2 calls)
 0: unbranch_bug.gen#3<0>
-gen#3(tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(4))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+gen#3(tmp#0##0:wybe.list(5), tmp#1##0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
@@ -41,8 +41,8 @@ gen#3(tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(4))<{<<wybe.io.io>>}; {<<wybe.io
     0:
 
     1:
-        foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(4)) @list:nn:nn
-        unbranch_bug.gen#3<0>(~tmp#0##1:wybe.list(4), ~tmp#1##0:wybe.list(4))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
+        foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(5)) @list:nn:nn
+        unbranch_bug.gen#3<0>(~tmp#0##1:wybe.list(5), ~tmp#1##0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
 
 
   LLVM code       :

--- a/wybelibs/wybe/array.wybe
+++ b/wybelibs/wybe/array.wybe
@@ -17,14 +17,14 @@ pub type raw_array(T) is address {}
 # Construct an array filled with the given element of a given length.
 pub def array(x:T, len:int):_(T) = ar where {
     ?size = len * word_size_bytes
-    foreign lpvm alloc(size, ?mem)
+    foreign lpvm alloc(size, ?data)
     ?offset = 0
     do {
         while offset < size
-        foreign lpvm mutate(mem, ?mem, offset, 1, size, 0, x)
+        foreign lpvm mutate(data, ?data, offset, 1, size, 0, x)
         !offset += word_size_bytes
     }
-    ?ar = array(len, mem)
+    ?ar = array(len, data)
 }
 
 
@@ -33,13 +33,14 @@ pub def array(x:T, len:int):_(T) = ar where {
 # Convert a list into an array
 pub def array(ls:list(T)):_(T) = ar where {
     ?len = length(ls) 
-    foreign lpvm alloc(len * word_size_bytes, ?mem)
+    ?size = len * word_size_bytes
+    foreign lpvm alloc(size, ?data)
     ?offset = 0
     for ?x in ls {
-        foreign lpvm mutate(mem, ?mem, offset, 1, word_size_bytes, 0, x)
+        foreign lpvm mutate(data, ?data, offset, 1, size, 0, x)
         !offset += word_size_bytes
     }
-    ?ar = array(len, mem)
+    ?ar = array(len, data)
 }
 
 
@@ -86,7 +87,7 @@ pub def {test} `[]`(!a:_(T), idx:int, x:T) {
 # probably want `[]`.
 # Update the array at the given index to the given element
 pub def {inline} unsafe_update(!a:_(T), idx:int, x:T) {
-    foreign lpvm mutate(a^raw_data, ?mem, idx * word_size_bytes, 0, 
-                                          a^length * word_size_bytes, 0, x)
-    !a^raw_data = mem
+    foreign lpvm mutate(a^raw_data, ?data, idx * word_size_bytes, 0, 
+                                           a^length * word_size_bytes, 0, x)
+    !a^raw_data = data
 }

--- a/wybelibs/wybe/array.wybe
+++ b/wybelibs/wybe/array.wybe
@@ -1,4 +1,4 @@
-# purpose: Standard Array type, a null-terminated array
+# purpose: Standard Array type, a fixed-length array
 # since  : 0.1
 
 pragma no_standard_library  # Standard library can't depend on itself!
@@ -12,32 +12,25 @@ pub constructor (T) array(length:int, raw_data:raw_array(T))
 pub type raw_array(T) is address {}
 
 
-# Get the head and tail of an array.
-# Fails if the array is empty 
-pub def {test} `[|]`(?head:T, ?tail:_(T), a:_(T)) {
-    array(?length, ?data) = a
-    (length > 0)
-    foreign lpvm access(data, 0, word_size_bytes, 0, ?head)
-    foreign llvm add(data, word_size_bytes, ?data)
-    ?tail = array(length - 1, data)
+## Construction procedures
+
+# Construct an array filled with the given element of a given length.
+pub def array(x:T, len:int):_(T) = ar where {
+    ?size = len * word_size_bytes
+    foreign lpvm alloc(size, ?mem)
+    ?offset = 0
+    do {
+        while offset < size
+        foreign lpvm mutate(mem, ?mem, offset, 1, size, 0, x)
+        !offset += word_size_bytes
+    }
+    ?ar = array(len, mem)
 }
 
-# Get the element of an array at a given index.
-# Fails if the index is out of the bounds of the array 
-pub def {test} `[]`(a:_(T), idx:int):T = x where {
-    (0 <= idx)
-    (idx < a^length)
-    ?x = a^unsafe_index(idx)
-}
 
-# WARNING: does not check that the index is in the bound of the array. You 
-# probably want `[]`.
-# Get the element of an array at a given index.
-pub def {inline} unsafe_index(a:_(T), idx:int):T = x where {
-    foreign lpvm access(a^raw_data, idx * word_size_bytes, word_size_bytes, 0, ?x)
-}
+## Conversion procedures
 
-# Conversion from list
+# Convert a list into an array
 pub def array(ls:list(T)):_(T) = ar where {
     ?len = length(ls) 
     foreign lpvm alloc(len * word_size_bytes, ?mem)
@@ -47,4 +40,53 @@ pub def array(ls:list(T)):_(T) = ar where {
         !offset += word_size_bytes
     }
     ?ar = array(len, mem)
+}
+
+
+## Common operations
+
+# Get the head and tail of an array.
+# Fails if the array is empty
+pub def {test} `[|]`(?head:T, ?tail:_(T), a:_(T)) {
+    array(?length, ?data) = a
+    (length > 0)
+    foreign lpvm access(data, 0, word_size_bytes, 0, ?head)
+    foreign llvm add(data, word_size_bytes, ?data)
+    ?tail = array(length - 1, data)
+}
+
+# Test if an index is within the bounds of an array
+pub def {test, inline} inbounds(a:_(T), idx:int) {
+    (0 <= idx)
+    (idx < a^length)
+}
+
+# Get the element of an array at a given index.
+# Fails when the index is out of the bounds of the array
+pub def {test} `[]`(a:_(T), idx:int):T = x where {
+    inbounds(a, idx)
+    ?x = a^unsafe_get(idx)
+}
+
+# WARNING: does not check that the index is in the bound of the array. You 
+# probably want `[]`.
+# Get the element of an array at a given index
+pub def {inline} unsafe_get(a:_(T), idx:int):T = x where {
+    foreign lpvm access(a^raw_data, idx * word_size_bytes, word_size_bytes, 0, ?x)
+}
+
+# Update the array at the given index to the given element.
+# Fails when the index is out of the bounds of the array
+pub def {test} `[]`(!a:_(T), idx:int, x:T) {
+    inbounds(a, idx)
+    unsafe_update(!a, idx, x)
+}
+
+# WARNING: does not check that the index is in the bound of the array. You 
+# probably want `[]`.
+# Update the array at the given index to the given element
+pub def {inline} unsafe_update(!a:_(T), idx:int, x:T) {
+    foreign lpvm mutate(a^raw_data, ?mem, idx * word_size_bytes, 0, 
+                                          a^length * word_size_bytes, 0, x)
+    !a^raw_data = mem
 }

--- a/wybelibs/wybe/float.wybe
+++ b/wybelibs/wybe/float.wybe
@@ -81,7 +81,7 @@ pub def min(x:_, y:_):_ = foreign c `llvm.minnum.f64`(x,y)
 pub def max(x:_, y:_):_ = foreign c `llvm.maxnum.f64`(x,y)
 
 
-## Conversions
+## Conversion procedures
 
 # The smallest whole number greater than or equal to the input, as a float.
 pub def ceil(x:_):_ = foreign c `llvm.ceil.f64`(x)

--- a/wybelibs/wybe/list.wybe
+++ b/wybelibs/wybe/list.wybe
@@ -124,7 +124,7 @@ pub def println(printer:{resource}(T), xs:_(T)) use !io {
 
 ## Conversion procedures
 
-# Conversion from an array
+# Convert an array into a list
 pub def list(ar:array(T)):_(T) = ls where {
     ?ls = []
     for ?x in ar {

--- a/wybelibs/wybe/string.wybe
+++ b/wybelibs/wybe/string.wybe
@@ -42,9 +42,9 @@ pub def c_string(s:_):c_string = str where {
        | else :: 
             ?len = length(s) + 1
             foreign lpvm alloc(len, ?str)
-            foreign lpvm mutate(str, ?str, len, true, 1, 0, '\0')
+            foreign lpvm mutate(str, ?str, len, true, len, 0, '\0')
             ?offset = 0
-            pack(s, !str, !offset)
+            pack(s, !str, len, !offset)
     }
 }
 
@@ -156,25 +156,25 @@ pub def read(?x:_) use !io { !read(?str:c_string); ?x = string(str) }
 ## Private helper procedures
 
 # Pack a string into a c_string, from offset
-# Note: mutates mem, increasing offset
-def pack(s:_, !mem:c_string, !offset:int) {
+# Note: mutates raw, increasing offset
+def pack(s:_, !raw:c_string, size:int, !offset:int) {
     case s in {
         buffer(_, ?str) :: 
             for ?c in str {
-                foreign lpvm mutate(mem, ?mem, offset, true, 1, 0, c)
+                foreign lpvm mutate(raw, ?raw, offset, true, size, 0, c)
                 incr(!offset)
             }
       | concat(?left, ?right) :: 
-            pack(left, !mem, !offset)
-            pack(right, !mem, !offset)
+            pack(left, !raw, size, !offset)
+            pack(right, !raw, size, !offset)
             incr(!offset)
       | slice(_, _) :: 
             for ?c in s {
-                foreign lpvm mutate(mem, ?mem, offset, true, 1, 0, c)
+                foreign lpvm mutate(raw, ?raw, offset, true, size, 0, c)
                 incr(!offset)
             }
       | singleton(?c) ::
-            foreign lpvm mutate(mem, ?mem, offset, true, 1, 0, c)
+            foreign lpvm mutate(raw, ?raw, offset, true, size, 0, c)
             incr(!offset)
     }
 }

--- a/wybelibs/wybe/string.wybe
+++ b/wybelibs/wybe/string.wybe
@@ -24,7 +24,7 @@ constructors empty
 
 ## Conversion procedures.
 
-# Conversion from c_string
+# Convert a c_string into a string
 pub def string(str:c_string):_ = s where {
     ?len = length(str)
     ?s = if { len = 0 :: empty 
@@ -33,10 +33,10 @@ pub def string(str:c_string):_ = s where {
             }
 }
 
-# Conversion from char
+# Convert a char into a string
 pub def string(c:char):_ = singleton(c)
 
-# Conversion to c_string
+# Convert a string into a c_string
 pub def c_string(s:_):c_string = str where {
     if { s = buffer(_, ?str) :: pass
        | else :: 


### PR DESCRIPTION
This PR primarily adds more functionality to the array type, allowing for updates and creation.

Other changes include:
* minor tweaks of the docs in the stdlib
* a fix to a parser "bug" that I encountered when testing this. E.g., something like:
```
?a = array([1,2,3])
if { !a[1] = 10 :: pass }
```
was parsed as
```
?a = array([1,2,3])
if { `[]`(a, 1) = 10 :: pass }
```
instead of the intended
```
?a = array([1,2,3])
if { (!a)[1] = 10 :: pass }
```
Funnily enough, the erroneous parse was actually type correct, so it compiled just fine