### PR TITLE
Fixed higher order with phantom arguments & higher order determinism checks

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2563,7 +2563,7 @@ data TypeSpec = TypeSpec {
     typeParams::[TypeSpec]
     }
     | HigherOrderType {
-        higherTypeDetism::ProcModifiers,
+        higherTypeModifiers::ProcModifiers,
         higherTypeParams::[TypeFlow]
     }
     | TypeVariable { typeVariableName :: TypeVarName }

--- a/test-cases/final-dump/higher_order_arity_error.exp
+++ b/test-cases/final-dump/higher_order_arity_error.exp
@@ -1,0 +1,3 @@
+Error detected during type checking of module(s) higher_order_arity_error
+[91mfinal-dump/higher_order_arity_error.wybe:2:5: Call from a to f with 1 argument(s), expected 2
+[0m

--- a/test-cases/final-dump/higher_order_arity_error.wybe
+++ b/test-cases/final-dump/higher_order_arity_error.wybe
@@ -1,0 +1,3 @@
+def a(f:(X, Y), x:X, y:Y) {
+    f(x)
+}

--- a/test-cases/final-dump/higher_order_phantom.exp
+++ b/test-cases/final-dump/higher_order_phantom.exp
@@ -1,0 +1,72 @@
+======================================================================
+AFTER EVERYTHING:
+ Module higher_order_phantom
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : 
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+a > {inline} (0 calls)
+0: higher_order_phantom.a<0>
+a(f##0:(wybe.phantom, ?wybe.phantom), x##0:wybe.phantom, ?#result##0:wybe.phantom)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    ~f##0:(wybe.phantom, ?wybe.phantom)(~x##0:wybe.phantom, ?#result##0:wybe.phantom) #0 @higher_order_phantom:nn:nn
+
+
+b > {inline,semipure} (0 calls)
+0: higher_order_phantom.b<0>
+b(f##0:{impure}(wybe.phantom, ?wybe.phantom), x##0:wybe.phantom, [y##0:wybe.phantom])<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    ~f##0:{impure}(wybe.phantom, ?wybe.phantom)(~x##0:wybe.phantom, ?y##1:wybe.phantom) #0 @higher_order_phantom:nn:nn
+
+
+c > {inline} (0 calls)
+0: higher_order_phantom.c<0>
+c(f##0:(wybe.phantom, ?X), x##0:wybe.phantom, ?#result##0:X)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    ~f##0:(wybe.phantom, ?X)(~x##0:wybe.phantom, ?#result##0:X) #0 @higher_order_phantom:nn:nn
+
+  LLVM code       :
+
+; ModuleID = 'higher_order_phantom'
+
+
+ 
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"higher_order_phantom.a<0>"(i64  %"f##0") alwaysinline   {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"higher_order_phantom.b<0>"(i64  %"f##0") alwaysinline   {
+entry:
+  %0 = inttoptr i64 %"f##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
+  %3 = tail call fastcc  i64  %2(i64  %"f##0", i64  undef)  
+  ret void 
+}
+
+
+define external fastcc  i64 @"higher_order_phantom.c<0>"(i64  %"f##0") alwaysinline   {
+entry:
+  %0 = inttoptr i64 %"f##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
+  %3 = tail call fastcc  i64  %2(i64  %"f##0", i64  undef)  
+  ret i64 %3 
+}

--- a/test-cases/final-dump/higher_order_phantom.wybe
+++ b/test-cases/final-dump/higher_order_phantom.wybe
@@ -1,0 +1,7 @@
+def a(f:(phantom, ?phantom), x:phantom):phantom = f(x)
+
+def {semipure} b(f:{impure}(phantom, ?phantom), x:phantom, y:phantom) {
+    !f(x, ?y)
+}
+
+def c(f:(phantom, ?X), x:phantom):X = f(x)


### PR DESCRIPTION
Previously, a higher order call with a phantom-typed *variable* argument was called, there was an error as phantoms aren't assigned in LLVM codegen. This PR fixes that, by replacing the phantoms with `undef`. Such higher order calls can also be omitted if it only produces phantoms as those values are never used in LLVM.

In testing, I accidentally had an arity error in one of my higher order calls, and in fixing this, I was lead to me discover a bug in the determinism checking of higher order calls. This PR also fixes that.