### PR TITLE
Unified resource transformations

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -18,7 +18,7 @@ module AST (
   Item(..), Visibility(..), isPublic,
   Determinism(..), determinismLEQ, determinismJoin, determinismMeet,
   determinismFail, determinismSucceed,
-  determinismSeq, determinismProceding, determinismName,
+  determinismSeq, determinismProceding, determinismName, determinismCanFail,
   impurityName, impuritySeq, expectedImpurity,
   inliningName,
   TypeProto(..), TypeModifiers(..), TypeSpec(..), typeVarSet, TypeVarName(..),
@@ -261,6 +261,13 @@ determinismName Failure  = "failing"
 determinismName Det      = ""
 determinismName SemiDet  = "test"
 -- NonDet = "generator"
+
+-- | Can the determinism fail?
+determinismCanFail :: Determinism -> Bool
+determinismCanFail Terminal = False
+determinismCanFail Failure  = True
+determinismCanFail Det      = False
+determinismCanFail SemiDet  = True
 
 
 -- | Internal representation of data

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -220,7 +220,6 @@ import           Options                   (LogSelection (..), Options (..),
 import           Parser                    (parseWybe)
 import           Resources                 (resourceCheckMod,
                                             transformProcResources,
-                                            transformProcGlobals,
                                             canonicaliseProcResources)
 import           Unique                    ( uniquenessCheckProc )
 import           Scanner                   (fileTokens)
@@ -810,15 +809,13 @@ compileModSCC mspecs = do
     stopOnError $ "type checking of module(s) "
                   ++ showModSpecs mspecs
     logDump Types Unbranch "TYPE CHECK"
-    mapM_ (transformModuleProcs transformProcResources)  mspecs
-    stopOnError $ "resource checking of module(s) "
-                  ++ showModSpecs mspecs
     mapM_ (transformModuleProcs uniquenessCheckProc)  mspecs
     stopOnError $ "uniqueness checking of module(s) "
                   ++ showModSpecs mspecs
-    mapM_ (transformModuleProcs transformProcGlobals)  mspecs
-    stopOnError $ "globalisation of module(s) "
+    mapM_ (transformModuleProcs transformProcResources)  mspecs
+    stopOnError $ "resource checking of module(s) "
                   ++ showModSpecs mspecs
+    
     ----------------------------------
     -- UNBRANCHING
     mapM_ (transformModuleProcs unbranchProc)  mspecs

--- a/src/Resources.hs
+++ b/src/Resources.hs
@@ -9,7 +9,7 @@
 
 module Resources (resourceCheckMod, canonicaliseProcResources,
                   canonicaliseResourceSpec,
-                  transformProcResources, transformProcGlobals) where
+                  transformProcResources) where
 
 import           AST
 import           Control.Monad
@@ -37,30 +37,18 @@ import Control.Monad.Extra (unlessM)
 -- BEGIN MAJOR DOC
 -- ###                 Resource Transformations.
 --
--- There are three passes related to resources within the Wybe compiler.
+-- There are two passes related to resources within the Wybe compiler.
 --
 -- The first pass canonicalises the `use` declarations in procedure prototypes.
 -- This resolves the module which each resource refers to.
 --
 -- The second, performed after type checking, transforms resource usage into
--- regular parameters/arguments. Here, each procedure is modifed to include
--- parameters corresponding to each resource and respective flow.
--- Each call is also transformed to include the resources as arguments.
--- The order of arguments is dictated by the ordering of the `ResourceSpec`
--- type, ordering by module then name. `use` blocks are also transformed to
--- contain LPVM `move` instructions of respectively used resources, to save
--- and subsequently restore the value of each resource variable.
---
--- The final pass tranforms resource into global variables. This pass must be
--- performed after uniqueness checking, as uniqueness checking assumes only the
--- second pass has been performed. The additional parameters and arguments
--- introduced in the second pass are removed here, as they are now passed in
--- global variables. Each reference to an in scope resource by name is
--- transformed into a load (input) or a store (output), or both (in/out).
+-- references to global variables. Each reference to an in scope resource by 
+-- name is transformed into a load (input) or a store (output), or both (in/out). 
 -- Finally, `use` blocks are also transformed to save (load) and then restore
 -- (store) each out-of-scope resource.
 --
--- The final two passes assume that type and mode checking has occured. Type
+-- The final pass assume that type and mode checking has occured. Type
 -- checking ensures that resources have the correct types, and mode checking
 -- ensures that resources, where applicable are in scope.
 --
@@ -137,7 +125,7 @@ canonicaliseResourceFlow pos spec = do
     return $ spec { resourceFlowRes = fst resTy }
 
 
---------- Transform resources into variables and parameters ---------
+--------- Transform resources into global variables ---------
 
 -- | Data type to store the necessary data for adding resources to a proc
 data ResourceState = ResourceState {
@@ -147,11 +135,6 @@ data ResourceState = ResourceState {
     -- ^ Tmp variables that have been generated so far
     resTmpCtr         :: Int,
     -- ^ The current tmp variable counter
-    resHaveGlobals    :: Maybe Bool,
-    -- ^ Do we currently have a #globals variable?
-    -- Nothing if we arent globalising
-
-    -- The following are only used when globalising
     resIn             :: Map ResourceSpec TypeSpec,
     -- ^ The set of resources that flow into the current stmt
     resOut            :: Map ResourceSpec TypeSpec,
@@ -162,236 +145,42 @@ data ResourceState = ResourceState {
     resLoopTmps       :: Map ResourceSpec (VarName, TypeSpec),
     -- ^ The tmp vars that are used to restore resources when breaking a loop
     resIsExecMain     :: Bool
-    -- ^ Are we currently globalising the executable main procedure
+    -- ^ Are we currently transforming the executable main procedure
 }
 
 -- | Initial ResourceState given a tmpCtr
-initResourceState :: Maybe Bool -> Int -> ResourceState
-initResourceState globals tmp = ResourceState{resResources=Map.empty,
-                                              resTmpVars=Map.empty,
-                                              resTmpCtr=tmp,
-                                              resHaveGlobals=globals,
-                                              resIn=Map.empty,
-                                              resOut=Map.empty,
-                                              resMentioned=Map.empty,
-                                              resLoopTmps=Map.empty,
-                                              resIsExecMain=False}
+initResourceState :: Int -> ResourceState
+initResourceState tmp = ResourceState{resResources=Map.empty,
+                                      resTmpVars=Map.empty,
+                                      resTmpCtr=tmp,
+                                      resIn=Map.empty,
+                                      resOut=Map.empty,
+                                      resMentioned=Map.empty,
+                                      resLoopTmps=Map.empty,
+                                      resIsExecMain=False}
 
 
 -- | State transformer using a ResourceState
 type Resourcer = StateT ResourceState Compiler
 
-
--- |Transform resources into ordinary variables in a single procedure
---  definition.  Also check that calls to procs that use resources are
---  annotated with a ! to indicate resource usage.  This transformation
---  just blindly transforms resources into variables and parameters,
---  counting on the later variable use/def analysis to ensure that
---  resources are defined before they're used or returned.
---
--- Note that type checking of all called procedures must have been completed
--- before this can be done, because called procs are only resolved when this
--- proc is type checked.
-transformProcResources :: ProcDef -> Int -> Compiler ProcDef
-transformProcResources pd _ = do
-    logResources "--------------------------------------\n"
-    logResources $ "Adding resources to:" ++ showProcDef 4 pd
-    let proto = procProto pd
-    let pos = procPos pd
-    let tmp = procTmpCount pd
-    let resFlows = procProtoResources proto
-    let params = procProtoParams proto
-    let ProcDefSrc body = procImpln pd
-    logResources $ "Declared resources: " ++ show resFlows
-    (body', resParams, tmp')
-        <- evalStateT (transformProc resFlows body pos)
-            $ initResourceState Nothing tmp
-    let proto' = proto { procProtoParams=params ++ resParams }
-    let pd' = pd { procProto=proto', procTmpCount=tmp',
-                   procImpln=ProcDefSrc body' }
-    logResources $ "Adding resources results in:" ++ showProcDef 4 pd'
-    return pd'
-
--- | Transform a ResourceFlowSpec with a type into a Param
-resourceParams :: (ResourceFlowSpec,TypeSpec) -> Param
-resourceParams (ResourceFlowSpec res flow, typ) =
-    Param (resourceVar res) typ flow (Resource res)
-
-
--- | Transform a given procedure's body and resources, producing the body with
--- resources transformed into arguments, the additional parameters for resources
--- and the new tmpCtr
-transformProc :: Set ResourceFlowSpec -> [Placed Stmt] -> OptPos
-              -> Resourcer ([Placed Stmt], [Param], Int)
-transformProc resourceFlows body pos = do
-    resFlows <- concat <$> mapM (simpleResourceFlows pos)
-                           (Set.elems resourceFlows)
-    modify $ \s -> s{resResources=Map.fromList $ mapFst resourceFlowRes <$> resFlows}
-    logResourcer $ "Declared resources: " ++ show resFlows
-    body' <- transformStmts body
-    tmp' <- gets resTmpCtr
-    return (body', resourceParams <$> resFlows, tmp')
-
-
--- | Transform a statement sequence, turning resources into arguments.
-transformStmts :: [Placed Stmt] -> Resourcer [Placed Stmt]
-transformStmts stmts = concat <$> mapM (placedApply transformStmt) stmts
-
-
--- | Transform a single statement, turning resources into arguments.
-transformStmt :: Stmt -> OptPos -> Resourcer [Placed Stmt]
-transformStmt stmt@(ProcCall func@(First m n mbId) detism resourceful args) pos = do
-    let procID = trustFromJust "transformStmt" mbId
-    procDef <- lift (getProcDef $ ProcSpec m n procID generalVersion)
-    let proto = procProto procDef
-    let callResFlows = Set.toList $ procProtoResources proto
-    let callParamTys = paramType <$> procProtoParams proto
-    let variant = procVariant procDef
-    let hasResfulHigherArgs = any isResourcefulHigherOrder callParamTys
-    let usesResources = not (List.null callResFlows) || hasResfulHigherArgs
-    unless (resourceful || not usesResources)
-        $ lift $ errmsg pos
-               $ "Call to resourceful proc without ! resource marker: "
-                    ++ showStmt 4 stmt
-    args' <- transformExps args
-    resArgs <- concat <$> mapM (resourceArgs pos) callResFlows
-    return [maybePlace (ProcCall func detism False $ args' ++ resArgs) pos]
-transformStmt stmt@(ProcCall (Higher func) detism resourceful args) pos = do
-    (func':args') <- transformExps $ func:args
-    case content func' of
-        Typed _ (HigherOrderType ProcModifiers{modifierResourceful=True} _) _ -> do
-            unless resourceful
-                $ lift $ errmsg pos
-                $ "Resourceful higher order call without ! resource marker: "
-                    ++ showStmt 4 stmt
-        Typed _ (HigherOrderType _ _) _ -> nop
-        _ -> shouldnt $ "bad resource higher call type" ++ show stmt
-    return [maybePlace (ProcCall (Higher func') detism False args') pos]
-transformStmt (ForeignCall lang name flags args) pos = do
-    args' <- transformExps args
-    return [maybePlace (ForeignCall lang name flags args') pos]
-transformStmt (TestBool var) pos = do
-    var' <- transformExp var pos
-    return [maybePlace (TestBool $ content var') pos]
-transformStmt (And stmts) pos = do
-    stmts' <- transformStmts stmts
-    return [maybePlace (And stmts') pos]
-transformStmt (Or [] _ _) pos =
-    return [failTest]
-transformStmt (Or [stmt] _ _) pos = do
-    placedApplyM transformStmt stmt
-transformStmt (Or (stmt:stmts) vars res) pos = do
-    stmt'  <- placedApplyM transformStmt stmt
-    stmt'' <- transformStmt (Or stmts vars res) pos
-    vars' <- fixVarDict vars
-    return [maybePlace (Or [seqToStmt stmt',seqToStmt stmt''] vars' res) pos]
-transformStmt (Not stmt) pos = do
-    stmt' <- placedApplyM transformStmt stmt
-    return [maybePlace (Not $ seqToStmt stmt') pos]
-transformStmt (Cond test thn els condVars exitVars res) pos = do
-    test' <- placedApplyM transformStmt test
-    thn' <- transformStmts thn
-    els' <- transformStmts els
-    condVars' <- fixVarDict condVars
-    exitVars' <- fixVarDict exitVars
-    return [maybePlace (Cond (seqToStmt test')
-            thn' els' condVars' exitVars' res) pos]
-transformStmt (Case exp cases deflt) pos = do
-    exp' <- placedApply transformExp exp
-    cases' <- transformCases cases
-    deflt' <- forM deflt transformStmts
-    return [maybePlace (Case exp' cases' deflt') pos]
-transformStmt (Loop body vars res) pos = do
-    body' <- transformStmts body
-    vars' <- fixVarDict vars
-    return [maybePlace (Loop body' vars' res) pos]
-transformStmt (For generators body) pos = do
-    body' <- transformStmts body
-    return [maybePlace (For generators body') pos]
-transformStmt (UseResources res vars body) pos = do
-    let vars' = trustFromJust "globalise use with no vars" vars
-    resMbTypes <- lift $ mapM (canonicaliseResourceSpec pos "use statement")
-                              res
-    let resTys = mapSnd (trustFromJust "transformStmt UseResources")
-               <$> resMbTypes
-    let vars' = trustFromJust "globalise use with no before" vars
-    s@ResourceState{resResources=oldResTypes,
-                    resTmpVars=oldTmp} <- get
-    (saves, restores, tmpVars) <- saveRestoreLocalsTmp pos $ Map.toList vars'
-    modify $ \s -> s{resTmpVars=tmpVars `Map.union` oldTmp,
-                     resResources=oldResTypes `Map.union` Map.fromList resTys}
-    body' <- transformStmts body
-    modify $ \s -> s{ resTmpVars=oldTmp }
-    return $ saves
-          ++ [UseResources res vars body' `maybePlace` pos]
-          ++ restores
-transformStmt Nop pos = return [maybePlace Nop pos]
-transformStmt Fail pos = return [maybePlace Fail pos]
-transformStmt Break pos = return [maybePlace Break pos]
-transformStmt Next pos = return [maybePlace Next pos]
-
-
--- | Transform a list of expressions
-transformExps :: [Placed Exp] -> Resourcer [Placed Exp]
-transformExps exps = mapM (placedApply transformExp) exps
-
-
--- | Transform a given expression
-transformExp :: Exp -> OptPos -> Resourcer (Placed Exp)
-transformExp (Typed exp ty cast) pos = do
-    exp' <- content <$> transformExp exp pos
-    return $ maybePlace (Typed exp' ty cast) pos
-transformExp (AnonProc mods params body clsd _) pos = do
-    body' <- transformStmts body
-    res <- (mapFst (`ResourceFlowSpec` ParamInOut) <$>) . Map.toList <$> gets resResources
-    let (params', res') = if modifierResourceful mods
-                  then (params ++ (resourceParams <$> res),
-                        Set.fromList $ fst <$> res)
-                  else (params, Set.empty)
-    return $ AnonProc mods params' body' clsd (Just res')
-                `maybePlace` pos
-transformExp exp pos = return $ maybePlace exp pos
-
-
--- Transform a list of cases, transforming resources into arguments
-transformCases :: [(Placed Exp,[Placed Stmt])]
-               -> Resourcer [(Placed Exp, [Placed Stmt])]
-transformCases [] = return []
-transformCases ((guard,body):rest) = do
-    body' <- transformStmts body
-    rest' <- transformCases rest
-    return $ (guard,body'):rest'
-
-
--- |Returns the list of args corresponding to the specified resource
--- flow spec.  This produces up to two arguments for each simple
--- resource, multiplied by all the simple resources a single resource
--- flow spec might refer to.
-resourceArgs :: OptPos -> ResourceFlowSpec -> Resourcer [Placed Exp]
-resourceArgs pos rflow = do
-    simpleSpecs <- simpleResourceFlows pos rflow
-    mapM (\(ResourceFlowSpec res flow,ty) -> do
-                   let var = resourceVar res
-                   let ftype = Resource res
-                   return $ Unplaced $ Typed (Var var flow ftype) ty Nothing)
-         simpleSpecs
-
-
-------------------------- Globalisation --------------------------------
-
--- | Transform a givn ProcDef, transforming resource usage into loads/stores of
--- global variables, and threads a global variable state through calls instead
--- of passing resources as parameters
+-- | Transform a given ProcDef, transforming resource usage into loads/stores of
+-- global variables, and threads the global variable state through calls. 
+-- Also check that calls to procs that use resources are annotated with a ! 
+-- to indicate resource usage. 
 --
 -- Note that this is the final pass of resource transformation, and must be
 -- performed after uniqueness checking, as the loads/stores cause all resource
 -- usage to appear as though it obeys uniquness checking
 --
+-- Note that type checking of all called procedures must have been completed
+-- before this can be done, because called procs are only resolved when this
+-- proc is type checked.
+--
 -- XXX this may interfere with uniqueness inference and/or destructive updates
-transformProcGlobals :: ProcDef -> Int -> Compiler ProcDef
-transformProcGlobals pd _ = do
+transformProcResources :: ProcDef -> Int -> Compiler ProcDef
+transformProcResources pd _ = do
     logResources "--------------------------------------\n"
-    logResources $ "Globalising resources in:" ++ showProcDef 4 pd
+    logResources $ "Transforming resources in:" ++ showProcDef 4 pd
     let name = procName pd
     let proto = procProto pd
     let detism = procDetism pd
@@ -401,40 +190,40 @@ transformProcGlobals pd _ = do
     let params = procProtoParams proto
     let res = procProtoResources proto
     let ProcDefSrc body = procImpln pd
-    (params', body', tmp') <- evalStateT (globaliseProc pos (Just name) variant
+    (params', body', tmp') <- evalStateT (transformProc pos (Just name) variant
                                             detism params res body)
-                                $ initResourceState (Just False) tmp
+                                $ initResourceState tmp
     let proto' = proto { procProtoParams=params' }
     let pd' = pd { procProto=proto', procTmpCount=tmp',
                    procImpln=ProcDefSrc body' }
     logResources "--------------------------------------\n"
-    logResources $ "Globalising results in:" ++ showProcDef 4 pd'
+    logResources $ "Transforming results in:" ++ showProcDef 4 pd'
     return pd'
 
 
--- Globalise a proc, tranforming resources into globals.
--- This returns an updated list of Params, transofrmed list of Stmts (body),
--- and the value of the tmpCtr after globalising the proc
-globaliseProc :: OptPos -> Maybe ProcName -> ProcVariant
+-- Transform a proc, tranforming resources into globals.
+-- This returns an updated list of Params, transformed list of Stmts (body),
+-- and the value of the tmpCtr after transforming the proc
+transformProc :: OptPos -> Maybe ProcName -> ProcVariant
               -> Determinism -> [Param] -> Set ResourceFlowSpec
               -> [Placed Stmt] -> Resourcer ([Param], [Placed Stmt], Int)
-globaliseProc pos name variant detism params ress body = do
-    logResourcer $ "Globalising proc " ++ fromMaybe "un-named (anon)" name
-    let hasHigherResources = any paramIsResourceful params
-    let (resFlows, realParams) = partitionEithers $ eitherResourceParam <$> params
+transformProc pos name variant detism params ress body = do
+    logResourcer $ "Transforming proc " ++ fromMaybe "un-named (anon)" name
+    resTys <- concat <$> mapM (simpleResourceFlows pos) (Set.elems ress)
+    let allParams = params ++ List.map resourceParams resTys
+    let hasHigherResources = any paramIsResourceful allParams
+    let (resFlows, realParams) = partitionEithers $ eitherResourceParam <$> allParams
     let needsGlobalParam = hasHigherResources || not (List.null resFlows)
     thisMod <- lift getModuleSpec
     let isExecMain = List.null thisMod && name == Just ""
     ResourceState{resResources=oldResources,
                   resMentioned=oldMentioned,
-                  resHaveGlobals=oldHaveGlobals,
                   resTmpVars=oldTmpVars,
                   resLoopTmps=oldLoopTmps,
                   resIsExecMain=oldIsExecMain} <- get
     let res = Map.fromList $ mapFst resourceFlowRes <$> resFlows
     modify $ \s -> s{resResources=res,
                      resMentioned=res,
-                     resHaveGlobals=Just needsGlobalParam,
                      resLoopTmps=Map.empty,
                      resIsExecMain=isExecMain}
     -- we must save and restore any non-out-flowing resources, as we cannot be
@@ -442,7 +231,7 @@ globaliseProc pos name variant detism params ress body = do
     let ress' = [res | ResourceFlowSpec res flow <- Set.toList ress
                 , not $ flowsOut flow
                 , not $ isSpecialResource res ]
-    body' <- fst <$> globaliseStmts [UseResources ress' (Just Map.empty) body
+    body' <- fst <$> transformStmts [UseResources ress' (Just Map.empty) body
                                         `maybePlace` pos]
     -- In the case of a proc that may fail, we need to roll back the state of
     -- resources we can if we fail. We can do this with the following
@@ -454,8 +243,7 @@ globaliseProc pos name variant detism params ress body = do
     -- Unbranching will then force the stores to be executed in the case of
     -- failure, ensuring the global variables are unmoddified
     newMentioned <- gets resMentioned
-    body'' <- if detism /= SemiDet && detism /= Failure
-                || Map.null newMentioned
+    body'' <- if detism /= SemiDet && detism /= Failure || Map.null newMentioned
               then return body'
               else do
                 (saves, restores, tmpVars, _) <- saveRestoreResourcesTmp pos
@@ -466,7 +254,6 @@ globaliseProc pos name variant detism params ress body = do
                             (restores ++ [Unplaced Fail])
                             (Just tmpVars) (Just tmpVars) (Just Set.empty)]
     modify $ \s -> s{resResources=oldResources,
-                     resHaveGlobals=oldHaveGlobals,
                      resTmpVars=oldTmpVars,
                      resLoopTmps=oldLoopTmps,
                      resIsExecMain=oldIsExecMain,
@@ -477,58 +264,57 @@ globaliseProc pos name variant detism params ress body = do
     return $ if isExecMain
     then let inRes = List.filter (flowsIn . resourceFlowFlow . fst) resFlows
              stores = storeResource pos . mapFst resourceFlowRes <$> inRes
-         in (params, stores ++ body'', tmp)
+         in (allParams, stores ++ body'', tmp)
     else (realParams, body'', tmp)
 
 
--- Globalise a list of Stmts, tranforming resources into globals
+-- Transform a list of Stmts, tranforming resources into globals
 -- The returned bool indicates if any of the Stmts could modify globals
-globaliseStmts :: [Placed Stmt] -> Resourcer ([Placed Stmt], Bool)
-globaliseStmts pstmts = (concat *** or) . unzip
-                     <$> mapM (placedApply globaliseStmt) pstmts
+transformStmts :: [Placed Stmt] -> Resourcer ([Placed Stmt], Bool)
+transformStmts pstmts = (concat *** or) . unzip
+                     <$> mapM (placedApply transformStmt) pstmts
 
 
--- Globalise a Stmt, tranforming resources into globals
+-- Transform a Stmt, tranforming resources into globals
 -- The returned bool indicates if the Stmt could modify a global
-globaliseStmt :: Stmt -> OptPos -> Resourcer ([Placed Stmt], Bool)
-globaliseStmt (ProcCall fn@(First m n mbId) d r args) pos = do
+transformStmt :: Stmt -> OptPos -> Resourcer ([Placed Stmt], Bool)
+transformStmt stmt@(ProcCall fn@(First m n mbId) d resourceful args) pos = do
     let procID = trustFromJust "transformStmt" mbId
+    procDef <- lift (getProcDef $ ProcSpec m n procID generalVersion)
+    let proto = procProto procDef
     let (res, args') = partitionEithers $ placedApply eitherResourceExp <$> args
-    (args'', ins, outs) <- globaliseExps args'
-    let argTys = fromMaybe AnyType . maybeExpType . content <$> args''
-    let hasResfulHigherArgs = any isResourcefulHigherOrder argTys
-    let needsGlobals = not (List.null res) || hasResfulHigherArgs
-    unlessM ((not needsGlobals ||) . trustFromJust "globaliseStmt first"
-                <$> gets resHaveGlobals)
-        $ lift $ errmsg pos $ "Cannot make resourceful call to " ++ showProcName n
-                           ++ " in current context"
-    proto <- procProto <$> lift (getProcDef $ ProcSpec m n procID generalVersion)
-    let paramTys = paramType <$> procProtoParams proto
-    let globals = any isResourcefulHigherOrder paramTys || not (List.null res)
+    unless (List.null res) $ shouldnt $ "statement with resource args " ++ show stmt
+    (args'', ins, outs) <- transformExps args'
+    let callResFlows = Set.toList $ procProtoResources proto
+    let callParamTys = paramType <$> procProtoParams proto
+    let hasResfulHigherArgs = any isResourcefulHigherOrder callParamTys
+    let usesResources = not (List.null callResFlows) || hasResfulHigherArgs
+    unless (resourceful || not usesResources)
+        $ lift $ errmsg pos
+               $ "Call to resourceful proc without ! resource marker: "
+                    ++ showStmt 4 stmt
+    resArgs <- concat <$> mapM (resourceArgs pos) 
+        (List.filter (isSpecialResource . resourceFlowRes) callResFlows)
     return (loadStoreResources pos ins outs
-                [ProcCall fn d r args'' `maybePlace` pos],
-            globals || not (Map.null outs))
-globaliseStmt (ProcCall (Higher fn) d r args) pos = do
-    (fn':args', ins, outs) <- globaliseExps $ fn:args
+                [ProcCall fn d False (args'' ++ resArgs) `maybePlace` pos],
+            usesResources || not (Map.null outs))
+transformStmt (ProcCall (Higher fn) d r args) pos = do
+    (fn':args', ins, outs) <- transformExps $ fn:args
     let globals = case maybeExpType $ content fn' of
                     Just (HigherOrderType mods _) -> modifierResourceful mods
                     _ -> shouldnt "glabalise badly typed higher"
-    unlessM ((not globals ||) . trustFromJust "globaliseStmt higher"
-                <$> gets resHaveGlobals)
-        $ lift $ errmsg pos $ "Cannot make resourceful call to " ++ show (content fn')
-                           ++ " in current context"
     return (loadStoreResources pos ins outs
-                [ProcCall (Higher fn') d r args' `maybePlace` pos],
+                [ProcCall (Higher fn') d False args' `maybePlace` pos],
             globals)
-globaliseStmt (ForeignCall lang name flags args) pos = do
-    (args', ins, outs) <- globaliseExps args
+transformStmt (ForeignCall lang name flags args) pos = do
+    (args', ins, outs) <- transformExps args
     return (loadStoreResources pos ins outs
                 [ForeignCall lang name flags args' `maybePlace` pos],
             not $ Map.null outs)
-globaliseStmt (Cond tst thn els condVars exitVars _) pos = do
-    (tst', tstGlobals) <- placedApply globaliseStmt tst
-    (thn', thnGlobals) <- globaliseStmts thn
-    (els', elsGlobals) <- globaliseStmts els
+transformStmt (Cond tst thn els condVars exitVars _) pos = do
+    (tst', tstGlobals) <- placedApply transformStmt tst
+    (thn', thnGlobals) <- transformStmts thn
+    (els', elsGlobals) <- transformStmts els
     (saves, restores) <- loadStoreResourcesIf pos tstGlobals
     condVars' <- fixVarDict condVars
     exitVars' <- fixVarDict exitVars
@@ -537,11 +323,11 @@ globaliseStmt (Cond tst thn els condVars exitVars _) pos = do
                             condVars' exitVars' (Just $ Map.keysSet res)
                         `maybePlace` pos],
             thnGlobals || elsGlobals)
-globaliseStmt (And stmts) pos = do
-    (stmts', globals) <- globaliseStmts stmts
+transformStmt (And stmts) pos = do
+    (stmts', globals) <- transformStmts stmts
     return ([And stmts' `maybePlace` pos], globals)
-globaliseStmt (Or disjs vars _) pos = do
-    (disjs', globals) <- unzip <$> mapM (placedApply globaliseStmt) disjs
+transformStmt (Or disjs vars _) pos = do
+    (disjs', globals) <- unzip <$> mapM (placedApply transformStmt) disjs
     -- we only need to save resources, and restore before each disj if
     -- any of the init use globals
     -- the last's restoration is handled implicity
@@ -552,75 +338,74 @@ globaliseStmt (Or disjs vars _) pos = do
     res <- gets resResources
     return (saves ++ [Or disjs'' vars' (Just $ Map.keysSet res) `maybePlace` pos],
             or globals)
-globaliseStmt (Not stmt) pos = do
-    ([stmt'], globals) <- globaliseStmts [stmt]
+transformStmt (Not stmt) pos = do
+    ([stmt'], globals) <- transformStmts [stmt]
     return ([Not stmt' `maybePlace` pos], globals)
-globaliseStmt (TestBool exp) pos = do
-    ([exp'], ins, outs) <- globaliseExps [exp `maybePlace` pos]
+transformStmt (TestBool exp) pos = do
+    ([exp'], ins, outs) <- transformExps [exp `maybePlace` pos]
     -- TestBool cannot modify a resource
-    unless (Map.null outs) $ shouldnt "globalise TestBool with out flowing resource"
+    unless (Map.null outs) $ shouldnt "transform TestBool with out flowing resource"
     return (loadStoreResources pos ins outs [TestBool (content exp') `maybePlace` pos],
             False)
-globaliseStmt (Loop stmts vars _) pos = do
+transformStmt (Loop stmts vars _) pos = do
     loopTmps <- gets resLoopTmps
     modify $ \s -> s{resLoopTmps=Map.empty}
-    (stmts',usesGlobals) <- globaliseStmts stmts
+    (stmts',usesGlobals) <- transformStmts stmts
     vars' <- fixVarDict vars
     res <- gets resResources
     modify $ \s -> s{resLoopTmps=loopTmps}
     return ([Loop stmts' vars' (Just $ Map.keysSet res) `maybePlace` pos], usesGlobals)
-globaliseStmt (UseResources res vars stmts) pos =
-    case List.filter (not . isSpecialResource) res of
-        [] -> globaliseStmts stmts
-        newRes' -> do
-            -- this handles the resources that were previously out-of-scope
-            let vars' = trustFromJust "globalise use with no vars" vars
-            resTypes <- (mapSnd (trustFromJust "globalise use") <$>)
-                    <$> lift (mapM (canonicaliseResourceSpec pos "use block") res)
-            ResourceState{resHaveGlobals=haveGlobals,
-                          resResources=resources,
-                          resMentioned=mentioned,
-                          resTmpVars=tmpVars,
-                          resLoopTmps=loopTmps,
-                          resIsExecMain=isExecMain} <- get
-            let resources' = Map.fromList resTypes
-            let haveGlobals' = trustFromJust "use resources with Nothing" haveGlobals
-            (loads, stores, newVars, newLoopTmps) <- saveRestoreResourcesTmp pos resTypes
-            modify $ \s -> s {resHaveGlobals=Just True,
-                              resResources=resources `Map.union` resources',
-                              resMentioned=mentioned `Map.union` resources',
-                              resLoopTmps=loopTmps `Map.union` newLoopTmps}
-            unless isExecMain $ modify $ \s -> s {resTmpVars=tmpVars `Map.union` newVars}
-            stmts' <- fst <$> globaliseStmts stmts
-            modify $ \s -> s {resHaveGlobals=haveGlobals,
-                              resResources=resources,
-                              resLoopTmps=loopTmps,
-                              resTmpVars=tmpVars}
-            -- no need to load and store resources in executable main
-            if isExecMain
-            then return (stmts', True)
-            else return
-                    -- load the old values of the resources
-                (loads
-                    -- store the values of the new resources,
-                    -- if theyve been assigned before the use block
-                ++ [storeResource pos (res, ty)
-                   | (res, ty) <- resTypes
-                   , resourceVar res `Map.member` vars' ]
-                ++ stmts'
-                    -- store the old values of the resources
-                ++ stores,
-                    True)
-globaliseStmt Nop pos = return ([Nop `maybePlace` pos], False)
-globaliseStmt Fail pos = return ([Fail `maybePlace` pos], False)
-globaliseStmt Break pos = do
+transformStmt (UseResources res vars stmts) pos = do
+    let (special, res') = List.partition isSpecialResource res
+    let vars' = trustFromJust "transform use with no vars" vars
+    resTypes <- (mapSnd (trustFromJust "transform use") <$>)
+            <$> lift (mapM (canonicaliseResourceSpec pos "use block") res')
+    ResourceState{resResources=resources,
+                  resMentioned=mentioned,
+                  resTmpVars=tmpVars,
+                  resLoopTmps=loopTmps,
+                  resIsExecMain=isExecMain} <- get
+    -- save/restore local variables that have been selected to be
+    (saves, restores, localTmpVars) <- saveRestoreLocalsTmp pos 
+                                    $ Map.toList vars'
+    (loads, stores, newVars, newLoopTmps) <- saveRestoreResourcesTmp pos resTypes
+    let resources' = Map.fromList resTypes
+    modify $ \s -> s {resResources=resources `Map.union` resources',
+                      resMentioned=mentioned `Map.union` resources',
+                      resLoopTmps=loopTmps `Map.union` newLoopTmps}
+    let tmpVars' = tmpVars `Map.union` localTmpVars
+    unless isExecMain $ 
+        modify $ \s -> s {resTmpVars=tmpVars' `Map.union` newVars}
+    -- saves/restores may manipulate globals
+    stmts' <- fst <$> transformStmts (saves ++ stmts ++ restores)
+    modify $ \s -> s {resResources=resources,
+                      resLoopTmps=loopTmps,
+                      resTmpVars=tmpVars}
+    -- no need to load and store resources in executable main
+    (, not $ List.null res') <$> if isExecMain
+    then return stmts'
+    else return
+            -- load the old values of the resources
+        (loads
+            -- store the values of the new resources,
+            -- if theyve been assigned before the use block
+         ++ [storeResource pos (res, ty)
+            | (res, ty) <- resTypes
+            , resourceVar res `Map.member` vars'
+            , res `Map.notMember` resources]
+         ++ stmts'
+            -- store the old values of the resources
+         ++ stores)
+transformStmt Nop pos = return ([Nop `maybePlace` pos], False)
+transformStmt Fail pos = return ([Fail `maybePlace` pos], False)
+transformStmt Break pos = do
     restores <- restoreLoopGlobals pos
     return (restores ++ [Break `maybePlace` pos], False)
-globaliseStmt Next pos = do
+transformStmt Next pos = do
     restores <- restoreLoopGlobals pos
     return (restores ++ [Next `maybePlace` pos], False)
-globaliseStmt Case{} _ = shouldnt "case in globalise"
-globaliseStmt For{} _ = shouldnt "for in globalise"
+transformStmt Case{} _ = shouldnt "case in transform"
+transformStmt For{} _ = shouldnt "for in transform"
 
 
 -- | Restore global variables for a loop
@@ -632,50 +417,57 @@ restoreLoopGlobals pos = do
            | (res, (tmp, ty)) <- Map.toList loopTmps]
 
 
--- | Globalise a list of expressions.
+-- | transform a list of expressions.
 -- This returns a list of inflowing and outflowing resources, and keeps the
 -- Resourcer monad's in and out resources in tact
-globaliseExps :: [Placed Exp]
+transformExps :: [Placed Exp]
               -> Resourcer ([Placed Exp], Map ResourceSpec TypeSpec,
                                           Map ResourceSpec TypeSpec)
-globaliseExps exps = do
+transformExps exps = do
     ResourceState{resIn=oldIn, resOut=oldOut} <- get
     modify $ \s -> s{resIn=Map.empty, resOut=Map.empty}
-    exps' <- globaliseExps' exps
+    exps' <- transformExps' exps
     state' <- get
     modify $ \s -> s{resIn=oldIn, resOut=oldOut}
     return (exps', resIn state', resOut state')
 
 
--- | Globalise a list of expresstions
-globaliseExps' :: [Placed Exp] -> Resourcer [Placed Exp]
-globaliseExps' = mapM (placedApply $ globaliseExp AnyType)
+-- | transform a list of expresstions
+transformExps' :: [Placed Exp] -> Resourcer [Placed Exp]
+transformExps' = mapM (placedApply $ transformExp AnyType)
 
 
--- | Globalise a single expression, adding any in flowing or out flowing
--- resources to the Resourcer moand as necessary.
-globaliseExp :: TypeSpec -> Exp -> OptPos -> Resourcer (Placed Exp)
-globaliseExp _ (Typed exp ty cast) pos = do
-    exp' <- globaliseExp ty exp pos
+-- | transform a single expression, adding any in flowing or out flowing
+-- resources to the Resourcer monad as necessary.
+transformExp :: TypeSpec -> Exp -> OptPos -> Resourcer (Placed Exp)
+transformExp _ (Typed exp ty cast) pos = do
+    exp' <- transformExp ty exp pos
     return $ Typed (content exp') ty cast `maybePlace` pos
-globaliseExp ty exp@(Var nm fl _) pos = do
+transformExp ty exp@(Var nm fl _) pos = do
     addResourceInOuts fl nm ty
     return $ exp `maybePlace` pos
-globaliseExp _ (Closure pspec exps) pos = do
-    exps' <- globaliseExps' exps
+transformExp _ (Closure pspec exps) pos = do
+    exps' <- transformExps' exps
     return $ Closure pspec exps' `maybePlace` pos
-globaliseExp _ (AnonProc mods@(ProcModifiers detism _ _ _ resful)
-                params body clsd res) pos = do
-    (params', body', _) <- globaliseProc pos Nothing AnonymousProc
-                                detism params Set.empty body
+transformExp _ (AnonProc mods@(ProcModifiers detism _ _ _ resful)
+                params body clsd _) pos = do
+    res <- List.map (`ResourceFlowSpec` ParamInOut) 
+         . List.filter (not . isSpecialResource)
+         . Map.keys
+        <$> gets resResources
+    let res' = if resful
+                then Set.fromList res
+                else Set.empty
+    (params', body', _) <- transformProc pos Nothing AnonymousProc
+                                detism params res' body
     let clsd' = trustFromJust "gloablise anon proc without clsd" clsd
     clsd'' <- if resful
               then (clsd' `Map.difference`) . resourceNameMap <$> gets resResources
               else do
                   mapM_ (uncurry $ addResourceInOuts ParamIn) $ Map.toList clsd'
                   return clsd'
-    return $ AnonProc mods params' body' (Just clsd'') res `maybePlace` pos
-globaliseExp _ exp pos = return $ exp `maybePlace` pos
+    return $ AnonProc mods params' body' (Just clsd'') (Just res') `maybePlace` pos
+transformExp _ exp pos = return $ exp `maybePlace` pos
 
 
 -- |Add the specified variable and type to the list of in or out resources if
@@ -730,6 +522,20 @@ simpleResourceFlows pos (ResourceFlowSpec spec flow) = do
                     | (spec,impln) <- Map.toList def]
 
 
+-- |Returns the list of args corresponding to the specified resource
+-- flow spec.  This produces up to two arguments for each simple
+-- resource, multiplied by all the simple resources a single resource
+-- flow spec might refer to.
+resourceArgs :: OptPos -> ResourceFlowSpec -> Resourcer [Placed Exp]
+resourceArgs pos rflow = do
+    simpleSpecs <- simpleResourceFlows pos rflow
+    mapM (\(ResourceFlowSpec res flow,ty) -> do
+                   let var = resourceVar res
+                   let ftype = Resource res
+                   return $ Unplaced $ Typed (Var var flow ftype) ty Nothing)
+         simpleSpecs
+
+
 -- | The local variable name to use for a resource.  This assumes the resource
 -- spec has already been canonicalised (fully module qualified).
 resourceVar :: ResourceSpec -> Ident
@@ -738,6 +544,12 @@ resourceVar (ResourceSpec mod name) =
     -- Always use resource name as variable name, regardless of module
     -- XXX This could cause collisions!
     name
+
+    
+-- | Transform a ResourceFlowSpec with a type into a Param
+resourceParams :: (ResourceFlowSpec,TypeSpec) -> Param
+resourceParams (ResourceFlowSpec res flow, typ) =
+    Param (resourceVar res) typ flow (Resource res)
 
 
 -- | Given a ResourceSpec and something, return Right of something if the
@@ -766,7 +578,7 @@ eitherResourceExp var@(Typed (Var _ _ (Resource res)) ty _) pos =
 eitherResourceExp exp pos = Right $ exp `maybePlace` pos
 
 
--- | Add tmp variables into a resource dictionary. If we are globalising, we
+-- | Add tmp variables into a resource dictionary. If we are transforming, we
 -- remove resources from the dict, and if the flag is true, we also
 -- add the #globals variable
 fixVarDict :: Maybe VarDict -> Resourcer (Maybe VarDict)
@@ -774,11 +586,8 @@ fixVarDict Nothing = return Nothing
 fixVarDict (Just vars) = do
     ress <- resourceNameMap <$> gets resResources
     tmpVars <- gets resTmpVars
-    haveGlobals <- gets resHaveGlobals
     let filter res _ = not $ res `Map.member` ress
-    Just <$> if isJust haveGlobals
-    then return $ Map.filterWithKey filter vars `Map.union` tmpVars
-    else return $ vars `Map.union` tmpVars
+    Just <$> return (Map.filterWithKey filter vars `Map.union` tmpVars)
 
 
 -- | Get a var as a resource of the given type
@@ -798,7 +607,6 @@ saveRestoreResourcesTmp :: OptPos -> [(ResourceSpec, TypeSpec)]
 saveRestoreResourcesTmp pos resTys = do
     tmp <- gets resTmpCtr
     modify $ \s -> s{resTmpCtr=tmp + length resTys}
-    global <- isJust <$> gets resHaveGlobals
     let tmpVars = mkTempName <$> [tmp..]
         (res, tys) = unzip resTys
         ress = zip tmpVars resTys
@@ -808,10 +616,7 @@ saveRestoreResourcesTmp pos resTys = do
                                         (setResource (resourceVar rs) (rs,ty))
         globalSave (t,(rs,ty)) = globalLoad rs ty $ setResource t (rs,ty)
         globalRestore (t,(rs,ty)) = globalStore rs ty $ getResource t (rs,ty)
-        (save, restore) = if global
-                          then (globalSave, globalRestore)
-                          else (localSave, localRestore)
-    return (rePlace pos . save <$> ress, rePlace pos . restore <$> ress,
+    return (rePlace pos . globalSave <$> ress, rePlace pos . globalRestore <$> ress,
             Map.fromList $ zip tmpVars (snd <$> resTys),
             Map.fromList $ zip res $ zip tmpVars tys)
 

--- a/src/Resources.hs
+++ b/src/Resources.hs
@@ -243,7 +243,7 @@ transformProc pos name variant detism params ress body = do
     -- Unbranching will then force the stores to be executed in the case of
     -- failure, ensuring the global variables are unmoddified
     newMentioned <- gets resMentioned
-    body'' <- if detism /= SemiDet && detism /= Failure || Map.null newMentioned
+    body'' <- if not (determinismCanFail detism) || Map.null newMentioned
               then return body'
               else do
                 (saves, restores, tmpVars, _) <- saveRestoreResourcesTmp pos

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -2676,9 +2676,6 @@ checkParamTyped :: ProcName -> OptPos -> (Int,Param) -> Compiler ()
 checkParamTyped name pos (num,Param{paramName=pName,paramType=ty,paramFlow=flow}) = do
     when (AnyType == ty) $
         reportUntyped name pos (" parameter " ++ show num)
-    when (isResourcefulHigherOrder ty && flowsOut flow)
-        $ errmsg pos $ "Out-flowing parameter '" ++ pName ++ "' of '" ++ name
-                    ++ "' cannot have type " ++ show ty
 
 
 checkStmtTyped :: ProcName -> OptPos -> Stmt -> OptPos -> Compiler ()

--- a/src/Unbranch.hs
+++ b/src/Unbranch.hs
@@ -657,8 +657,8 @@ unbranchExp (Typed exp ty cast) pos = do
     let cast' = unbranchType <$> cast
     return $ maybePlace (Typed exp' ty' cast') pos
 unbranchExp exp@(AnonProc mods params pstmts clsd res) pos = do
-    let clsd' = trustFromJust "unbranch annon proc without closed" clsd
-    let res' = trustFromJust "unbranch annon proc without resources" res
+    let clsd' = trustFromJust "unbranch anon proc without closed" clsd
+    let res' = trustFromJust "unbranch anon proc without resources" res
     name <- newProcName
     logUnbranch $ "Creating Closure for " ++ show exp ++ " under " ++ name
     let ProcModifiers detism inlining impurity _ _ = mods

--- a/src/Unique.hs
+++ b/src/Unique.hs
@@ -85,7 +85,7 @@ uniquenessCheckProc :: ProcDef -> Int -> Compiler ProcDef
 uniquenessCheckProc def _ = do
     let name = showProcName $ procName def
     let pos = procPos def
-    logMsg Uniqueness $ "Uniqueness checking proc: " ++ name
+    logMsg Uniqueness $ "Uniqueness checking proc: " ++ showProcName name
     let detism = procDetism def
     let params = procProtoParams $ procProto def
     let ress = procProtoResources $ procProto def

--- a/test-cases/final-dump/break_in_loop_in_do.exp
+++ b/test-cases/final-dump/break_in_loop_in_do.exp
@@ -26,21 +26,21 @@ gen#1 > {inline} (2 calls)
 gen#1([counter##0:wybe.int])<{<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm load(<<break_in_loop_in_do.counter>>:wybe.int, ?%counter##1:wybe.int) @break_in_loop_in_do:nn:nn
+    foreign lpvm load(<<break_in_loop_in_do.counter>>:wybe.int, ?%tmp#1##0:wybe.int) @break_in_loop_in_do:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~counter##1:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
 gen#2 > {inline} (1 calls)
 0: break_in_loop_in_do.gen#2<0>
-gen#2(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<wybe.io.io>>}; {<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}>:
+gen#2([tmp#0##0:wybe.int], tmp#1##0:wybe.int)<{<<wybe.io.io>>}; {<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm store(tmp#0##0:wybe.int, <<break_in_loop_in_do.counter>>:wybe.int) @break_in_loop_in_do:nn:nn
+    foreign lpvm store(%tmp#1##0:wybe.int, <<break_in_loop_in_do.counter>>:wybe.int) @break_in_loop_in_do:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
@@ -85,10 +85,10 @@ entry:
 }
 
 
-define external fastcc  void @"break_in_loop_in_do.gen#2<0>"(i64  %"tmp#0##0") alwaysinline   {
+define external fastcc  void @"break_in_loop_in_do.gen#2<0>"(i64  %"tmp#1##0") alwaysinline   {
 entry:
-  store  i64 %"tmp#0##0", i64* @"resource#break_in_loop_in_do.counter" 
-  tail call ccc  void  @print_int(i64  %"tmp#0##0")  
+  store  i64 %"tmp#1##0", i64* @"resource#break_in_loop_in_do.counter" 
+  tail call ccc  void  @print_int(i64  %"tmp#1##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -35,7 +35,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm alloc(16:wybe.int, ?tmp#59##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#59##0:wybe.list(T), ?tmp#60##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:T) @list:nn:nn
     foreign lpvm mutate(~tmp#60##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.list(wybe.int)), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.list(T)) @list:nn:nn
-    foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%tmp#30##0:wybe.int) @higher_order_resources:nn:nn
+    foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%tmp#29##0:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm store(-1000:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
     wybe.list.gen#5<0>(higher_order_resources.gen#1<1><>:{resource}(T), ~tmp#0##0:wybe.list(T), ~tmp#0##0:wybe.list(T))<Everything; Everything> #31 @list:nn:nn
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%maximum##1:wybe.int) @higher_order_resources:nn:nn
@@ -90,7 +90,7 @@ module top-level code > public {semipure} (0 calls)
     foreign c print_int(~maximum##3:wybe.int, ~tmp#121##0:wybe.phantom, ?tmp#122##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#122##0:wybe.phantom, ?tmp#123##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#123##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~tmp#30##0:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
+    foreign lpvm store(~tmp#29##0:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
 
 
 gen#1 > {inline} (1 calls)
@@ -114,7 +114,7 @@ gen#2 > {inline} (1 calls)
 gen#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%maximum##3:wybe.int) @higher_order_resources:nn:nn
+    foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%tmp#32##0:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm store(-1000:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
     wybe.list.gen#5<0>(higher_order_resources.gen#3<0><>:{resource}(T), anon#2#1##0:wybe.list(T), anon#2#1##0:wybe.list(T))<Everything; Everything> #5 @list:nn:nn
     wybe.string.print<0>("> ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @higher_order_resources:nn:nn
@@ -123,7 +123,7 @@ gen#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wy
     foreign c print_int(~maximum##2:wybe.int, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#37##0:wybe.phantom, ?tmp#38##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#38##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~maximum##3:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
+    foreign lpvm store(~tmp#32##0:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
     wybe.list.length1<0>(~anon#2#1##0:wybe.list(T), 0:wybe.int, ?tmp#28##0:wybe.int) #6 @list:nn:nn
     higher_order_resources.take_max<0>(~tmp#28##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #4 @higher_order_resources:nn:nn
 gen#2 > {inline} (1 calls)

--- a/test-cases/final-dump/resource_tmp_vars.exp
+++ b/test-cases/final-dump/resource_tmp_vars.exp
@@ -25,14 +25,14 @@ module top-level code > public {semipure} (0 calls)
 
 gen#1 > {inline} (1 calls)
 0: resource_tmp_vars.gen#1<0>
-gen#1(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<wybe.io.io>>}; {<<resource_tmp_vars.counter>>, <<wybe.io.io>>}>:
+gen#1([tmp#0##0:wybe.int], tmp#1##0:wybe.int)<{<<wybe.io.io>>}; {<<resource_tmp_vars.counter>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
     foreign c print_int(1:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(tmp#0##0:wybe.int, <<resource_tmp_vars.counter>>:wybe.int) @resource_tmp_vars:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#5##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @int:nn:nn
+    foreign lpvm store(%tmp#1##0:wybe.int, <<resource_tmp_vars.counter>>:wybe.int) @resource_tmp_vars:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#5##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
@@ -70,12 +70,12 @@ entry:
 }
 
 
-define external fastcc  void @"resource_tmp_vars.gen#1<0>"(i64  %"tmp#0##0") alwaysinline   {
+define external fastcc  void @"resource_tmp_vars.gen#1<0>"(i64  %"tmp#1##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  1)  
   tail call ccc  void  @putchar(i8  10)  
-  store  i64 %"tmp#0##0", i64* @"resource#resource_tmp_vars.counter" 
-  tail call ccc  void  @print_int(i64  %"tmp#0##0")  
+  store  i64 %"tmp#1##0", i64* @"resource#resource_tmp_vars.counter" 
+  tail call ccc  void  @print_int(i64  %"tmp#1##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }


### PR DESCRIPTION
This PR unifies the resource transformation passes that transform resources into params/args and then globals. Uniqueness checking interfered with this before, however, now I have changed that pass to handle pre-resource transformation code by using the resources found in a proc's prototype instead of the parameterised resources.

This unification isn't strictly necessary, however it does simplify the resource module greatly.