### PR TITLE
Fix for #342

### DIFF
--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -281,14 +281,14 @@ flattenStmt' stmt@(ProcCall fn@(First [] "=" id) callDetism res [arg1,arg2]) pos
     logFlatten $ "Flattening assignment with arg1 outputs? " ++ show arg1outs
                  ++ " and arg2 outputs? " ++ show arg2outs
     case (arg1content, arg2content) of
-      (Fncall mod name args, _)
+      (Fncall mod name bang args, _)
         | not arg1outs && arg2outs -> do
-        let stmt' = ProcCall (First mod name Nothing) Det False (args++[arg2])
+        let stmt' = ProcCall (First mod name Nothing) Det bang (args++[arg2])
         flattenStmt stmt' pos detism
-      (_, Fncall mod name args)
+      (_, Fncall mod name bang args)
         | not arg2outs && arg1outs -> do
         (arg1':args') <- flattenStmtArgs (arg1:args) pos
-        emit pos $ ProcCall (First mod name Nothing) Det False (args'++[arg1'])
+        emit pos $ ProcCall (First mod name Nothing) Det bang (args'++[arg1'])
         flushPostponed
       (_,_) | callDetism == Det
                 && (varCheck arg1content arg2outs || varCheck arg2content arg1outs)
@@ -595,8 +595,8 @@ flattenExp (CaseExp pexpr cases deflt) ty castFrom pos = do
     pexpr' <- flattenPExp pexpr
     flattenStmt (translateExpCases pexpr' resultName cases deflt) pos Det
     return $ maybePlace (Var resultName ParamIn Ordinary) pos
-flattenExp (Fncall mod name exps) ty castFrom pos = do
-    let stmtBuilder = ProcCall (First mod name Nothing) Det False
+flattenExp (Fncall mod name bang exps) ty castFrom pos = do
+    let stmtBuilder = ProcCall (First mod name Nothing) Det bang
     flattenCall stmtBuilder False ty castFrom pos exps
 flattenExp (ForeignFn lang name flags exps) ty castFrom pos = do
     flattenCall (ForeignCall lang name flags) True ty castFrom pos exps

--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -596,6 +596,8 @@ flattenExp (CaseExp pexpr cases deflt) ty castFrom pos = do
     flattenStmt (translateExpCases pexpr' resultName cases deflt) pos Det
     return $ maybePlace (Var resultName ParamIn Ordinary) pos
 flattenExp (Fncall mod name bang exps) ty castFrom pos = do
+    when bang $ lift 
+        $ errmsg pos "function call cannot have preceding !"
     let stmtBuilder = ProcCall (First mod name Nothing) Det bang
     flattenCall stmtBuilder False ty castFrom pos exps
 flattenExp (ForeignFn lang name flags exps) ty castFrom pos = do

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1058,12 +1058,14 @@ procToPartial :: [FlowDirection] -> Bool -> CallInfo -> (Maybe CallInfo, Bool)
 procToPartial callFlows hasBang info@FirstInfo{fiPartial=False,
                                                fiTypes=tys,
                                                fiFlows=flows,
+                                               fiInRes=inRes,
+                                               fiOutRes=outRes,
                                                fiNeedsResBang=resful,
                                                fiDetism=detism,
                                                fiImpurity=impurity}
-    | not hasBang  && not (List.null callFlows) && last callFlows == ParamOut
-                   && (length callFlows < length tys
-                       || length callFlows <= length tys + 1 && resful)
+    | not hasBang && not (List.null callFlows) && last callFlows == ParamOut
+                  && (length callFlows < length tys
+                      || length callFlows <= length tys + 1 && usesResources)
         = (Just info{fiPartial=True,
                      fiTypes=closedTys ++ [higherTy],
                      fiFlows=closedFls ++ [ParamOut]}, needsBang)
@@ -1071,6 +1073,7 @@ procToPartial callFlows hasBang info@FirstInfo{fiPartial=False,
     nClosed = length callFlows - 1
     (closedTys, higherTys) = List.splitAt nClosed tys
     (closedFls, higherFls) = List.splitAt nClosed flows
+    usesResources = not (Set.null inRes) || not (Set.null outRes)
     needsBang = resful || impurity > Pure
     higherTy = HigherOrderType (normaliseModifiers
                                 $ ProcModifiers detism MayInline

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1612,8 +1612,7 @@ matchTypes caller callee pos _ callTypes callFlows
                         (typeFlowMode <$> callTFs) (typeFlowMode <$> tfs) [1..]
                 else typeError $ ReasonArity caller callee pos nCallTFs (length tfs')
             _ ->
-                void $ getTyping 
-                     $ unifyTypes (ReasonHigher caller callee pos)
+                void $ unifyTypes (ReasonHigher caller callee pos)
                         fnTy $ HigherOrderType defaultProcModifiers callTFs
     let typing' = snd typing
     let errs = typingErrs typing'

--- a/src/Unique.hs
+++ b/src/Unique.hs
@@ -335,7 +335,7 @@ uniquenessCheckExp (CondExp stmt e1 e2) pos =
     (placedApply uniquenessCheckStmt stmt `withDetism` SemiDet
      >> placedApply uniquenessCheckExp e1)
     `joinUniqueness` placedApply uniquenessCheckExp e2
-uniquenessCheckExp (Fncall _ _ exps) pos =
+uniquenessCheckExp (Fncall _ _ _ exps) pos =
     mapM_  (placedApply uniquenessCheckExp) exps
 uniquenessCheckExp (ForeignFn _ _ _ exps) pos =
     mapM_  (placedApply uniquenessCheckExp) exps

--- a/test-cases/final-dump/bang_expression_error.exp
+++ b/test-cases/final-dump/bang_expression_error.exp
@@ -1,0 +1,6 @@
+Error detected during preliminary processing of module bang_expression_error
+[91mfinal-dump/bang_expression_error.wybe:4:28: function call cannot have preceding !
+[0m[91mfinal-dump/bang_expression_error.wybe:4:36: function call cannot have preceding !
+[0m[91mfinal-dump/bang_expression_error.wybe:10:33: function call cannot have preceding !
+[0m[91mfinal-dump/bang_expression_error.wybe:10:63: function call cannot have preceding !
+[0m

--- a/test-cases/final-dump/bang_expression_error.wybe
+++ b/test-cases/final-dump/bang_expression_error.wybe
@@ -1,0 +1,12 @@
+
+def my_map(f:{resource}(T,?T), lst:list(T)):list(T) = 
+    if {
+        lst = [?h|?t] :: [!f(h) | !my_map(f, t)]
+    |   else          :: []
+    }
+    
+def my_map2(f:{resource}(T,?T), lst:list(T)):list(T) = 
+    if {
+        lst = [?h|?t] :: [h2 | !my_map2(f, t)] where { ?h2 = !f(h) }
+    |   else          :: []
+    }


### PR DESCRIPTION
This code
```
def my_map(f:{resource}(T,?T), lst:list(T)):list(T) =
    if {
        lst = [?h|?t] :: [h2 | !my_map(f, t)] where { !f(h, ?h2) }
    |   else          :: []
    }
```
now compiles fine. Note the `!` before the `my_map` call.

The call to `f` occurs before the recursive call, which is what I think we want to happen.