### PR TITLE
Reduced continuation inputs; modified gen-sym'd proc names

### DIFF
--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -93,6 +93,7 @@ flattenBody stmts varSet detism = do
 -- the variable set alone.
 insertOutVar :: Set VarName -> Exp -> OptPos -> Set VarName
 insertOutVar varSet (Var name ParamOut _) _ = Set.insert name varSet
+insertOutVar varSet (Typed exp _ _) pos = insertOutVar varSet exp pos
 insertOutVar varSet expr _ = varSet
 
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -2282,9 +2282,7 @@ modeCheckExp m name defPos assigned _
     (ss',_) <- modecheckStmts m name defPos (addBindings inArgs assigned)
                              detism True ss
     let paramVars = expVar . content . paramToVar <$> params
-    let vars = foldStmts (const . const)
-                         ((const .) . (. expInputs) . Set.union) Set.empty ss'
-    let toClose = vars `Set.difference` Set.fromList paramVars
+    let toClose = stmtsInputs ss' `Set.difference` Set.fromList paramVars
     varDict <- mapFromUnivSetM ultimateVarType Set.empty
                 $ bindingVars assigned
     let closed = Map.filterWithKey (const . flip Set.member toClose) varDict

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -224,22 +224,25 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm icmp_ne(ch##0:wybe.char, ~tmp#1##0:wybe.char, ?tmp#2##0:wybe.bool) @char:nn:nn
     case ~tmp#2##0:wybe.bool of
     0:
-        foreign c {impure} malloc_count(?tmp#10##0:wybe.int) @memory_management:nn:nn
-        wybe.string.print<0>("** malloc count: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @drone:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~tmp#10##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        drone.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6
 
     1:
         drone.loop<0>[410bae77d3](~tmp#0##0:drone.drone_info, ~ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @drone:nn:nn
-        foreign c {impure} malloc_count(?tmp#10##0:wybe.int) @memory_management:nn:nn
-        wybe.string.print<0>("** malloc count: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @drone:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~tmp#10##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        drone.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
 
+
+
+#cont#1 > (2 calls)
+0: drone.#cont#1<0>
+#cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign c {impure} malloc_count(?mc##0:wybe.int) @memory_management:nn:nn
+    wybe.string.print<0>("** malloc count: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~mc##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
 do_action > (2 calls)
@@ -247,7 +250,7 @@ do_action > (2 calls)
 do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?success##2:wybe.bool)<{}; {}>:
   AliasPairs: [(d##0,d##2)]
   InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(5,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(32,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 [0]]))]
+  MultiSpeczDepInfo: [(5,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(10,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(15,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(20,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(25,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(30,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(32,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp#21##0:wybe.bool) @char:nn:nn
     case ~tmp#21##0:wybe.bool of
     0:
@@ -267,13 +270,13 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                         case ~tmp#16##0:wybe.bool of
                         0:
                             foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
-                            drone.gen#2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
+                            drone.do_action#cont#1<0>(~d##0:drone.drone_info, 0:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
                             foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @drone:nn:nn
                             foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
                             foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int) @drone:nn:nn
-                            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -281,7 +284,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                         foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @drone:nn:nn
                         foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
                         foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int) @drone:nn:nn
-                        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -289,7 +292,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                     foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @drone:nn:nn
                     foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
                     foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int) @drone:nn:nn
-                    drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -297,7 +300,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                 foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @drone:nn:nn
                 foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
                 foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int) @drone:nn:nn
-                drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -305,7 +308,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
             foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
             foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
             foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @drone:nn:nn
-            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -313,8 +316,24 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
         foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
         foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @drone:nn:nn
-        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
+
+
+
+do_action#cont#1 > (7 calls)
+0: drone.do_action#cont#1<0>
+do_action#cont#1(d##0:drone.drone_info, success##0:wybe.bool, ?d##1:drone.drone_info, [?success##0:wybe.bool])<{}; {}>:
+  AliasPairs: [(d##0,d##1)]
+  InterestingCallProperties: [InterestingUnaliased 0]
+    case success##0:wybe.bool of
+    0:
+        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
+
+    1:
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
+        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
 
 
 
@@ -330,66 +349,18 @@ drone_init(?#result##0:drone.drone_info)<{}; {}>:
     foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
 
 
-gen#1 > {inline} (2 calls)
-0: drone.gen#1<0>
-gen#1([ch##0:wybe.char], [d##0:drone.drone_info], [tmp#0##0:drone.drone_info])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign c {impure} malloc_count(?mc##0:wybe.int) @memory_management:nn:nn
-    wybe.string.print<0>("** malloc count: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~mc##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
-
-gen#2 > (7 calls)
-0: drone.gen#2<0>
-gen#2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp#0##0:wybe.bool], ?d##1:drone.drone_info, [?success##0:wybe.bool])<{}; {}>:
-  AliasPairs: [(d##0,d##1)]
-  InterestingCallProperties: [InterestingUnaliased 1]
-    case success##0:wybe.bool of
-    0:
-        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
-
-    1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
-        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
-
-
-
-gen#3 > (4 calls)
-0: drone.gen#3<0>
-gen#3([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 1]
-  MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @char:nn:nn
-    foreign c read_char(?ch##1:wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @char:nn:nn
-    foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp#3##0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp#3##0:wybe.char, ?tmp#4##0:wybe.bool) @char:nn:nn
-    case ~tmp#4##0:wybe.bool of
-    0:
-
-    1:
-        drone.loop<0>(~d##0:drone.drone_info, ~ch##1:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @drone:nn:nn
-
-
-
 loop > (2 calls)
 0: drone.loop<0>
 loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(5,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]]))]
+  MultiSpeczDepInfo: [(5,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]]))]
     foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
     foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
     foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
-        drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #12
+        drone.loop#cont#1<0>(_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #12
 
     1:
         foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
@@ -399,14 +370,14 @@ loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>
             foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp#5##0:wybe.bool) @bool:nn:nn
             case ~tmp#5##0:wybe.bool of
             0:
-                drone.gen#3<0>(_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11
+                drone.loop#cont#1<0>(_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11
 
             1:
                 wybe.string.print<0>("invalid action!":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #13 @string:nn:nn
                 foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @io:nn:nn
                 foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
                 foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-                drone.gen#3<0>(_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
+                drone.loop#cont#1<0>(_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
 
 
         1:
@@ -431,8 +402,27 @@ loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>
             foreign c print_int(~tmp#26##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
             foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
+            drone.loop#cont#1<0>(_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
 
+
+
+
+loop#cont#1 > (4 calls)
+0: drone.loop#cont#1<0>
+loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: [InterestingUnaliased 1]
+  MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @char:nn:nn
+    foreign c read_char(?ch##1:wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @char:nn:nn
+    foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
+    foreign lpvm cast(-1:wybe.int, ?tmp#3##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp#3##0:wybe.char, ?tmp#4##0:wybe.bool) @char:nn:nn
+    case ~tmp#4##0:wybe.bool of
+    0:
+
+    1:
+        drone.loop<0>(~d##0:drone.drone_info, ~ch##1:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @drone:nn:nn
 
 
 
@@ -890,22 +880,25 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm icmp_ne(ch##0:wybe.char, ~tmp#1##0:wybe.char, ?tmp#2##0:wybe.bool) @char:nn:nn
     case ~tmp#2##0:wybe.bool of
     0:
-        foreign c {impure} malloc_count(?tmp#10##0:wybe.int) @memory_management:nn:nn
-        wybe.string.print<0>("** malloc count: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @drone:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~tmp#10##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        drone.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6
 
     1:
         drone.loop<0>[410bae77d3](~tmp#0##0:drone.drone_info, ~ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @drone:nn:nn
-        foreign c {impure} malloc_count(?tmp#10##0:wybe.int) @memory_management:nn:nn
-        wybe.string.print<0>("** malloc count: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @drone:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~tmp#10##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        drone.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
 
+
+
+#cont#1 > (2 calls)
+0: drone.#cont#1<0>
+#cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign c {impure} malloc_count(?mc##0:wybe.int) @memory_management:nn:nn
+    wybe.string.print<0>("** malloc count: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~mc##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
 do_action > (2 calls)
@@ -913,7 +906,7 @@ do_action > (2 calls)
 do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?success##2:wybe.bool)<{}; {}>:
   AliasPairs: [(d##0,d##2)]
   InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(5,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(32,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 [0]]))]
+  MultiSpeczDepInfo: [(5,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(10,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(15,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(20,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(25,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(30,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(32,(drone.do_action#cont#1<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp#21##0:wybe.bool) @char:nn:nn
     case ~tmp#21##0:wybe.bool of
     0:
@@ -933,13 +926,13 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                         case ~tmp#16##0:wybe.bool of
                         0:
                             foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
-                            drone.gen#2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
+                            drone.do_action#cont#1<0>(~d##0:drone.drone_info, 0:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
                             foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @drone:nn:nn
                             foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
                             foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int) @drone:nn:nn
-                            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -947,7 +940,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                         foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @drone:nn:nn
                         foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
                         foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int) @drone:nn:nn
-                        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -955,7 +948,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                     foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @drone:nn:nn
                     foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
                     foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int) @drone:nn:nn
-                    drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -963,7 +956,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                 foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @drone:nn:nn
                 foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
                 foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int) @drone:nn:nn
-                drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -971,7 +964,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
             foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
             foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
             foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @drone:nn:nn
-            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -979,7 +972,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
         foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
         foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @drone:nn:nn
-        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
  [410bae77d3] [NonAliasedParam 0] :
@@ -1002,13 +995,13 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                         case ~tmp#16##0:wybe.bool of
                         0:
                             foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
-                            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
+                            drone.do_action#cont#1<0>[410bae77d3](~d##0:drone.drone_info, 0:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
                             foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @drone:nn:nn
                             foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
                             foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int) @drone:nn:nn
-                            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -1016,7 +1009,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                         foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @drone:nn:nn
                         foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
                         foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int) @drone:nn:nn
-                        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -1024,7 +1017,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                     foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @drone:nn:nn
                     foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
                     foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int) @drone:nn:nn
-                    drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -1032,7 +1025,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
                 foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @drone:nn:nn
                 foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
                 foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int) @drone:nn:nn
-                drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -1040,7 +1033,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
             foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
             foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
             foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int) @drone:nn:nn
-            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
@@ -1048,8 +1041,34 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
         foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
         foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @drone:nn:nn
-        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        drone.do_action#cont#1<0>[410bae77d3](~d##1:drone.drone_info, 1:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
+
+
+
+do_action#cont#1 > (7 calls)
+0: drone.do_action#cont#1<0>[410bae77d3]
+do_action#cont#1(d##0:drone.drone_info, success##0:wybe.bool, ?d##1:drone.drone_info, [?success##0:wybe.bool])<{}; {}>:
+  AliasPairs: [(d##0,d##1)]
+  InterestingCallProperties: [InterestingUnaliased 0]
+    case success##0:wybe.bool of
+    0:
+        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
+
+    1:
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
+        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
+
+ [410bae77d3] [NonAliasedParam 0] :
+    case success##0:wybe.bool of
+    0:
+        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
+
+    1:
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
+        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
 
 
 
@@ -1065,48 +1084,118 @@ drone_init(?#result##0:drone.drone_info)<{}; {}>:
     foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
 
 
-gen#1 > {inline} (2 calls)
-0: drone.gen#1<0>
-gen#1([ch##0:wybe.char], [d##0:drone.drone_info], [tmp#0##0:drone.drone_info])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+loop > (2 calls)
+0: drone.loop<0>[410bae77d3]
+loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
-  InterestingCallProperties: []
-    foreign c {impure} malloc_count(?mc##0:wybe.int) @memory_management:nn:nn
-    wybe.string.print<0>("** malloc count: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~mc##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
-
-gen#2 > (7 calls)
-0: drone.gen#2<0>[6dacb8fd25]
-gen#2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp#0##0:wybe.bool], ?d##1:drone.drone_info, [?success##0:wybe.bool])<{}; {}>:
-  AliasPairs: [(d##0,d##1)]
-  InterestingCallProperties: [InterestingUnaliased 1]
-    case success##0:wybe.bool of
+  InterestingCallProperties: [InterestingUnaliased 0]
+  MultiSpeczDepInfo: [(5,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]]))]
+    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
+        drone.loop#cont#1<0>(_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #12
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
-        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
+        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            drone.do_action<0>(~d##0:drone.drone_info, ?d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
+            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp#5##0:wybe.bool) @bool:nn:nn
+            case ~tmp#5##0:wybe.bool of
+            0:
+                drone.loop#cont#1<0>(_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11
 
- [6dacb8fd25] [NonAliasedParam 1] :
-    case success##0:wybe.bool of
+            1:
+                wybe.string.print<0>("invalid action!":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #13 @string:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+                foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+                drone.loop#cont#1<0>(_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
+
+
+        1:
+            wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #14 @drone:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int) @drone:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~tmp#17##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int:nn:nn
+            foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+            wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #15 @drone:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#20##0:wybe.int) @drone:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~tmp#20##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
+            foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+            wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #16 @drone:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#23##0:wybe.int) @drone:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#24##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~tmp#23##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @int:nn:nn
+            foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+            wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #17 @drone:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.int) @drone:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~tmp#26##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            drone.loop#cont#1<0>(_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
+
+
+ [410bae77d3] [NonAliasedParam 0] :
+    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
+        drone.loop#cont#1<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #12
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int) @drone:nn:nn
-        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~d##0:drone.drone_info, ?d##1:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int) @drone:nn:nn
+        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            drone.do_action<0>[410bae77d3](~d##0:drone.drone_info, ?d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
+            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp#5##0:wybe.bool) @bool:nn:nn
+            case ~tmp#5##0:wybe.bool of
+            0:
+                drone.loop#cont#1<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11
+
+            1:
+                wybe.string.print<0>("invalid action!":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #13 @string:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+                foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+                drone.loop#cont#1<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
+
+
+        1:
+            wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #14 @drone:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int) @drone:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~tmp#17##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int:nn:nn
+            foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+            wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #15 @drone:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#20##0:wybe.int) @drone:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~tmp#20##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
+            foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+            wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #16 @drone:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#23##0:wybe.int) @drone:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#24##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~tmp#23##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @int:nn:nn
+            foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+            wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #17 @drone:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.int) @drone:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~tmp#26##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            drone.loop#cont#1<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
 
 
 
-gen#3 > (4 calls)
-0: drone.gen#3<0>[6dacb8fd25]
-gen#3([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+
+loop#cont#1 > (4 calls)
+0: drone.loop#cont#1<0>[6dacb8fd25]
+loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 1]
   MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
@@ -1132,115 +1221,6 @@ gen#3([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>
 
     1:
         drone.loop<0>[410bae77d3](~d##0:drone.drone_info, ~ch##1:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @drone:nn:nn
-
-
-
-loop > (2 calls)
-0: drone.loop<0>[410bae77d3]
-loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(5,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
-    case ~tmp#7##0:wybe.bool of
-    0:
-        drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #12
-
-    1:
-        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
-        case ~tmp#6##0:wybe.bool of
-        0:
-            drone.do_action<0>(~d##0:drone.drone_info, ?d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
-            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp#5##0:wybe.bool) @bool:nn:nn
-            case ~tmp#5##0:wybe.bool of
-            0:
-                drone.gen#3<0>(_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11
-
-            1:
-                wybe.string.print<0>("invalid action!":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #13 @string:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
-                foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-                drone.gen#3<0>(_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
-
-
-        1:
-            wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #14 @drone:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int) @drone:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~tmp#17##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int:nn:nn
-            foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-            wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #15 @drone:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#20##0:wybe.int) @drone:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~tmp#20##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
-            foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-            wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #16 @drone:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#23##0:wybe.int) @drone:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#24##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~tmp#23##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @int:nn:nn
-            foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-            wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #17 @drone:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.int) @drone:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~tmp#26##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
-
-
- [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
-    case ~tmp#7##0:wybe.bool of
-    0:
-        drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #12
-
-    1:
-        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
-        case ~tmp#6##0:wybe.bool of
-        0:
-            drone.do_action<0>[410bae77d3](~d##0:drone.drone_info, ?d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
-            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp#5##0:wybe.bool) @bool:nn:nn
-            case ~tmp#5##0:wybe.bool of
-            0:
-                drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11
-
-            1:
-                wybe.string.print<0>("invalid action!":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #13 @string:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
-                foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-                drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
-
-
-        1:
-            wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #14 @drone:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int) @drone:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~tmp#17##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int:nn:nn
-            foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-            wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #15 @drone:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#20##0:wybe.int) @drone:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~tmp#20##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
-            foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-            wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #16 @drone:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#23##0:wybe.int) @drone:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#24##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~tmp#23##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @int:nn:nn
-            foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-            wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #17 @drone:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.int) @drone:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~tmp#26##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
-
 
 
 
@@ -1338,15 +1318,19 @@ entry:
   br i1 %2, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %0, i8  %1)  
-  %3 = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %3)  
-  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"drone.#cont#1<0>"()  
   ret void 
 if.else:
-  %4 = tail call ccc  i64  @malloc_count()  
+  musttail call fastcc  void  @"drone.#cont#1<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"drone.#cont#1<0>"()    {
+entry:
+  %0 = tail call ccc  i64  @malloc_count()  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %4)  
+  tail call ccc  void  @print_int(i64  %0)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -1371,7 +1355,7 @@ if.then:
   %11 = add   i64 %7, 8 
   %12 = inttoptr i64 %11 to i64* 
   store  i64 %4, i64* %12 
-  %13 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %7, i1  1)  
+  %13 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %7, i1  1)  
   %14 = insertvalue {i64, i1} undef, i64 %13, 0 
   %15 = insertvalue {i64, i1} %14, i1 1, 1 
   ret {i64, i1} %15 
@@ -1393,7 +1377,7 @@ if.then1:
   %27 = add   i64 %23, 8 
   %28 = inttoptr i64 %27 to i64* 
   store  i64 %20, i64* %28 
-  %29 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %23, i1  1)  
+  %29 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %23, i1  1)  
   %30 = insertvalue {i64, i1} undef, i64 %29, 0 
   %31 = insertvalue {i64, i1} %30, i1 1, 1 
   ret {i64, i1} %31 
@@ -1413,7 +1397,7 @@ if.then2:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %39, i8*  %40, i32  %41, i1  0)  
   %42 = inttoptr i64 %38 to i64* 
   store  i64 %35, i64* %42 
-  %43 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %38, i1  1)  
+  %43 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %38, i1  1)  
   %44 = insertvalue {i64, i1} undef, i64 %43, 0 
   %45 = insertvalue {i64, i1} %44, i1 1, 1 
   ret {i64, i1} %45 
@@ -1433,7 +1417,7 @@ if.then3:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %53, i8*  %54, i32  %55, i1  0)  
   %56 = inttoptr i64 %52 to i64* 
   store  i64 %49, i64* %56 
-  %57 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %52, i1  1)  
+  %57 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %52, i1  1)  
   %58 = insertvalue {i64, i1} undef, i64 %57, 0 
   %59 = insertvalue {i64, i1} %58, i1 1, 1 
   ret {i64, i1} %59 
@@ -1455,7 +1439,7 @@ if.then4:
   %71 = add   i64 %67, 16 
   %72 = inttoptr i64 %71 to i64* 
   store  i64 %64, i64* %72 
-  %73 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %67, i1  1)  
+  %73 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %67, i1  1)  
   %74 = insertvalue {i64, i1} undef, i64 %73, 0 
   %75 = insertvalue {i64, i1} %74, i1 1, 1 
   ret {i64, i1} %75 
@@ -1477,12 +1461,12 @@ if.then5:
   %87 = add   i64 %83, 16 
   %88 = inttoptr i64 %87 to i64* 
   store  i64 %80, i64* %88 
-  %89 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %83, i1  1)  
+  %89 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %83, i1  1)  
   %90 = insertvalue {i64, i1} undef, i64 %89, 0 
   %91 = insertvalue {i64, i1} %90, i1 1, 1 
   ret {i64, i1} %91 
 if.else5:
-  %92 = tail call fastcc  i64  @"drone.gen#2<0>"(i64  %"d##0", i1  0)  
+  %92 = tail call fastcc  i64  @"drone.do_action#cont#1<0>"(i64  %"d##0", i1  0)  
   %93 = insertvalue {i64, i1} undef, i64 %92, 0 
   %94 = insertvalue {i64, i1} %93, i1 0, 1 
   ret {i64, i1} %94 
@@ -1501,7 +1485,7 @@ if.then:
   %5 = add   i64 %"d##0", 8 
   %6 = inttoptr i64 %5 to i64* 
   store  i64 %4, i64* %6 
-  %7 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %7 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %"d##0", i1  1)  
   %8 = insertvalue {i64, i1} undef, i64 %7, 0 
   %9 = insertvalue {i64, i1} %8, i1 1, 1 
   ret {i64, i1} %9 
@@ -1516,7 +1500,7 @@ if.then1:
   %15 = add   i64 %"d##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   store  i64 %14, i64* %16 
-  %17 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %17 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %"d##0", i1  1)  
   %18 = insertvalue {i64, i1} undef, i64 %17, 0 
   %19 = insertvalue {i64, i1} %18, i1 1, 1 
   ret {i64, i1} %19 
@@ -1529,7 +1513,7 @@ if.then2:
   %23 = sub   i64 %22, 1 
   %24 = inttoptr i64 %"d##0" to i64* 
   store  i64 %23, i64* %24 
-  %25 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %25 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %"d##0", i1  1)  
   %26 = insertvalue {i64, i1} undef, i64 %25, 0 
   %27 = insertvalue {i64, i1} %26, i1 1, 1 
   ret {i64, i1} %27 
@@ -1542,7 +1526,7 @@ if.then3:
   %31 = add   i64 %30, 1 
   %32 = inttoptr i64 %"d##0" to i64* 
   store  i64 %31, i64* %32 
-  %33 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %33 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %"d##0", i1  1)  
   %34 = insertvalue {i64, i1} undef, i64 %33, 0 
   %35 = insertvalue {i64, i1} %34, i1 1, 1 
   ret {i64, i1} %35 
@@ -1557,7 +1541,7 @@ if.then4:
   %41 = add   i64 %"d##0", 16 
   %42 = inttoptr i64 %41 to i64* 
   store  i64 %40, i64* %42 
-  %43 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %43 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %"d##0", i1  1)  
   %44 = insertvalue {i64, i1} undef, i64 %43, 0 
   %45 = insertvalue {i64, i1} %44, i1 1, 1 
   ret {i64, i1} %45 
@@ -1572,49 +1556,19 @@ if.then5:
   %51 = add   i64 %"d##0", 16 
   %52 = inttoptr i64 %51 to i64* 
   store  i64 %50, i64* %52 
-  %53 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %53 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %"d##0", i1  1)  
   %54 = insertvalue {i64, i1} undef, i64 %53, 0 
   %55 = insertvalue {i64, i1} %54, i1 1, 1 
   ret {i64, i1} %55 
 if.else5:
-  %56 = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  0)  
+  %56 = tail call fastcc  i64  @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %"d##0", i1  0)  
   %57 = insertvalue {i64, i1} undef, i64 %56, 0 
   %58 = insertvalue {i64, i1} %57, i1 0, 1 
   ret {i64, i1} %58 
 }
 
 
-define external fastcc  i64 @"drone.drone_init<0>"()    {
-entry:
-  %0 = trunc i64 32 to i32  
-  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
-  %2 = ptrtoint i8* %1 to i64 
-  %3 = inttoptr i64 %2 to i64* 
-  store  i64 0, i64* %3 
-  %4 = add   i64 %2, 8 
-  %5 = inttoptr i64 %4 to i64* 
-  store  i64 0, i64* %5 
-  %6 = add   i64 %2, 16 
-  %7 = inttoptr i64 %6 to i64* 
-  store  i64 0, i64* %7 
-  %8 = add   i64 %2, 24 
-  %9 = inttoptr i64 %8 to i64* 
-  store  i64 0, i64* %9 
-  ret i64 %2 
-}
-
-
-define external fastcc  void @"drone.gen#1<0>"() alwaysinline   {
-entry:
-  %0 = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %0)  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-}
-
-
-define external fastcc  i64 @"drone.gen#2<0>"(i64  %"d##0", i1  %"success##0")    {
+define external fastcc  i64 @"drone.do_action#cont#1<0>"(i64  %"d##0", i1  %"success##0")    {
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
@@ -1638,7 +1592,7 @@ if.else:
 }
 
 
-define external fastcc  i64 @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  %"success##0")    {
+define external fastcc  i64 @"drone.do_action#cont#1<0>[410bae77d3]"(i64  %"d##0", i1  %"success##0")    {
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
@@ -1655,29 +1609,23 @@ if.else:
 }
 
 
-define external fastcc  void @"drone.gen#3<0>"(i64  %"d##0")    {
+define external fastcc  i64 @"drone.drone_init<0>"()    {
 entry:
-  %0 = tail call ccc  i8  @read_char()  
-  %1 = icmp ne i8 %0, trunc i64 -1 to i8 
-  br i1 %1, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"drone.loop<0>"(i64  %"d##0", i8  %0)  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")    {
-entry:
-  %0 = tail call ccc  i8  @read_char()  
-  %1 = icmp ne i8 %0, trunc i64 -1 to i8 
-  br i1 %1, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"d##0", i8  %0)  
-  ret void 
-if.else:
-  ret void 
+  %0 = trunc i64 32 to i32  
+  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
+  %2 = ptrtoint i8* %1 to i64 
+  %3 = inttoptr i64 %2 to i64* 
+  store  i64 0, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 0, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 0, i64* %7 
+  %8 = add   i64 %2, 24 
+  %9 = inttoptr i64 %8 to i64* 
+  store  i64 0, i64* %9 
+  ret i64 %2 
 }
 
 
@@ -1691,7 +1639,7 @@ if.then:
   %3 = icmp eq i8 %"ch##0", 112 
   br i1 %3, label %if.then1, label %if.else1 
 if.else:
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
+  tail call fastcc  void  @"drone.loop#cont#1<0>"(i64  %"d##0")  
   ret void 
 if.then1:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.3, i32 0, i32 0) to i64))  
@@ -1714,7 +1662,7 @@ if.then1:
   %14 = load  i64, i64* %13 
   tail call ccc  void  @print_int(i64  %14)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
+  tail call fastcc  void  @"drone.loop#cont#1<0>"(i64  %"d##0")  
   ret void 
 if.else1:
   %15 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
@@ -1725,10 +1673,10 @@ if.else1:
 if.then2:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %16)  
+  tail call fastcc  void  @"drone.loop#cont#1<0>"(i64  %16)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %16)  
+  tail call fastcc  void  @"drone.loop#cont#1<0>"(i64  %16)  
   ret void 
 }
 
@@ -1743,7 +1691,7 @@ if.then:
   %3 = icmp eq i8 %"ch##0", 112 
   br i1 %3, label %if.then1, label %if.else1 
 if.else:
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
+  tail call fastcc  void  @"drone.loop#cont#1<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.then1:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.3, i32 0, i32 0) to i64))  
@@ -1766,7 +1714,7 @@ if.then1:
   %14 = load  i64, i64* %13 
   tail call ccc  void  @print_int(i64  %14)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
+  tail call fastcc  void  @"drone.loop#cont#1<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.else1:
   %15 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
@@ -1777,10 +1725,36 @@ if.else1:
 if.then2:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %16)  
+  tail call fastcc  void  @"drone.loop#cont#1<0>[6dacb8fd25]"(i64  %16)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %16)  
+  tail call fastcc  void  @"drone.loop#cont#1<0>[6dacb8fd25]"(i64  %16)  
+  ret void 
+}
+
+
+define external fastcc  void @"drone.loop#cont#1<0>"(i64  %"d##0")    {
+entry:
+  %0 = tail call ccc  i8  @read_char()  
+  %1 = icmp ne i8 %0, trunc i64 -1 to i8 
+  br i1 %1, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"drone.loop<0>"(i64  %"d##0", i8  %0)  
+  ret void 
+if.else:
+  ret void 
+}
+
+
+define external fastcc  void @"drone.loop#cont#1<0>[6dacb8fd25]"(i64  %"d##0")    {
+entry:
+  %0 = tail call ccc  i8  @read_char()  
+  %1 = icmp ne i8 %0, trunc i64 -1 to i8 
+  br i1 %1, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"d##0", i8  %0)  
+  ret void 
+if.else:
   ret void 
 }
 

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -335,6 +335,14 @@ count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
 
 
 
+count#cont#1 > {inline} (2 calls)
+0: int_list.count#cont#1<0>
+count#cont#1(tmp#2##0:wybe.int, tmp#3##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
+
+
 extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
 extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, outByReference #result##0:int_list.int_list)<{}; {}>:
@@ -354,46 +362,6 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, outByReference #res
         int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
         foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~takeReference tmp#2##0:int_list.int_list) @int_list:nn:nn
 
-
-
-gen#1 > {inline} (2 calls)
-0: int_list.gen#1<0>
-gen#1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp#2##0:wybe.int, tmp#3##0:wybe.int, [x##0:wybe.int], ?#result##0:wybe.int)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
-
-
-gen#2 > (2 calls)
-0: int_list.gen#2<0>[410bae77d3]
-gen#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##1:int_list.int_list)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
-    case ~tmp#3##0:wybe.bool of
-    0:
-        int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
-
-    1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list) @int_list:nn:nn
-        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
-        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
-        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
-        int_list.gen#2<0>(~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
-
-
-
-gen#3 > {inline} (1 calls)
-0: int_list.gen#3<0>
-gen#3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##2:int_list.int_list)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
-    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
-    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
-    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-    int_list.gen#2<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
 greater > (3 calls)
@@ -582,7 +550,39 @@ range > public {inline} (0 calls)
 range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list.int_list)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    int_list.gen#2<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, 0:int_list.int_list, ?result##1:int_list.int_list) #1 @int_list:nn:nn
+    int_list.range#cont#1<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##1:int_list.int_list) #1 @int_list:nn:nn
+
+
+range#cont#1 > (2 calls)
+0: int_list.range#cont#1<0>[410bae77d3]
+range#cont#1(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, ?result##1:int_list.int_list)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: [InterestingUnaliased 0]
+  MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.range#cont#1<0>,fromList [NonAliasedParamCond 0 [0]]))]
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
+    0:
+        int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
+
+    1:
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#11##0:int_list.int_list, ?tmp#12##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        int_list.range#cont#1<0>(~tmp#13##0:int_list.int_list, ~tmp#14##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##1:int_list.int_list) #4 @int_list:nn:nn
+
+
+
+range#cont#2 > {inline} (1 calls)
+0: int_list.range#cont#2<0>
+range#cont#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, ?result##2:int_list.int_list)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
+    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+    int_list.range#cont#1<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
 remove > public (1 calls)
@@ -846,11 +846,11 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.range#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.range#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.range#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign c {impure} malloc_count(?mc1##0:wybe.int) @memory_management:nn:nn
-    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp#0##0:int_list.int_list) #34 @int_list:nn:nn
-    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp#1##0:int_list.int_list) #35 @int_list:nn:nn
-    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp#2##0:int_list.int_list) #36 @int_list:nn:nn
+    int_list.range#cont#1<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#0##0:int_list.int_list) #34 @int_list:nn:nn
+    int_list.range#cont#1<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, ?tmp#1##0:int_list.int_list) #35 @int_list:nn:nn
+    int_list.range#cont#1<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, ?tmp#2##0:int_list.int_list) #36 @int_list:nn:nn
     wybe.string.print<0>("x y z:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #37 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
@@ -1287,6 +1287,14 @@ count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
 
 
 
+count#cont#1 > {inline} (2 calls)
+0: int_list.count#cont#1<0>
+count#cont#1(tmp#2##0:wybe.int, tmp#3##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
+
+
 extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
 extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, outByReference #result##0:int_list.int_list)<{}; {}>:
@@ -1317,59 +1325,6 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, outByReference #res
         int_list.extend<0>[410bae77d3](~t##0:int_list.int_list, ~lst2##0:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
         foreign lpvm mutate(~lst1##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~takeReference tmp#2##0:int_list.int_list) @int_list:nn:nn
 
-
-
-gen#1 > {inline} (2 calls)
-0: int_list.gen#1<0>
-gen#1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp#2##0:wybe.int, tmp#3##0:wybe.int, [x##0:wybe.int], ?#result##0:wybe.int)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
-
-
-gen#2 > (2 calls)
-0: int_list.gen#2<0>
-gen#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##1:int_list.int_list)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
-    case ~tmp#3##0:wybe.bool of
-    0:
-        int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
-
-    1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list) @int_list:nn:nn
-        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
-        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
-        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
-        int_list.gen#2<0>(~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
-
- [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
-    case ~tmp#3##0:wybe.bool of
-    0:
-        int_list.reverse_helper<0>[410bae77d3](~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
-
-    1:
-        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list) @int_list:nn:nn
-        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
-        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
-        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
-        int_list.gen#2<0>[410bae77d3](~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
-
-
-
-gen#3 > {inline} (1 calls)
-0: int_list.gen#3<0>
-gen#3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##2:int_list.int_list)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
-    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
-    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
-    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-    int_list.gen#2<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
 greater > (3 calls)
@@ -1618,7 +1573,52 @@ range > public {inline} (0 calls)
 range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list.int_list)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    int_list.gen#2<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, 0:int_list.int_list, ?result##1:int_list.int_list) #1 @int_list:nn:nn
+    int_list.range#cont#1<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##1:int_list.int_list) #1 @int_list:nn:nn
+
+
+range#cont#1 > (2 calls)
+0: int_list.range#cont#1<0>
+range#cont#1(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, ?result##1:int_list.int_list)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: [InterestingUnaliased 0]
+  MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.range#cont#1<0>,fromList [NonAliasedParamCond 0 [0]]))]
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
+    0:
+        int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
+
+    1:
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#11##0:int_list.int_list, ?tmp#12##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        int_list.range#cont#1<0>(~tmp#13##0:int_list.int_list, ~tmp#14##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##1:int_list.int_list) #4 @int_list:nn:nn
+
+ [410bae77d3] [NonAliasedParam 0] :
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
+    0:
+        int_list.reverse_helper<0>[410bae77d3](~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
+
+    1:
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:int_list.int_list) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#11##0:int_list.int_list, ?tmp#12##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        int_list.range#cont#1<0>[410bae77d3](~tmp#13##0:int_list.int_list, ~tmp#14##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##1:int_list.int_list) #4 @int_list:nn:nn
+
+
+
+range#cont#2 > {inline} (1 calls)
+0: int_list.range#cont#2<0>
+range#cont#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, ?result##2:int_list.int_list)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int) @int_list:nn:nn
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list) @int_list:nn:nn
+    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+    int_list.range#cont#1<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
 remove > public (1 calls)
@@ -1825,6 +1825,13 @@ if.else1:
 }
 
 
+define external fastcc  i64 @"int_list.count#cont#1<0>"(i64  %"tmp#2##0", i64  %"tmp#3##0") alwaysinline   {
+entry:
+  %0 = add   i64 %"tmp#2##0", %"tmp#3##0" 
+  ret i64 %0 
+}
+
+
 define external fastcc  void @"int_list.extend<0>"(i64  %"lst1##0", i64  %"lst2##0", i64*  %"#result##0")    {
 entry:
   %0 = icmp ne i64 %"lst1##0", 0 
@@ -1867,73 +1874,6 @@ if.then:
 if.else:
   store  i64 %"lst2##0", i64* %"#result##0" 
   ret void 
-}
-
-
-define external fastcc  i64 @"int_list.gen#1<0>"(i64  %"tmp#2##0", i64  %"tmp#3##0") alwaysinline   {
-entry:
-  %0 = add   i64 %"tmp#2##0", %"tmp#3##0" 
-  ret i64 %0 
-}
-
-
-define external fastcc  i64 @"int_list.gen#2<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")    {
-entry:
-  %0 = icmp slt i64 %"start##0", %"stop##0" 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = trunc i64 16 to i32  
-  %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
-  %3 = ptrtoint i8* %2 to i64 
-  %4 = inttoptr i64 %3 to i64* 
-  store  i64 %"start##0", i64* %4 
-  %5 = add   i64 %3, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  store  i64 %"result##0", i64* %6 
-  %7 = add   i64 %"start##0", %"step##0" 
-  %8 = musttail call fastcc  i64  @"int_list.gen#2<0>"(i64  %3, i64  %7, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
-  ret i64 %8 
-if.else:
-  %9 = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"result##0", i64  0)  
-  ret i64 %9 
-}
-
-
-define external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")    {
-entry:
-  %0 = icmp slt i64 %"start##0", %"stop##0" 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = trunc i64 16 to i32  
-  %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
-  %3 = ptrtoint i8* %2 to i64 
-  %4 = inttoptr i64 %3 to i64* 
-  store  i64 %"start##0", i64* %4 
-  %5 = add   i64 %3, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  store  i64 %"result##0", i64* %6 
-  %7 = add   i64 %"start##0", %"step##0" 
-  %8 = musttail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  %3, i64  %7, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
-  ret i64 %8 
-if.else:
-  %9 = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"result##0", i64  0)  
-  ret i64 %9 
-}
-
-
-define external fastcc  i64 @"int_list.gen#3<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0") alwaysinline   {
-entry:
-  %0 = trunc i64 16 to i32  
-  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
-  %2 = ptrtoint i8* %1 to i64 
-  %3 = inttoptr i64 %2 to i64* 
-  store  i64 %"start##0", i64* %3 
-  %4 = add   i64 %2, 8 
-  %5 = inttoptr i64 %4 to i64* 
-  store  i64 %"result##0", i64* %5 
-  %6 = add   i64 %"start##0", %"step##0" 
-  %7 = musttail call fastcc  i64  @"int_list.gen#2<0>"(i64  %2, i64  %6, i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
-  ret i64 %7 
 }
 
 
@@ -2223,8 +2163,68 @@ entry:
 
 define external fastcc  i64 @"int_list.range<0>"(i64  %"start##0", i64  %"stop##0", i64  %"step##0") alwaysinline   {
 entry:
-  %0 = tail call fastcc  i64  @"int_list.gen#2<0>"(i64  0, i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  0)  
+  %0 = tail call fastcc  i64  @"int_list.range#cont#1<0>"(i64  0, i64  %"start##0", i64  %"step##0", i64  %"stop##0")  
   ret i64 %0 
+}
+
+
+define external fastcc  i64 @"int_list.range#cont#1<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0")    {
+entry:
+  %0 = icmp slt i64 %"start##0", %"stop##0" 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = trunc i64 16 to i32  
+  %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
+  %3 = ptrtoint i8* %2 to i64 
+  %4 = inttoptr i64 %3 to i64* 
+  store  i64 %"start##0", i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %"result##0", i64* %6 
+  %7 = add   i64 %"start##0", %"step##0" 
+  %8 = musttail call fastcc  i64  @"int_list.range#cont#1<0>"(i64  %3, i64  %7, i64  %"step##0", i64  %"stop##0")  
+  ret i64 %8 
+if.else:
+  %9 = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"result##0", i64  0)  
+  ret i64 %9 
+}
+
+
+define external fastcc  i64 @"int_list.range#cont#1<0>[410bae77d3]"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0")    {
+entry:
+  %0 = icmp slt i64 %"start##0", %"stop##0" 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = trunc i64 16 to i32  
+  %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
+  %3 = ptrtoint i8* %2 to i64 
+  %4 = inttoptr i64 %3 to i64* 
+  store  i64 %"start##0", i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %"result##0", i64* %6 
+  %7 = add   i64 %"start##0", %"step##0" 
+  %8 = musttail call fastcc  i64  @"int_list.range#cont#1<0>[410bae77d3]"(i64  %3, i64  %7, i64  %"step##0", i64  %"stop##0")  
+  ret i64 %8 
+if.else:
+  %9 = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"result##0", i64  0)  
+  ret i64 %9 
+}
+
+
+define external fastcc  i64 @"int_list.range#cont#2<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0") alwaysinline   {
+entry:
+  %0 = trunc i64 16 to i32  
+  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
+  %2 = ptrtoint i8* %1 to i64 
+  %3 = inttoptr i64 %2 to i64* 
+  store  i64 %"start##0", i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 %"result##0", i64* %5 
+  %6 = add   i64 %"start##0", %"step##0" 
+  %7 = musttail call fastcc  i64  @"int_list.range#cont#1<0>"(i64  %2, i64  %6, i64  %"step##0", i64  %"stop##0")  
+  ret i64 %7 
 }
 
 
@@ -2755,11 +2755,11 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.range#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.range#cont#1<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.range#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign c {impure} malloc_count(?mc1##0:wybe.int) @memory_management:nn:nn
-    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp#0##0:int_list.int_list) #34 @int_list:nn:nn
-    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp#1##0:int_list.int_list) #35 @int_list:nn:nn
-    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp#2##0:int_list.int_list) #36 @int_list:nn:nn
+    int_list.range#cont#1<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#0##0:int_list.int_list) #34 @int_list:nn:nn
+    int_list.range#cont#1<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, ?tmp#1##0:int_list.int_list) #35 @int_list:nn:nn
+    int_list.range#cont#1<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, ?tmp#2##0:int_list.int_list) #36 @int_list:nn:nn
     wybe.string.print<0>("x y z:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #37 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
@@ -3053,7 +3053,7 @@ declare external ccc  void @print_int(i64)
 declare external ccc  i64 @malloc_count()    
 
 
-declare external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64, i64, i64, i64, i64)    
+declare external fastcc  i64 @"int_list.range#cont#1<0>[410bae77d3]"(i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -3065,9 +3065,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 define external fastcc  void @"int_list_test.<0>"()    {
 entry:
   %0 = tail call ccc  i64  @malloc_count()  
-  %1 = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  1, i64  1, i64  10, i64  0)  
-  %2 = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  2, i64  2, i64  20, i64  0)  
-  %3 = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  3, i64  3, i64  30, i64  0)  
+  %1 = tail call fastcc  i64  @"int_list.range#cont#1<0>[410bae77d3]"(i64  0, i64  1, i64  1, i64  10)  
+  %2 = tail call fastcc  i64  @"int_list.range#cont#1<0>[410bae77d3]"(i64  0, i64  2, i64  2, i64  20)  
+  %3 = tail call fastcc  i64  @"int_list.range#cont#1<0>[410bae77d3]"(i64  0, i64  3, i64  3, i64  30)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %1)  

--- a/test-cases/final-dump/afterbreak.exp
+++ b/test-cases/final-dump/afterbreak.exp
@@ -14,38 +14,38 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    afterbreak.gen#1<0>(1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @afterbreak:nn:nn
+    afterbreak.#cont#1<0>(1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @afterbreak:nn:nn
 
 
-gen#1 > (2 calls)
-0: afterbreak.gen#1<0>
-gen#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (2 calls)
+0: afterbreak.#cont#1<0>
+#cont#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_sgt(x##0:wybe.int, 10:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(tmp#0##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        afterbreak.gen#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @afterbreak:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(tmp#0##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        afterbreak.#cont#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @afterbreak:nn:nn
 
     1:
 
 
 
-gen#2 > {inline} (1 calls)
-0: afterbreak.gen#2<0>
-gen#2([tmp#0##0:wybe.int], [x##0:wybe.int], y##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#2 > {inline} (1 calls)
+0: afterbreak.#cont#2<0>
+#cont#2([x##0:wybe.int], y##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @int:nn:nn
     foreign c print_int(y##0:wybe.int, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    afterbreak.gen#1<0>(~y##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @afterbreak:nn:nn
+    afterbreak.#cont#1<0>(~y##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @afterbreak:nn:nn
 
   LLVM code       :
 
@@ -69,12 +69,12 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"afterbreak.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"afterbreak.gen#1<0>"(i64  1)  
+  tail call fastcc  void  @"afterbreak.#cont#1<0>"(i64  1)  
   ret void 
 }
 
 
-define external fastcc  void @"afterbreak.gen#1<0>"(i64  %"x##0")    {
+define external fastcc  void @"afterbreak.#cont#1<0>"(i64  %"x##0")    {
 entry:
   %0 = icmp sgt i64 %"x##0", 10 
   br i1 %0, label %if.then, label %if.else 
@@ -84,15 +84,15 @@ if.else:
   %1 = add   i64 %"x##0", 1 
   tail call ccc  void  @print_int(i64  %1)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"afterbreak.gen#1<0>"(i64  %1)  
+  musttail call fastcc  void  @"afterbreak.#cont#1<0>"(i64  %1)  
   ret void 
 }
 
 
-define external fastcc  void @"afterbreak.gen#2<0>"(i64  %"y##0") alwaysinline   {
+define external fastcc  void @"afterbreak.#cont#2<0>"(i64  %"y##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"y##0")  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"afterbreak.gen#1<0>"(i64  %"y##0")  
+  musttail call fastcc  void  @"afterbreak.#cont#1<0>"(i64  %"y##0")  
   ret void 
 }

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -33,6 +33,7 @@ bar > public (1 calls)
 bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(6,(student.printStudent<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course) @student:nn:nn
     foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int) @student:nn:nn
     foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#0##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "intro to cs":wybe.string) @student:nn:nn
@@ -48,7 +49,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    student.printStudent<0>(~tmp#1##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @alias_data:nn:nn
+    student.printStudent<0>[410bae77d3](~tmp#1##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @alias_data:nn:nn
 
   LLVM code       :
 
@@ -76,13 +77,16 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
 @alias_data.4 =    constant [?? x i8] c"student2\00"
 
 
-declare external fastcc  void @"student.printStudent<0>"(i64)    
+declare external fastcc  void @"student.printStudent<0>[410bae77d3]"(i64)    
 
 
 declare external ccc  void @putchar(i8)    
 
 
 declare external fastcc  void @"wybe.string.print<0>"(i64)    
+
+
+declare external fastcc  void @"student.printStudent<0>"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -127,7 +131,7 @@ entry:
   tail call fastcc  void  @"student.printStudent<0>"(i64  %8)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %8)  
+  tail call fastcc  void  @"student.printStudent<0>[410bae77d3]"(i64  %8)  
   ret void 
 }
 --------------------------------------------------
@@ -166,20 +170,22 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(2,(student.printStudent<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course) @student:nn:nn
     foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int) @student:nn:nn
     foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string) @student:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#9##0:student.student) @student:nn:nn
     foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int) @student:nn:nn
     foreign lpvm mutate(~tmp#10##0:student.student, ?tmp#11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:student.course) @student:nn:nn
-    student.printStudent<0>(~tmp#11##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @student:nn:nn
+    student.printStudent<0>[410bae77d3](~tmp#11##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @student:nn:nn
 
 
 printStudent > public (1 calls)
-0: student.printStudent<0>
+0: student.printStudent<0>[410bae77d3]
 printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
-  InterestingCallProperties: []
+  InterestingCallProperties: [InterestingUnaliased 0]
+  MultiSpeczDepInfo: [(10,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 [0]]))]
     wybe.string.print<0>("student id: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @student:nn:nn
     foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @student:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @int:nn:nn
@@ -196,6 +202,26 @@ printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     wybe.string.print<0>("course name: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @student:nn:nn
     foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @student:nn:nn
     wybe.string.print<0>(~tmp#3##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+ [410bae77d3] [NonAliasedParam 0] :
+    wybe.string.print<0>("student id: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @student:nn:nn
+    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @student:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:student.course) @student:nn:nn
+    wybe.string.print<0>("course code: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @student:nn:nn
+    foreign lpvm access(tmp#1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @student:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    wybe.string.print<0>("course name: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @student:nn:nn
+    foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @student:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#3##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
@@ -235,6 +261,9 @@ printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
 declare external ccc  void @putchar(i8)    
 
 
+declare external fastcc  void @"wybe.string.print<0>[410bae77d3]"(i64)    
+
+
 declare external fastcc  void @"wybe.string.print<0>"(i64)    
 
 
@@ -265,7 +294,7 @@ entry:
   %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
   store  i64 %2, i64* %11 
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %8)  
+  tail call fastcc  void  @"student.printStudent<0>[410bae77d3]"(i64  %8)  
   ret void 
 }
 
@@ -290,6 +319,31 @@ entry:
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  %9)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"student.printStudent<0>[410bae77d3]"(i64  %"stu##0")    {
+entry:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.3, i32 0, i32 0) to i64))  
+  %0 = inttoptr i64 %"stu##0" to i64* 
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  %2 = add   i64 %"stu##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.5, i32 0, i32 0) to i64))  
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  tail call ccc  void  @print_int(i64  %6)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.7, i32 0, i32 0) to i64))  
+  %7 = add   i64 %4, 8 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %9)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -326,7 +380,8 @@ entry:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ?#success##0:wybe.bool) #3
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ?tmp#9##0:wybe.comparison) #4 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -391,7 +446,8 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string)<{};
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#0##0:wybe.bool) #1
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#8##0:wybe.comparison) #1 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#8##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -403,7 +459,7 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string)<{};
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -427,8 +483,9 @@ entry:
   %10 = icmp eq i64 %1, %6 
   br i1 %10, label %if.then, label %if.else 
 if.then:
-  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  ret i1 %11 
+  %11 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %12 = icmp eq i2 %11, 1 
+  ret i1 %12 
 if.else:
   ret i1 0 
 }
@@ -524,12 +581,13 @@ entry:
   %10 = icmp eq i64 %1, %6 
   br i1 %10, label %if.then, label %if.else 
 if.then:
-  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  %12 = xor i1 %11, 1 
-  ret i1 %12 
-if.else:
-  %13 = xor i1 0, 1 
+  %11 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %12 = icmp eq i2 %11, 1 
+  %13 = xor i1 %12, 1 
   ret i1 %13 
+if.else:
+  %14 = xor i1 0, 1 
+  ret i1 %14 
 }
 --------------------------------------------------
  Module student.student
@@ -574,7 +632,8 @@ if.else:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            wybe.string.=<0>(~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ?#success##0:wybe.bool) #4
+            wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ?tmp#14##0:wybe.comparison) #4 @string:nn:nn
+            foreign llvm icmp_eq(~tmp#14##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -651,7 +710,8 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student)<{
             foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            wybe.string.=<0>(~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#0##0:wybe.bool) #1
+            wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#13##0:wybe.comparison) #1 @string:nn:nn
+            foreign llvm icmp_eq(~tmp#13##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
             foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -664,7 +724,7 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student)<{
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -703,8 +763,9 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %22 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %15, i64  %20)  
-  ret i1 %22 
+  %22 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %15, i64  %20, i64  %15, i64  %20)  
+  %23 = icmp eq i2 %22, 1 
+  ret i1 %23 
 if.else1:
   ret i1 0 
 }
@@ -813,13 +874,14 @@ if.then:
   %21 = icmp eq i64 %17, %12 
   br i1 %21, label %if.then1, label %if.else1 
 if.else:
+  %26 = xor i1 0, 1 
+  ret i1 %26 
+if.then1:
+  %22 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %15, i64  %20, i64  %15, i64  %20)  
+  %23 = icmp eq i2 %22, 1 
+  %24 = xor i1 %23, 1 
+  ret i1 %24 
+if.else1:
   %25 = xor i1 0, 1 
   ret i1 %25 
-if.then1:
-  %22 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %15, i64  %20)  
-  %23 = xor i1 %22, 1 
-  ret i1 %23 
-if.else1:
-  %24 = xor i1 0, 1 
-  ret i1 %24 
 }

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -32,14 +32,6 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-gen#1 > {inline} (2 calls)
-0: alias_fork1.gen#1<0>
-gen#1([k1##0:wybe.int], [k2##0:wybe.int], [l1##0:mytree.tree], [l2##0:mytree.tree], [r1##0:mytree.tree], [r2##0:mytree.tree], [tl##0:mytree.tree], tmp#2##0:mytree.tree, [tr##0:mytree.tree], ?#result##0:mytree.tree)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(~tmp#2##0:mytree.tree, ?#result##0:mytree.tree) @alias_fork1:nn:nn
-
-
 simpleMerge > public (1 calls)
 0: alias_fork1.simpleMerge<0>
 simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}>:
@@ -83,6 +75,14 @@ simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?#result##0:mytree.tree)<{}; {
 
 
 
+
+
+simpleMerge#cont#1 > {inline} (2 calls)
+0: alias_fork1.simpleMerge#cont#1<0>
+simpleMerge#cont#1(tmp#2##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(~tmp#2##0:mytree.tree, ?#result##0:mytree.tree) @alias_fork1:nn:nn
 
   LLVM code       :
 
@@ -148,12 +148,6 @@ entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork1.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
-}
-
-
-define external fastcc  i64 @"alias_fork1.gen#1<0>"(i64  %"tmp#2##0") alwaysinline   {
-entry:
-  ret i64 %"tmp#2##0" 
 }
 
 
@@ -232,6 +226,12 @@ if.else2:
   store  i64 %6, i64* %30 
   ret i64 %25 
 }
+
+
+define external fastcc  i64 @"alias_fork1.simpleMerge#cont#1<0>"(i64  %"tmp#2##0") alwaysinline   {
+entry:
+  ret i64 %"tmp#2##0" 
+}
 --------------------------------------------------
  Module mytree
   representation  : (not a type)
@@ -269,7 +269,8 @@ printTree1 > public (3 calls)
 0: mytree.printTree1<0>
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: [(prefix##0,prefix##3)]
-  InterestingCallProperties: []
+  InterestingCallProperties: [InterestingUnaliased 1]
+  MultiSpeczDepInfo: [(1,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 [1]])),(2,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 [1]]))]
     foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
     case ~tmp#2##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -34,7 +34,7 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#21##0:wybe.bool)
     case ~tmp#21##0:wybe.bool of
     0:
-        alias_fork2.gen#1<0>(~tmp#3##0:mytree.tree, ~tmp#0##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
+        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, ~tmp#0##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
 
     1:
         foreign lpvm access(~tmp#0##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
@@ -42,13 +42,13 @@ module top-level code > public {semipure} (0 calls)
         foreign lpvm mutate(~tmp#25##0:mytree.tree, ?tmp#26##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree) @mytree:nn:nn
         foreign lpvm mutate(~tmp#26##0:mytree.tree, ?tmp#27##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @mytree:nn:nn
         foreign lpvm mutate(~tmp#27##0:mytree.tree, ?tmp#4##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @mytree:nn:nn
-        alias_fork2.gen#1<0>(~tmp#3##0:mytree.tree, ~tmp#4##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9
+        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, ~tmp#4##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9
 
 
 
-gen#1 > (2 calls)
-0: alias_fork2.gen#1<0>
-gen#1(t##0:mytree.tree, t1##0:mytree.tree, [tmp#0##0:mytree.tree], [tmp#1##0:mytree.tree], [tmp#2##0:mytree.tree], [tmp#3##0:mytree.tree])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (2 calls)
+0: alias_fork2.#cont#1<0>
+#cont#1(t##0:mytree.tree, t1##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>("expect t1 - 1000:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @string:nn:nn
@@ -178,15 +178,15 @@ if.then:
   %19 = add   i64 %15, 16 
   %20 = inttoptr i64 %19 to i64* 
   store  i64 0, i64* %20 
-  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %8, i64  %15)  
+  tail call fastcc  void  @"alias_fork2.#cont#1<0>"(i64  %8, i64  %15)  
   ret void 
 if.else:
-  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %8, i64  %2)  
+  tail call fastcc  void  @"alias_fork2.#cont#1<0>"(i64  %8, i64  %2)  
   ret void 
 }
 
 
-define external fastcc  void @"alias_fork2.gen#1<0>"(i64  %"t##0", i64  %"t1##0")    {
+define external fastcc  void @"alias_fork2.#cont#1<0>"(i64  %"t##0", i64  %"t1##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -256,7 +256,8 @@ printTree1 > public (3 calls)
 0: mytree.printTree1<0>
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: [(prefix##0,prefix##3)]
-  InterestingCallProperties: []
+  InterestingCallProperties: [InterestingUnaliased 1]
+  MultiSpeczDepInfo: [(1,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 [1]])),(2,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 [1]]))]
     foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
     case ~tmp#2##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -195,7 +195,8 @@ printTree1 > public (3 calls)
 0: mytree.printTree1<0>
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: [(prefix##0,prefix##3)]
-  InterestingCallProperties: []
+  InterestingCallProperties: [InterestingUnaliased 1]
+  MultiSpeczDepInfo: [(1,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 [1]])),(2,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 [1]]))]
     foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
     case ~tmp#2##0:wybe.bool of
     0:

--- a/test-cases/final-dump/alloc_args.exp
+++ b/test-cases/final-dump/alloc_args.exp
@@ -22,9 +22,10 @@ foo > {noinline} (1 calls)
 foo(size##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(2,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm alloc(~size##0:wybe.int, ?str##0:wybe.string) @alloc_args:nn:nn
     foreign lpvm mutate(~str##0:wybe.string, ?str##1:wybe.string, 0:wybe.int, 1:wybe.bool, 1:wybe.int, 0:wybe.int, 0:wybe.int) @alloc_args:nn:nn
-    wybe.string.print<0>(~str##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~str##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
@@ -40,7 +41,7 @@ foo(size##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
 declare external ccc  void @putchar(i8)    
 
 
-declare external fastcc  void @"wybe.string.print<0>"(i64)    
+declare external fastcc  void @"wybe.string.print<0>[410bae77d3]"(i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -63,7 +64,7 @@ entry:
   %2 = ptrtoint i8* %1 to i64 
   %3 = inttoptr i64 %2 to i64* 
   store  i64 0, i64* %3 
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %2)  
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -40,14 +40,93 @@ module top-level code > public {semipure} (0 calls)
     anon_field.=<0>(~tmp#0##0:anon_field, ~tmp#2##0:anon_field, ?tmp#17##0:wybe.bool) #3 @anon_field:nn:nn
     case ~tmp#17##0:wybe.bool of
     0:
-        anon_field.gen#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6
+        anon_field.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6
 
     1:
         wybe.string.print<0>("uh oh":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @string:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#28##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        anon_field.gen#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
+        anon_field.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
+
+
+
+#cont#1 > (2 calls)
+0: anon_field.#cont#1<0>
+#cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm alloc(24:wybe.int, ?tmp#20##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#21##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#21##0:anon_field, ?tmp#22##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#22##0:anon_field, ?tmp#4##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign llvm and(~tmp#4##0:wybe.int, 3:wybe.int, ?tmp#24##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#24##0:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.bool)
+    case ~tmp#25##0:wybe.bool of
+    0:
+        anon_field.#cont#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7
+
+    1:
+        wybe.string.print<0>("good":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#29##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?tmp#30##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#30##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        anon_field.#cont#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
+
+
+
+#cont#2 > (3 calls)
+0: anon_field.#cont#2<0>
+#cont#2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm alloc(24:wybe.int, ?tmp#18##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#18##0:anon_field, ?tmp#19##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#19##0:anon_field, ?tmp#20##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#6##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#24##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#24##0:anon_field, ?tmp#25##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#25##0:anon_field, ?tmp#26##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#26##0:anon_field, ?tmp#8##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    anon_field.=<0>(~tmp#6##0:anon_field, ~tmp#8##0:anon_field, ?tmp#14##0:wybe.bool) #4 @anon_field:nn:nn
+    case ~tmp#14##0:wybe.bool of
+    0:
+        anon_field.#cont#3<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7
+
+    1:
+        wybe.string.print<0>("bad":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#28##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        anon_field.#cont#3<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6
+
+
+
+#cont#3 > (2 calls)
+0: anon_field.#cont#3<0>
+#cont#3()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm alloc(8:wybe.int, ?tmp#15##0:anon_field) @anon_field:nn:nn
+    foreign lpvm mutate(~tmp#15##0:anon_field, ?tmp#16##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
+    foreign llvm or(~tmp#16##0:anon_field, 2:wybe.int, ?tmp#11##0:anon_field) @anon_field:nn:nn
+    foreign llvm and(tmp#11##0:wybe.int, 3:wybe.int, ?tmp#18##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#18##0:wybe.int, 2:wybe.int, ?tmp#19##0:wybe.bool)
+    case ~tmp#19##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(~tmp#11##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?tmp#10##0:wybe.int) @anon_field:nn:nn
+        foreign llvm icmp_ne(~tmp#10##0:wybe.int, 2:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
+        case ~tmp#13##0:wybe.bool of
+        0:
+
+        1:
+            wybe.string.print<0>("maybe":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
 
 
 
@@ -246,85 +325,6 @@ foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_fie
 
 
 
-gen#1 > (2 calls)
-0: anon_field.gen#1<0>
-gen#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#20##0:anon_field) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#21##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#21##0:anon_field, ?tmp#22##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#22##0:anon_field, ?tmp#4##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
-    foreign llvm and(~tmp#4##0:wybe.int, 3:wybe.int, ?tmp#24##0:wybe.int)
-    foreign llvm icmp_eq(~tmp#24##0:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.bool)
-    case ~tmp#25##0:wybe.bool of
-    0:
-        anon_field.gen#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7
-
-    1:
-        wybe.string.print<0>("good":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#29##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?tmp#30##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#30##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        anon_field.gen#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
-
-
-
-gen#2 > (3 calls)
-0: anon_field.gen#2<0>
-gen#2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#18##0:anon_field) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#18##0:anon_field, ?tmp#19##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#19##0:anon_field, ?tmp#20##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#6##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp#24##0:anon_field) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#24##0:anon_field, ?tmp#25##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#25##0:anon_field, ?tmp#26##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#26##0:anon_field, ?tmp#8##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
-    anon_field.=<0>(~tmp#6##0:anon_field, ~tmp#8##0:anon_field, ?tmp#14##0:wybe.bool) #4 @anon_field:nn:nn
-    case ~tmp#14##0:wybe.bool of
-    0:
-        anon_field.gen#3<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7
-
-    1:
-        wybe.string.print<0>("bad":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#28##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        anon_field.gen#3<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6
-
-
-
-gen#3 > (2 calls)
-0: anon_field.gen#3<0>
-gen#3()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?tmp#15##0:anon_field) @anon_field:nn:nn
-    foreign lpvm mutate(~tmp#15##0:anon_field, ?tmp#16##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int) @anon_field:nn:nn
-    foreign llvm or(~tmp#16##0:anon_field, 2:wybe.int, ?tmp#11##0:anon_field) @anon_field:nn:nn
-    foreign llvm and(tmp#11##0:wybe.int, 3:wybe.int, ?tmp#18##0:wybe.int)
-    foreign llvm icmp_eq(~tmp#18##0:wybe.int, 2:wybe.int, ?tmp#19##0:wybe.bool)
-    case ~tmp#19##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(~tmp#11##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?tmp#10##0:wybe.int) @anon_field:nn:nn
-        foreign llvm icmp_ne(~tmp#10##0:wybe.int, 2:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
-        case ~tmp#13##0:wybe.bool of
-        0:
-
-        1:
-            wybe.string.print<0>("maybe":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
-
-
-
 i > {inline} (5 calls)
 0: anon_field.i<0>
 i(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
@@ -435,10 +435,102 @@ entry:
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"anon_field.gen#1<0>"()  
+  musttail call fastcc  void  @"anon_field.#cont#1<0>"()  
   ret void 
 if.else:
-  musttail call fastcc  void  @"anon_field.gen#1<0>"()  
+  musttail call fastcc  void  @"anon_field.#cont#1<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"anon_field.#cont#1<0>"()    {
+entry:
+  %0 = trunc i64 24 to i32  
+  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
+  %2 = ptrtoint i8* %1 to i64 
+  %3 = inttoptr i64 %2 to i1* 
+  store  i1 0, i1* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 1, i64* %7 
+  %8 = and i64 %2, 3 
+  %9 = icmp eq i64 %8, 0 
+  br i1 %9, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.3, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"anon_field.#cont#2<0>"()  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"anon_field.#cont#2<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"anon_field.#cont#2<0>"()    {
+entry:
+  %0 = trunc i64 24 to i32  
+  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
+  %2 = ptrtoint i8* %1 to i64 
+  %3 = inttoptr i64 %2 to i1* 
+  store  i1 0, i1* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 1, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 1, i64* %7 
+  %8 = trunc i64 24 to i32  
+  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
+  %10 = ptrtoint i8* %9 to i64 
+  %11 = inttoptr i64 %10 to i1* 
+  store  i1 0, i1* %11 
+  %12 = add   i64 %10, 8 
+  %13 = inttoptr i64 %12 to i64* 
+  store  i64 2, i64* %13 
+  %14 = add   i64 %10, 16 
+  %15 = inttoptr i64 %14 to i64* 
+  store  i64 1, i64* %15 
+  %16 = tail call fastcc  i1  @"anon_field.=<0>"(i64  %2, i64  %10)  
+  br i1 %16, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.5, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"anon_field.#cont#3<0>"()  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"anon_field.#cont#3<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"anon_field.#cont#3<0>"()    {
+entry:
+  %0 = trunc i64 8 to i32  
+  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
+  %2 = ptrtoint i8* %1 to i64 
+  %3 = inttoptr i64 %2 to i64* 
+  store  i64 1, i64* %3 
+  %4 = or i64 %2, 2 
+  %5 = and i64 %4, 3 
+  %6 = icmp eq i64 %5, 2 
+  br i1 %6, label %if.then, label %if.else 
+if.then:
+  %7 = add   i64 %4, -2 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = icmp ne i64 %9, 2 
+  br i1 %10, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.7, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+if.else1:
   ret void 
 }
 
@@ -675,98 +767,6 @@ if.else:
   %16 = insertvalue {i64, i1, i64, i1} %15, i64 undef, 2 
   %17 = insertvalue {i64, i1, i64, i1} %16, i1 0, 3 
   ret {i64, i1, i64, i1} %17 
-}
-
-
-define external fastcc  void @"anon_field.gen#1<0>"()    {
-entry:
-  %0 = trunc i64 24 to i32  
-  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
-  %2 = ptrtoint i8* %1 to i64 
-  %3 = inttoptr i64 %2 to i1* 
-  store  i1 0, i1* %3 
-  %4 = add   i64 %2, 8 
-  %5 = inttoptr i64 %4 to i64* 
-  store  i64 1, i64* %5 
-  %6 = add   i64 %2, 16 
-  %7 = inttoptr i64 %6 to i64* 
-  store  i64 1, i64* %7 
-  %8 = and i64 %2, 3 
-  %9 = icmp eq i64 %8, 0 
-  br i1 %9, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"anon_field.gen#2<0>"()  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"anon_field.gen#2<0>"()  
-  ret void 
-}
-
-
-define external fastcc  void @"anon_field.gen#2<0>"()    {
-entry:
-  %0 = trunc i64 24 to i32  
-  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
-  %2 = ptrtoint i8* %1 to i64 
-  %3 = inttoptr i64 %2 to i1* 
-  store  i1 0, i1* %3 
-  %4 = add   i64 %2, 8 
-  %5 = inttoptr i64 %4 to i64* 
-  store  i64 1, i64* %5 
-  %6 = add   i64 %2, 16 
-  %7 = inttoptr i64 %6 to i64* 
-  store  i64 1, i64* %7 
-  %8 = trunc i64 24 to i32  
-  %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
-  %10 = ptrtoint i8* %9 to i64 
-  %11 = inttoptr i64 %10 to i1* 
-  store  i1 0, i1* %11 
-  %12 = add   i64 %10, 8 
-  %13 = inttoptr i64 %12 to i64* 
-  store  i64 2, i64* %13 
-  %14 = add   i64 %10, 16 
-  %15 = inttoptr i64 %14 to i64* 
-  store  i64 1, i64* %15 
-  %16 = tail call fastcc  i1  @"anon_field.=<0>"(i64  %2, i64  %10)  
-  br i1 %16, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.5, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"anon_field.gen#3<0>"()  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"anon_field.gen#3<0>"()  
-  ret void 
-}
-
-
-define external fastcc  void @"anon_field.gen#3<0>"()    {
-entry:
-  %0 = trunc i64 8 to i32  
-  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
-  %2 = ptrtoint i8* %1 to i64 
-  %3 = inttoptr i64 %2 to i64* 
-  store  i64 1, i64* %3 
-  %4 = or i64 %2, 2 
-  %5 = and i64 %4, 3 
-  %6 = icmp eq i64 %5, 2 
-  br i1 %6, label %if.then, label %if.else 
-if.then:
-  %7 = add   i64 %4, -2 
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = load  i64, i64* %8 
-  %10 = icmp ne i64 %9, 2 
-  br i1 %10, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.7, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-if.else1:
-  ret void 
 }
 
 

--- a/test-cases/final-dump/backwards_assign.exp
+++ b/test-cases/final-dump/backwards_assign.exp
@@ -14,20 +14,12 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    backwards_assign.gen#1<0>(0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @backwards_assign:nn:nn
+    backwards_assign.#cont#1<0>(0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @backwards_assign:nn:nn
 
 
-backwards_assign > {inline} (3 calls)
-0: backwards_assign.backwards_assign<0>
-backwards_assign(?output##0:wybe.int, input##0:wybe.int)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm add(~input##0:wybe.int, 1:wybe.int, ?output##0:wybe.int) @int:nn:nn
-
-
-gen#1 > (2 calls)
-0: backwards_assign.gen#1<0>
-gen#1(i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (2 calls)
+0: backwards_assign.#cont#1<0>
+#cont#1(i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @int:nn:nn
@@ -40,8 +32,16 @@ gen#1(i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     0:
 
     1:
-        backwards_assign.gen#1<0>(~i##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @backwards_assign:nn:nn
+        backwards_assign.#cont#1<0>(~i##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @backwards_assign:nn:nn
 
+
+
+backwards_assign > {inline} (3 calls)
+0: backwards_assign.backwards_assign<0>
+backwards_assign(?output##0:wybe.int, input##0:wybe.int)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm add(~input##0:wybe.int, 1:wybe.int, ?output##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -65,7 +65,22 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"backwards_assign.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"backwards_assign.gen#1<0>"(i64  0)  
+  tail call fastcc  void  @"backwards_assign.#cont#1<0>"(i64  0)  
+  ret void 
+}
+
+
+define external fastcc  void @"backwards_assign.#cont#1<0>"(i64  %"i##0")    {
+entry:
+  tail call ccc  void  @print_int(i64  %"i##0")  
+  tail call ccc  void  @putchar(i8  10)  
+  %0 = add   i64 %"i##0", 1 
+  %1 = icmp slt i64 %0, 10 
+  br i1 %1, label %if.then, label %if.else 
+if.then:
+  musttail call fastcc  void  @"backwards_assign.#cont#1<0>"(i64  %0)  
+  ret void 
+if.else:
   ret void 
 }
 
@@ -74,19 +89,4 @@ define external fastcc  i64 @"backwards_assign.backwards_assign<0>"(i64  %"input
 entry:
   %0 = add   i64 %"input##0", 1 
   ret i64 %0 
-}
-
-
-define external fastcc  void @"backwards_assign.gen#1<0>"(i64  %"i##0")    {
-entry:
-  tail call ccc  void  @print_int(i64  %"i##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  %0 = add   i64 %"i##0", 1 
-  %1 = icmp slt i64 %0, 10 
-  br i1 %1, label %if.then, label %if.else 
-if.then:
-  musttail call fastcc  void  @"backwards_assign.gen#1<0>"(i64  %0)  
-  ret void 
-if.else:
-  ret void 
 }

--- a/test-cases/final-dump/break_in_loop_in_do.exp
+++ b/test-cases/final-dump/break_in_loop_in_do.exp
@@ -21,9 +21,9 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-gen#1 > {inline} (2 calls)
-0: break_in_loop_in_do.gen#1<0>
-gen#1([counter##0:wybe.int])<{<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > {inline} (2 calls)
+0: break_in_loop_in_do.#cont#1<0>
+#cont#1([counter##0:wybe.int])<{<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<break_in_loop_in_do.counter>>:wybe.int, ?%counter##1:wybe.int) @break_in_loop_in_do:nn:nn
@@ -33,9 +33,9 @@ gen#1([counter##0:wybe.int])<{<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}; 
     foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-gen#2 > {inline} (1 calls)
-0: break_in_loop_in_do.gen#2<0>
-gen#2(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<wybe.io.io>>}; {<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}>:
+#cont#2 > {inline} (1 calls)
+0: break_in_loop_in_do.#cont#2<0>
+#cont#2(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<wybe.io.io>>}; {<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm store(tmp#0##0:wybe.int, <<break_in_loop_in_do.counter>>:wybe.int) @break_in_loop_in_do:nn:nn
@@ -76,7 +76,7 @@ entry:
 }
 
 
-define external fastcc  void @"break_in_loop_in_do.gen#1<0>"() alwaysinline   {
+define external fastcc  void @"break_in_loop_in_do.#cont#1<0>"() alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#break_in_loop_in_do.counter" 
   tail call ccc  void  @print_int(i64  %0)  
@@ -85,7 +85,7 @@ entry:
 }
 
 
-define external fastcc  void @"break_in_loop_in_do.gen#2<0>"(i64  %"tmp#0##0") alwaysinline   {
+define external fastcc  void @"break_in_loop_in_do.#cont#2<0>"(i64  %"tmp#0##0") alwaysinline   {
 entry:
   store  i64 %"tmp#0##0", i64* @"resource#break_in_loop_in_do.counter" 
   tail call ccc  void  @print_int(i64  %"tmp#0##0")  

--- a/test-cases/final-dump/bug214.exp
+++ b/test-cases/final-dump/bug214.exp
@@ -21,12 +21,84 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(3,(bug214.#cont#2<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
     bug214.position.origin<0>(?tmp#0##0:bug214.position) #0 @bug214:nn:nn
     bug214.position.origin<0>(?tmp#2##0:bug214.position) #1 @bug214:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#17##0:bug214) @bug214:nn:nn
-    foreign lpvm mutate(~tmp#17##0:bug214, ?tmp#18##0:bug214, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:bug214.position) @bug214:nn:nn
+    foreign lpvm mutate(~tmp#17##0:bug214, ?tmp#18##0:bug214, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:bug214.position) @bug214:nn:nn
     foreign lpvm mutate(~tmp#18##0:bug214, ?tmp#1##0:bug214, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @bug214:nn:nn
-    bug214.gen#2<0>(~tmp#0##0:bug214.position, ~tmp#1##0:bug214, ~tmp#0##0:bug214.position, ~tmp#1##0:bug214, ~tmp#2##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @bug214:nn:nn
+    bug214.#cont#2<0>[7477e50a09](~tmp#0##0:bug214.position, ~tmp#1##0:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @bug214:nn:nn
+
+
+#cont#1 > {inline} (0 calls)
+0: bug214.#cont#1<0>
+#cont#1(pos##0:bug214.position, sub##0:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.string.print<0>("Part 1: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @bug214:nn:nn
+    bug214.position.print<0>(pos##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @bug214:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @char:nn:nn
+    foreign c putchar(' ':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @char:nn:nn
+    foreign lpvm access(pos##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @bug214:nn:nn
+    foreign lpvm access(~pos##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @bug214:nn:nn
+    foreign llvm mul(~tmp#6##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+    foreign c print_int(~tmp#5##0:wybe.int, ~tmp#16##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    wybe.string.print<0>("Part 2: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @bug214:nn:nn
+    foreign lpvm access(~sub##0:bug214, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:bug214.position) @bug214:nn:nn
+    bug214.position.print<0>(tmp#8##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9 @bug214:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @char:nn:nn
+    foreign c putchar(' ':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @char:nn:nn
+    foreign lpvm access(tmp#8##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @bug214:nn:nn
+    foreign lpvm access(~tmp#8##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @bug214:nn:nn
+    foreign llvm mul(~tmp#10##0:wybe.int, ~tmp#12##0:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
+    foreign c print_int(~tmp#9##0:wybe.int, ~tmp#28##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#37##0:wybe.phantom, ?tmp#38##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#38##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+
+#cont#2 > (3 calls)
+0: bug214.#cont#2<0>[7477e50a09]
+#cont#2(pos##0:bug214.position, sub##0:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1]
+  MultiSpeczDepInfo: [(4,(bug214.move<0>,fromList [NonAliasedParamCond 0 [0]])),(5,(bug214.move<1>,fromList [NonAliasedParamCond 0 [1]])),(6,(bug214.#cont#2<0>,fromList [NonAliasedParamCond 0 [0],NonAliasedParamCond 1 [1]])),(7,(bug214.#cont#2<0>,fromList [NonAliasedParamCond 0 [0],NonAliasedParamCond 1 [1]]))]
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @c_string:nn:nn
+    foreign c read_line(?tmp#16##0:wybe.c_string, ~tmp#15##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @c_string:nn:nn
+    foreign lpvm store(%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @c_string:nn:nn
+    wybe.string.string<0>(~tmp#16##0:wybe.c_string, ?dir_str##0:wybe.string) #8 @string:nn:nn
+    bug214.direction.parse_direction<0>(~dir_str##0:wybe.string, ?tmp#3##0:bug214.direction, ?tmp#14##0:wybe.bool) #1 @bug214:nn:nn
+    case ~tmp#14##0:wybe.bool of
+    0:
+        bug214.#cont#2<0>(~pos##0:bug214.position, ~sub##0:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @bug214:nn:nn
+
+    1:
+        foreign c read_int(?units##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int:nn:nn
+        foreign c read_line(?tmp#21##0:wybe.c_string, ~tmp#19##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @c_string:nn:nn
+        foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @c_string:nn:nn
+        bug214.move<0>(~pos##0:bug214.position, ?pos##1:bug214.position, tmp#3##0:bug214.direction, units##0:wybe.int) #4 @bug214:nn:nn
+        bug214.move<1>(~sub##0:bug214, ?sub##1:bug214, ~tmp#3##0:bug214.direction, ~units##0:wybe.int) #5 @bug214:nn:nn
+        bug214.#cont#2<0>(~pos##1:bug214.position, ~sub##1:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @bug214:nn:nn
+
+ [7477e50a09] [NonAliasedParam 0,NonAliasedParam 1] :
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @c_string:nn:nn
+    foreign c read_line(?tmp#16##0:wybe.c_string, ~tmp#15##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @c_string:nn:nn
+    foreign lpvm store(%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @c_string:nn:nn
+    wybe.string.string<0>(~tmp#16##0:wybe.c_string, ?dir_str##0:wybe.string) #8 @string:nn:nn
+    bug214.direction.parse_direction<0>(~dir_str##0:wybe.string, ?tmp#3##0:bug214.direction, ?tmp#14##0:wybe.bool) #1 @bug214:nn:nn
+    case ~tmp#14##0:wybe.bool of
+    0:
+        bug214.#cont#2<0>[7477e50a09](~pos##0:bug214.position, ~sub##0:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @bug214:nn:nn
+
+    1:
+        foreign c read_int(?units##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int:nn:nn
+        foreign c read_line(?tmp#21##0:wybe.c_string, ~tmp#19##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @c_string:nn:nn
+        foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @c_string:nn:nn
+        bug214.move<0>[410bae77d3](~pos##0:bug214.position, ?pos##1:bug214.position, tmp#3##0:bug214.direction, units##0:wybe.int) #4 @bug214:nn:nn
+        bug214.move<1>[410bae77d3](~sub##0:bug214, ?sub##1:bug214, ~tmp#3##0:bug214.direction, ~units##0:wybe.int) #5 @bug214:nn:nn
+        bug214.#cont#2<0>[7477e50a09](~pos##1:bug214.position, ~sub##1:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @bug214:nn:nn
+
 
 
 = > public {inline} (1 calls)
@@ -71,61 +143,8 @@ aim(#rec##0:bug214, ?#rec##1:bug214, #field##0:wybe.int)<{}; {}>:
     foreign lpvm mutate(~#rec##0:bug214, ?#rec##1:bug214, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @bug214:nn:nn
 
 
-gen#1 > {inline} (0 calls)
-0: bug214.gen#1<0>
-gen#1(pos##0:bug214.position, sub##0:bug214, [tmp#0##0:bug214.position], [tmp#1##0:bug214], [tmp#2##0:bug214.position])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    wybe.string.print<0>("Part 1: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @bug214:nn:nn
-    bug214.position.print<0>(pos##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @bug214:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @char:nn:nn
-    foreign c putchar(' ':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @char:nn:nn
-    foreign lpvm access(pos##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int) @bug214:nn:nn
-    foreign lpvm access(~pos##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @bug214:nn:nn
-    foreign llvm mul(~tmp#6##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
-    foreign c print_int(~tmp#5##0:wybe.int, ~tmp#16##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @int:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    wybe.string.print<0>("Part 2: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @bug214:nn:nn
-    foreign lpvm access(~sub##0:bug214, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:bug214.position) @bug214:nn:nn
-    bug214.position.print<0>(tmp#8##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9 @bug214:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @char:nn:nn
-    foreign c putchar(' ':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @char:nn:nn
-    foreign lpvm access(tmp#8##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @bug214:nn:nn
-    foreign lpvm access(~tmp#8##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int) @bug214:nn:nn
-    foreign llvm mul(~tmp#10##0:wybe.int, ~tmp#12##0:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
-    foreign c print_int(~tmp#9##0:wybe.int, ~tmp#28##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#37##0:wybe.phantom, ?tmp#38##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#38##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
-
-gen#2 > (3 calls)
-0: bug214.gen#2<0>
-gen#2(pos##0:bug214.position, sub##0:bug214, tmp#0##0:bug214.position, tmp#1##0:bug214, tmp#2##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1]
-  MultiSpeczDepInfo: [(4,(bug214.move<0>,fromList [NonAliasedParamCond 0 [0]])),(5,(bug214.move<1>,fromList [NonAliasedParamCond 0 [1]])),(6,(bug214.gen#2<0>,fromList [NonAliasedParamCond 0 [0],NonAliasedParamCond 1 [1]])),(7,(bug214.gen#2<0>,fromList [NonAliasedParamCond 0 [0],NonAliasedParamCond 1 [1]]))]
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @c_string:nn:nn
-    foreign c read_line(?tmp#16##0:wybe.c_string, ~tmp#15##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @c_string:nn:nn
-    foreign lpvm store(%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @c_string:nn:nn
-    wybe.string.string<0>(~tmp#16##0:wybe.c_string, ?dir_str##0:wybe.string) #8 @string:nn:nn
-    bug214.direction.parse_direction<0>(~dir_str##0:wybe.string, ?tmp#3##0:bug214.direction, ?tmp#14##0:wybe.bool) #1 @bug214:nn:nn
-    case ~tmp#14##0:wybe.bool of
-    0:
-        bug214.gen#2<0>(~pos##0:bug214.position, ~sub##0:bug214, ~tmp#0##0:bug214.position, ~tmp#1##0:bug214, ~tmp#2##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @bug214:nn:nn
-
-    1:
-        foreign c read_int(?units##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int:nn:nn
-        foreign c read_line(?tmp#21##0:wybe.c_string, ~tmp#19##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @c_string:nn:nn
-        foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @c_string:nn:nn
-        bug214.move<0>(~pos##0:bug214.position, ?pos##1:bug214.position, tmp#3##0:bug214.direction, units##0:wybe.int) #4 @bug214:nn:nn
-        bug214.move<1>(~sub##0:bug214, ?sub##1:bug214, ~tmp#3##0:bug214.direction, ~units##0:wybe.int) #5 @bug214:nn:nn
-        bug214.gen#2<0>(~pos##1:bug214.position, ~sub##1:bug214, ~tmp#0##0:bug214.position, ~tmp#1##0:bug214, ~tmp#2##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @bug214:nn:nn
-
-
-
 move > (1 calls)
-0: bug214.move<0>
+0: bug214.move<0>[410bae77d3]
 move(pos##0:bug214.position, ?pos##1:bug214.position, dir##0:bug214.direction, units##0:wybe.int)<{}; {}>:
   AliasPairs: [(pos##0,pos##1)]
   InterestingCallProperties: [InterestingUnaliased 0]
@@ -157,8 +176,37 @@ move(pos##0:bug214.position, ?pos##1:bug214.position, dir##0:bug214.direction, u
         foreign llvm add(~tmp#2##0:wybe.int, ~units##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~pos##0:bug214.position, ?pos##1:bug214.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @bug214:nn:nn
 
+ [410bae77d3] [NonAliasedParam 0] :
+    foreign llvm icmp_eq(dir##0:bug214.direction, 0:bug214.direction, ?tmp#14##0:wybe.bool)
+    case ~tmp#14##0:wybe.bool of
+    0:
+        foreign llvm icmp_eq(dir##0:bug214.direction, 1:bug214.direction, ?tmp#17##0:wybe.bool)
+        case ~tmp#17##0:wybe.bool of
+        0:
+            foreign llvm icmp_eq(~dir##0:bug214.direction, 2:bug214.direction, ?tmp#20##0:wybe.bool)
+            case ~tmp#20##0:wybe.bool of
+            0:
+                foreign llvm move(~pos##0:bug214.position, ?pos##1:bug214.position)
+
+            1:
+                foreign lpvm access(pos##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int) @bug214:nn:nn
+                foreign llvm sub(~tmp#8##0:wybe.int, ~units##0:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+                foreign lpvm {noalias} mutate(~pos##0:bug214.position, ?pos##1:bug214.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int) @bug214:nn:nn
+
+
+        1:
+            foreign lpvm access(pos##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @bug214:nn:nn
+            foreign llvm add(~tmp#5##0:wybe.int, ~units##0:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+            foreign lpvm {noalias} mutate(~pos##0:bug214.position, ?pos##1:bug214.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int) @bug214:nn:nn
+
+
+    1:
+        foreign lpvm access(pos##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @bug214:nn:nn
+        foreign llvm add(~tmp#2##0:wybe.int, ~units##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~pos##0:bug214.position, ?pos##1:bug214.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @bug214:nn:nn
+
 move > (1 calls)
-1: bug214.move<1>
+1: bug214.move<1>[410bae77d3]
 move(sub##0:bug214, ?sub##2:bug214, dir##0:bug214.direction, units##0:wybe.int)<{}; {}>:
   AliasPairs: [(sub##0,sub##2)]
   InterestingCallProperties: [InterestingUnaliased 0]
@@ -191,6 +239,44 @@ move(sub##0:bug214, ?sub##2:bug214, dir##0:bug214.direction, units##0:wybe.int)<
         foreign llvm add(~tmp#3##0:wybe.int, units##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~tmp#1##0:bug214.position, ?tmp#1##1:bug214.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @bug214:nn:nn
         foreign lpvm {noalias} mutate(~sub##0:bug214, ?sub##1:bug214, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##1:bug214.position) @bug214:nn:nn
+        foreign lpvm access(sub##1:bug214, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:bug214.position) @bug214:nn:nn
+        foreign lpvm access(tmp#5##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @bug214:nn:nn
+        foreign lpvm access(sub##1:bug214, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @bug214:nn:nn
+        foreign llvm mul(~tmp#10##0:wybe.int, ~units##0:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
+        foreign llvm add(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#6##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~tmp#5##0:bug214.position, ?tmp#5##1:bug214.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:wybe.int) @bug214:nn:nn
+        foreign lpvm {noalias} mutate(~sub##1:bug214, ?sub##2:bug214, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:bug214.position) @bug214:nn:nn
+
+ [410bae77d3] [NonAliasedParam 0] :
+    foreign llvm icmp_eq(dir##0:bug214.direction, 0:bug214.direction, ?tmp#22##0:wybe.bool)
+    case ~tmp#22##0:wybe.bool of
+    0:
+        foreign llvm icmp_eq(dir##0:bug214.direction, 1:bug214.direction, ?tmp#25##0:wybe.bool)
+        case ~tmp#25##0:wybe.bool of
+        0:
+            foreign llvm icmp_eq(~dir##0:bug214.direction, 2:bug214.direction, ?tmp#28##0:wybe.bool)
+            case ~tmp#28##0:wybe.bool of
+            0:
+                foreign llvm move(~sub##0:bug214, ?sub##2:bug214)
+
+            1:
+                foreign lpvm access(sub##0:bug214, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.int) @bug214:nn:nn
+                foreign llvm sub(~tmp#16##0:wybe.int, ~units##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
+                foreign lpvm mutate(~sub##0:bug214, ?sub##2:bug214, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#15##0:wybe.int) @bug214:nn:nn
+
+
+        1:
+            foreign lpvm access(sub##0:bug214, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.int) @bug214:nn:nn
+            foreign llvm add(~tmp#13##0:wybe.int, ~units##0:wybe.int, ?tmp#12##0:wybe.int) @int:nn:nn
+            foreign lpvm mutate(~sub##0:bug214, ?sub##2:bug214, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#12##0:wybe.int) @bug214:nn:nn
+
+
+    1:
+        foreign lpvm access(sub##0:bug214, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:bug214.position) @bug214:nn:nn
+        foreign lpvm access(tmp#1##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @bug214:nn:nn
+        foreign llvm add(~tmp#3##0:wybe.int, units##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~tmp#1##0:bug214.position, ?tmp#1##1:bug214.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @bug214:nn:nn
+        foreign lpvm {noalias} mutate(~sub##0:bug214, ?sub##1:bug214, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##1:bug214.position) @bug214:nn:nn
         foreign lpvm access(sub##1:bug214, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:bug214.position) @bug214:nn:nn
         foreign lpvm access(tmp#5##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int) @bug214:nn:nn
         foreign lpvm access(sub##1:bug214, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int) @bug214:nn:nn
@@ -321,7 +407,79 @@ entry:
   %6 = add   i64 %4, 8 
   %7 = inttoptr i64 %6 to i64* 
   store  i64 0, i64* %7 
-  tail call fastcc  void  @"bug214.gen#2<0>"(i64  %0, i64  %4, i64  %0, i64  %4, i64  %1)  
+  tail call fastcc  void  @"bug214.#cont#2<0>[7477e50a09]"(i64  %0, i64  %4)  
+  ret void 
+}
+
+
+define external fastcc  void @"bug214.#cont#1<0>"(i64  %"pos##0", i64  %"sub##0") alwaysinline   {
+entry:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.1, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"bug214.position.print<0>"(i64  %"pos##0")  
+  tail call ccc  void  @putchar(i8  32)  
+  %0 = inttoptr i64 %"pos##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = add   i64 %"pos##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = mul   i64 %1, %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.3, i32 0, i32 0) to i64))  
+  %6 = inttoptr i64 %"sub##0" to i64* 
+  %7 = load  i64, i64* %6 
+  tail call fastcc  void  @"bug214.position.print<0>"(i64  %7)  
+  tail call ccc  void  @putchar(i8  32)  
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  %10 = add   i64 %7, 8 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = load  i64, i64* %11 
+  %13 = mul   i64 %9, %12 
+  tail call ccc  void  @print_int(i64  %13)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"bug214.#cont#2<0>"(i64  %"pos##0", i64  %"sub##0")    {
+entry:
+  %0 = tail call ccc  i64  @read_line()  
+  %1 = tail call fastcc  i64  @"wybe.string.string<0>"(i64  %0)  
+  %2 = tail call fastcc  {i2, i1}  @"bug214.direction.parse_direction<0>"(i64  %1)  
+  %3 = extractvalue {i2, i1} %2, 0 
+  %4 = extractvalue {i2, i1} %2, 1 
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  %5 = tail call ccc  i64  @read_int()  
+  %6 = tail call ccc  i64  @read_line()  
+  %7 = tail call fastcc  i64  @"bug214.move<0>"(i64  %"pos##0", i2  %3, i64  %5)  
+  %8 = tail call fastcc  i64  @"bug214.move<1>"(i64  %"sub##0", i2  %3, i64  %5)  
+  musttail call fastcc  void  @"bug214.#cont#2<0>"(i64  %7, i64  %8)  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"bug214.#cont#2<0>"(i64  %"pos##0", i64  %"sub##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"bug214.#cont#2<0>[7477e50a09]"(i64  %"pos##0", i64  %"sub##0")    {
+entry:
+  %0 = tail call ccc  i64  @read_line()  
+  %1 = tail call fastcc  i64  @"wybe.string.string<0>"(i64  %0)  
+  %2 = tail call fastcc  {i2, i1}  @"bug214.direction.parse_direction<0>"(i64  %1)  
+  %3 = extractvalue {i2, i1} %2, 0 
+  %4 = extractvalue {i2, i1} %2, 1 
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  %5 = tail call ccc  i64  @read_int()  
+  %6 = tail call ccc  i64  @read_line()  
+  %7 = tail call fastcc  i64  @"bug214.move<0>[410bae77d3]"(i64  %"pos##0", i2  %3, i64  %5)  
+  %8 = tail call fastcc  i64  @"bug214.move<1>[410bae77d3]"(i64  %"sub##0", i2  %3, i64  %5)  
+  musttail call fastcc  void  @"bug214.#cont#2<0>[7477e50a09]"(i64  %7, i64  %8)  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"bug214.#cont#2<0>[7477e50a09]"(i64  %"pos##0", i64  %"sub##0")  
   ret void 
 }
 
@@ -384,57 +542,6 @@ entry:
 }
 
 
-define external fastcc  void @"bug214.gen#1<0>"(i64  %"pos##0", i64  %"sub##0") alwaysinline   {
-entry:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.1, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"bug214.position.print<0>"(i64  %"pos##0")  
-  tail call ccc  void  @putchar(i8  32)  
-  %0 = inttoptr i64 %"pos##0" to i64* 
-  %1 = load  i64, i64* %0 
-  %2 = add   i64 %"pos##0", 8 
-  %3 = inttoptr i64 %2 to i64* 
-  %4 = load  i64, i64* %3 
-  %5 = mul   i64 %1, %4 
-  tail call ccc  void  @print_int(i64  %5)  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.3, i32 0, i32 0) to i64))  
-  %6 = inttoptr i64 %"sub##0" to i64* 
-  %7 = load  i64, i64* %6 
-  tail call fastcc  void  @"bug214.position.print<0>"(i64  %7)  
-  tail call ccc  void  @putchar(i8  32)  
-  %8 = inttoptr i64 %7 to i64* 
-  %9 = load  i64, i64* %8 
-  %10 = add   i64 %7, 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = load  i64, i64* %11 
-  %13 = mul   i64 %9, %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-}
-
-
-define external fastcc  void @"bug214.gen#2<0>"(i64  %"pos##0", i64  %"sub##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0")    {
-entry:
-  %0 = tail call ccc  i64  @read_line()  
-  %1 = tail call fastcc  i64  @"wybe.string.string<0>"(i64  %0)  
-  %2 = tail call fastcc  {i2, i1}  @"bug214.direction.parse_direction<0>"(i64  %1)  
-  %3 = extractvalue {i2, i1} %2, 0 
-  %4 = extractvalue {i2, i1} %2, 1 
-  br i1 %4, label %if.then, label %if.else 
-if.then:
-  %5 = tail call ccc  i64  @read_int()  
-  %6 = tail call ccc  i64  @read_line()  
-  %7 = tail call fastcc  i64  @"bug214.move<0>"(i64  %"pos##0", i2  %3, i64  %5)  
-  %8 = tail call fastcc  i64  @"bug214.move<1>"(i64  %"sub##0", i2  %3, i64  %5)  
-  musttail call fastcc  void  @"bug214.gen#2<0>"(i64  %7, i64  %8, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0")  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"bug214.gen#2<0>"(i64  %"pos##0", i64  %"sub##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0")  
-  ret void 
-}
-
-
 define external fastcc  i64 @"bug214.move<0>"(i64  %"pos##0", i2  %"dir##0", i64  %"units##0")    {
 entry:
   %0 = icmp eq i2 %"dir##0", 0 
@@ -491,6 +598,46 @@ if.then2:
   %36 = inttoptr i64 %35 to i64* 
   store  i64 %28, i64* %36 
   ret i64 %31 
+if.else2:
+  ret i64 %"pos##0" 
+}
+
+
+define external fastcc  i64 @"bug214.move<0>[410bae77d3]"(i64  %"pos##0", i2  %"dir##0", i64  %"units##0")    {
+entry:
+  %0 = icmp eq i2 %"dir##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"pos##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %2, %"units##0" 
+  %4 = inttoptr i64 %"pos##0" to i64* 
+  store  i64 %3, i64* %4 
+  ret i64 %"pos##0" 
+if.else:
+  %5 = icmp eq i2 %"dir##0", 1 
+  br i1 %5, label %if.then1, label %if.else1 
+if.then1:
+  %6 = add   i64 %"pos##0", 8 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %8, %"units##0" 
+  %10 = add   i64 %"pos##0", 8 
+  %11 = inttoptr i64 %10 to i64* 
+  store  i64 %9, i64* %11 
+  ret i64 %"pos##0" 
+if.else1:
+  %12 = icmp eq i2 %"dir##0", 2 
+  br i1 %12, label %if.then2, label %if.else2 
+if.then2:
+  %13 = add   i64 %"pos##0", 8 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = sub   i64 %15, %"units##0" 
+  %17 = add   i64 %"pos##0", 8 
+  %18 = inttoptr i64 %17 to i64* 
+  store  i64 %16, i64* %18 
+  ret i64 %"pos##0" 
 if.else2:
   ret i64 %"pos##0" 
 }
@@ -585,6 +732,79 @@ if.then2:
   %64 = inttoptr i64 %63 to i64* 
   store  i64 %56, i64* %64 
   ret i64 %59 
+if.else2:
+  ret i64 %"sub##0" 
+}
+
+
+define external fastcc  i64 @"bug214.move<1>[410bae77d3]"(i64  %"sub##0", i2  %"dir##0", i64  %"units##0")    {
+entry:
+  %0 = icmp eq i2 %"dir##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"sub##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %4, %"units##0" 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i8* 
+  %10 = inttoptr i64 %2 to i8* 
+  %11 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
+  %12 = inttoptr i64 %8 to i64* 
+  store  i64 %5, i64* %12 
+  %13 = inttoptr i64 %"sub##0" to i64* 
+  store  i64 %8, i64* %13 
+  %14 = inttoptr i64 %"sub##0" to i64* 
+  %15 = load  i64, i64* %14 
+  %16 = add   i64 %15, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = load  i64, i64* %17 
+  %19 = add   i64 %"sub##0", 8 
+  %20 = inttoptr i64 %19 to i64* 
+  %21 = load  i64, i64* %20 
+  %22 = mul   i64 %21, %"units##0" 
+  %23 = add   i64 %18, %22 
+  %24 = trunc i64 16 to i32  
+  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
+  %26 = ptrtoint i8* %25 to i64 
+  %27 = inttoptr i64 %26 to i8* 
+  %28 = inttoptr i64 %15 to i8* 
+  %29 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %27, i8*  %28, i32  %29, i1  0)  
+  %30 = add   i64 %26, 8 
+  %31 = inttoptr i64 %30 to i64* 
+  store  i64 %23, i64* %31 
+  %32 = inttoptr i64 %"sub##0" to i64* 
+  store  i64 %26, i64* %32 
+  ret i64 %"sub##0" 
+if.else:
+  %33 = icmp eq i2 %"dir##0", 1 
+  br i1 %33, label %if.then1, label %if.else1 
+if.then1:
+  %34 = add   i64 %"sub##0", 8 
+  %35 = inttoptr i64 %34 to i64* 
+  %36 = load  i64, i64* %35 
+  %37 = add   i64 %36, %"units##0" 
+  %38 = add   i64 %"sub##0", 8 
+  %39 = inttoptr i64 %38 to i64* 
+  store  i64 %37, i64* %39 
+  ret i64 %"sub##0" 
+if.else1:
+  %40 = icmp eq i2 %"dir##0", 2 
+  br i1 %40, label %if.then2, label %if.else2 
+if.then2:
+  %41 = add   i64 %"sub##0", 8 
+  %42 = inttoptr i64 %41 to i64* 
+  %43 = load  i64, i64* %42 
+  %44 = sub   i64 %43, %"units##0" 
+  %45 = add   i64 %"sub##0", 8 
+  %46 = inttoptr i64 %45 to i64* 
+  store  i64 %44, i64* %46 
+  ret i64 %"sub##0" 
 if.else2:
   ret i64 %"sub##0" 
 }
@@ -719,13 +939,16 @@ parse_direction > public (0 calls)
 parse_direction(str##0:wybe.string, ?dir##0:bug214.direction, ?#success##0:wybe.bool)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.string.=<0>("forward":wybe.string, str##0:wybe.string, ?tmp#5##0:wybe.bool) #0 @bug214:nn:nn
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, "forward":wybe.string, str##0:wybe.string, "forward":wybe.string, str##0:wybe.string, ?tmp#8##0:wybe.comparison) #6 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#8##0:wybe.comparison, 1:wybe.comparison, ?tmp#5##0:wybe.bool) @comparison:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
-        wybe.string.=<0>("down":wybe.string, str##0:wybe.string, ?tmp#4##0:wybe.bool) #2 @bug214:nn:nn
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, "down":wybe.string, str##0:wybe.string, "down":wybe.string, str##0:wybe.string, ?tmp#11##0:wybe.comparison) #7 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#11##0:wybe.comparison, 1:wybe.comparison, ?tmp#4##0:wybe.bool) @comparison:nn:nn
         case ~tmp#4##0:wybe.bool of
         0:
-            wybe.string.=<0>("up":wybe.string, ~str##0:wybe.string, ?tmp#3##0:wybe.bool) #4 @bug214:nn:nn
+            wybe.string.<=>#cont#2<0>(1:wybe.comparison, "up":wybe.string, ~str##0:wybe.string, "up":wybe.string, ~str##0:wybe.string, ?tmp#14##0:wybe.comparison) #8 @string:nn:nn
+            foreign llvm icmp_eq(~tmp#14##0:wybe.comparison, 1:wybe.comparison, ?tmp#3##0:wybe.bool) @comparison:nn:nn
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
@@ -789,7 +1012,7 @@ up(?#result##0:bug214.direction)<{}; {}>:
 @bug214.direction.4 =    constant [?? x i8] c"up\00"
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -819,30 +1042,33 @@ entry:
 
 define external fastcc  {i2, i1} @"bug214.direction.parse_direction<0>"(i64  %"str##0")    {
 entry:
-  %0 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.1, i32 0, i32 0) to i64), i64  %"str##0")  
-  br i1 %0, label %if.then, label %if.else 
+  %0 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.1, i32 0, i32 0) to i64), i64  %"str##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.1, i32 0, i32 0) to i64), i64  %"str##0")  
+  %1 = icmp eq i2 %0, 1 
+  br i1 %1, label %if.then, label %if.else 
 if.then:
-  %1 = insertvalue {i2, i1} undef, i2 0, 0 
-  %2 = insertvalue {i2, i1} %1, i1 1, 1 
-  ret {i2, i1} %2 
+  %2 = insertvalue {i2, i1} undef, i2 0, 0 
+  %3 = insertvalue {i2, i1} %2, i1 1, 1 
+  ret {i2, i1} %3 
 if.else:
-  %3 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.3, i32 0, i32 0) to i64), i64  %"str##0")  
-  br i1 %3, label %if.then1, label %if.else1 
+  %4 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.3, i32 0, i32 0) to i64), i64  %"str##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.3, i32 0, i32 0) to i64), i64  %"str##0")  
+  %5 = icmp eq i2 %4, 1 
+  br i1 %5, label %if.then1, label %if.else1 
 if.then1:
-  %4 = insertvalue {i2, i1} undef, i2 1, 0 
-  %5 = insertvalue {i2, i1} %4, i1 1, 1 
-  ret {i2, i1} %5 
+  %6 = insertvalue {i2, i1} undef, i2 1, 0 
+  %7 = insertvalue {i2, i1} %6, i1 1, 1 
+  ret {i2, i1} %7 
 if.else1:
-  %6 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.5, i32 0, i32 0) to i64), i64  %"str##0")  
-  br i1 %6, label %if.then2, label %if.else2 
+  %8 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.5, i32 0, i32 0) to i64), i64  %"str##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bug214.direction.5, i32 0, i32 0) to i64), i64  %"str##0")  
+  %9 = icmp eq i2 %8, 1 
+  br i1 %9, label %if.then2, label %if.else2 
 if.then2:
-  %7 = insertvalue {i2, i1} undef, i2 2, 0 
-  %8 = insertvalue {i2, i1} %7, i1 1, 1 
-  ret {i2, i1} %8 
+  %10 = insertvalue {i2, i1} undef, i2 2, 0 
+  %11 = insertvalue {i2, i1} %10, i1 1, 1 
+  ret {i2, i1} %11 
 if.else2:
-  %9 = insertvalue {i2, i1} undef, i2 undef, 0 
-  %10 = insertvalue {i2, i1} %9, i1 0, 1 
-  ret {i2, i1} %10 
+  %12 = insertvalue {i2, i1} undef, i2 undef, 0 
+  %13 = insertvalue {i2, i1} %12, i1 0, 1 
+  ret {i2, i1} %13 
 }
 
 

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -18,7 +18,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(8,(caret.gen#1<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(8,(caret.#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position) @position:nn:nn
     foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @position:nn:nn
@@ -34,7 +34,35 @@ module top-level code > public {semipure} (0 calls)
     foreign c print_int(~ten##0:wybe.int, ~tmp#30##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    caret.gen#1<0>[410bae77d3](~tmp#24##0:caret.region, _:caret.region, _:position.position, _:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8
+    caret.#cont#1<0>[410bae77d3](~tmp#24##0:caret.region)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8
+
+
+#cont#1 > (2 calls)
+0: caret.#cont#1<0>[410bae77d3]
+#cont#1(reg##0:caret.region)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: [InterestingUnaliased 0]
+    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign llvm add(~tmp#5##0:wybe.int, 1:wybe.int, ?tmp#5##1:wybe.int) @int:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#6##0:position.position, ?tmp#6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int) @position:nn:nn
+    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
+    wybe.string.print<0>("now ten = ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @caret:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+ [410bae77d3] [NonAliasedParam 0] :
+    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position) @caret:nn:nn
+    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
+    foreign llvm add(~tmp#5##0:wybe.int, 1:wybe.int, ?tmp#5##1:wybe.int) @int:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#6##0:position.position, ?tmp#6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int) @position:nn:nn
+    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
+    wybe.string.print<0>("now ten = ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @caret:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
 expand_region > public (0 calls)
@@ -63,34 +91,6 @@ expand_region(reg##0:caret.region, ?reg##4:caret.region, point##0:position.posit
     foreign lpvm {noalias} mutate(~tmp#10##1:position.position, ?tmp#15##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#16##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~reg##3:caret.region, ?reg##4:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#15##1:position.position) @caret:nn:nn
 
-
-gen#1 > (2 calls)
-0: caret.gen#1<0>[410bae77d3]
-gen#1(reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##0:position.position], [tmp#2##0:position.position])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position) @caret:nn:nn
-    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
-    foreign llvm add(~tmp#5##0:wybe.int, 1:wybe.int, ?tmp#5##1:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~tmp#6##0:position.position, ?tmp#6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int) @position:nn:nn
-    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
-    wybe.string.print<0>("now ten = ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @caret:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
- [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position) @caret:nn:nn
-    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int) @position:nn:nn
-    foreign llvm add(~tmp#5##0:wybe.int, 1:wybe.int, ?tmp#5##1:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~tmp#6##0:position.position, ?tmp#6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int) @position:nn:nn
-    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int) @position:nn:nn
-    wybe.string.print<0>("now ten = ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @caret:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
   LLVM code       :
 
 ; ModuleID = 'caret'
@@ -111,6 +111,12 @@ gen#1(reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##0:position.position]
 @caret.0 =    constant [?? x i8] c"ten = \00"
 
 
+declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)    
+
+
+declare external fastcc  i64 @"wybe.int.min<0>"(i64, i64)    
+
+
 declare external ccc  void @putchar(i8)    
 
 
@@ -118,12 +124,6 @@ declare external ccc  void @print_int(i64)
 
 
 declare external fastcc  void @"wybe.string.print<0>"(i64)    
-
-
-declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)    
-
-
-declare external fastcc  i64 @"wybe.int.min<0>"(i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -163,7 +163,52 @@ entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %19)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"caret.gen#1<0>[410bae77d3]"(i64  %14)  
+  tail call fastcc  void  @"caret.#cont#1<0>[410bae77d3]"(i64  %14)  
+  ret void 
+}
+
+
+define external fastcc  void @"caret.#cont#1<0>"(i64  %"reg##0")    {
+entry:
+  %0 = add   i64 %"reg##0", 8 
+  %1 = inttoptr i64 %0 to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %4, 1 
+  %6 = trunc i64 16 to i32  
+  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
+  %8 = ptrtoint i8* %7 to i64 
+  %9 = inttoptr i64 %8 to i8* 
+  %10 = inttoptr i64 %2 to i8* 
+  %11 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
+  %12 = inttoptr i64 %8 to i64* 
+  store  i64 %5, i64* %12 
+  %13 = inttoptr i64 %8 to i64* 
+  %14 = load  i64, i64* %13 
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.3, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %14)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"caret.#cont#1<0>[410bae77d3]"(i64  %"reg##0")    {
+entry:
+  %0 = add   i64 %"reg##0", 8 
+  %1 = inttoptr i64 %0 to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  %5 = add   i64 %4, 1 
+  %6 = inttoptr i64 %2 to i64* 
+  store  i64 %5, i64* %6 
+  %7 = inttoptr i64 %2 to i64* 
+  %8 = load  i64, i64* %7 
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.3, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %8)  
+  tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
@@ -271,51 +316,6 @@ entry:
   %83 = inttoptr i64 %82 to i64* 
   store  i64 %70, i64* %83 
   ret i64 %78 
-}
-
-
-define external fastcc  void @"caret.gen#1<0>"(i64  %"reg##0")    {
-entry:
-  %0 = add   i64 %"reg##0", 8 
-  %1 = inttoptr i64 %0 to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = inttoptr i64 %2 to i64* 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %4, 1 
-  %6 = trunc i64 16 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i8* 
-  %10 = inttoptr i64 %2 to i8* 
-  %11 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %9, i8*  %10, i32  %11, i1  0)  
-  %12 = inttoptr i64 %8 to i64* 
-  store  i64 %5, i64* %12 
-  %13 = inttoptr i64 %8 to i64* 
-  %14 = load  i64, i64* %13 
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %14)  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-}
-
-
-define external fastcc  void @"caret.gen#1<0>[410bae77d3]"(i64  %"reg##0")    {
-entry:
-  %0 = add   i64 %"reg##0", 8 
-  %1 = inttoptr i64 %0 to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = inttoptr i64 %2 to i64* 
-  %4 = load  i64, i64* %3 
-  %5 = add   i64 %4, 1 
-  %6 = inttoptr i64 %2 to i64* 
-  store  i64 %5, i64* %6 
-  %7 = inttoptr i64 %2 to i64* 
-  %8 = load  i64, i64* %7 
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %8)  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
 }
 --------------------------------------------------
  Module caret.region

--- a/test-cases/final-dump/char-escape.exp
+++ b/test-cases/final-dump/char-escape.exp
@@ -31,7 +31,8 @@ test > (10 calls)
 0: char-escape.test<0>
 test(ch##0:wybe.char, code##0:wybe.int, name##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
-  InterestingCallProperties: []
+  InterestingCallProperties: [InterestingUnaliased 2]
+  MultiSpeczDepInfo: [(2,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 [2]])),(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 [2]]))]
     foreign lpvm cast(~ch##0:wybe.char, ?tmp#0##0:wybe.int) @char:nn:nn
     foreign llvm icmp_eq(~code##0:wybe.int, ~tmp#0##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of

--- a/test-cases/final-dump/det_for.exp
+++ b/test-cases/final-dump/det_for.exp
@@ -14,7 +14,20 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    det_for.gen#1<0>(0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @det_for:nn:nn
+    det_for.#cont#1<0>(0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @det_for:nn:nn
+
+
+#cont#1 > (2 calls)
+0: det_for.#cont#1<0>
+#cont#1(tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm add(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#0##1:wybe.int) @int:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    det_for.#cont#1<0>(~tmp#0##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @det_for:nn:nn
 
 
 [|] > {inline} (1 calls)
@@ -24,19 +37,6 @@ module top-level code > public {inline,semipure} (0 calls)
   InterestingCallProperties: []
     foreign llvm move(current##0:wybe.int, ?value##0:wybe.int) @det_for:nn:nn
     foreign llvm add(~current##0:wybe.int, 1:wybe.int, ?next##0:wybe.int) @int:nn:nn
-
-
-gen#1 > (2 calls)
-0: det_for.gen#1<0>
-gen#1(tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm add(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#0##1:wybe.int) @int:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    det_for.gen#1<0>(~tmp#0##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @det_for:nn:nn
 
   LLVM code       :
 
@@ -60,7 +60,17 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"det_for.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"det_for.gen#1<0>"(i64  0)  
+  tail call fastcc  void  @"det_for.#cont#1<0>"(i64  0)  
+  ret void 
+}
+
+
+define external fastcc  void @"det_for.#cont#1<0>"(i64  %"tmp#0##0")    {
+entry:
+  %0 = add   i64 %"tmp#0##0", 1 
+  tail call ccc  void  @print_int(i64  %"tmp#0##0")  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"det_for.#cont#1<0>"(i64  %0)  
   ret void 
 }
 
@@ -71,14 +81,4 @@ entry:
   %1 = insertvalue {i64, i64} undef, i64 %"current##0", 0 
   %2 = insertvalue {i64, i64} %1, i64 %0, 1 
   ret {i64, i64} %2 
-}
-
-
-define external fastcc  void @"det_for.gen#1<0>"(i64  %"tmp#0##0")    {
-entry:
-  %0 = add   i64 %"tmp#0##0", 1 
-  tail call ccc  void  @print_int(i64  %"tmp#0##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"det_for.gen#1<0>"(i64  %0)  
-  ret void 
 }

--- a/test-cases/final-dump/disjunctive-cond.exp
+++ b/test-cases/final-dump/disjunctive-cond.exp
@@ -18,12 +18,12 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    disjunctive-cond.gen#1<0>(1:wybe.bool, 0:wybe.bool, _:wybe.bool, _:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9
+    disjunctive-cond.#cont#1<0>(1:wybe.bool, 0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9
 
 
-gen#1 > (5 calls)
-0: disjunctive-cond.gen#1<0>
-gen#1(a##0:wybe.bool, b##0:wybe.bool, [tmp#0##0:wybe.bool], [tmp#1##0:wybe.bool])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (5 calls)
+0: disjunctive-cond.#cont#1<0>
+#cont#1(a##0:wybe.bool, b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     case ~a##0:wybe.bool of
@@ -34,14 +34,14 @@ gen#1(a##0:wybe.bool, b##0:wybe.bool, [tmp#0##0:wybe.bool], [tmp#1##0:wybe.bool]
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
             foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            disjunctive-cond.gen#2<0>(0:wybe.bool, 0:wybe.bool, _:wybe.bool, _:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
+            disjunctive-cond.#cont#2<0>(0:wybe.bool, 0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
 
         1:
             wybe.string.print<0>("also good":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @string:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
             foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            disjunctive-cond.gen#2<0>(0:wybe.bool, 1:wybe.bool, _:wybe.bool, _:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+            disjunctive-cond.#cont#2<0>(0:wybe.bool, 1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
 
 
     1:
@@ -49,13 +49,13 @@ gen#1(a##0:wybe.bool, b##0:wybe.bool, [tmp#0##0:wybe.bool], [tmp#1##0:wybe.bool]
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        disjunctive-cond.gen#2<0>(1:wybe.bool, ~b##0:wybe.bool, _:wybe.bool, _:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1
+        disjunctive-cond.#cont#2<0>(1:wybe.bool, ~b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1
 
 
 
-gen#2 > (3 calls)
-0: disjunctive-cond.gen#2<0>
-gen#2(a##0:wybe.bool, b##0:wybe.bool, [tmp#0##0:wybe.bool], [tmp#1##0:wybe.bool])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#2 > (3 calls)
+0: disjunctive-cond.#cont#2<0>
+#cont#2(a##0:wybe.bool, b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     case ~a##0:wybe.bool of
@@ -63,10 +63,10 @@ gen#2(a##0:wybe.bool, b##0:wybe.bool, [tmp#0##0:wybe.bool], [tmp#1##0:wybe.bool]
         foreign llvm xor(b##0:wybe.bool, 1:wybe.bool, ?tmp#2##0:wybe.bool) @bool:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            disjunctive-cond.gen#3<0>(0:wybe.bool, ~b##0:wybe.bool, _:wybe.bool, _:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11
+            disjunctive-cond.#cont#3<0>(0:wybe.bool, ~b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #11
 
         1:
-            disjunctive-cond.gen#3<0>(0:wybe.bool, ~b##0:wybe.bool, _:wybe.bool, _:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
+            disjunctive-cond.#cont#3<0>(0:wybe.bool, ~b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10
 
 
     1:
@@ -76,21 +76,21 @@ gen#2(a##0:wybe.bool, b##0:wybe.bool, [tmp#0##0:wybe.bool], [tmp#1##0:wybe.bool]
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
             foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            disjunctive-cond.gen#3<0>(1:wybe.bool, 0:wybe.bool, _:wybe.bool, _:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4
+            disjunctive-cond.#cont#3<0>(1:wybe.bool, 0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4
 
         1:
             wybe.string.print<0>("no good":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #13 @string:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
             foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            disjunctive-cond.gen#3<0>(1:wybe.bool, 1:wybe.bool, _:wybe.bool, _:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1
+            disjunctive-cond.#cont#3<0>(1:wybe.bool, 1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1
 
 
 
 
-gen#3 > (7 calls)
-0: disjunctive-cond.gen#3<0>
-gen#3(a##0:wybe.bool, b##0:wybe.bool, [tmp#0##0:wybe.bool], [tmp#1##0:wybe.bool])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#3 > (7 calls)
+0: disjunctive-cond.#cont#3<0>
+#cont#3(a##0:wybe.bool, b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     case ~a##0:wybe.bool of
@@ -170,35 +170,35 @@ define external fastcc  void @"disjunctive-cond.<0>"()    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"disjunctive-cond.gen#1<0>"(i1  1, i1  0)  
+  tail call fastcc  void  @"disjunctive-cond.#cont#1<0>"(i1  1, i1  0)  
   ret void 
 }
 
 
-define external fastcc  void @"disjunctive-cond.gen#1<0>"(i1  %"a##0", i1  %"b##0")    {
+define external fastcc  void @"disjunctive-cond.#cont#1<0>"(i1  %"a##0", i1  %"b##0")    {
 entry:
   br i1 %"a##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"disjunctive-cond.gen#2<0>"(i1  1, i1  %"b##0")  
+  musttail call fastcc  void  @"disjunctive-cond.#cont#2<0>"(i1  1, i1  %"b##0")  
   ret void 
 if.else:
   br i1 %"b##0", label %if.then1, label %if.else1 
 if.then1:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"disjunctive-cond.gen#2<0>"(i1  0, i1  1)  
+  musttail call fastcc  void  @"disjunctive-cond.#cont#2<0>"(i1  0, i1  1)  
   ret void 
 if.else1:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"disjunctive-cond.gen#2<0>"(i1  0, i1  0)  
+  musttail call fastcc  void  @"disjunctive-cond.#cont#2<0>"(i1  0, i1  0)  
   ret void 
 }
 
 
-define external fastcc  void @"disjunctive-cond.gen#2<0>"(i1  %"a##0", i1  %"b##0")    {
+define external fastcc  void @"disjunctive-cond.#cont#2<0>"(i1  %"a##0", i1  %"b##0")    {
 entry:
   br i1 %"a##0", label %if.then, label %if.else 
 if.then:
@@ -209,23 +209,23 @@ if.else:
 if.then1:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"disjunctive-cond.gen#3<0>"(i1  1, i1  1)  
+  musttail call fastcc  void  @"disjunctive-cond.#cont#3<0>"(i1  1, i1  1)  
   ret void 
 if.else1:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @disjunctive-cond.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"disjunctive-cond.gen#3<0>"(i1  1, i1  0)  
+  musttail call fastcc  void  @"disjunctive-cond.#cont#3<0>"(i1  1, i1  0)  
   ret void 
 if.then2:
-  musttail call fastcc  void  @"disjunctive-cond.gen#3<0>"(i1  0, i1  %"b##0")  
+  musttail call fastcc  void  @"disjunctive-cond.#cont#3<0>"(i1  0, i1  %"b##0")  
   ret void 
 if.else2:
-  musttail call fastcc  void  @"disjunctive-cond.gen#3<0>"(i1  0, i1  %"b##0")  
+  musttail call fastcc  void  @"disjunctive-cond.#cont#3<0>"(i1  0, i1  %"b##0")  
   ret void 
 }
 
 
-define external fastcc  void @"disjunctive-cond.gen#3<0>"(i1  %"a##0", i1  %"b##0")    {
+define external fastcc  void @"disjunctive-cond.#cont#3<0>"(i1  %"a##0", i1  %"b##0")    {
 entry:
   br i1 %"a##0", label %if.then, label %if.else 
 if.then:

--- a/test-cases/final-dump/higher_order_append.exp
+++ b/test-cases/final-dump/higher_order_append.exp
@@ -38,15 +38,37 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm alloc(16:wybe.int, ?tmp#45##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#45##0:wybe.list(T), ?tmp#46##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
     foreign lpvm mutate(~tmp#46##0:wybe.list(T), ?tmp#10##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.list(T)) @list:nn:nn
-    wybe.list.map<1>(higher_order_append.gen#1<1><tmp#10##0:wybe.list(wybe.int)>:(wybe.list(wybe.int), ?wybe.list(wybe.int)), tmp#0##0:wybe.list(wybe.list(wybe.int)), outByReference y##0:wybe.list(wybe.list(wybe.int))) #13 @higher_order_append:nn:nn
-    wybe.list.print<0>(higher_order_append.gen#2<0><>:{resource}(T), ~tmp#0##0:wybe.list(T))<Everything; Everything> #16 @list:nn:nn
+    wybe.list.map<1>(higher_order_append.#anon#1<1><tmp#10##0:wybe.list(wybe.int)>:(wybe.list(wybe.int), ?wybe.list(wybe.int)), tmp#0##0:wybe.list(wybe.list(wybe.int)), outByReference y##0:wybe.list(wybe.list(wybe.int))) #13 @higher_order_append:nn:nn
+    wybe.list.print<0>(higher_order_append.#closure#1<0><>:{resource}(T), ~tmp#0##0:wybe.list(T))<Everything; Everything> #16 @list:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#49##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#49##0:wybe.phantom, ?tmp#50##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#50##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    wybe.list.print<0>(higher_order_append.gen#2<0><>:{resource}(T), ~y##0:wybe.list(T))<Everything; Everything> #17 @list:nn:nn
+    wybe.list.print<0>(higher_order_append.#closure#1<0><>:{resource}(T), ~y##0:wybe.list(T))<Everything; Everything> #17 @list:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#54##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+
+#anon#1 > {inline} (1 calls)
+0: higher_order_append.#anon#1<0>
+#anon#1(^cons##0:wybe.list(wybe.int), anon#1#1##0:wybe.list(wybe.int), ?anon#1#2##0:wybe.list(wybe.int))<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    higher_order_append.append<0>(~anon#1#1##0:wybe.list(wybe.int), ~cons##0:wybe.list(wybe.int), outByReference anon#1#2##0:wybe.list(wybe.int)) #0 @higher_order_append:nn:nn
+#anon#1 > {inline} (1 calls)
+1: higher_order_append.#anon#1<1>
+#anon#1(^cons##0:wybe.list(wybe.int), anon#1#1##0:wybe.list(wybe.int), ?anon#1#2##0:wybe.list(wybe.int))<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    higher_order_append.append<0>(~anon#1#1##0:wybe.list(wybe.int), ~^cons##0:wybe.list(wybe.int), outByReference anon#1#2##0:wybe.list(wybe.int)) #1 @higher_order_append:nn:nn
+
+
+#closure#1 > {inline} (2 calls)
+0: higher_order_append.#closure#1<0>
+#closure#1(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.list.print<0>(higher_order_append.print_list_of_ints#closure#1<0><>:{resource}(wybe.int), ~l##0:wybe.list(wybe.int))<Everything; Everything> #1 @higher_order_append:nn:nn
 
 
 append > (2 calls)
@@ -70,44 +92,22 @@ append(front##0:wybe.list(wybe.int), back##0:wybe.list(wybe.int), outByReference
 
 
 
-gen#1 > {inline} (1 calls)
-0: higher_order_append.gen#1<0>
-gen#1(^cons##0:wybe.list(wybe.int), anon#1#1##0:wybe.list(wybe.int), ?anon#1#2##0:wybe.list(wybe.int))<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    higher_order_append.append<0>(~anon#1#1##0:wybe.list(wybe.int), ~cons##0:wybe.list(wybe.int), outByReference anon#1#2##0:wybe.list(wybe.int)) #0 @higher_order_append:nn:nn
-gen#1 > {inline} (1 calls)
-1: higher_order_append.gen#1<1>
-gen#1(^cons##0:wybe.list(wybe.int), anon#1#1##0:wybe.list(wybe.int), ?anon#1#2##0:wybe.list(wybe.int))<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    higher_order_append.append<0>(~anon#1#1##0:wybe.list(wybe.int), ~^cons##0:wybe.list(wybe.int), outByReference anon#1#2##0:wybe.list(wybe.int)) #1 @higher_order_append:nn:nn
-
-
-gen#2 > {inline} (2 calls)
-0: higher_order_append.gen#2<0>
-gen#2(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    wybe.list.print<0>(higher_order_append.gen#4<0><>:{resource}(wybe.int), ~l##0:wybe.list(wybe.int))<Everything; Everything> #1 @higher_order_append:nn:nn
-
-
-gen#4 > {inline} (1 calls)
-0: higher_order_append.gen#4<0>
-gen#4(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~x##0:wybe.int, ~tmp#1##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @int:nn:nn
-    foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-
-
 print_list_of_ints > {inline} (1 calls)
 0: higher_order_append.print_list_of_ints<0>
 print_list_of_ints(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.list.print<0>(higher_order_append.gen#4<0><>:{resource}(wybe.int), ~l##0:wybe.list(wybe.int))<Everything; Everything> #0 @higher_order_append:nn:nn
+    wybe.list.print<0>(higher_order_append.print_list_of_ints#closure#1<0><>:{resource}(wybe.int), ~l##0:wybe.list(wybe.int))<Everything; Everything> #0 @higher_order_append:nn:nn
+
+
+print_list_of_ints#closure#1 > {inline} (1 calls)
+0: higher_order_append.print_list_of_ints#closure#1<0>
+print_list_of_ints#closure#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~tmp#1##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @int:nn:nn
+    foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
   LLVM code       :
 
@@ -117,16 +117,16 @@ print_list_of_ints(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>
  
 
 
-@higher_order_append.0 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_append.gen#2<0>" to i64)]
+@higher_order_append.0 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_append.#closure#1<0>" to i64)]
 
 
-@higher_order_append.1 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_append.gen#4<0>" to i64)]
-
-
-declare external fastcc  void @"wybe.list.print<0>"(i64, i64)    
+@higher_order_append.1 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_append.print_list_of_ints#closure#1<0>" to i64)]
 
 
 declare external ccc  void @print_int(i64)    
+
+
+declare external fastcc  void @"wybe.list.print<0>"(i64, i64)    
 
 
 declare external ccc  void @putchar(i8)    
@@ -212,7 +212,7 @@ entry:
   %50 = ptrtoint i8* %49 to i64 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 ptrtoint (i64 (i64, i64)* @"higher_order_append.gen#1<1>" to i64), i64* %52 
+  store  i64 ptrtoint (i64 (i64, i64)* @"higher_order_append.#anon#1<1>" to i64), i64* %52 
   %53 = getelementptr  i64, i64* %51, i64 1 
   store  i64 %44, i64* %53 
   %54 = alloca i64 
@@ -222,6 +222,34 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.0, i32 0, i32 0) to i64), i64  %55)  
   tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  i64 @"higher_order_append.#anon#1<0>"(i64  %"cons##0", i64  %"anon#1#1##0") alwaysinline   {
+entry:
+  %0 = alloca i64 
+   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %"cons##0", i64*  %0)  
+  %1 = load  i64, i64* %0 
+  ret i64 %1 
+}
+
+
+define external fastcc  i64 @"higher_order_append.#anon#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
+entry:
+  %0 = add   i64 %"#env##0", 8 
+  %1 = inttoptr i64 %0 to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = alloca i64 
+   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %2, i64*  %3)  
+  %4 = load  i64, i64* %3 
+  ret i64 %4 
+}
+
+
+define external fastcc  void @"higher_order_append.#closure#1<0>"(i64  %"#env##0", i64  %"l##0") alwaysinline   {
+entry:
+  musttail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")  
   ret void 
 }
 
@@ -252,43 +280,15 @@ if.else:
 }
 
 
-define external fastcc  i64 @"higher_order_append.gen#1<0>"(i64  %"cons##0", i64  %"anon#1#1##0") alwaysinline   {
-entry:
-  %0 = alloca i64 
-   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %"cons##0", i64*  %0)  
-  %1 = load  i64, i64* %0 
-  ret i64 %1 
-}
-
-
-define external fastcc  i64 @"higher_order_append.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
-entry:
-  %0 = add   i64 %"#env##0", 8 
-  %1 = inttoptr i64 %0 to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = alloca i64 
-   call fastcc  void  @"higher_order_append.append<0>"(i64  %"anon#1#1##0", i64  %2, i64*  %3)  
-  %4 = load  i64, i64* %3 
-  ret i64 %4 
-}
-
-
-define external fastcc  void @"higher_order_append.gen#2<0>"(i64  %"#env##0", i64  %"l##0") alwaysinline   {
-entry:
-  musttail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"higher_order_append.gen#4<0>"(i64  %"#env##0", i64  %"x##0") alwaysinline   {
-entry:
-  tail call ccc  void  @print_int(i64  %"x##0")  
-  ret void 
-}
-
-
 define external fastcc  void @"higher_order_append.print_list_of_ints<0>"(i64  %"l##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.list.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_append.1, i32 0, i32 0) to i64), i64  %"l##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"higher_order_append.print_list_of_ints#closure#1<0>"(i64  %"#env##0", i64  %"x##0") alwaysinline   {
+entry:
+  tail call ccc  void  @print_int(i64  %"x##0")  
   ret void 
 }

--- a/test-cases/final-dump/higher_order_impure.exp
+++ b/test-cases/final-dump/higher_order_impure.exp
@@ -15,21 +15,21 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_impure.gen#1<0>(_:wybe.list(wybe.int)) #0 @higher_order_impure:nn:nn
+    higher_order_impure.#anon#1<0>(_:wybe.list(wybe.int)) #0 @higher_order_impure:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @float:nn:nn
     foreign c print_float(3.0:wybe.float, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @float:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-gen#1 > {inline,impure} (1 calls)
-0: higher_order_impure.gen#1<0>
-gen#1([^l2##0:wybe.list(wybe.int)])<{}; {}>:
+#anon#1 > {inline,impure} (1 calls)
+0: higher_order_impure.#anon#1<0>
+#anon#1([^l2##0:wybe.list(wybe.int)])<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-gen#1 > {inline,impure} (1 calls)
-1: higher_order_impure.gen#1<1>
-gen#1([^l2##0:wybe.list(wybe.int)])<{}; {}>:
+#anon#1 > {inline,impure} (1 calls)
+1: higher_order_impure.#anon#1<1>
+#anon#1([^l2##0:wybe.list(wybe.int)])<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
@@ -64,20 +64,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"higher_order_impure.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"higher_order_impure.gen#1<0>"()  
+  tail call fastcc  void  @"higher_order_impure.#anon#1<0>"()  
   tail call ccc  void  @print_float(double  3.000000e0)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"higher_order_impure.gen#1<0>"() alwaysinline   {
+define external fastcc  void @"higher_order_impure.#anon#1<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"higher_order_impure.gen#1<1>"(i64  %"#env##0") alwaysinline   {
+define external fastcc  void @"higher_order_impure.#anon#1<1>"(i64  %"#env##0") alwaysinline   {
 entry:
   ret void 
 }

--- a/test-cases/final-dump/higher_order_inline.exp
+++ b/test-cases/final-dump/higher_order_inline.exp
@@ -20,9 +20,9 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-gen#1 > {inline} (1 calls)
-0: higher_order_inline.gen#1<0>
-gen#1(a##0:A, ?#result##0:A)<{}; {}>:
+#closure#1 > {inline} (1 calls)
+0: higher_order_inline.#closure#1<0>
+#closure#1(a##0:A, ?#result##0:A)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~a##0:A, ?#result##0:A) @predicate:nn:nn
@@ -55,7 +55,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"higher_order_inline.gen#1<0>"(i64  %"#env##0", i64  %"a##0") alwaysinline   {
+define external fastcc  i64 @"higher_order_inline.#closure#1<0>"(i64  %"#env##0", i64  %"a##0") alwaysinline   {
 entry:
   ret i64 %"a##0" 
 }

--- a/test-cases/final-dump/higher_order_loop.exp
+++ b/test-cases/final-dump/higher_order_loop.exp
@@ -15,17 +15,17 @@ module top-level code > public {semipure} (0 calls)
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.list(T)) @list:nn:nn
-    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#10##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, higher_order_loop.gen#2<0><>:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#10##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, higher_order_loop.#closure#2<0><>:T) @list:nn:nn
     foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#2##0:wybe.list({resource}(wybe.int)), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#13##0:wybe.list(T)) @list:nn:nn
-    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#14##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, higher_order_loop.gen#1<0><>:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#0##0:wybe.list({resource}(wybe.int)), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
-    higher_order_loop.gen#3<0>(~tmp#0##0:wybe.list({resource}(wybe.int)), ~tmp#0##0:wybe.list({resource}(wybe.int)), higher_order_loop.gen#1<0><>:{resource}(wybe.int), ~tmp#2##0:wybe.list({resource}(wybe.int)), higher_order_loop.gen#2<0><>:{resource}(wybe.int), 0:wybe.list({resource}(wybe.int)), ~tmp#0##0:wybe.list({resource}(wybe.int)))<Everything; Everything> #3 @higher_order_loop:nn:nn
+    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#14##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, higher_order_loop.#closure#1<0><>:T) @list:nn:nn
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#0##0:wybe.list({resource}(wybe.int)), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
+    higher_order_loop.#cont#1<0>(~tmp#0##0:wybe.list({resource}(wybe.int)))<Everything; Everything> #3 @higher_order_loop:nn:nn
 
 
-gen#1 > {inline} (1 calls)
-0: higher_order_loop.gen#1<0>
-gen#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#closure#1 > {inline} (1 calls)
+0: higher_order_loop.#closure#1<0>
+#closure#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @int:nn:nn
@@ -34,9 +34,9 @@ gen#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-gen#2 > {inline} (1 calls)
-0: higher_order_loop.gen#2<0>
-gen#2(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#closure#2 > {inline} (1 calls)
+0: higher_order_loop.#closure#2<0>
+#closure#2(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @int:nn:nn
@@ -44,9 +44,9 @@ gen#2(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-gen#3 > (2 calls)
-0: higher_order_loop.gen#3<0>
-gen#3(fs##0:wybe.list({resource}(wybe.int)), tmp#0##0:wybe.list({resource}(wybe.int)), tmp#1##0:{resource}(wybe.int), tmp#2##0:wybe.list({resource}(wybe.int)), tmp#3##0:{resource}(wybe.int), tmp#4##0:wybe.list({resource}(wybe.int)), tmp#5##0:wybe.list({resource}(wybe.int)))<Everything; Everything>:
+#cont#1 > (2 calls)
+0: higher_order_loop.#cont#1<0>
+#cont#1(tmp#5##0:wybe.list({resource}(wybe.int)))<Everything; Everything>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
@@ -57,7 +57,7 @@ gen#3(fs##0:wybe.list({resource}(wybe.int)), tmp#0##0:wybe.list({resource}(wybe.
         foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?f##0:{resource}(wybe.int)) @list:nn:nn
         foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list({resource}(wybe.int))) @list:nn:nn
         ~f##0:{resource}(wybe.int)(10:wybe.int) #1 @higher_order_loop:nn:nn
-        higher_order_loop.gen#3<0>(~fs##0:wybe.list({resource}(wybe.int)), ~tmp#0##0:wybe.list({resource}(wybe.int)), ~tmp#1##0:{resource}(wybe.int), ~tmp#2##0:wybe.list({resource}(wybe.int)), ~tmp#3##0:{resource}(wybe.int), ~tmp#4##0:wybe.list({resource}(wybe.int)), ~tmp#5##1:wybe.list({resource}(wybe.int)))<Everything; Everything> #2 @higher_order_loop:nn:nn
+        higher_order_loop.#cont#1<0>(~tmp#5##1:wybe.list({resource}(wybe.int)))<Everything; Everything> #2 @higher_order_loop:nn:nn
 
 
   LLVM code       :
@@ -68,10 +68,10 @@ gen#3(fs##0:wybe.list({resource}(wybe.int)), tmp#0##0:wybe.list({resource}(wybe.
  
 
 
-@higher_order_loop.1 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_loop.gen#1<0>" to i64)]
+@higher_order_loop.1 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_loop.#closure#1<0>" to i64)]
 
 
-@higher_order_loop.0 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_loop.gen#2<0>" to i64)]
+@higher_order_loop.0 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_loop.#closure#2<0>" to i64)]
 
 
 declare external ccc  void @print_int(i64)    
@@ -104,12 +104,12 @@ entry:
   %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
   store  i64 %2, i64* %11 
-  tail call fastcc  void  @"higher_order_loop.gen#3<0>"(i64  %8, i64  %8, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_loop.1, i32 0, i32 0) to i64), i64  %2, i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_loop.0, i32 0, i32 0) to i64), i64  0, i64  %8)  
+  tail call fastcc  void  @"higher_order_loop.#cont#1<0>"(i64  %8)  
   ret void 
 }
 
 
-define external fastcc  void @"higher_order_loop.gen#1<0>"(i64  %"#env##0", i64  %"x##0") alwaysinline   {
+define external fastcc  void @"higher_order_loop.#closure#1<0>"(i64  %"#env##0", i64  %"x##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -117,14 +117,14 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_loop.gen#2<0>"(i64  %"#env##0", i64  %"x##0") alwaysinline   {
+define external fastcc  void @"higher_order_loop.#closure#2<0>"(i64  %"#env##0", i64  %"x##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"higher_order_loop.gen#3<0>"(i64  %"fs##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0")    {
+define external fastcc  void @"higher_order_loop.#cont#1<0>"(i64  %"tmp#5##0")    {
 entry:
   %0 = icmp ne i64 %"tmp#5##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -138,7 +138,7 @@ if.then:
   %7 = load  i64, i64* %6 
   %8 = inttoptr i64 %7 to void (i64, i64)* 
   tail call fastcc  void  %8(i64  %2, i64  10)  
-  musttail call fastcc  void  @"higher_order_loop.gen#3<0>"(i64  %"fs##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5)  
+  musttail call fastcc  void  @"higher_order_loop.#cont#1<0>"(i64  %5)  
   ret void 
 if.else:
   ret void 

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -14,26 +14,92 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_refs.app<0>(higher_order_refs.gen#1<1><>:(wybe.float, ?wybe.float), 1.0:wybe.float, ?tmp#0##0:wybe.float) #0 @higher_order_refs:nn:nn
+    higher_order_refs.app<0>(higher_order_refs.#anon#1<1><>:(wybe.float, ?wybe.float), 1.0:wybe.float, ?tmp#0##0:wybe.float) #0 @higher_order_refs:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @float:nn:nn
     foreign c print_float(~tmp#0##0:wybe.float, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @float:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-    higher_order_refs.app<0>(higher_order_refs.gen#2<1><>:(wybe.float, ?wybe.float), 1.0:wybe.float, ?tmp#1##0:wybe.float) #2 @higher_order_refs:nn:nn
+    higher_order_refs.app<0>(higher_order_refs.#anon#2<1><>:(wybe.float, ?wybe.float), 1.0:wybe.float, ?tmp#1##0:wybe.float) #2 @higher_order_refs:nn:nn
     foreign c print_float(~tmp#1##0:wybe.float, ~tmp#13##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @float:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
-    higher_order_refs.app<0>(higher_order_refs.gen#3<1><0.5:wybe.float>:(wybe.float, ?wybe.float), 1.0:wybe.float, ?tmp#3##0:wybe.float) #4 @higher_order_refs:nn:nn
+    higher_order_refs.app<0>(higher_order_refs.#anon#3<1><0.5:wybe.float>:(wybe.float, ?wybe.float), 1.0:wybe.float, ?tmp#3##0:wybe.float) #4 @higher_order_refs:nn:nn
     foreign c print_float(~tmp#3##0:wybe.float, ~tmp#17##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @float:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
-    higher_order_refs.app<0>(higher_order_refs.gen#4<0><>:(wybe.float, ?wybe.float), 1.0:wybe.float, ?tmp#5##0:wybe.float) #6 @higher_order_refs:nn:nn
+    higher_order_refs.app<0>(higher_order_refs.#closure#1<0><>:(wybe.float, ?wybe.float), 1.0:wybe.float, ?tmp#5##0:wybe.float) #6 @higher_order_refs:nn:nn
     foreign c print_float(~tmp#5##0:wybe.float, ~tmp#21##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @float:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
-    higher_order_refs.app<0>(higher_order_refs.gen#5<0><>:(wybe.int, ?wybe.int), 1:wybe.int, ?tmp#6##0:wybe.int) #8 @higher_order_refs:nn:nn
+    higher_order_refs.app<0>(higher_order_refs.#closure#2<0><>:(wybe.int, ?wybe.int), 1:wybe.int, ?tmp#6##0:wybe.int) #8 @higher_order_refs:nn:nn
     foreign c print_int(~tmp#6##0:wybe.int, ~tmp#25##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
-    higher_order_refs.app<0>(higher_order_refs.gen#6<0><_:wybe.int>:(wybe.int, ?wybe.int), 1:wybe.int, ?tmp#8##0:wybe.int) #10 @higher_order_refs:nn:nn
+    higher_order_refs.app<0>(higher_order_refs.#closure#3<0><_:wybe.int>:(wybe.int, ?wybe.int), 1:wybe.int, ?tmp#8##0:wybe.int) #10 @higher_order_refs:nn:nn
     foreign c print_int(~tmp#8##0:wybe.int, ~tmp#29##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#32##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#33##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+
+#anon#1 > {inline} (1 calls)
+0: higher_order_refs.#anon#1<0>
+#anon#1(anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(~anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float) @higher_order_refs:nn:nn
+#anon#1 > {inline} (1 calls)
+1: higher_order_refs.#anon#1<1>
+#anon#1(anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(~anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float) @higher_order_refs:nn:nn
+
+
+#anon#2 > {inline} (1 calls)
+0: higher_order_refs.#anon#2<0>
+#anon#2(anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(~anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float) @higher_order_refs:nn:nn
+#anon#2 > {inline} (1 calls)
+1: higher_order_refs.#anon#2<1>
+#anon#2(anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(~anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float) @higher_order_refs:nn:nn
+
+
+#anon#3 > {inline} (1 calls)
+0: higher_order_refs.#anon#3<0>
+#anon#3(^y##0:wybe.float, anon#3#1##0:wybe.float, ?anon#3#2##0:wybe.float)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm fsub(~anon#3#1##0:wybe.float, ~y##0:wybe.float, ?anon#3#2##0:wybe.float) @float:nn:nn
+#anon#3 > {inline} (1 calls)
+1: higher_order_refs.#anon#3<1>
+#anon#3(^y##0:wybe.float, anon#3#1##0:wybe.float, ?anon#3#2##0:wybe.float)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm fsub(~anon#3#1##0:wybe.float, ~^y##0:wybe.float, ?anon#3#2##0:wybe.float) @float:nn:nn
+
+
+#closure#1 > {inline} (1 calls)
+0: higher_order_refs.#closure#1<0>
+#closure#1(a##0:A, ?#result##0:A)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(~a##0:A, ?#result##0:A) @predicate:nn:nn
+
+
+#closure#2 > {inline} (1 calls)
+0: higher_order_refs.#closure#2<0>
+#closure#2(i##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
+
+
+#closure#3 > {inline} (1 calls)
+0: higher_order_refs.#closure#3<0>
+#closure#3([^x##0:wybe.int], y##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm add(~y##0:wybe.int, 10:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
 add_one > {inline} (1 calls)
@@ -57,72 +123,6 @@ app(f##0:(I, ?J), i##0:I, ?#result##0:J)<{}; {}>:
   InterestingCallProperties: []
     ~f##0:(I, ?J)(~i##0:I, ?#result##0:J) #0 @higher_order_refs:nn:nn
 
-
-gen#1 > {inline} (1 calls)
-0: higher_order_refs.gen#1<0>
-gen#1(anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(~anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float) @higher_order_refs:nn:nn
-gen#1 > {inline} (1 calls)
-1: higher_order_refs.gen#1<1>
-gen#1(anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(~anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float) @higher_order_refs:nn:nn
-
-
-gen#2 > {inline} (1 calls)
-0: higher_order_refs.gen#2<0>
-gen#2(anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(~anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float) @higher_order_refs:nn:nn
-gen#2 > {inline} (1 calls)
-1: higher_order_refs.gen#2<1>
-gen#2(anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(~anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float) @higher_order_refs:nn:nn
-
-
-gen#3 > {inline} (1 calls)
-0: higher_order_refs.gen#3<0>
-gen#3(^y##0:wybe.float, anon#3#1##0:wybe.float, ?anon#3#2##0:wybe.float)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm fsub(~anon#3#1##0:wybe.float, ~y##0:wybe.float, ?anon#3#2##0:wybe.float) @float:nn:nn
-gen#3 > {inline} (1 calls)
-1: higher_order_refs.gen#3<1>
-gen#3(^y##0:wybe.float, anon#3#1##0:wybe.float, ?anon#3#2##0:wybe.float)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm fsub(~anon#3#1##0:wybe.float, ~^y##0:wybe.float, ?anon#3#2##0:wybe.float) @float:nn:nn
-
-
-gen#4 > {inline} (1 calls)
-0: higher_order_refs.gen#4<0>
-gen#4(a##0:A, ?#result##0:A)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(~a##0:A, ?#result##0:A) @predicate:nn:nn
-
-
-gen#5 > {inline} (1 calls)
-0: higher_order_refs.gen#5<0>
-gen#5(i##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
-
-
-gen#6 > {inline} (1 calls)
-0: higher_order_refs.gen#6<0>
-gen#6([^x##0:wybe.int], y##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm add(~y##0:wybe.int, 10:wybe.int, ?#result##0:wybe.int) @int:nn:nn
-
   LLVM code       :
 
 ; ModuleID = 'higher_order_refs'
@@ -131,22 +131,22 @@ gen#6([^x##0:wybe.int], y##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
  
 
 
-@higher_order_refs.0 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#1<1>" to i64)]
+@higher_order_refs.0 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.#anon#1<1>" to i64)]
 
 
-@higher_order_refs.1 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#2<1>" to i64)]
+@higher_order_refs.1 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.#anon#2<1>" to i64)]
 
 
-@higher_order_refs.2 =    constant [2 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#3<1>" to i64), i64 bitcast (double 5.000000e-1 to i64)]
+@higher_order_refs.2 =    constant [2 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.#anon#3<1>" to i64), i64 bitcast (double 5.000000e-1 to i64)]
 
 
-@higher_order_refs.3 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#4<0>" to i64)]
+@higher_order_refs.3 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.#closure#1<0>" to i64)]
 
 
-@higher_order_refs.4 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#5<0>" to i64)]
+@higher_order_refs.4 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.#closure#2<0>" to i64)]
 
 
-@higher_order_refs.5 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.gen#6<0>" to i64)]
+@higher_order_refs.5 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_refs.#closure#3<0>" to i64)]
 
 
 declare external ccc  void @putchar(i8)    
@@ -192,6 +192,73 @@ entry:
 }
 
 
+define external fastcc  double @"higher_order_refs.#anon#1<0>"(double  %"anon#1#1##0") alwaysinline   {
+entry:
+  ret double %"anon#1#1##0" 
+}
+
+
+define external fastcc  i64 @"higher_order_refs.#anon#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
+entry:
+  %0 = bitcast i64 %"anon#1#1##0" to double 
+  %1 = bitcast double %0 to i64 
+  ret i64 %1 
+}
+
+
+define external fastcc  double @"higher_order_refs.#anon#2<0>"(double  %"anon#2#1##0") alwaysinline   {
+entry:
+  ret double %"anon#2#1##0" 
+}
+
+
+define external fastcc  i64 @"higher_order_refs.#anon#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
+entry:
+  %0 = bitcast i64 %"anon#2#1##0" to double 
+  %1 = bitcast double %0 to i64 
+  ret i64 %1 
+}
+
+
+define external fastcc  double @"higher_order_refs.#anon#3<0>"(double  %"y##0", double  %"anon#3#1##0") alwaysinline   {
+entry:
+  %0 = fsub double %"anon#3#1##0", %"y##0" 
+  ret double %0 
+}
+
+
+define external fastcc  i64 @"higher_order_refs.#anon#3<1>"(i64  %"#env##0", i64  %"anon#3#1##0") alwaysinline   {
+entry:
+  %0 = add   i64 %"#env##0", 8 
+  %1 = inttoptr i64 %0 to double* 
+  %2 = load  double, double* %1 
+  %3 = bitcast i64 %"anon#3#1##0" to double 
+  %4 = fsub double %3, %2 
+  %5 = bitcast double %4 to i64 
+  ret i64 %5 
+}
+
+
+define external fastcc  i64 @"higher_order_refs.#closure#1<0>"(i64  %"#env##0", i64  %"a##0") alwaysinline   {
+entry:
+  ret i64 %"a##0" 
+}
+
+
+define external fastcc  i64 @"higher_order_refs.#closure#2<0>"(i64  %"#env##0", i64  %"i##0") alwaysinline   {
+entry:
+  %0 = add   i64 %"i##0", 1 
+  ret i64 %0 
+}
+
+
+define external fastcc  i64 @"higher_order_refs.#closure#3<0>"(i64  %"#env##0", i64  %"y##0") alwaysinline   {
+entry:
+  %0 = add   i64 %"y##0", 10 
+  ret i64 %0 
+}
+
+
 define external fastcc  i64 @"higher_order_refs.add_one<0>"(i64  %"i##0") alwaysinline   {
 entry:
   %0 = add   i64 %"i##0", 1 
@@ -213,71 +280,4 @@ entry:
   %2 = inttoptr i64 %1 to i64 (i64, i64)* 
   %3 = tail call fastcc  i64  %2(i64  %"f##0", i64  %"i##0")  
   ret i64 %3 
-}
-
-
-define external fastcc  double @"higher_order_refs.gen#1<0>"(double  %"anon#1#1##0") alwaysinline   {
-entry:
-  ret double %"anon#1#1##0" 
-}
-
-
-define external fastcc  i64 @"higher_order_refs.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
-entry:
-  %0 = bitcast i64 %"anon#1#1##0" to double 
-  %1 = bitcast double %0 to i64 
-  ret i64 %1 
-}
-
-
-define external fastcc  double @"higher_order_refs.gen#2<0>"(double  %"anon#2#1##0") alwaysinline   {
-entry:
-  ret double %"anon#2#1##0" 
-}
-
-
-define external fastcc  i64 @"higher_order_refs.gen#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
-entry:
-  %0 = bitcast i64 %"anon#2#1##0" to double 
-  %1 = bitcast double %0 to i64 
-  ret i64 %1 
-}
-
-
-define external fastcc  double @"higher_order_refs.gen#3<0>"(double  %"y##0", double  %"anon#3#1##0") alwaysinline   {
-entry:
-  %0 = fsub double %"anon#3#1##0", %"y##0" 
-  ret double %0 
-}
-
-
-define external fastcc  i64 @"higher_order_refs.gen#3<1>"(i64  %"#env##0", i64  %"anon#3#1##0") alwaysinline   {
-entry:
-  %0 = add   i64 %"#env##0", 8 
-  %1 = inttoptr i64 %0 to double* 
-  %2 = load  double, double* %1 
-  %3 = bitcast i64 %"anon#3#1##0" to double 
-  %4 = fsub double %3, %2 
-  %5 = bitcast double %4 to i64 
-  ret i64 %5 
-}
-
-
-define external fastcc  i64 @"higher_order_refs.gen#4<0>"(i64  %"#env##0", i64  %"a##0") alwaysinline   {
-entry:
-  ret i64 %"a##0" 
-}
-
-
-define external fastcc  i64 @"higher_order_refs.gen#5<0>"(i64  %"#env##0", i64  %"i##0") alwaysinline   {
-entry:
-  %0 = add   i64 %"i##0", 1 
-  ret i64 %0 
-}
-
-
-define external fastcc  i64 @"higher_order_refs.gen#6<0>"(i64  %"#env##0", i64  %"y##0") alwaysinline   {
-entry:
-  %0 = add   i64 %"y##0", 10 
-  ret i64 %0 
 }

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -37,7 +37,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm mutate(~tmp#60##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.list(wybe.int)), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.list(T)) @list:nn:nn
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%tmp#30##0:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm store(-1000:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
-    wybe.list.gen#5<0>(higher_order_resources.gen#1<1><>:{resource}(T), ~tmp#0##0:wybe.list(T), ~tmp#0##0:wybe.list(T))<Everything; Everything> #31 @list:nn:nn
+    wybe.list.map#cont#1<0>(higher_order_resources.#anon#1<1><>:{resource}(T), ~tmp#0##0:wybe.list(T))<Everything; Everything> #31 @list:nn:nn
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%maximum##1:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#64##0:wybe.phantom) @int:nn:nn
     foreign c print_int(~maximum##1:wybe.int, ~tmp#64##0:wybe.phantom, ?tmp#65##0:wybe.phantom) @int:nn:nn
@@ -84,7 +84,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm mutate(~tmp#116##0:wybe.list(T), ?tmp#117##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#12##0:T) @list:nn:nn
     foreign lpvm mutate(~tmp#117##0:wybe.list(T), ?tmp#11##0:wybe.list(wybe.list(wybe.int)), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#16##0:wybe.list(T)) @list:nn:nn
     foreign lpvm store(-1000:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
-    wybe.list.gen#5<0>(higher_order_resources.gen#2<1><>:{resource}(T), ~tmp#11##0:wybe.list(T), ~tmp#11##0:wybe.list(T))<Everything; Everything> #33 @list:nn:nn
+    wybe.list.map#cont#1<0>(higher_order_resources.#anon#2<1><>:{resource}(T), ~tmp#11##0:wybe.list(T))<Everything; Everything> #33 @list:nn:nn
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%maximum##3:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#121##0:wybe.phantom) @int:nn:nn
     foreign c print_int(~maximum##3:wybe.int, ~tmp#121##0:wybe.phantom, ?tmp#122##0:wybe.phantom) @int:nn:nn
@@ -93,30 +93,30 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~tmp#30##0:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
 
 
-gen#1 > {inline} (1 calls)
-0: higher_order_resources.gen#1<0>
-gen#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
+#anon#1 > {inline} (1 calls)
+0: higher_order_resources.#anon#1<0>
+#anon#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.list.length1<0>(~anon#1#1##0:wybe.list(T), 0:wybe.int, ?tmp#10##0:wybe.int) #2 @list:nn:nn
     higher_order_resources.take_max<0>(~tmp#10##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #1 @higher_order_resources:nn:nn
-gen#1 > {inline} (1 calls)
-1: higher_order_resources.gen#1<1>
-gen#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
+#anon#1 > {inline} (1 calls)
+1: higher_order_resources.#anon#1<1>
+#anon#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.list.length1<0>(~anon#1#1##0:wybe.list(T), 0:wybe.int, ?tmp#1##0:wybe.int) #1 @list:nn:nn
     higher_order_resources.take_max<0>(~tmp#1##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #2 @higher_order_resources:nn:nn
 
 
-gen#2 > {inline} (1 calls)
-0: higher_order_resources.gen#2<0>
-gen#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
+#anon#2 > {inline} (1 calls)
+0: higher_order_resources.#anon#2<0>
+#anon#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%maximum##3:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm store(-1000:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
-    wybe.list.gen#5<0>(higher_order_resources.gen#3<0><>:{resource}(T), anon#2#1##0:wybe.list(T), anon#2#1##0:wybe.list(T))<Everything; Everything> #5 @list:nn:nn
+    wybe.list.map#cont#1<0>(higher_order_resources.#anon#2#closure#1<0><>:{resource}(T), anon#2#1##0:wybe.list(T))<Everything; Everything> #5 @list:nn:nn
     wybe.string.print<0>("> ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @higher_order_resources:nn:nn
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%maximum##2:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @int:nn:nn
@@ -126,14 +126,14 @@ gen#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wy
     foreign lpvm store(~maximum##3:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
     wybe.list.length1<0>(~anon#2#1##0:wybe.list(T), 0:wybe.int, ?tmp#28##0:wybe.int) #6 @list:nn:nn
     higher_order_resources.take_max<0>(~tmp#28##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #4 @higher_order_resources:nn:nn
-gen#2 > {inline} (1 calls)
-1: higher_order_resources.gen#2<1>
-gen#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
+#anon#2 > {inline} (1 calls)
+1: higher_order_resources.#anon#2<1>
+#anon#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%tmp#1##0:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm store(-1000:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
-    wybe.list.gen#5<0>(higher_order_resources.gen#3<0><>:{resource}(T), anon#2#1##0:wybe.list(T), anon#2#1##0:wybe.list(T))<Everything; Everything> #1 @list:nn:nn
+    wybe.list.map#cont#1<0>(higher_order_resources.#anon#2#closure#1<0><>:{resource}(T), anon#2#1##0:wybe.list(T))<Everything; Everything> #1 @list:nn:nn
     wybe.string.print<0>("> ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @higher_order_resources:nn:nn
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%tmp#2##0:wybe.int) @higher_order_resources:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
@@ -145,9 +145,9 @@ gen#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wy
     higher_order_resources.take_max<0>(~tmp#6##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #4 @higher_order_resources:nn:nn
 
 
-gen#3 > {inline} (1 calls)
-0: higher_order_resources.gen#3<0>
-gen#3(i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
+#anon#2#closure#1 > {inline} (1 calls)
+0: higher_order_resources.#anon#2#closure#1<0>
+#anon#2#closure#1(i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     higher_order_resources.take_max<0>(~i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}> #0
@@ -185,13 +185,13 @@ take_max(i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_re
 @higher_order_resources.5 =    constant [?? x i8] c"> \00"
 
 
-@higher_order_resources.0 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#1<1>" to i64)]
+@higher_order_resources.0 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.#anon#1<1>" to i64)]
 
 
-@higher_order_resources.3 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#2<1>" to i64)]
+@higher_order_resources.4 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.#anon#2#closure#1<0>" to i64)]
 
 
-@higher_order_resources.4 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.gen#3<0>" to i64)]
+@higher_order_resources.3 =    constant [1 x i64] [i64 ptrtoint (void (i64, i64)* @"higher_order_resources.#anon#2<1>" to i64)]
 
 
 declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)    
@@ -209,7 +209,7 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print<0>"(i64)    
 
 
-declare external fastcc  void @"wybe.list.gen#5<0>"(i64, i64, i64)    
+declare external fastcc  void @"wybe.list.map#cont#1<0>"(i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -278,7 +278,7 @@ entry:
   store  i64 %32, i64* %41 
   %42 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
-  tail call fastcc  void  @"wybe.list.gen#5<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.0, i32 0, i32 0) to i64), i64  %38, i64  %38)  
+  tail call fastcc  void  @"wybe.list.map#cont#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.0, i32 0, i32 0) to i64), i64  %38)  
   %43 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   tail call ccc  void  @print_int(i64  %43)  
   tail call ccc  void  @putchar(i8  10)  
@@ -381,7 +381,7 @@ entry:
   %115 = inttoptr i64 %114 to i64* 
   store  i64 %106, i64* %115 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
-  tail call fastcc  void  @"wybe.list.gen#5<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.3, i32 0, i32 0) to i64), i64  %112, i64  %112)  
+  tail call fastcc  void  @"wybe.list.map#cont#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.3, i32 0, i32 0) to i64), i64  %112)  
   %116 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   tail call ccc  void  @print_int(i64  %116)  
   tail call ccc  void  @putchar(i8  10)  
@@ -390,7 +390,7 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#1<0>"(i64  %"anon#1#1##0") alwaysinline   {
+define external fastcc  void @"higher_order_resources.#anon#1<0>"(i64  %"anon#1#1##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#1#1##0", i64  0)  
   musttail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %0)  
@@ -398,7 +398,7 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
+define external fastcc  void @"higher_order_resources.#anon#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %"anon#1#1##0", i64  0)  
   tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %0)  
@@ -406,11 +406,11 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#2<0>"(i64  %"anon#2#1##0") alwaysinline   {
+define external fastcc  void @"higher_order_resources.#anon#2<0>"(i64  %"anon#2#1##0") alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
-  tail call fastcc  void  @"wybe.list.gen#5<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.4, i32 0, i32 0) to i64), i64  %"anon#2#1##0", i64  %"anon#2#1##0")  
+  tail call fastcc  void  @"wybe.list.map#cont#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.4, i32 0, i32 0) to i64), i64  %"anon#2#1##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.6, i32 0, i32 0) to i64))  
   %1 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   tail call ccc  void  @print_int(i64  %1)  
@@ -422,11 +422,11 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
+define external fastcc  void @"higher_order_resources.#anon#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
 entry:
   %0 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   store  i64 -1000, i64* @"resource#higher_order_resources.maximum" 
-  tail call fastcc  void  @"wybe.list.gen#5<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.4, i32 0, i32 0) to i64), i64  %"anon#2#1##0", i64  %"anon#2#1##0")  
+  tail call fastcc  void  @"wybe.list.map#cont#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_resources.4, i32 0, i32 0) to i64), i64  %"anon#2#1##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_resources.6, i32 0, i32 0) to i64))  
   %1 = load  i64, i64* @"resource#higher_order_resources.maximum" 
   tail call ccc  void  @print_int(i64  %1)  
@@ -438,7 +438,7 @@ entry:
 }
 
 
-define external fastcc  void @"higher_order_resources.gen#3<0>"(i64  %"#env##0", i64  %"i##0") alwaysinline   {
+define external fastcc  void @"higher_order_resources.#anon#2#closure#1<0>"(i64  %"#env##0", i64  %"i##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"higher_order_resources.take_max<0>"(i64  %"i##0")  
   ret void 

--- a/test-cases/final-dump/higher_order_sort.exp
+++ b/test-cases/final-dump/higher_order_sort.exp
@@ -9,24 +9,6 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-gen#1 > (2 calls)
-0: higher_order_sort.gen#1<0>
-gen#1(<=##0:(X, X, ?wybe.bool), sorted##0:wybe.list(X), tmp#0##0:wybe.list(X), tmp#1##0:wybe.list(X), xs##0:wybe.list(X), ?sorted##2:wybe.list(X))<{}; {}>:
-  AliasPairs: [(sorted##0,sorted##2)]
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#1##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool)
-    case ~tmp#4##0:wybe.bool of
-    0:
-        foreign llvm move(~sorted##0:wybe.list(X), ?sorted##2:wybe.list(X))
-
-    1:
-        foreign lpvm access(tmp#1##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:X) @list:nn:nn
-        foreign lpvm access(~tmp#1##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##1:wybe.list(X)) @list:nn:nn
-        higher_order_sort.insert<0>(<=##0:(X, X, ?wybe.bool), ~x##0:X, ~sorted##0:wybe.list(X), outByReference sorted##1:wybe.list(X)) #1 @higher_order_sort:nn:nn
-        higher_order_sort.gen#1<0>(~<=##0:(X, X, ?wybe.bool), ~sorted##1:wybe.list(X), ~tmp#0##0:wybe.list(X), ~tmp#1##1:wybe.list(X), ~xs##0:wybe.list(X), ?sorted##2:wybe.list(X)) #2 @higher_order_sort:nn:nn
-
-
-
 insert > (2 calls)
 0: higher_order_sort.insert<0>
 insert(<=##0:(X, X, ?wybe.bool), x##0:X, xs##0:wybe.list(X), outByReference xs##1:wybe.list(X))<{}; {}>:
@@ -63,7 +45,25 @@ sort > {inline} (0 calls)
 sort(<=##0:(X, X, ?wybe.bool), xs##0:wybe.list(X), ?sorted##1:wybe.list(X))<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_sort.gen#1<0>(~<=##0:(X, X, ?wybe.bool), 0:wybe.list(X), 0:wybe.list(X), ~xs##0:wybe.list(X), ~xs##0:wybe.list(X), ?sorted##1:wybe.list(X)) #1 @higher_order_sort:nn:nn
+    higher_order_sort.sort#cont#1<0>(~<=##0:(X, X, ?wybe.bool), 0:wybe.list(X), ~xs##0:wybe.list(X), ?sorted##1:wybe.list(X)) #1 @higher_order_sort:nn:nn
+
+
+sort#cont#1 > (2 calls)
+0: higher_order_sort.sort#cont#1<0>
+sort#cont#1(<=##0:(X, X, ?wybe.bool), sorted##0:wybe.list(X), tmp#1##0:wybe.list(X), ?sorted##2:wybe.list(X))<{}; {}>:
+  AliasPairs: [(sorted##0,sorted##2)]
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#1##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool)
+    case ~tmp#4##0:wybe.bool of
+    0:
+        foreign llvm move(~sorted##0:wybe.list(X), ?sorted##2:wybe.list(X))
+
+    1:
+        foreign lpvm access(tmp#1##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:X) @list:nn:nn
+        foreign lpvm access(~tmp#1##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##1:wybe.list(X)) @list:nn:nn
+        higher_order_sort.insert<0>(<=##0:(X, X, ?wybe.bool), ~x##0:X, ~sorted##0:wybe.list(X), outByReference sorted##1:wybe.list(X)) #1 @higher_order_sort:nn:nn
+        higher_order_sort.sort#cont#1<0>(~<=##0:(X, X, ?wybe.bool), ~sorted##1:wybe.list(X), ~tmp#1##1:wybe.list(X), ?sorted##2:wybe.list(X)) #2 @higher_order_sort:nn:nn
+
 
   LLVM code       :
 
@@ -77,26 +77,6 @@ declare external ccc  i8* @wybe_malloc(i32)
 
 
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
-
-
-define external fastcc  i64 @"higher_order_sort.gen#1<0>"(i64  %"<=##0", i64  %"sorted##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"xs##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#1##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#1##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#1##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = alloca i64 
-   call fastcc  void  @"higher_order_sort.insert<0>"(i64  %"<=##0", i64  %2, i64  %"sorted##0", i64*  %6)  
-  %7 = load  i64, i64* %6 
-  %8 = musttail call fastcc  i64  @"higher_order_sort.gen#1<0>"(i64  %"<=##0", i64  %7, i64  %"tmp#0##0", i64  %5, i64  %"xs##0")  
-  ret i64 %8 
-if.else:
-  ret i64 %"sorted##0" 
-}
 
 
 define external fastcc  void @"higher_order_sort.insert<0>"(i64  %"<=##0", i64  %"x##0", i64  %"xs##0", i64*  %"xs##1")    {
@@ -153,6 +133,26 @@ if.else1:
 
 define external fastcc  i64 @"higher_order_sort.sort<0>"(i64  %"<=##0", i64  %"xs##0") alwaysinline   {
 entry:
-  %0 = tail call fastcc  i64  @"higher_order_sort.gen#1<0>"(i64  %"<=##0", i64  0, i64  0, i64  %"xs##0", i64  %"xs##0")  
+  %0 = tail call fastcc  i64  @"higher_order_sort.sort#cont#1<0>"(i64  %"<=##0", i64  0, i64  %"xs##0")  
   ret i64 %0 
+}
+
+
+define external fastcc  i64 @"higher_order_sort.sort#cont#1<0>"(i64  %"<=##0", i64  %"sorted##0", i64  %"tmp#1##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#1##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#1##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#1##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = alloca i64 
+   call fastcc  void  @"higher_order_sort.insert<0>"(i64  %"<=##0", i64  %2, i64  %"sorted##0", i64*  %6)  
+  %7 = load  i64, i64* %6 
+  %8 = musttail call fastcc  i64  @"higher_order_sort.sort#cont#1<0>"(i64  %"<=##0", i64  %7, i64  %5)  
+  ret i64 %8 
+if.else:
+  ret i64 %"sorted##0" 
 }

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -14,17 +14,180 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_tests.gen#1<0>(_:wybe.int, ?tmp#8##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    higher_order_tests.#anon#1<0>(_:wybe.int, ?tmp#8##0:wybe.bool) #0 @higher_order_tests:nn:nn
     case ~tmp#8##0:wybe.bool of
     0:
-        higher_order_tests.gen#2<0>(higher_order_tests.gen#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+        higher_order_tests.#cont#1<0>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
 
     1:
         wybe.string.print<0>("*1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        higher_order_tests.gen#2<0>(higher_order_tests.gen#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+        higher_order_tests.#cont#1<0>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#anon#1 > {inline} (1 calls)
+0: higher_order_tests.#anon#1<0>
+#anon#1([anon#1#1##0:wybe.int], ?#success##0:wybe.bool)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+#anon#1 > {inline} (3 calls)
+1: higher_order_tests.#anon#1<1>
+#anon#1(anon#1#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+
+#anon#2 > {inline} (1 calls)
+0: higher_order_tests.#anon#2<0>
+#anon#2(anon#2#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_eq(~anon#2#1##0:wybe.int, 1:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
+#anon#2 > {inline} (3 calls)
+1: higher_order_tests.#anon#2<1>
+#anon#2(anon#2#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_eq(~anon#2#1##0:wybe.int, 1:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
+
+
+#cont#1 > (2 calls)
+0: higher_order_tests.#cont#1<0>
+#cont#1(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    t##0:(I, ?wybe.bool)(1:I, ?tmp#7##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#7##0:wybe.bool of
+    0:
+        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        wybe.string.print<0>("1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#2 > (2 calls)
+0: higher_order_tests.#cont#2<0>
+#cont#2(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    t##0:(I, ?wybe.bool)(2:I, ?tmp#6##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#6##0:wybe.bool of
+    0:
+        higher_order_tests.#cont#3<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        wybe.string.print<0>("*2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        higher_order_tests.#cont#3<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#3 > (2 calls)
+0: higher_order_tests.#cont#3<0>
+#cont#3(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#5##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#5##0:wybe.bool of
+    0:
+        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        wybe.string.print<0>("2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#4 > (2 calls)
+0: higher_order_tests.#cont#4<0>
+#cont#4([t##0:(wybe.int, ?wybe.bool)])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.string.print<0>("------":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    higher_order_tests.#anon#2<0>(1:wybe.int, ?tmp#4##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#4##0:wybe.bool of
+    0:
+        higher_order_tests.#cont#5<0>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4
+
+    1:
+        wybe.string.print<0>("*1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        higher_order_tests.#cont#5<0>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+
+
+#cont#5 > (2 calls)
+0: higher_order_tests.#cont#5<0>
+#cont#5(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    t##0:(I, ?wybe.bool)(1:I, ?tmp#3##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#3##0:wybe.bool of
+    0:
+        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        wybe.string.print<0>("1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#7##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#6 > (2 calls)
+0: higher_order_tests.#cont#6<0>
+#cont#6(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    t##0:(I, ?wybe.bool)(2:I, ?tmp#2##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+        higher_order_tests.#cont#7<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        wybe.string.print<0>("*2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        higher_order_tests.#cont#7<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#7 > (2 calls)
+0: higher_order_tests.#cont#7<0>
+#cont#7(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#1##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#1##0:wybe.bool of
+    0:
+
+    1:
+        wybe.string.print<0>("2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
 
@@ -42,169 +205,6 @@ do_test2(f##0:(I, ?wybe.bool), i##0:I, ?#success##0:wybe.bool)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~f##0:(I, ?wybe.bool)(~i##0:I, ?#success##0:wybe.bool) #0 @higher_order_tests:nn:nn
-
-
-gen#1 > {inline} (1 calls)
-0: higher_order_tests.gen#1<0>
-gen#1([anon#1#1##0:wybe.int], ?#success##0:wybe.bool)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
-gen#1 > {inline} (3 calls)
-1: higher_order_tests.gen#1<1>
-gen#1(anon#1#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
-
-
-gen#2 > (2 calls)
-0: higher_order_tests.gen#2<0>
-gen#2(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(1:I, ?tmp#7##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#7##0:wybe.bool of
-    0:
-        higher_order_tests.gen#3<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        wybe.string.print<0>("1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        higher_order_tests.gen#3<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#3 > (2 calls)
-0: higher_order_tests.gen#3<0>
-gen#3(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(2:I, ?tmp#6##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#6##0:wybe.bool of
-    0:
-        higher_order_tests.gen#4<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        wybe.string.print<0>("*2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        higher_order_tests.gen#4<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#4 > (2 calls)
-0: higher_order_tests.gen#4<0>
-gen#4(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#5##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#5##0:wybe.bool of
-    0:
-        higher_order_tests.gen#5<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        wybe.string.print<0>("2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        higher_order_tests.gen#5<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#5 > (2 calls)
-0: higher_order_tests.gen#5<0>
-gen#5([t##0:(wybe.int, ?wybe.bool)])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    wybe.string.print<0>("------":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    higher_order_tests.gen#6<0>(1:wybe.int, ?tmp#4##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#4##0:wybe.bool of
-    0:
-        higher_order_tests.gen#7<0>(higher_order_tests.gen#6<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4
-
-    1:
-        wybe.string.print<0>("*1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        higher_order_tests.gen#7<0>(higher_order_tests.gen#6<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-
-
-gen#6 > {inline} (1 calls)
-0: higher_order_tests.gen#6<0>
-gen#6(anon#2#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_eq(~anon#2#1##0:wybe.int, 1:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
-gen#6 > {inline} (3 calls)
-1: higher_order_tests.gen#6<1>
-gen#6(anon#2#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_eq(~anon#2#1##0:wybe.int, 1:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
-
-
-gen#7 > (2 calls)
-0: higher_order_tests.gen#7<0>
-gen#7(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(1:I, ?tmp#3##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#3##0:wybe.bool of
-    0:
-        higher_order_tests.gen#8<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        wybe.string.print<0>("1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#7##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        higher_order_tests.gen#8<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#8 > (2 calls)
-0: higher_order_tests.gen#8<0>
-gen#8(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(2:I, ?tmp#2##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#2##0:wybe.bool of
-    0:
-        higher_order_tests.gen#9<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        wybe.string.print<0>("*2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        higher_order_tests.gen#9<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#9 > (2 calls)
-0: higher_order_tests.gen#9<0>
-gen#9(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#1##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#1##0:wybe.bool of
-    0:
-
-    1:
-        wybe.string.print<0>("2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
 
   LLVM code       :
 
@@ -244,10 +244,10 @@ gen#9(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
 @higher_order_tests.7 =    constant [?? x i8] c"2\00"
 
 
-@higher_order_tests.2 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#1<1>" to i64)]
+@higher_order_tests.2 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.#anon#1<1>" to i64)]
 
 
-@higher_order_tests.11 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.gen#6<1>" to i64)]
+@higher_order_tests.11 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"higher_order_tests.#anon#2<1>" to i64)]
 
 
 declare external ccc  void @putchar(i8)    
@@ -264,15 +264,172 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"higher_order_tests.<0>"()    {
 entry:
-  %0 = tail call fastcc  i1  @"higher_order_tests.gen#1<0>"()  
+  %0 = tail call fastcc  i1  @"higher_order_tests.#anon#1<0>"()  
   br i1 %0, label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"higher_order_tests.gen#2<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"higher_order_tests.#cont#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.2, i32 0, i32 0) to i64))  
   ret void 
 if.else:
-  tail call fastcc  void  @"higher_order_tests.gen#2<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"higher_order_tests.#cont#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.2, i32 0, i32 0) to i64))  
+  ret void 
+}
+
+
+define external fastcc  i1 @"higher_order_tests.#anon#1<0>"() alwaysinline   {
+entry:
+  ret i1 1 
+}
+
+
+define external fastcc  i64 @"higher_order_tests.#anon#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
+entry:
+  %0 = zext i1 1 to i64  
+  ret i64 %0 
+}
+
+
+define external fastcc  i1 @"higher_order_tests.#anon#2<0>"(i64  %"anon#2#1##0") alwaysinline   {
+entry:
+  %0 = icmp eq i64 %"anon#2#1##0", 1 
+  ret i1 %0 
+}
+
+
+define external fastcc  i64 @"higher_order_tests.#anon#2<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
+entry:
+  %0 = icmp eq i64 %"anon#2#1##0", 1 
+  %1 = zext i1 %0 to i64  
+  ret i64 %1 
+}
+
+
+define external fastcc  void @"higher_order_tests.#cont#1<0>"(i64  %"t##0")    {
+entry:
+  %0 = inttoptr i64 %"t##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
+  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  1)  
+  %4 = trunc i64 %3 to i1  
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.4, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"higher_order_tests.#cont#2<0>"(i64  %"t##0")  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"higher_order_tests.#cont#2<0>"(i64  %"t##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"higher_order_tests.#cont#2<0>"(i64  %"t##0")    {
+entry:
+  %0 = inttoptr i64 %"t##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
+  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  2)  
+  %4 = trunc i64 %3 to i1  
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.6, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"higher_order_tests.#cont#3<0>"(i64  %"t##0")  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"higher_order_tests.#cont#3<0>"(i64  %"t##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"higher_order_tests.#cont#3<0>"(i64  %"t##0")    {
+entry:
+  %0 = inttoptr i64 %"t##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
+  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  2)  
+  %4 = trunc i64 %3 to i1  
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.8, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"higher_order_tests.#cont#4<0>"()  
+  ret void 
+if.else:
+  tail call fastcc  void  @"higher_order_tests.#cont#4<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"higher_order_tests.#cont#4<0>"()    {
+entry:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.10, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  %0 = tail call fastcc  i1  @"higher_order_tests.#anon#2<0>"(i64  1)  
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.1, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"higher_order_tests.#cont#5<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.11, i32 0, i32 0) to i64))  
+  ret void 
+if.else:
+  tail call fastcc  void  @"higher_order_tests.#cont#5<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.11, i32 0, i32 0) to i64))  
+  ret void 
+}
+
+
+define external fastcc  void @"higher_order_tests.#cont#5<0>"(i64  %"t##0")    {
+entry:
+  %0 = inttoptr i64 %"t##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
+  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  1)  
+  %4 = trunc i64 %3 to i1  
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.4, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"higher_order_tests.#cont#6<0>"(i64  %"t##0")  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"higher_order_tests.#cont#6<0>"(i64  %"t##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"higher_order_tests.#cont#6<0>"(i64  %"t##0")    {
+entry:
+  %0 = inttoptr i64 %"t##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
+  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  2)  
+  %4 = trunc i64 %3 to i1  
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.6, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"higher_order_tests.#cont#7<0>"(i64  %"t##0")  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"higher_order_tests.#cont#7<0>"(i64  %"t##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"higher_order_tests.#cont#7<0>"(i64  %"t##0")    {
+entry:
+  %0 = inttoptr i64 %"t##0" to i64* 
+  %1 = load  i64, i64* %0 
+  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
+  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  2)  
+  %4 = trunc i64 %3 to i1  
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.8, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+if.else:
   ret void 
 }
 
@@ -296,161 +453,4 @@ entry:
   %3 = tail call fastcc  i64  %2(i64  %"f##0", i64  %"i##0")  
   %4 = trunc i64 %3 to i1  
   ret i1 %4 
-}
-
-
-define external fastcc  i1 @"higher_order_tests.gen#1<0>"() alwaysinline   {
-entry:
-  ret i1 1 
-}
-
-
-define external fastcc  i64 @"higher_order_tests.gen#1<1>"(i64  %"#env##0", i64  %"anon#1#1##0") alwaysinline   {
-entry:
-  %0 = zext i1 1 to i64  
-  ret i64 %0 
-}
-
-
-define external fastcc  void @"higher_order_tests.gen#2<0>"(i64  %"t##0")    {
-entry:
-  %0 = inttoptr i64 %"t##0" to i64* 
-  %1 = load  i64, i64* %0 
-  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
-  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  1)  
-  %4 = trunc i64 %3 to i1  
-  br i1 %4, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.4, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"higher_order_tests.gen#3<0>"(i64  %"t##0")  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"higher_order_tests.gen#3<0>"(i64  %"t##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"higher_order_tests.gen#3<0>"(i64  %"t##0")    {
-entry:
-  %0 = inttoptr i64 %"t##0" to i64* 
-  %1 = load  i64, i64* %0 
-  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
-  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  2)  
-  %4 = trunc i64 %3 to i1  
-  br i1 %4, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.6, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"higher_order_tests.gen#4<0>"(i64  %"t##0")  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"higher_order_tests.gen#4<0>"(i64  %"t##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"higher_order_tests.gen#4<0>"(i64  %"t##0")    {
-entry:
-  %0 = inttoptr i64 %"t##0" to i64* 
-  %1 = load  i64, i64* %0 
-  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
-  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  2)  
-  %4 = trunc i64 %3 to i1  
-  br i1 %4, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.8, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"higher_order_tests.gen#5<0>"()  
-  ret void 
-if.else:
-  tail call fastcc  void  @"higher_order_tests.gen#5<0>"()  
-  ret void 
-}
-
-
-define external fastcc  void @"higher_order_tests.gen#5<0>"()    {
-entry:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.10, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  %0 = tail call fastcc  i1  @"higher_order_tests.gen#6<0>"(i64  1)  
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.11, i32 0, i32 0) to i64))  
-  ret void 
-if.else:
-  tail call fastcc  void  @"higher_order_tests.gen#7<0>"(i64  ptrtoint (i64* getelementptr inbounds ([1 x i64], [1 x i64]* @higher_order_tests.11, i32 0, i32 0) to i64))  
-  ret void 
-}
-
-
-define external fastcc  i1 @"higher_order_tests.gen#6<0>"(i64  %"anon#2#1##0") alwaysinline   {
-entry:
-  %0 = icmp eq i64 %"anon#2#1##0", 1 
-  ret i1 %0 
-}
-
-
-define external fastcc  i64 @"higher_order_tests.gen#6<1>"(i64  %"#env##0", i64  %"anon#2#1##0") alwaysinline   {
-entry:
-  %0 = icmp eq i64 %"anon#2#1##0", 1 
-  %1 = zext i1 %0 to i64  
-  ret i64 %1 
-}
-
-
-define external fastcc  void @"higher_order_tests.gen#7<0>"(i64  %"t##0")    {
-entry:
-  %0 = inttoptr i64 %"t##0" to i64* 
-  %1 = load  i64, i64* %0 
-  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
-  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  1)  
-  %4 = trunc i64 %3 to i1  
-  br i1 %4, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.4, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"higher_order_tests.gen#8<0>"(i64  %"t##0")  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"higher_order_tests.gen#8<0>"(i64  %"t##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"higher_order_tests.gen#8<0>"(i64  %"t##0")    {
-entry:
-  %0 = inttoptr i64 %"t##0" to i64* 
-  %1 = load  i64, i64* %0 
-  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
-  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  2)  
-  %4 = trunc i64 %3 to i1  
-  br i1 %4, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.6, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"higher_order_tests.gen#9<0>"(i64  %"t##0")  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"higher_order_tests.gen#9<0>"(i64  %"t##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"higher_order_tests.gen#9<0>"(i64  %"t##0")    {
-entry:
-  %0 = inttoptr i64 %"t##0" to i64* 
-  %1 = load  i64, i64* %0 
-  %2 = inttoptr i64 %1 to i64 (i64, i64)* 
-  %3 = tail call fastcc  i64  %2(i64  %"t##0", i64  2)  
-  %4 = trunc i64 %3 to i1  
-  br i1 %4, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @higher_order_tests.8, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-if.else:
-  ret void 
 }

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -23,10 +23,42 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(1,(int_sequence.#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_sequence) @int_sequence:nn:nn
     foreign lpvm mutate(~tmp#5##0:int_sequence, ?tmp#6##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @int_sequence:nn:nn
     foreign lpvm mutate(~tmp#6##0:int_sequence, ?tmp#1##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @int_sequence:nn:nn
-    int_sequence.gen#1<0>(~tmp#1##0:int_sequence, ~tmp#1##0:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @int_sequence:nn:nn
+    int_sequence.#cont#1<0>[410bae77d3](~tmp#1##0:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @int_sequence:nn:nn
+
+
+#cont#1 > (2 calls)
+0: int_sequence.#cont#1<0>[410bae77d3]
+#cont#1(tmp#0##0:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: [InterestingUnaliased 0]
+  MultiSpeczDepInfo: [(0,(int_sequence.[|]<0>,fromList [NonAliasedParamCond 2 [0]])),(2,(int_sequence.#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
+    int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0 @int_sequence:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        int_sequence.#cont#1<0>[410bae77d3](~tmp#0##1:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @int_sequence:nn:nn
+
+ [410bae77d3] [NonAliasedParam 0] :
+    int_sequence.[|]<0>[785a827a1b](?i##0:wybe.int, ?tmp#0##1:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0 @int_sequence:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        int_sequence.#cont#1<0>[410bae77d3](~tmp#0##1:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @int_sequence:nn:nn
+
 
 
 .. > public {inline} (2 calls)
@@ -103,37 +135,6 @@ module top-level code > public {semipure} (0 calls)
         foreign lpvm mutate(~seq##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int) @int_sequence:nn:nn
         foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @int_sequence:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
-
-
-
-gen#1 > (2 calls)
-0: int_sequence.gen#1<0>[410bae77d3]
-gen#1(tmp#0##0:int_sequence, tmp#1##0:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(0,(int_sequence.[|]<0>,fromList [NonAliasedParamCond 2 [0]])),(2,(int_sequence.gen#1<0>,fromList [NonAliasedParamCond 0 []]))]
-    int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0 @int_sequence:nn:nn
-    case ~tmp#2##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        int_sequence.gen#1<0>[410bae77d3](~tmp#0##1:int_sequence, ~tmp#1##0:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @int_sequence:nn:nn
-
- [410bae77d3] [NonAliasedParam 0] :
-    int_sequence.[|]<0>[785a827a1b](?i##0:wybe.int, ?tmp#0##1:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0 @int_sequence:nn:nn
-    case ~tmp#2##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        int_sequence.gen#1<0>[410bae77d3](~tmp#0##1:int_sequence, ~tmp#1##0:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @int_sequence:nn:nn
 
 
 
@@ -215,7 +216,41 @@ entry:
   %4 = add   i64 %2, 8 
   %5 = inttoptr i64 %4 to i64* 
   store  i64 10, i64* %5 
-  tail call fastcc  void  @"int_sequence.gen#1<0>"(i64  %2, i64  %2)  
+  tail call fastcc  void  @"int_sequence.#cont#1<0>[410bae77d3]"(i64  %2)  
+  ret void 
+}
+
+
+define external fastcc  void @"int_sequence.#cont#1<0>"(i64  %"tmp#0##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"int_sequence.#cont#1<0>[410bae77d3]"(i64  %2)  
+  ret void 
+if.else:
+  ret void 
+}
+
+
+define external fastcc  void @"int_sequence.#cont#1<0>[410bae77d3]"(i64  %"tmp#0##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"int_sequence.#cont#1<0>[410bae77d3]"(i64  %2)  
+  ret void 
+if.else:
   ret void 
 }
 
@@ -325,40 +360,6 @@ if.else:
   %14 = insertvalue {i64, i64, i1} %13, i64 undef, 1 
   %15 = insertvalue {i64, i64, i1} %14, i1 0, 2 
   ret {i64, i64, i1} %15 
-}
-
-
-define external fastcc  void @"int_sequence.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
-entry:
-  %0 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %1 = extractvalue {i64, i64, i1} %0, 0 
-  %2 = extractvalue {i64, i64, i1} %0, 1 
-  %3 = extractvalue {i64, i64, i1} %0, 2 
-  br i1 %3, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %1)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"int_sequence.gen#1<0>[410bae77d3]"(i64  %2, i64  %"tmp#1##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"int_sequence.gen#1<0>[410bae77d3]"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
-entry:
-  %0 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
-  %1 = extractvalue {i64, i64, i1} %0, 0 
-  %2 = extractvalue {i64, i64, i1} %0, 1 
-  %3 = extractvalue {i64, i64, i1} %0, 2 
-  br i1 %3, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %1)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"int_sequence.gen#1<0>[410bae77d3]"(i64  %2, i64  %"tmp#1##0")  
-  ret void 
-if.else:
-  ret void 
 }
 
 

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -30,16 +30,16 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm mutate(~tmp#9##0:list_loop.intlist, ?tmp#10##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist) @list_loop:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#13##0:list_loop.intlist) @list_loop:nn:nn
     foreign lpvm mutate(~tmp#13##0:list_loop.intlist, ?tmp#14##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#14##0:list_loop.intlist, ?tmp#15##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#14##0:list_loop.intlist, ?tmp#15##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#10##0:list_loop.intlist) @list_loop:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:list_loop.intlist) @list_loop:nn:nn
     foreign lpvm mutate(~tmp#18##0:list_loop.intlist, ?tmp#19##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#19##0:list_loop.intlist, ?tmp#20##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#15##0:list_loop.intlist) @list_loop:nn:nn
-    list_loop.gen#1<0>(~tmp#20##0:list_loop.intlist, ~tmp#20##0:list_loop.intlist, ~tmp#15##0:list_loop.intlist, ~tmp#10##0:list_loop.intlist, 0:list_loop.intlist, ~tmp#20##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#19##0:list_loop.intlist, ?tmp#20##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#15##0:list_loop.intlist) @list_loop:nn:nn
+    list_loop.#cont#1<0>(~tmp#20##0:list_loop.intlist, ~tmp#20##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @list_loop:nn:nn
 
 
-gen#1 > (2 calls)
-0: list_loop.gen#1<0>
-gen#1(l##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.intlist, tmp#2##0:list_loop.intlist, tmp#3##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (2 calls)
+0: list_loop.#cont#1<0>
+#cont#1(l##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_ne(l##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
@@ -49,55 +49,55 @@ gen#1(l##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.int
     1:
         foreign lpvm access(l##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @list_loop:nn:nn
         foreign lpvm access(~l##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l##1:list_loop.intlist) @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(h##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        list_loop.gen#3<0>(~h##0:wybe.int, ~l##1:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @list_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(h##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        list_loop.#cont#3<0>(~h##0:wybe.int, ~l##1:list_loop.intlist, ~x##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @list_loop:nn:nn
 
 
 
-gen#2 > {inline} (1 calls)
-0: list_loop.gen#2<0>
-gen#2(h##0:wybe.int, l##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.intlist, tmp#2##0:list_loop.intlist, tmp#3##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#2 > {inline} (1 calls)
+0: list_loop.#cont#2<0>
+#cont#2(h##0:wybe.int, l##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @int:nn:nn
     foreign c print_int(h##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    list_loop.gen#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @list_loop:nn:nn
+    list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~x##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @list_loop:nn:nn
 
 
-gen#3 > (2 calls)
-0: list_loop.gen#3<0>
-gen#3(h##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.intlist, tmp#2##0:list_loop.intlist, tmp#3##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#3 > (2 calls)
+0: list_loop.#cont#3<0>
+#cont#3(h##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_ne(l2##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
     case ~tmp#6##0:wybe.bool of
     0:
-        list_loop.gen#1<0>(~l##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @list_loop:nn:nn
+        list_loop.#cont#1<0>(~l##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @list_loop:nn:nn
 
     1:
         foreign lpvm access(l2##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h2##0:wybe.int) @list_loop:nn:nn
         foreign lpvm access(~l2##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l2##1:list_loop.intlist) @list_loop:nn:nn
         wybe.string.print<0>("    ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(h##0:wybe.int, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @int:nn:nn
-        foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(h##0:wybe.int, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int:nn:nn
+        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
         wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~h2##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        list_loop.gen#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##1:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @list_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~h2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##1:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @list_loop:nn:nn
 
 
 
-gen#4 > {inline} (1 calls)
-0: list_loop.gen#4<0>
-gen#4(h##0:wybe.int, h2##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.intlist, tmp#2##0:list_loop.intlist, tmp#3##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#4 > {inline} (1 calls)
+0: list_loop.#cont#4<0>
+#cont#4(h##0:wybe.int, h2##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>("    ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @list_loop:nn:nn
@@ -109,7 +109,7 @@ gen#4(h##0:wybe.int, h2##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.int
     foreign c print_int(~h2##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    list_loop.gen#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @list_loop:nn:nn
+    list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @list_loop:nn:nn
 
   LLVM code       :
 
@@ -172,12 +172,12 @@ entry:
   %16 = add   i64 %14, 8 
   %17 = inttoptr i64 %16 to i64* 
   store  i64 %8, i64* %17 
-  tail call fastcc  void  @"list_loop.gen#1<0>"(i64  %14, i64  %14, i64  %8, i64  %2, i64  0, i64  %14)  
+  tail call fastcc  void  @"list_loop.#cont#1<0>"(i64  %14, i64  %14)  
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen#1<0>"(i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
+define external fastcc  void @"list_loop.#cont#1<0>"(i64  %"l##0", i64  %"x##0")    {
 entry:
   %0 = icmp ne i64 %"l##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -189,23 +189,23 @@ if.then:
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %2, i64  %5, i64  %"x##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.#cont#3<0>"(i64  %2, i64  %5, i64  %"x##0", i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen#2<0>"(i64  %"h##0", i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0") alwaysinline   {
+define external fastcc  void @"list_loop.#cont#2<0>"(i64  %"h##0", i64  %"l##0", i64  %"x##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"h##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"x##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.#cont#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"x##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
+define external fastcc  void @"list_loop.#cont#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"x##0")    {
 entry:
   %0 = icmp ne i64 %"l2##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -220,22 +220,22 @@ if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %5, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
+  musttail call fastcc  void  @"list_loop.#cont#3<0>"(i64  %"h##0", i64  %"l##0", i64  %5, i64  %"x##0")  
   ret void 
 if.else:
-  tail call fastcc  void  @"list_loop.gen#1<0>"(i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.#cont#1<0>"(i64  %"l##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen#4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0") alwaysinline   {
+define external fastcc  void @"list_loop.#cont#4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"x##0") alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.#cont#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"x##0")  
   ret void 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -20,41 +20,6 @@ AFTER EVERYTHING:
   submodules      : loop_bug.int_list
   procs           : 
 
-gen#1 > (2 calls)
-0: loop_bug.gen#1<0>
-gen#1([h##0:wybe.int], lst##0:loop_bug.int_list, t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
-    case ~tmp#2##0:wybe.bool of
-    0:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @char:nn:nn
-        foreign c putchar(']':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @char:nn:nn
-        foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
-
-    1:
-        foreign lpvm access(t##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##1:wybe.int) @loop_bug:nn:nn
-        foreign lpvm access(~t##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##1:loop_bug.int_list) @loop_bug:nn:nn
-        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @loop_bug:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~h##1:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @int:nn:nn
-        foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-        loop_bug.gen#1<0>(_:wybe.int, ~lst##0:loop_bug.int_list, ~t##1:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @loop_bug:nn:nn
-
-
-
-gen#2 > {inline} (1 calls)
-0: loop_bug.gen#2<0>
-gen#2(h##0:wybe.int, lst##0:loop_bug.int_list, t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @loop_bug:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @int:nn:nn
-    foreign c print_int(~h##0:wybe.int, ~tmp#1##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @int:nn:nn
-    foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-    loop_bug.gen#1<0>(_:wybe.int, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @loop_bug:nn:nn
-
-
 print > public (0 calls)
 0: loop_bug.print<0>
 print(lst##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
@@ -70,11 +35,46 @@ print(lst##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
 
     1:
         foreign lpvm access(lst##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @loop_bug:nn:nn
-        foreign lpvm access(lst##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:loop_bug.int_list) @loop_bug:nn:nn
+        foreign lpvm access(~lst##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:loop_bug.int_list) @loop_bug:nn:nn
         foreign c print_int(~h##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @int:nn:nn
         foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-        loop_bug.gen#1<0>(_:wybe.int, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @loop_bug:nn:nn
+        loop_bug.print#cont#1<0>(_:wybe.int, ~t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @loop_bug:nn:nn
 
+
+
+print#cont#1 > (2 calls)
+0: loop_bug.print#cont#1<0>
+print#cont#1([h##0:wybe.int], t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
+    0:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @char:nn:nn
+        foreign c putchar(']':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @char:nn:nn
+        foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
+
+    1:
+        foreign lpvm access(t##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##1:wybe.int) @loop_bug:nn:nn
+        foreign lpvm access(~t##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##1:loop_bug.int_list) @loop_bug:nn:nn
+        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @loop_bug:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~h##1:wybe.int, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @int:nn:nn
+        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+        loop_bug.print#cont#1<0>(_:wybe.int, ~t##1:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @loop_bug:nn:nn
+
+
+
+print#cont#2 > {inline} (1 calls)
+0: loop_bug.print#cont#2<0>
+print#cont#2(h##0:wybe.int, t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @loop_bug:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~h##0:wybe.int, ~tmp#1##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @int:nn:nn
+    foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+    loop_bug.print#cont#1<0>(_:wybe.int, ~t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @loop_bug:nn:nn
 
   LLVM code       :
 
@@ -90,48 +90,19 @@ print(lst##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
 @loop_bug.0 =    constant [?? x i8] c", \00"
 
 
-declare external ccc  void @putchar(i8)    
-
-
 declare external ccc  void @print_int(i64)    
 
 
 declare external fastcc  void @"wybe.string.print<0>"(i64)    
 
 
+declare external ccc  void @putchar(i8)    
+
+
 declare external ccc  i8* @wybe_malloc(i32)    
 
 
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
-
-
-define external fastcc  void @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %"t##0")    {
-entry:
-  %0 = icmp ne i64 %"t##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"t##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"t##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %2)  
-  musttail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %5)  
-  ret void 
-if.else:
-  tail call ccc  void  @putchar(i8  93)  
-  ret void 
-}
-
-
-define external fastcc  void @"loop_bug.gen#2<0>"(i64  %"h##0", i64  %"lst##0", i64  %"t##0") alwaysinline   {
-entry:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %"h##0")  
-  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %"t##0")  
-  ret void 
-}
 
 
 define external fastcc  void @"loop_bug.print<0>"(i64  %"lst##0")    {
@@ -146,10 +117,39 @@ if.then:
   %4 = inttoptr i64 %3 to i64* 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %2)  
-  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %5)  
+  musttail call fastcc  void  @"loop_bug.print#cont#1<0>"(i64  %5)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  
+  ret void 
+}
+
+
+define external fastcc  void @"loop_bug.print#cont#1<0>"(i64  %"t##0")    {
+entry:
+  %0 = icmp ne i64 %"t##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"t##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"t##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.1, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %2)  
+  musttail call fastcc  void  @"loop_bug.print#cont#1<0>"(i64  %5)  
+  ret void 
+if.else:
+  tail call ccc  void  @putchar(i8  93)  
+  ret void 
+}
+
+
+define external fastcc  void @"loop_bug.print#cont#2<0>"(i64  %"h##0", i64  %"t##0") alwaysinline   {
+entry:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.1, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %"h##0")  
+  tail call fastcc  void  @"loop_bug.print#cont#1<0>"(i64  %"t##0")  
   ret void 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/loop_terminators.exp
+++ b/test-cases/final-dump/loop_terminators.exp
@@ -9,39 +9,16 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-gen#1 > {inline} (2 calls)
-0: loop_terminators.gen#1<0>
-gen#1()<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-
-
-gen#2 > {inline} (2 calls)
-0: loop_terminators.gen#2<0>
-gen#2()<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-
-
-gen#3 > {inline} (1 calls)
-0: loop_terminators.gen#3<0>
-gen#3()<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-
-
-gen#4 > {inline} (1 calls)
-0: loop_terminators.gen#4<0>
-gen#4()<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    wybe.string.c_string<0>("lol":wybe.string, ?tmp#2##0:wybe.c_string) #1 @control:nn:nn
-    foreign c {terminal,semipure} error_exit(c"loop_terminators:14:11":wybe.c_string, ~tmp#2##0:wybe.c_string) @control:nn:nn
-
-
 loop0 > {inline} (0 calls)
 0: loop_terminators.loop0<0>
 loop0()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
+loop0#cont#1 > {inline} (2 calls)
+0: loop_terminators.loop0#cont#1<0>
+loop0#cont#1()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
@@ -53,9 +30,23 @@ loop1()<{}; {}>:
   InterestingCallProperties: []
 
 
+loop1#cont#1 > {inline} (2 calls)
+0: loop_terminators.loop1#cont#1<0>
+loop1#cont#1()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
 loop2 > {inline} (0 calls)
 0: loop_terminators.loop2<0>
 loop2()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+
+loop2#cont#1 > {inline} (1 calls)
+0: loop_terminators.loop2#cont#1<0>
+loop2#cont#1()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
@@ -67,6 +58,15 @@ loop3()<{}; {}>:
   InterestingCallProperties: []
     wybe.string.c_string<0>("lol":wybe.string, ?tmp#0##0:wybe.c_string) #1 @control:nn:nn
     foreign c {terminal,semipure} error_exit(c"loop_terminators:14:11":wybe.c_string, ~tmp#0##0:wybe.c_string) @control:nn:nn
+
+
+loop3#cont#1 > {inline} (1 calls)
+0: loop_terminators.loop3#cont#1<0>
+loop3#cont#1()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.string.c_string<0>("lol":wybe.string, ?tmp#2##0:wybe.c_string) #1 @control:nn:nn
+    foreign c {terminal,semipure} error_exit(c"loop_terminators:14:11":wybe.c_string, ~tmp#2##0:wybe.c_string) @control:nn:nn
 
   LLVM code       :
 
@@ -97,33 +97,13 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  void @"loop_terminators.gen#1<0>"() alwaysinline   {
-entry:
-  ret void 
-}
-
-
-define external fastcc  void @"loop_terminators.gen#2<0>"() alwaysinline   {
-entry:
-  ret void 
-}
-
-
-define external fastcc  void @"loop_terminators.gen#3<0>"() alwaysinline   {
-entry:
-  ret void 
-}
-
-
-define external fastcc  void @"loop_terminators.gen#4<0>"() alwaysinline   {
-entry:
-  %0 = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_terminators.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_terminators.2, i32 0, i32 0) to i64), i64  %0)  
-  ret void 
-}
-
-
 define external fastcc  void @"loop_terminators.loop0<0>"() alwaysinline   {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.loop0#cont#1<0>"() alwaysinline   {
 entry:
   ret void 
 }
@@ -135,13 +115,33 @@ entry:
 }
 
 
+define external fastcc  void @"loop_terminators.loop1#cont#1<0>"() alwaysinline   {
+entry:
+  ret void 
+}
+
+
 define external fastcc  void @"loop_terminators.loop2<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
+define external fastcc  void @"loop_terminators.loop2#cont#1<0>"() alwaysinline   {
+entry:
+  ret void 
+}
+
+
 define external fastcc  void @"loop_terminators.loop3<0>"() alwaysinline   {
+entry:
+  %0 = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_terminators.1, i32 0, i32 0) to i64))  
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_terminators.2, i32 0, i32 0) to i64), i64  %0)  
+  ret void 
+}
+
+
+define external fastcc  void @"loop_terminators.loop3#cont#1<0>"() alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_terminators.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_terminators.2, i32 0, i32 0) to i64), i64  %0)  

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -36,7 +36,8 @@ printTree1 > public (3 calls)
 0: mytree.printTree1<0>
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: [(prefix##0,prefix##3)]
-  InterestingCallProperties: []
+  InterestingCallProperties: [InterestingUnaliased 1]
+  MultiSpeczDepInfo: [(1,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 [1]])),(2,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 [1]]))]
     foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
     case ~tmp#2##0:wybe.bool of
     0:

--- a/test-cases/final-dump/need.exp
+++ b/test-cases/final-dump/need.exp
@@ -16,18 +16,18 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    need.gen#1<0> #0 @need:nn:nn
+    need.#anon#1<0> #0 @need:nn:nn
 
 
-gen#1 > {inline,impure} (1 calls)
-0: need.gen#1<0>
-gen#1()<{}; {}>:
+#anon#1 > {inline,impure} (1 calls)
+0: need.#anon#1<0>
+#anon#1()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     need.iota<0>(1000:wybe.int, outByReference l##0:wybe.list(wybe.int)) #0 @need:nn:nn
-gen#1 > {inline,impure} (1 calls)
-1: need.gen#1<1>
-gen#1()<{}; {}>:
+#anon#1 > {inline,impure} (1 calls)
+1: need.#anon#1<1>
+#anon#1()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     need.iota<0>(1000:wybe.int, outByReference tmp#0##0:wybe.list(wybe.int)) #1 @need:nn:nn
@@ -75,12 +75,12 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"need.<0>"() alwaysinline   {
 entry:
-  musttail call fastcc  void  @"need.gen#1<0>"()  
+  musttail call fastcc  void  @"need.#anon#1<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"need.gen#1<0>"() alwaysinline   {
+define external fastcc  void @"need.#anon#1<0>"() alwaysinline   {
 entry:
   %0 = alloca i64 
    call fastcc  void  @"need.iota<0>"(i64  1000, i64*  %0)  
@@ -88,7 +88,7 @@ entry:
 }
 
 
-define external fastcc  void @"need.gen#1<1>"(i64  %"#env##0") alwaysinline   {
+define external fastcc  void @"need.#anon#1<1>"(i64  %"#env##0") alwaysinline   {
 entry:
   %0 = alloca i64 
    call fastcc  void  @"need.iota<0>"(i64  1000, i64*  %0)  

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -22,12 +22,12 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    nested_loop.gen#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @nested_loop:nn:nn
+    nested_loop.#cont#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @nested_loop:nn:nn
 
 
-gen#1 > {inline} (1 calls)
-0: nested_loop.gen#1<0>
-gen#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > {inline} (1 calls)
+0: nested_loop.#cont#1<0>
+#cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>("Outer":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
@@ -38,19 +38,19 @@ gen#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    nested_loop.gen#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @nested_loop:nn:nn
+    nested_loop.#cont#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @nested_loop:nn:nn
 
 
-gen#2 > {inline} (2 calls)
-0: nested_loop.gen#2<0>
-gen#2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#2 > {inline} (2 calls)
+0: nested_loop.#cont#2<0>
+#cont#2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>("Inner":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#1##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    nested_loop.gen#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @nested_loop:nn:nn
+    nested_loop.#cont#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @nested_loop:nn:nn
 
   LLVM code       :
 
@@ -90,26 +90,26 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"nested_loop.gen#2<0>"()  
+  musttail call fastcc  void  @"nested_loop.#cont#2<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"nested_loop.gen#1<0>"() alwaysinline   {
+define external fastcc  void @"nested_loop.#cont#1<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"nested_loop.gen#2<0>"()  
+  musttail call fastcc  void  @"nested_loop.#cont#2<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"nested_loop.gen#2<0>"() alwaysinline   {
+define external fastcc  void @"nested_loop.#cont#2<0>"() alwaysinline   {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"nested_loop.gen#2<0>"()  
+  musttail call fastcc  void  @"nested_loop.#cont#2<0>"()  
   ret void 
 }

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -81,13 +81,15 @@ entry:
     foreign lpvm access(~#left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person1:nn:nn
     foreign lpvm access(#right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person1:nn:nn
     foreign lpvm access(~#right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person1:nn:nn
-    wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.comparison) #4 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#1##0:wybe.bool) @comparison:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?#success##0:wybe.bool) #3
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.comparison) #5 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -145,14 +147,16 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.p
     foreign lpvm access(~#left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person1:nn:nn
     foreign lpvm access(#right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person1:nn:nn
     foreign lpvm access(~#right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person1:nn:nn
-    wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
-    case ~tmp#7##0:wybe.bool of
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.comparison) #1 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#8##0:wybe.bool) @comparison:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#0##0:wybe.bool) #2
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.comparison) #2 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -164,7 +168,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.p
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -185,11 +189,13 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  ret i1 %11 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  ret i1 %13 
 if.else:
   ret i1 0 
 }
@@ -282,13 +288,15 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  %12 = xor i1 %11, 1 
-  ret i1 %12 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  %14 = xor i1 %13, 1 
+  ret i1 %14 
 if.else:
-  %13 = xor i1 0, 1 
-  ret i1 %13 
+  %15 = xor i1 0, 1 
+  ret i1 %15 
 }

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -83,13 +83,15 @@ entry:
     foreign lpvm access(~#left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person2:nn:nn
     foreign lpvm access(#right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person2:nn:nn
     foreign lpvm access(~#right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person2:nn:nn
-    wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.comparison) #4 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#1##0:wybe.bool) @comparison:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?#success##0:wybe.bool) #3
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.comparison) #5 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -147,14 +149,16 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.p
     foreign lpvm access(~#left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person2:nn:nn
     foreign lpvm access(#right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person2:nn:nn
     foreign lpvm access(~#right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person2:nn:nn
-    wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
-    case ~tmp#7##0:wybe.bool of
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.comparison) #1 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#8##0:wybe.bool) @comparison:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#0##0:wybe.bool) #2
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.comparison) #2 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -166,7 +170,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.p
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -187,11 +191,13 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  ret i1 %11 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  ret i1 %13 
 if.else:
   ret i1 0 
 }
@@ -284,13 +290,15 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  %12 = xor i1 %11, 1 
-  ret i1 %12 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  %14 = xor i1 %13, 1 
+  ret i1 %14 
 if.else:
-  %13 = xor i1 0, 1 
-  ret i1 %13 
+  %15 = xor i1 0, 1 
+  ret i1 %15 
 }

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -89,13 +89,15 @@ entry:
     foreign lpvm access(~#left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person3:nn:nn
     foreign lpvm access(#right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person3:nn:nn
     foreign lpvm access(~#right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person3:nn:nn
-    wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.comparison) #4 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#1##0:wybe.bool) @comparison:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?#success##0:wybe.bool) #3
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.comparison) #5 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -153,14 +155,16 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.p
     foreign lpvm access(~#left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person3:nn:nn
     foreign lpvm access(#right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person3:nn:nn
     foreign lpvm access(~#right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person3:nn:nn
-    wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
-    case ~tmp#7##0:wybe.bool of
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.comparison) #1 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#8##0:wybe.bool) @comparison:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#0##0:wybe.bool) #2
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.comparison) #2 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -172,7 +176,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.p
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -193,11 +197,13 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  ret i1 %11 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  ret i1 %13 
 if.else:
   ret i1 0 
 }
@@ -290,13 +296,15 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  %12 = xor i1 %11, 1 
-  ret i1 %12 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  %14 = xor i1 %13, 1 
+  ret i1 %14 
 if.else:
-  %13 = xor i1 0, 1 
-  ret i1 %13 
+  %15 = xor i1 0, 1 
+  ret i1 %15 
 }

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -89,13 +89,15 @@ entry:
     foreign lpvm access(~#left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person4:nn:nn
     foreign lpvm access(#right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person4:nn:nn
     foreign lpvm access(~#right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person4:nn:nn
-    wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.comparison) #4 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#1##0:wybe.bool) @comparison:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?#success##0:wybe.bool) #3
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.comparison) #5 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -153,14 +155,16 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.p
     foreign lpvm access(~#left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person4:nn:nn
     foreign lpvm access(#right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person4:nn:nn
     foreign lpvm access(~#right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person4:nn:nn
-    wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
-    case ~tmp#7##0:wybe.bool of
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.comparison) #1 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#8##0:wybe.bool) @comparison:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#0##0:wybe.bool) #2
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.comparison) #2 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -172,7 +176,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.p
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -193,11 +197,13 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  ret i1 %11 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  ret i1 %13 
 if.else:
   ret i1 0 
 }
@@ -290,13 +296,15 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  %12 = xor i1 %11, 1 
-  ret i1 %12 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  %14 = xor i1 %13, 1 
+  ret i1 %14 
 if.else:
-  %13 = xor i1 0, 1 
-  ret i1 %13 
+  %15 = xor i1 0, 1 
+  ret i1 %15 
 }

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -124,13 +124,15 @@ entry:
     foreign lpvm access(~#left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string) @person5:nn:nn
     foreign lpvm access(#right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string) @person5:nn:nn
     foreign lpvm access(~#right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string) @person5:nn:nn
-    wybe.string.=<0>(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#1##0:wybe.bool) #2
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.comparison) #4 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#1##0:wybe.bool) @comparison:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?#success##0:wybe.bool) #3
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.comparison) #5 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -188,14 +190,16 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.p
     foreign lpvm access(~#left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string) @person5:nn:nn
     foreign lpvm access(#right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string) @person5:nn:nn
     foreign lpvm access(~#right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string) @person5:nn:nn
-    wybe.string.=<0>(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.bool) #1
-    case ~tmp#7##0:wybe.bool of
+    wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.comparison) #1 @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.comparison, 1:wybe.comparison, ?tmp#8##0:wybe.bool) @comparison:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#0##0:wybe.bool) #2
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.comparison) #2 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -207,7 +211,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.p
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -228,11 +232,13 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  ret i1 %11 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  ret i1 %13 
 if.else:
   ret i1 0 
 }
@@ -325,13 +331,15 @@ entry:
   %7 = add   i64 %"#right##0", 8 
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
-  %10 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %1, i64  %6)  
-  br i1 %10, label %if.then, label %if.else 
+  %10 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %1, i64  %6, i64  %1, i64  %6)  
+  %11 = icmp eq i2 %10, 1 
+  br i1 %11, label %if.then, label %if.else 
 if.then:
-  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  %12 = xor i1 %11, 1 
-  ret i1 %12 
+  %12 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %13 = icmp eq i2 %12, 1 
+  %14 = xor i1 %13, 1 
+  ret i1 %14 
 if.else:
-  %13 = xor i1 0, 1 
-  ret i1 %13 
+  %15 = xor i1 0, 1 
+  ret i1 %15 
 }

--- a/test-cases/final-dump/proc_beer.exp
+++ b/test-cases/final-dump/proc_beer.exp
@@ -15,7 +15,7 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    proc_beer.gen#1<0>(99:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @proc_beer:nn:nn
+    proc_beer.beer99#cont#1<0>(99:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @proc_beer:nn:nn
 
 
 beer99 > public {inline} (1 calls)
@@ -23,12 +23,12 @@ beer99 > public {inline} (1 calls)
 beer99()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    proc_beer.gen#1<0>(99:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_beer:nn:nn
+    proc_beer.beer99#cont#1<0>(99:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_beer:nn:nn
 
 
-gen#1 > (2 calls)
-0: proc_beer.gen#1<0>
-gen#1(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+beer99#cont#1 > (2 calls)
+0: proc_beer.beer99#cont#1<0>
+beer99#cont#1(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_sge(count##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
@@ -44,13 +44,13 @@ gen#1(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
         foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
         foreign llvm sub(~count##0:wybe.int, 1:wybe.int, ?tmp#8##0:wybe.int) @int:nn:nn
-        proc_beer.gen#1<0>(~tmp#8##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @proc_beer:nn:nn
+        proc_beer.beer99#cont#1<0>(~tmp#8##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @proc_beer:nn:nn
 
 
 
-gen#2 > {inline} (1 calls)
-0: proc_beer.gen#2<0>
-gen#2(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+beer99#cont#2 > {inline} (1 calls)
+0: proc_beer.beer99#cont#2<0>
+beer99#cont#2(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @int:nn:nn
@@ -61,7 +61,7 @@ gen#2(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
     foreign llvm sub(~count##0:wybe.int, 1:wybe.int, ?count##1:wybe.int) @int:nn:nn
-    proc_beer.gen#1<0>(~count##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @proc_beer:nn:nn
+    proc_beer.beer99#cont#1<0>(~count##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @proc_beer:nn:nn
 
   LLVM code       :
 
@@ -94,19 +94,19 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"proc_beer.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  99)  
+  tail call fastcc  void  @"proc_beer.beer99#cont#1<0>"(i64  99)  
   ret void 
 }
 
 
 define external fastcc  void @"proc_beer.beer99<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  99)  
+  tail call fastcc  void  @"proc_beer.beer99#cont#1<0>"(i64  99)  
   ret void 
 }
 
 
-define external fastcc  void @"proc_beer.gen#1<0>"(i64  %"count##0")    {
+define external fastcc  void @"proc_beer.beer99#cont#1<0>"(i64  %"count##0")    {
 entry:
   %0 = icmp sge i64 %"count##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -115,19 +115,19 @@ if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %1 = sub   i64 %"count##0", 1 
-  musttail call fastcc  void  @"proc_beer.gen#1<0>"(i64  %1)  
+  musttail call fastcc  void  @"proc_beer.beer99#cont#1<0>"(i64  %1)  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"proc_beer.gen#2<0>"(i64  %"count##0") alwaysinline   {
+define external fastcc  void @"proc_beer.beer99#cont#2<0>"(i64  %"count##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  %"count##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %0 = sub   i64 %"count##0", 1 
-  musttail call fastcc  void  @"proc_beer.gen#1<0>"(i64  %0)  
+  musttail call fastcc  void  @"proc_beer.beer99#cont#1<0>"(i64  %0)  
   ret void 
 }

--- a/test-cases/final-dump/proc_factorial.exp
+++ b/test-cases/final-dump/proc_factorial.exp
@@ -15,7 +15,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    proc_factorial.gen#1<0>(5:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) #2 @proc_factorial:nn:nn
+    proc_factorial.factorial#cont#1<0>(5:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) #2 @proc_factorial:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
@@ -27,12 +27,12 @@ factorial > public {inline} (1 calls)
 factorial(n##0:wybe.int, ?result##1:wybe.int)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    proc_factorial.gen#1<0>(~n##0:wybe.int, 1:wybe.int, ?result##1:wybe.int) #0 @proc_factorial:nn:nn
+    proc_factorial.factorial#cont#1<0>(~n##0:wybe.int, 1:wybe.int, ?result##1:wybe.int) #0 @proc_factorial:nn:nn
 
 
-gen#1 > (2 calls)
-0: proc_factorial.gen#1<0>
-gen#1(n##0:wybe.int, result##0:wybe.int, ?result##1:wybe.int)<{}; {}>:
+factorial#cont#1 > (2 calls)
+0: proc_factorial.factorial#cont#1<0>
+factorial#cont#1(n##0:wybe.int, result##0:wybe.int, ?result##1:wybe.int)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_sgt(n##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
@@ -43,18 +43,18 @@ gen#1(n##0:wybe.int, result##0:wybe.int, ?result##1:wybe.int)<{}; {}>:
     1:
         foreign llvm mul(n##0:wybe.int, ~result##0:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
         foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#8##0:wybe.int) @int:nn:nn
-        proc_factorial.gen#1<0>(~tmp#8##0:wybe.int, ~tmp#7##0:wybe.int, ?result##1:wybe.int) #2 @proc_factorial:nn:nn
+        proc_factorial.factorial#cont#1<0>(~tmp#8##0:wybe.int, ~tmp#7##0:wybe.int, ?result##1:wybe.int) #2 @proc_factorial:nn:nn
 
 
 
-gen#2 > {inline} (1 calls)
-0: proc_factorial.gen#2<0>
-gen#2(n##0:wybe.int, result##0:wybe.int, ?result##2:wybe.int)<{}; {}>:
+factorial#cont#2 > {inline} (1 calls)
+0: proc_factorial.factorial#cont#2<0>
+factorial#cont#2(n##0:wybe.int, result##0:wybe.int, ?result##2:wybe.int)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm mul(n##0:wybe.int, ~result##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
     foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-    proc_factorial.gen#1<0>(~tmp#1##0:wybe.int, ~tmp#0##0:wybe.int, ?result##2:wybe.int) #2 @proc_factorial:nn:nn
+    proc_factorial.factorial#cont#1<0>(~tmp#1##0:wybe.int, ~tmp#0##0:wybe.int, ?result##2:wybe.int) #2 @proc_factorial:nn:nn
 
   LLVM code       :
 
@@ -78,7 +78,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"proc_factorial.<0>"()    {
 entry:
-  %0 = tail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  5, i64  1)  
+  %0 = tail call fastcc  i64  @"proc_factorial.factorial#cont#1<0>"(i64  5, i64  1)  
   tail call ccc  void  @print_int(i64  %0)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -87,29 +87,29 @@ entry:
 
 define external fastcc  i64 @"proc_factorial.factorial<0>"(i64  %"n##0") alwaysinline   {
 entry:
-  %0 = tail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  %"n##0", i64  1)  
+  %0 = tail call fastcc  i64  @"proc_factorial.factorial#cont#1<0>"(i64  %"n##0", i64  1)  
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"proc_factorial.gen#1<0>"(i64  %"n##0", i64  %"result##0")    {
+define external fastcc  i64 @"proc_factorial.factorial#cont#1<0>"(i64  %"n##0", i64  %"result##0")    {
 entry:
   %0 = icmp sgt i64 %"n##0", 1 
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = mul   i64 %"n##0", %"result##0" 
   %2 = sub   i64 %"n##0", 1 
-  %3 = musttail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  %2, i64  %1)  
+  %3 = musttail call fastcc  i64  @"proc_factorial.factorial#cont#1<0>"(i64  %2, i64  %1)  
   ret i64 %3 
 if.else:
   ret i64 %"result##0" 
 }
 
 
-define external fastcc  i64 @"proc_factorial.gen#2<0>"(i64  %"n##0", i64  %"result##0") alwaysinline   {
+define external fastcc  i64 @"proc_factorial.factorial#cont#2<0>"(i64  %"n##0", i64  %"result##0") alwaysinline   {
 entry:
   %0 = mul   i64 %"n##0", %"result##0" 
   %1 = sub   i64 %"n##0", 1 
-  %2 = musttail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  %1, i64  %0)  
+  %2 = musttail call fastcc  i64  @"proc_factorial.factorial#cont#1<0>"(i64  %1, i64  %0)  
   ret i64 %2 
 }

--- a/test-cases/final-dump/proc_gcd.exp
+++ b/test-cases/final-dump/proc_gcd.exp
@@ -16,7 +16,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    proc_gcd.gen#1<0>(18:wybe.int, 24:wybe.int, _:wybe.int, 18:wybe.int, 24:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @proc_gcd:nn:nn
+    proc_gcd.gcd#cont#1<0>(_:wybe.int, 18:wybe.int, 24:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @proc_gcd:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
     foreign c print_int(~r##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
@@ -27,12 +27,12 @@ gcd > public {inline} (1 calls)
 gcd(a##0:wybe.int, b##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    proc_gcd.gen#1<0>(~a##0:wybe.int, ~b##0:wybe.int, _:wybe.int, ~a##0:wybe.int, ~b##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_gcd:nn:nn
+    proc_gcd.gcd#cont#1<0>(_:wybe.int, ~a##0:wybe.int, ~b##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_gcd:nn:nn
 
 
-gen#1 > (2 calls)
-0: proc_gcd.gen#1<0>
-gen#1(a##0:wybe.int, b##0:wybe.int, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+gcd#cont#1 > (2 calls)
+0: proc_gcd.gcd#cont#1<0>
+gcd#cont#1([t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_ne(y##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
@@ -41,18 +41,18 @@ gen#1(a##0:wybe.int, b##0:wybe.int, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.in
         foreign llvm move(~x##0:wybe.int, ?r##0:wybe.int) @proc_gcd:nn:nn
 
     1:
-        proc_gcd.mod<0>(~x##0:wybe.int, y##0:wybe.int, ?tmp#8##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @proc_gcd:nn:nn
-        proc_gcd.gen#1<0>(~a##0:wybe.int, ~b##0:wybe.int, _:wybe.int, ~y##0:wybe.int, ~tmp#8##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @proc_gcd:nn:nn
+        proc_gcd.mod<0>(~x##0:wybe.int, y##0:wybe.int, ?tmp#6##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @proc_gcd:nn:nn
+        proc_gcd.gcd#cont#1<0>(_:wybe.int, ~y##0:wybe.int, ~tmp#6##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @proc_gcd:nn:nn
 
 
 
-gen#2 > {inline} (1 calls)
-0: proc_gcd.gen#2<0>
-gen#2(a##0:wybe.int, b##0:wybe.int, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+gcd#cont#2 > {inline} (1 calls)
+0: proc_gcd.gcd#cont#2<0>
+gcd#cont#2([t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     proc_gcd.mod<0>(~x##0:wybe.int, y##0:wybe.int, ?y##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_gcd:nn:nn
-    proc_gcd.gen#1<0>(~a##0:wybe.int, ~b##0:wybe.int, _:wybe.int, ~y##0:wybe.int, ~y##1:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @proc_gcd:nn:nn
+    proc_gcd.gcd#cont#1<0>(_:wybe.int, ~y##0:wybe.int, ~y##1:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @proc_gcd:nn:nn
 
 
 mod > public (1 calls)
@@ -92,7 +92,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"proc_gcd.<0>"()    {
 entry:
-  %0 = tail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  18, i64  24, i64  18, i64  24)  
+  %0 = tail call fastcc  i64  @"proc_gcd.gcd#cont#1<0>"(i64  18, i64  24)  
   tail call ccc  void  @print_int(i64  %0)  
   ret void 
 }
@@ -100,28 +100,28 @@ entry:
 
 define external fastcc  i64 @"proc_gcd.gcd<0>"(i64  %"a##0", i64  %"b##0") alwaysinline   {
 entry:
-  %0 = tail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"a##0", i64  %"b##0")  
+  %0 = musttail call fastcc  i64  @"proc_gcd.gcd#cont#1<0>"(i64  %"a##0", i64  %"b##0")  
   ret i64 %0 
 }
 
 
-define external fastcc  i64 @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"proc_gcd.gcd#cont#1<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %0 = icmp ne i64 %"y##0", 0 
   br i1 %0, label %if.then, label %if.else 
 if.then:
   %1 = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
-  %2 = musttail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %1)  
+  %2 = musttail call fastcc  i64  @"proc_gcd.gcd#cont#1<0>"(i64  %"y##0", i64  %1)  
   ret i64 %2 
 if.else:
   ret i64 %"x##0" 
 }
 
 
-define external fastcc  i64 @"proc_gcd.gen#2<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0") alwaysinline   {
+define external fastcc  i64 @"proc_gcd.gcd#cont#2<0>"(i64  %"x##0", i64  %"y##0") alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
-  %1 = musttail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %0)  
+  %1 = musttail call fastcc  i64  @"proc_gcd.gcd#cont#1<0>"(i64  %"y##0", i64  %0)  
   ret i64 %1 
 }
 

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -15,39 +15,11 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    proc_yorn.gen#1<0>("Well, yes or no?":wybe.string, ?r##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @proc_yorn:nn:nn
+    proc_yorn.yorn#cont#1<0>("Well, yes or no?":wybe.string, ?r##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @proc_yorn:nn:nn
     wybe.bool.print<0>(~r##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @bool:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
-
-gen#1 > (2 calls)
-0: proc_yorn.gen#1<0>
-gen#1(prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    wybe.string.print<0>(prompt##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_yorn:nn:nn
-    wybe.string.print<0>(" (y/n) ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @proc_yorn:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @char:nn:nn
-    foreign c read_char(?response##0:wybe.char, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @char:nn:nn
-    foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
-    foreign llvm icmp_ne(response##0:wybe.char, 'y':wybe.char, ?tmp#5##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(response##0:wybe.char, 'Y':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp#5##0:wybe.bool, ~tmp#6##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
-    foreign llvm xor(~tmp#7##0:wybe.bool, 1:wybe.bool, ?tmp#0##0:wybe.bool) @bool:nn:nn
-    proc_yorn.is_yes_or_no<0>(~response##0:wybe.char, ?tmp#1##0:wybe.bool) #4 @proc_yorn:nn:nn
-    case ~tmp#1##0:wybe.bool of
-    0:
-        wybe.string.print<0>("Please answer 'yes' or 'no'.":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @string:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        proc_yorn.gen#1<0>(~prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @proc_yorn:nn:nn
-
-    1:
-        foreign llvm move(~tmp#0##0:wybe.bool, ?result##1:wybe.bool)
-
 
 
 is_yes > {inline} (4 calls)
@@ -81,7 +53,35 @@ yorn > public {inline} (1 calls)
 yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    proc_yorn.gen#1<0>(~prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_yorn:nn:nn
+    proc_yorn.yorn#cont#1<0>(~prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_yorn:nn:nn
+
+
+yorn#cont#1 > (2 calls)
+0: proc_yorn.yorn#cont#1<0>
+yorn#cont#1(prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    wybe.string.print<0>(prompt##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_yorn:nn:nn
+    wybe.string.print<0>(" (y/n) ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @proc_yorn:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @char:nn:nn
+    foreign c read_char(?response##0:wybe.char, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @char:nn:nn
+    foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
+    foreign llvm icmp_ne(response##0:wybe.char, 'y':wybe.char, ?tmp#5##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(response##0:wybe.char, 'Y':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#5##0:wybe.bool, ~tmp#6##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
+    foreign llvm xor(~tmp#7##0:wybe.bool, 1:wybe.bool, ?tmp#0##0:wybe.bool) @bool:nn:nn
+    proc_yorn.is_yes_or_no<0>(~response##0:wybe.char, ?tmp#1##0:wybe.bool) #4 @proc_yorn:nn:nn
+    case ~tmp#1##0:wybe.bool of
+    0:
+        wybe.string.print<0>("Please answer 'yes' or 'no'.":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @string:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        proc_yorn.yorn#cont#1<0>(~prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @proc_yorn:nn:nn
+
+    1:
+        foreign llvm move(~tmp#0##0:wybe.bool, ?result##1:wybe.bool)
+
 
   LLVM code       :
 
@@ -129,31 +129,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"proc_yorn.<0>"()    {
 entry:
-  %0 = tail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.1, i32 0, i32 0) to i64))  
+  %0 = tail call fastcc  i1  @"proc_yorn.yorn#cont#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.1, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.bool.print<0>"(i1  %0)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
-}
-
-
-define external fastcc  i1 @"proc_yorn.gen#1<0>"(i64  %"prompt##0")    {
-entry:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %"prompt##0")  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.3, i32 0, i32 0) to i64))  
-  %0 = tail call ccc  i8  @read_char()  
-  %1 = icmp ne i8 %0, 121 
-  %2 = icmp ne i8 %0, 89 
-  %3 = and i1 %1, %2 
-  %4 = xor i1 %3, 1 
-  %5 = tail call fastcc  i1  @"proc_yorn.is_yes_or_no<0>"(i8  %0)  
-  br i1 %5, label %if.then, label %if.else 
-if.then:
-  ret i1 %4 
-if.else:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.5, i32 0, i32 0) to i64))  
-  tail call ccc  void  @putchar(i8  10)  
-  %6 = musttail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  %"prompt##0")  
-  ret i1 %6 
 }
 
 
@@ -183,6 +162,27 @@ entry:
 
 define external fastcc  i1 @"proc_yorn.yorn<0>"(i64  %"prompt##0") alwaysinline   {
 entry:
-  %0 = musttail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  %"prompt##0")  
+  %0 = musttail call fastcc  i1  @"proc_yorn.yorn#cont#1<0>"(i64  %"prompt##0")  
   ret i1 %0 
+}
+
+
+define external fastcc  i1 @"proc_yorn.yorn#cont#1<0>"(i64  %"prompt##0")    {
+entry:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  %"prompt##0")  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.3, i32 0, i32 0) to i64))  
+  %0 = tail call ccc  i8  @read_char()  
+  %1 = icmp ne i8 %0, 121 
+  %2 = icmp ne i8 %0, 89 
+  %3 = and i1 %1, %2 
+  %4 = xor i1 %3, 1 
+  %5 = tail call fastcc  i1  @"proc_yorn.is_yes_or_no<0>"(i8  %0)  
+  br i1 %5, label %if.then, label %if.else 
+if.then:
+  ret i1 %4 
+if.else:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.5, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  %6 = musttail call fastcc  i1  @"proc_yorn.yorn#cont#1<0>"(i64  %"prompt##0")  
+  ret i1 %6 
 }

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -9,9 +9,17 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-gen#1 > (2 calls)
-0: proc_yorn2.gen#1<0>
-gen#1(prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+yorn > public {inline} (0 calls)
+0: proc_yorn2.yorn<0>
+yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    proc_yorn2.yorn#cont#1<0>(~prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_yorn2:nn:nn
+
+
+yorn#cont#1 > (2 calls)
+0: proc_yorn2.yorn#cont#1<0>
+yorn#cont#1(prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>(prompt##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_yorn2:nn:nn
@@ -28,19 +36,11 @@ gen#1(prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        proc_yorn2.gen#1<0>(~prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @proc_yorn2:nn:nn
+        proc_yorn2.yorn#cont#1<0>(~prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @proc_yorn2:nn:nn
 
     1:
         foreign llvm move(~tmp#0##0:wybe.bool, ?result##1:wybe.bool)
 
-
-
-yorn > public {inline} (0 calls)
-0: proc_yorn2.yorn<0>
-yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    proc_yorn2.gen#1<0>(~prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @proc_yorn2:nn:nn
 
   LLVM code       :
 
@@ -77,7 +77,14 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
 
 
-define external fastcc  i1 @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")    {
+define external fastcc  i1 @"proc_yorn2.yorn<0>"(i64  %"prompt##0") alwaysinline   {
+entry:
+  %0 = musttail call fastcc  i1  @"proc_yorn2.yorn#cont#1<0>"(i64  %"prompt##0")  
+  ret i1 %0 
+}
+
+
+define external fastcc  i1 @"proc_yorn2.yorn#cont#1<0>"(i64  %"prompt##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  %"prompt##0")  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn2.1, i32 0, i32 0) to i64))  
@@ -91,13 +98,6 @@ if.then:
 if.else:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn2.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %4 = musttail call fastcc  i1  @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")  
+  %4 = musttail call fastcc  i1  @"proc_yorn2.yorn#cont#1<0>"(i64  %"prompt##0")  
   ret i1 %4 
-}
-
-
-define external fastcc  i1 @"proc_yorn2.yorn<0>"(i64  %"prompt##0") alwaysinline   {
-entry:
-  %0 = musttail call fastcc  i1  @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")  
-  ret i1 %0 
 }

--- a/test-cases/final-dump/resource_rollback.exp
+++ b/test-cases/final-dump/resource_rollback.exp
@@ -25,28 +25,19 @@ module top-level code > public {semipure} (0 calls)
     case ~tmp#3##0:wybe.bool of
     0:
         foreign lpvm store(0:wybe.int, <<resource_rollback.res>>:wybe.int) @resource_rollback:nn:nn
-        resource_rollback.gen#1<0><{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}> #4
+        resource_rollback.#cont#1<0><{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}> #4
 
     1:
         foreign c print_string(~s##0:wybe.c_string, ~tmp#7##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @c_string:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        resource_rollback.gen#1<0><{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+        resource_rollback.#cont#1<0><{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}> #3
 
 
 
-foo > {noinline} (3 calls)
-0: resource_rollback.foo<0>
-foo(?s##0:wybe.c_string, ?#success##0:wybe.bool, %call_source_location##0:wybe.c_string)<{<<resource_rollback.res>>}; {<<resource_rollback.res>>}>:
-  AliasPairs: [(call_source_location##0,s##0)]
-  InterestingCallProperties: []
-    foreign llvm move(~call_source_location##0:wybe.c_string, ?s##0:wybe.c_string) @resource_rollback:nn:nn
-    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-
-
-gen#1 > (2 calls)
-0: resource_rollback.gen#1<0>
-gen#1()<{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (2 calls)
+0: resource_rollback.#cont#1<0>
+#cont#1()<{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<resource_rollback.res>>:wybe.int, ?%res##0:wybe.int) @resource_rollback:nn:nn
@@ -57,6 +48,15 @@ gen#1()<{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; 
     foreign c print_int(~ser##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+
+foo > {noinline} (3 calls)
+0: resource_rollback.foo<0>
+foo(?s##0:wybe.c_string, ?#success##0:wybe.bool, %call_source_location##0:wybe.c_string)<{<<resource_rollback.res>>}; {<<resource_rollback.res>>}>:
+  AliasPairs: [(call_source_location##0,s##0)]
+  InterestingCallProperties: []
+    foreign llvm move(~call_source_location##0:wybe.c_string, ?s##0:wybe.c_string) @resource_rollback:nn:nn
+    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -103,11 +103,23 @@ entry:
 if.then:
   tail call ccc  void  @print_string(i64  %1)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"resource_rollback.gen#1<0>"()  
+  musttail call fastcc  void  @"resource_rollback.#cont#1<0>"()  
   ret void 
 if.else:
   store  i64 0, i64* @"resource#resource_rollback.res" 
-  musttail call fastcc  void  @"resource_rollback.gen#1<0>"()  
+  musttail call fastcc  void  @"resource_rollback.#cont#1<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"resource_rollback.#cont#1<0>"()    {
+entry:
+  %0 = load  i64, i64* @"resource#resource_rollback.res" 
+  tail call ccc  void  @print_int(i64  %0)  
+  tail call ccc  void  @putchar(i8  10)  
+  %1 = load  i64, i64* @"resource#resource_rollback.ser" 
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
@@ -117,16 +129,4 @@ entry:
   %0 = insertvalue {i64, i1} undef, i64 %"call_source_location##0", 0 
   %1 = insertvalue {i64, i1} %0, i1 0, 1 
   ret {i64, i1} %1 
-}
-
-
-define external fastcc  void @"resource_rollback.gen#1<0>"()    {
-entry:
-  %0 = load  i64, i64* @"resource#resource_rollback.res" 
-  tail call ccc  void  @print_int(i64  %0)  
-  tail call ccc  void  @putchar(i8  10)  
-  %1 = load  i64, i64* @"resource#resource_rollback.ser" 
-  tail call ccc  void  @print_int(i64  %1)  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
 }

--- a/test-cases/final-dump/resource_tmp_vars.exp
+++ b/test-cases/final-dump/resource_tmp_vars.exp
@@ -23,9 +23,9 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-gen#1 > {inline} (1 calls)
-0: resource_tmp_vars.gen#1<0>
-gen#1(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<wybe.io.io>>}; {<<resource_tmp_vars.counter>>, <<wybe.io.io>>}>:
+#cont#1 > {inline} (1 calls)
+0: resource_tmp_vars.#cont#1<0>
+#cont#1(tmp#0##0:wybe.int, [tmp#1##0:wybe.int])<{<<wybe.io.io>>}; {<<resource_tmp_vars.counter>>, <<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
@@ -70,7 +70,7 @@ entry:
 }
 
 
-define external fastcc  void @"resource_tmp_vars.gen#1<0>"(i64  %"tmp#0##0") alwaysinline   {
+define external fastcc  void @"resource_tmp_vars.#cont#1<0>"(i64  %"tmp#0##0") alwaysinline   {
 entry:
   tail call ccc  void  @print_int(i64  1)  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/simple_loop.exp
+++ b/test-cases/final-dump/simple_loop.exp
@@ -14,12 +14,12 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    simple_loop.gen#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @simple_loop:nn:nn
+    simple_loop.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @simple_loop:nn:nn
 
 
-gen#1 > (2 calls)
-0: simple_loop.gen#1<0>
-gen#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (2 calls)
+0: simple_loop.#cont#1<0>
+#cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#1##0:wybe.phantom) @char:nn:nn
@@ -32,7 +32,7 @@ gen#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     1:
         foreign c putchar(~c##0:wybe.char, ~tmp#2##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @char:nn:nn
         foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
-        simple_loop.gen#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @simple_loop:nn:nn
+        simple_loop.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @simple_loop:nn:nn
 
 
   LLVM code       :
@@ -57,19 +57,19 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"simple_loop.<0>"() alwaysinline   {
 entry:
-  musttail call fastcc  void  @"simple_loop.gen#1<0>"()  
+  musttail call fastcc  void  @"simple_loop.#cont#1<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"simple_loop.gen#1<0>"()    {
+define external fastcc  void @"simple_loop.#cont#1<0>"()    {
 entry:
   %0 = tail call ccc  i8  @read_char()  
   %1 = icmp ne i8 %0, 97 
   br i1 %1, label %if.then, label %if.else 
 if.then:
   tail call ccc  void  @putchar(i8  %0)  
-  musttail call fastcc  void  @"simple_loop.gen#1<0>"()  
+  musttail call fastcc  void  @"simple_loop.#cont#1<0>"()  
   ret void 
 if.else:
   ret void 

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -92,355 +92,26 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#28##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    stmt_for.using_xrange<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #19 @stmt_for:nn:nn
-    wybe.string.print<0>("\nusing_xrange_reverse":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #36 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    stmt_for.using_xrange_reverse<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #21 @stmt_for:nn:nn
-    wybe.string.print<0>("\nusing_irange":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #37 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#34##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#35##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    stmt_for.using_irange<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #23 @stmt_for:nn:nn
-    wybe.string.print<0>("\nusing_irange_reverse":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #38 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#37##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#37##0:wybe.phantom, ?tmp#38##0:wybe.phantom) @io:nn:nn
-    foreign lpvm store(~%tmp#38##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    stmt_for.using_irange_reverse<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #25 @stmt_for:nn:nn
-
-
-gen#1 > (2 calls)
-0: stmt_for.gen#1<0>
-gen#1(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
-    case ~tmp#13##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
-        case ~tmp#15##0:wybe.bool of
-        0:
-
-        1:
-            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int) @list:nn:nn
-            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int)) @list:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~i##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
-            foreign c print_int(~j##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            stmt_for.gen#1<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
-
-
-
-
-gen#10 > (2 calls)
-0: stmt_for.gen#10<0>
-gen#10(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
-    case ~tmp#9##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
-        case ~tmp#6##0:wybe.bool of
-        0:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            stmt_for.gen#10<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_for:nn:nn
-
-        1:
-
-
-
-
-gen#11 > (3 calls)
-0: stmt_for.gen#11<0>
-gen#11(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
-    case ~tmp#9##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
-        case ~tmp#6##0:wybe.bool of
-        0:
-            stmt_for.gen#11<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
-
-        1:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            stmt_for.gen#11<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_for:nn:nn
-
-
-
-
-gen#12 > (2 calls)
-0: stmt_for.gen#12<0>
-gen#12(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
-    case ~tmp#9##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
-        case ~tmp#6##0:wybe.bool of
-        0:
-
-        1:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            stmt_for.gen#12<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_for:nn:nn
-
-
-
-
-gen#13 > (2 calls)
-0: stmt_for.gen#13<0>
-gen#13(tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0 @stmt_for:nn:nn
-    case ~tmp#2##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_for.gen#13<0>(~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
-
-
-
-gen#14 > (2 calls)
-0: stmt_for.gen#14<0>
-gen#14(tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0 @stmt_for:nn:nn
-    case ~tmp#2##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_for.gen#14<0>(~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
-
-
-
-gen#2 > (2 calls)
-0: stmt_for.gen#2<0>
-gen#2(tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#3##0:wybe.bool) #0 @stmt_for:nn:nn
-    case ~tmp#3##0:wybe.bool of
-    0:
-        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
-
-    1:
-        foreign llvm icmp_slt(~i##0:wybe.int, 5:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
-        case ~tmp#2##0:wybe.bool of
-        0:
-            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-
-        1:
-            stmt_for.gen#2<0>(~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #2 @stmt_for:nn:nn
-
-
-
-
-gen#3 > (2 calls)
-0: stmt_for.gen#3<0>
-gen#3(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
-    case ~tmp#13##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
-        case ~tmp#15##0:wybe.bool of
-        0:
-
-        1:
-            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int) @list:nn:nn
-            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int)) @list:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~i##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
-            foreign c print_int(~j##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            stmt_for.gen#3<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
-
-
-
-
-gen#4 > (2 calls)
-0: stmt_for.gen#4<0>
-gen#4(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#4##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
-    case ~tmp#7##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#4##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_for.gen#4<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
-
-
-
-gen#5 > (2 calls)
-0: stmt_for.gen#5<0>
-gen#5(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
-    case ~tmp#9##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
-        case ~tmp#6##0:wybe.bool of
-        0:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            stmt_for.gen#5<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_for:nn:nn
-
-        1:
-
-
-
-
-gen#6 > (2 calls)
-0: stmt_for.gen#6<0>
-gen#6(tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0 @stmt_for:nn:nn
-    case ~tmp#2##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_for.gen#6<0>(~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
-
-
-
-gen#7 > (2 calls)
-0: stmt_for.gen#7<0>
-gen#7(tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0 @stmt_for:nn:nn
-    case ~tmp#2##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_for.gen#7<0>(~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
-
-
-
-gen#8 > (3 calls)
-0: stmt_for.gen#8<0>
-gen#8(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
-    case ~tmp#9##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
-        case ~tmp#6##0:wybe.bool of
-        0:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            stmt_for.gen#8<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
-
-        1:
-            stmt_for.gen#8<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
-
-
-
-
-gen#9 > (3 calls)
-0: stmt_for.gen#9<0>
-gen#9(tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
-    case ~tmp#9##0:wybe.bool of
-    0:
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
-        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
-        case ~tmp#6##0:wybe.bool of
-        0:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
-            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
-            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-            stmt_for.gen#9<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
-
-        1:
-            stmt_for.gen#9<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
-
-
+    stmt_for.xrange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#30##0:stmt_for.int_sequence) #36 @stmt_for:nn:nn
+    stmt_for.using_xrange#cont#1<0>(~tmp#30##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #37 @stmt_for:nn:nn
+    wybe.string.print<0>("\nusing_xrange_reverse":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #38 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#32##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#32##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#33##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    stmt_for.xrange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#34##0:stmt_for.int_sequence) #39 @stmt_for:nn:nn
+    stmt_for.using_xrange_reverse#cont#1<0>(~tmp#34##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #40 @stmt_for:nn:nn
+    wybe.string.print<0>("\nusing_irange":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #41 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    stmt_for.irange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#38##0:stmt_for.int_sequence) #42 @stmt_for:nn:nn
+    stmt_for.using_irange#cont#1<0>(~tmp#38##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #43 @stmt_for:nn:nn
+    wybe.string.print<0>("\nusing_irange_reverse":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #44 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#40##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#40##0:wybe.phantom, ?tmp#41##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#41##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    stmt_for.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#42##0:stmt_for.int_sequence) #45 @stmt_for:nn:nn
+    stmt_for.using_irange_reverse#cont#1<0>(~tmp#42##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #46 @stmt_for:nn:nn
 
 
 irange > public (2 calls)
@@ -476,20 +147,50 @@ multiple_generator()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:T) @list:nn:nn
     foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#6##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#4##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#1<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#4##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.list(T)) @list:nn:nn
+    stmt_for.multiple_generator#cont#1<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @stmt_for:nn:nn
+
+
+multiple_generator#cont#1 > (2 calls)
+0: stmt_for.multiple_generator#cont#1<0>
+multiple_generator#cont#1(tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
+    case ~tmp#13##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
+        case ~tmp#15##0:wybe.bool of
+        0:
+
+        1:
+            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int) @list:nn:nn
+            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int)) @list:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~i##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
+            foreign c print_int(~j##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            stmt_for.multiple_generator#cont#1<0>(~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
+
+
 
 
 semi_det_for_loop > public (0 calls)
@@ -498,7 +199,29 @@ semi_det_for_loop(?#success##0:wybe.bool)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#2<0>(~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #1 @stmt_for:nn:nn
+    stmt_for.semi_det_for_loop#cont#1<0>(~tmp#1##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #1 @stmt_for:nn:nn
+
+
+semi_det_for_loop#cont#1 > (2 calls)
+0: stmt_for.semi_det_for_loop#cont#1<0>
+semi_det_for_loop#cont#1(tmp#0##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#3##0:wybe.bool) #0 @stmt_for:nn:nn
+    case ~tmp#3##0:wybe.bool of
+    0:
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+    1:
+        foreign llvm icmp_slt(~i##0:wybe.int, 5:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
+        0:
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
+
+        1:
+            stmt_for.semi_det_for_loop#cont#1<0>(~tmp#0##1:stmt_for.int_sequence, ?#success##0:wybe.bool) #2 @stmt_for:nn:nn
+
+
 
 
 shortest_generator_termination > public (1 calls)
@@ -511,20 +234,50 @@ shortest_generator_termination()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T) @list:nn:nn
     foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#6##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#3<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:wybe.list(T)) @list:nn:nn
+    stmt_for.shortest_generator_termination#cont#1<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8 @stmt_for:nn:nn
+
+
+shortest_generator_termination#cont#1 > (2 calls)
+0: stmt_for.shortest_generator_termination#cont#1<0>
+shortest_generator_termination#cont#1(tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
+    case ~tmp#13##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
+        case ~tmp#15##0:wybe.bool of
+        0:
+
+        1:
+            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int) @list:nn:nn
+            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int)) @list:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~i##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
+            foreign c print_int(~j##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            stmt_for.shortest_generator_termination#cont#1<0>(~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
+
+
 
 
 single_generator > public (1 calls)
@@ -537,11 +290,31 @@ single_generator()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#12##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#13##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#16##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#17##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#4<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
+    stmt_for.single_generator#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
+
+
+single_generator#cont#1 > (2 calls)
+0: stmt_for.single_generator#cont#1<0>
+single_generator#cont#1(tmp#4##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#4##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
+    case ~tmp#7##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#4##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        stmt_for.single_generator#cont#1<0>(~tmp#4##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
+
 
 
 using_break > public (1 calls)
@@ -554,32 +327,94 @@ using_break()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#5<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
+    stmt_for.using_break#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
 
 
-using_irange > public (1 calls)
+using_break#cont#1 > (2 calls)
+0: stmt_for.using_break#cont#1<0>
+using_break#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            stmt_for.using_break#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_for:nn:nn
+
+        1:
+
+
+
+
+using_irange > public {inline} (1 calls)
 0: stmt_for.using_irange<0>
 using_irange()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     stmt_for.irange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#6<0>(~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @stmt_for:nn:nn
+    stmt_for.using_irange#cont#1<0>(~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @stmt_for:nn:nn
 
 
-using_irange_reverse > public (1 calls)
+using_irange#cont#1 > (2 calls)
+0: stmt_for.using_irange#cont#1<0>
+using_irange#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0 @stmt_for:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        stmt_for.using_irange#cont#1<0>(~tmp#0##1:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
+
+
+
+using_irange_reverse > public {inline} (1 calls)
 0: stmt_for.using_irange_reverse<0>
 using_irange_reverse()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     stmt_for.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#7<0>(~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @stmt_for:nn:nn
+    stmt_for.using_irange_reverse#cont#1<0>(~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @stmt_for:nn:nn
+
+
+using_irange_reverse#cont#1 > (2 calls)
+0: stmt_for.using_irange_reverse#cont#1<0>
+using_irange_reverse#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0 @stmt_for:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        stmt_for.using_irange_reverse#cont#1<0>(~tmp#0##1:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
+
 
 
 using_next > public (1 calls)
@@ -592,14 +427,41 @@ using_next()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#8<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
+    stmt_for.using_next#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+
+
+using_next#cont#1 > (3 calls)
+0: stmt_for.using_next#cont#1<0>
+using_next#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            stmt_for.using_next#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
+
+        1:
+            stmt_for.using_next#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
+
+
 
 
 using_unless > public (1 calls)
@@ -612,14 +474,41 @@ using_unless()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#9<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
+    stmt_for.using_unless#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+
+
+using_unless#cont#1 > (3 calls)
+0: stmt_for.using_unless#cont#1<0>
+using_unless#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            stmt_for.using_unless#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
+
+        1:
+            stmt_for.using_unless#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
+
+
 
 
 using_until > public (1 calls)
@@ -632,14 +521,40 @@ using_until()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#10<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
+    stmt_for.using_until#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+
+
+using_until#cont#1 > (2 calls)
+0: stmt_for.using_until#cont#1<0>
+using_until#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            stmt_for.using_until#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_for:nn:nn
+
+        1:
+
+
 
 
 using_when > public (1 calls)
@@ -652,14 +567,41 @@ using_when()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#11<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
+    stmt_for.using_when#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+
+
+using_when#cont#1 > (3 calls)
+0: stmt_for.using_when#cont#1<0>
+using_when#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            stmt_for.using_when#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_for:nn:nn
+
+        1:
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            stmt_for.using_when#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_for:nn:nn
+
+
 
 
 using_while > public (1 calls)
@@ -672,32 +614,94 @@ using_while()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T)) @list:nn:nn
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T)) @list:nn:nn
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T) @list:nn:nn
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T)) @list:nn:nn
-    stmt_for.gen#12<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.list(T)) @list:nn:nn
+    stmt_for.using_while#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_for:nn:nn
 
 
-using_xrange > public (1 calls)
+using_while#cont#1 > (2 calls)
+0: stmt_for.using_while#cont#1<0>
+using_while#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int) @list:nn:nn
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int)) @list:nn:nn
+        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+
+        1:
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @int:nn:nn
+            foreign c print_int(~i##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @int:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+            foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+            stmt_for.using_while#cont#1<0>(~tmp#5##1:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_for:nn:nn
+
+
+
+
+using_xrange > public {inline} (1 calls)
 0: stmt_for.using_xrange<0>
 using_xrange()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     stmt_for.xrange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#13<0>(~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @stmt_for:nn:nn
+    stmt_for.using_xrange#cont#1<0>(~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @stmt_for:nn:nn
 
 
-using_xrange_reverse > public (1 calls)
+using_xrange#cont#1 > (2 calls)
+0: stmt_for.using_xrange#cont#1<0>
+using_xrange#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0 @stmt_for:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        stmt_for.using_xrange#cont#1<0>(~tmp#0##1:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
+
+
+
+using_xrange_reverse > public {inline} (1 calls)
 0: stmt_for.using_xrange_reverse<0>
 using_xrange_reverse()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     stmt_for.xrange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#14<0>(~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @stmt_for:nn:nn
+    stmt_for.using_xrange_reverse#cont#1<0>(~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @stmt_for:nn:nn
+
+
+using_xrange_reverse#cont#1 > (2 calls)
+0: stmt_for.using_xrange_reverse#cont#1<0>
+using_xrange_reverse#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0 @stmt_for:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        stmt_for.using_xrange_reverse#cont#1<0>(~tmp#0##1:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_for:nn:nn
+
 
 
 xrange > public (3 calls)
@@ -842,332 +846,20 @@ entry:
   tail call fastcc  void  @"stmt_for.using_unless<0>"()  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.19, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.using_xrange<0>"()  
+  %0 = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  1, i64  1, i64  10)  
+  tail call fastcc  void  @"stmt_for.using_xrange#cont#1<0>"(i64  %0)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.21, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.using_xrange_reverse<0>"()  
+  %1 = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  10, i64  -1, i64  1)  
+  tail call fastcc  void  @"stmt_for.using_xrange_reverse#cont#1<0>"(i64  %1)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.23, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.using_irange<0>"()  
+  %2 = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  1, i64  1, i64  10)  
+  tail call fastcc  void  @"stmt_for.using_irange#cont#1<0>"(i64  %2)  
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.25, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.using_irange_reverse<0>"()  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#8##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#8##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#8##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = icmp ne i64 %"tmp#9##0", 0 
-  br i1 %6, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  %7 = inttoptr i64 %"tmp#9##0" to i64* 
-  %8 = load  i64, i64* %7 
-  %9 = add   i64 %"tmp#9##0", 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = load  i64, i64* %10 
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %8)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %5, i64  %11, i64  %"x##0", i64  %"y##0")  
-  ret void 
-if.else1:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#5##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = icmp eq i64 %2, 3 
-  br i1 %6, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  ret void 
-if.else1:
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#5##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = icmp slt i64 %2, 3 
-  br i1 %6, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
-  ret void 
-if.else1:
-  musttail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#5##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = icmp slt i64 %2, 3 
-  br i1 %6, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
-  ret void 
-if.else1:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#13<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
-entry:
-  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %1 = extractvalue {i64, i64, i1} %0, 0 
-  %2 = extractvalue {i64, i64, i1} %0, 1 
-  %3 = extractvalue {i64, i64, i1} %0, 2 
-  br i1 %3, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %1)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %2, i64  %"tmp#1##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#14<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
-entry:
-  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %1 = extractvalue {i64, i64, i1} %0, 0 
-  %2 = extractvalue {i64, i64, i1} %0, 1 
-  %3 = extractvalue {i64, i64, i1} %0, 2 
-  br i1 %3, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %1)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %2, i64  %"tmp#1##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  i1 @"stmt_for.gen#2<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
-entry:
-  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %1 = extractvalue {i64, i64, i1} %0, 0 
-  %2 = extractvalue {i64, i64, i1} %0, 1 
-  %3 = extractvalue {i64, i64, i1} %0, 2 
-  br i1 %3, label %if.then, label %if.else 
-if.then:
-  %4 = icmp slt i64 %1, 5 
-  br i1 %4, label %if.then1, label %if.else1 
-if.else:
-  ret i1 1 
-if.then1:
-  %5 = musttail call fastcc  i1  @"stmt_for.gen#2<0>"(i64  %2, i64  %"tmp#1##0")  
-  ret i1 %5 
-if.else1:
-  ret i1 0 
-}
-
-
-define external fastcc  void @"stmt_for.gen#3<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#8##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#8##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#8##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = icmp ne i64 %"tmp#9##0", 0 
-  br i1 %6, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  %7 = inttoptr i64 %"tmp#9##0" to i64* 
-  %8 = load  i64, i64* %7 
-  %9 = add   i64 %"tmp#9##0", 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = load  i64, i64* %10 
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %8)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#3<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %5, i64  %11, i64  %"x##0", i64  %"y##0")  
-  ret void 
-if.else1:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"x##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#4##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#4##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#4##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %5, i64  %"x##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#5<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#5##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = icmp eq i64 %2, 3 
-  br i1 %6, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  ret void 
-if.else1:
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#5<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
-entry:
-  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %1 = extractvalue {i64, i64, i1} %0, 0 
-  %2 = extractvalue {i64, i64, i1} %0, 1 
-  %3 = extractvalue {i64, i64, i1} %0, 2 
-  br i1 %3, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %1)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %2, i64  %"tmp#1##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#7<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
-entry:
-  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %1 = extractvalue {i64, i64, i1} %0, 0 
-  %2 = extractvalue {i64, i64, i1} %0, 1 
-  %3 = extractvalue {i64, i64, i1} %0, 2 
-  br i1 %3, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %1)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#7<0>"(i64  %2, i64  %"tmp#1##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#5##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = icmp eq i64 %2, 3 
-  br i1 %6, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  musttail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
-  ret void 
-if.else1:
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %0 = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %0, label %if.then, label %if.else 
-if.then:
-  %1 = inttoptr i64 %"tmp#5##0" to i64* 
-  %2 = load  i64, i64* %1 
-  %3 = add   i64 %"tmp#5##0", 8 
-  %4 = inttoptr i64 %3 to i64* 
-  %5 = load  i64, i64* %4 
-  %6 = icmp slt i64 %2, 3 
-  br i1 %6, label %if.then1, label %if.else1 
-if.else:
-  ret void 
-if.then1:
-  musttail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
-  ret void 
-if.else1:
-  tail call ccc  void  @print_int(i64  %2)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %5, i64  %"x##0")  
+  %3 = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  10, i64  -1, i64  1)  
+  tail call fastcc  void  @"stmt_for.using_irange_reverse#cont#1<0>"(i64  %3)  
   ret void 
 }
 
@@ -1257,7 +949,38 @@ entry:
   %34 = add   i64 %32, 8 
   %35 = inttoptr i64 %34 to i64* 
   store  i64 %26, i64* %35 
-  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %14, i64  %8, i64  %2, i64  0, i64  %32, i64  %26, i64  %20, i64  0, i64  %14, i64  %32, i64  %14, i64  %32)  
+  tail call fastcc  void  @"stmt_for.multiple_generator#cont#1<0>"(i64  %14, i64  %32)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.multiple_generator#cont#1<0>"(i64  %"tmp#8##0", i64  %"tmp#9##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#8##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#8##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#8##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"tmp#9##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  %7 = inttoptr i64 %"tmp#9##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"tmp#9##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call ccc  void  @print_int(i64  %8)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.multiple_generator#cont#1<0>"(i64  %5, i64  %11)  
+  ret void 
+if.else1:
   ret void 
 }
 
@@ -1265,8 +988,28 @@ entry:
 define external fastcc  i1 @"stmt_for.semi_det_for_loop<0>"()    {
 entry:
   %0 = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  0, i64  1, i64  10)  
-  %1 = tail call fastcc  i1  @"stmt_for.gen#2<0>"(i64  %0, i64  %0)  
+  %1 = tail call fastcc  i1  @"stmt_for.semi_det_for_loop#cont#1<0>"(i64  %0)  
   ret i1 %1 
+}
+
+
+define external fastcc  i1 @"stmt_for.semi_det_for_loop#cont#1<0>"(i64  %"tmp#0##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  %4 = icmp slt i64 %1, 5 
+  br i1 %4, label %if.then1, label %if.else1 
+if.else:
+  ret i1 1 
+if.then1:
+  %5 = musttail call fastcc  i1  @"stmt_for.semi_det_for_loop#cont#1<0>"(i64  %2)  
+  ret i1 %5 
+if.else1:
+  ret i1 0 
 }
 
 
@@ -1320,7 +1063,38 @@ entry:
   %34 = add   i64 %32, 8 
   %35 = inttoptr i64 %34 to i64* 
   store  i64 %26, i64* %35 
-  tail call fastcc  void  @"stmt_for.gen#3<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %32, i64  %26, i64  0, i64  %20, i64  %32, i64  %20, i64  %32)  
+  tail call fastcc  void  @"stmt_for.shortest_generator_termination#cont#1<0>"(i64  %20, i64  %32)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.shortest_generator_termination#cont#1<0>"(i64  %"tmp#8##0", i64  %"tmp#9##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#8##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#8##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#8##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp ne i64 %"tmp#9##0", 0 
+  br i1 %6, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  %7 = inttoptr i64 %"tmp#9##0" to i64* 
+  %8 = load  i64, i64* %7 
+  %9 = add   i64 %"tmp#9##0", 8 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call ccc  void  @print_int(i64  %8)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.shortest_generator_termination#cont#1<0>"(i64  %5, i64  %11)  
+  ret void 
+if.else1:
   ret void 
 }
 
@@ -1351,7 +1125,26 @@ entry:
   %16 = add   i64 %14, 8 
   %17 = inttoptr i64 %16 to i64* 
   store  i64 %8, i64* %17 
-  tail call fastcc  void  @"stmt_for.gen#4<0>"(i64  %14, i64  %8, i64  %2, i64  0, i64  %14, i64  %14)  
+  tail call fastcc  void  @"stmt_for.single_generator#cont#1<0>"(i64  %14)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.single_generator#cont#1<0>"(i64  %"tmp#4##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#4##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#4##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#4##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.single_generator#cont#1<0>"(i64  %5)  
+  ret void 
+if.else:
   ret void 
 }
 
@@ -1390,23 +1183,81 @@ entry:
   %22 = add   i64 %20, 8 
   %23 = inttoptr i64 %22 to i64* 
   store  i64 %14, i64* %23 
-  tail call fastcc  void  @"stmt_for.gen#5<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
+  tail call fastcc  void  @"stmt_for.using_break#cont#1<0>"(i64  %20)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.using_irange<0>"()    {
+define external fastcc  void @"stmt_for.using_break#cont#1<0>"(i64  %"tmp#5##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#5##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  ret void 
+if.else1:
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_break#cont#1<0>"(i64  %5)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_irange<0>"() alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  1, i64  1, i64  10)  
-  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %0, i64  %0)  
+  tail call fastcc  void  @"stmt_for.using_irange#cont#1<0>"(i64  %0)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.using_irange_reverse<0>"()    {
+define external fastcc  void @"stmt_for.using_irange#cont#1<0>"(i64  %"tmp#0##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_irange#cont#1<0>"(i64  %2)  
+  ret void 
+if.else:
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_irange_reverse<0>"() alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  10, i64  -1, i64  1)  
-  tail call fastcc  void  @"stmt_for.gen#7<0>"(i64  %0, i64  %0)  
+  tail call fastcc  void  @"stmt_for.using_irange_reverse#cont#1<0>"(i64  %0)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_irange_reverse#cont#1<0>"(i64  %"tmp#0##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_irange_reverse#cont#1<0>"(i64  %2)  
+  ret void 
+if.else:
   ret void 
 }
 
@@ -1445,7 +1296,32 @@ entry:
   %22 = add   i64 %20, 8 
   %23 = inttoptr i64 %22 to i64* 
   store  i64 %14, i64* %23 
-  tail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
+  tail call fastcc  void  @"stmt_for.using_next#cont#1<0>"(i64  %20)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_next#cont#1<0>"(i64  %"tmp#5##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#5##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  musttail call fastcc  void  @"stmt_for.using_next#cont#1<0>"(i64  %5)  
+  ret void 
+if.else1:
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_next#cont#1<0>"(i64  %5)  
   ret void 
 }
 
@@ -1484,7 +1360,32 @@ entry:
   %22 = add   i64 %20, 8 
   %23 = inttoptr i64 %22 to i64* 
   store  i64 %14, i64* %23 
-  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
+  tail call fastcc  void  @"stmt_for.using_unless#cont#1<0>"(i64  %20)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_unless#cont#1<0>"(i64  %"tmp#5##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#5##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp slt i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  musttail call fastcc  void  @"stmt_for.using_unless#cont#1<0>"(i64  %5)  
+  ret void 
+if.else1:
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_unless#cont#1<0>"(i64  %5)  
   ret void 
 }
 
@@ -1523,7 +1424,31 @@ entry:
   %22 = add   i64 %20, 8 
   %23 = inttoptr i64 %22 to i64* 
   store  i64 %14, i64* %23 
-  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
+  tail call fastcc  void  @"stmt_for.using_until#cont#1<0>"(i64  %20)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_until#cont#1<0>"(i64  %"tmp#5##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#5##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp eq i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  ret void 
+if.else1:
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_until#cont#1<0>"(i64  %5)  
   ret void 
 }
 
@@ -1562,7 +1487,32 @@ entry:
   %22 = add   i64 %20, 8 
   %23 = inttoptr i64 %22 to i64* 
   store  i64 %14, i64* %23 
-  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
+  tail call fastcc  void  @"stmt_for.using_when#cont#1<0>"(i64  %20)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_when#cont#1<0>"(i64  %"tmp#5##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#5##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp slt i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_when#cont#1<0>"(i64  %5)  
+  ret void 
+if.else1:
+  musttail call fastcc  void  @"stmt_for.using_when#cont#1<0>"(i64  %5)  
   ret void 
 }
 
@@ -1601,23 +1551,81 @@ entry:
   %22 = add   i64 %20, 8 
   %23 = inttoptr i64 %22 to i64* 
   store  i64 %14, i64* %23 
-  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %20, i64  %14, i64  %8, i64  %2, i64  0, i64  %20, i64  %20)  
+  tail call fastcc  void  @"stmt_for.using_while#cont#1<0>"(i64  %20)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.using_xrange<0>"()    {
+define external fastcc  void @"stmt_for.using_while#cont#1<0>"(i64  %"tmp#5##0")    {
+entry:
+  %0 = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = inttoptr i64 %"tmp#5##0" to i64* 
+  %2 = load  i64, i64* %1 
+  %3 = add   i64 %"tmp#5##0", 8 
+  %4 = inttoptr i64 %3 to i64* 
+  %5 = load  i64, i64* %4 
+  %6 = icmp slt i64 %2, 3 
+  br i1 %6, label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  tail call ccc  void  @print_int(i64  %2)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_while#cont#1<0>"(i64  %5)  
+  ret void 
+if.else1:
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_xrange<0>"() alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  1, i64  1, i64  10)  
-  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %0, i64  %0)  
+  tail call fastcc  void  @"stmt_for.using_xrange#cont#1<0>"(i64  %0)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.using_xrange_reverse<0>"()    {
+define external fastcc  void @"stmt_for.using_xrange#cont#1<0>"(i64  %"tmp#0##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_xrange#cont#1<0>"(i64  %2)  
+  ret void 
+if.else:
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_xrange_reverse<0>"() alwaysinline   {
 entry:
   %0 = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  10, i64  -1, i64  1)  
-  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %0, i64  %0)  
+  tail call fastcc  void  @"stmt_for.using_xrange_reverse#cont#1<0>"(i64  %0)  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.using_xrange_reverse#cont#1<0>"(i64  %"tmp#0##0")    {
+entry:
+  %0 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %1 = extractvalue {i64, i64, i1} %0, 0 
+  %2 = extractvalue {i64, i64, i1} %0, 1 
+  %3 = extractvalue {i64, i64, i1} %0, 2 
+  br i1 %3, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"stmt_for.using_xrange_reverse#cont#1<0>"(i64  %2)  
+  ret void 
+if.else:
   ret void 
 }
 
@@ -1705,7 +1713,7 @@ entry:
             foreign llvm move(undef:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence)
 
         1:
-            stmt_for.int_sequence.gen#1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #5
+            stmt_for.int_sequence.[|]#cont#1<0>(~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #5
 
 
     1:
@@ -1717,9 +1725,23 @@ entry:
             foreign llvm move(undef:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence)
 
         1:
-            stmt_for.int_sequence.gen#1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #3
+            stmt_for.int_sequence.[|]#cont#1<0>(~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #3
 
 
+
+
+[|]#cont#1 > (2 calls)
+0: stmt_for.int_sequence.[|]#cont#1<0>
+[|]#cont#1(en##0:wybe.int, s##0:wybe.int, st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(s##0:wybe.int, ?value##0:wybe.int) @stmt_for:nn:nn
+    foreign llvm add(~s##0:wybe.int, st##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:stmt_for.int_sequence) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#7##0:stmt_for.int_sequence, ?tmp#8##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#8##0:stmt_for.int_sequence, ?tmp#9##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st##0:wybe.int) @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#9##0:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en##0:wybe.int) @stmt_for:nn:nn
+    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 end > public {inline} (0 calls)
@@ -1734,20 +1756,6 @@ end(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wyb
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_for:nn:nn
-
-
-gen#1 > (2 calls)
-0: stmt_for.int_sequence.gen#1<0>
-gen#1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(s##0:wybe.int, ?value##0:wybe.int) @stmt_for:nn:nn
-    foreign llvm add(~s##0:wybe.int, st##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:stmt_for.int_sequence) @stmt_for:nn:nn
-    foreign lpvm mutate(~tmp#7##0:stmt_for.int_sequence, ?tmp#8##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @stmt_for:nn:nn
-    foreign lpvm mutate(~tmp#8##0:stmt_for.int_sequence, ?tmp#9##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st##0:wybe.int) @stmt_for:nn:nn
-    foreign lpvm mutate(~tmp#9##0:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en##0:wybe.int) @stmt_for:nn:nn
-    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 int_sequence > public {inline} (1 calls)
@@ -1893,7 +1901,7 @@ if.else:
   %20 = icmp sgt i64 %7, %1 
   br i1 %20, label %if.then2, label %if.else2 
 if.then1:
-  %10 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen#1<0>"(i64  %7, i64  %1, i64  %4)  
+  %10 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]#cont#1<0>"(i64  %7, i64  %1, i64  %4)  
   %11 = extractvalue {i64, i64, i1} %10, 0 
   %12 = extractvalue {i64, i64, i1} %10, 1 
   %13 = extractvalue {i64, i64, i1} %10, 2 
@@ -1907,7 +1915,7 @@ if.else1:
   %19 = insertvalue {i64, i64, i1} %18, i1 0, 2 
   ret {i64, i64, i1} %19 
 if.then2:
-  %21 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen#1<0>"(i64  %7, i64  %1, i64  %4)  
+  %21 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]#cont#1<0>"(i64  %7, i64  %1, i64  %4)  
   %22 = extractvalue {i64, i64, i1} %21, 0 
   %23 = extractvalue {i64, i64, i1} %21, 1 
   %24 = extractvalue {i64, i64, i1} %21, 2 
@@ -1920,6 +1928,27 @@ if.else2:
   %29 = insertvalue {i64, i64, i1} %28, i64 undef, 1 
   %30 = insertvalue {i64, i64, i1} %29, i1 0, 2 
   ret {i64, i64, i1} %30 
+}
+
+
+define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.[|]#cont#1<0>"(i64  %"en##0", i64  %"s##0", i64  %"st##0")    {
+entry:
+  %0 = add   i64 %"s##0", %"st##0" 
+  %1 = trunc i64 24 to i32  
+  %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
+  %3 = ptrtoint i8* %2 to i64 
+  %4 = inttoptr i64 %3 to i64* 
+  store  i64 %0, i64* %4 
+  %5 = add   i64 %3, 8 
+  %6 = inttoptr i64 %5 to i64* 
+  store  i64 %"st##0", i64* %6 
+  %7 = add   i64 %3, 16 
+  %8 = inttoptr i64 %7 to i64* 
+  store  i64 %"en##0", i64* %8 
+  %9 = insertvalue {i64, i64, i1} undef, i64 %"s##0", 0 
+  %10 = insertvalue {i64, i64, i1} %9, i64 %3, 1 
+  %11 = insertvalue {i64, i64, i1} %10, i1 1, 2 
+  ret {i64, i64, i1} %11 
 }
 
 
@@ -1945,27 +1974,6 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   store  i64 %"#field##0", i64* %7 
   ret i64 %2 
-}
-
-
-define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.gen#1<0>"(i64  %"en##0", i64  %"s##0", i64  %"st##0")    {
-entry:
-  %0 = add   i64 %"s##0", %"st##0" 
-  %1 = trunc i64 24 to i32  
-  %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
-  %3 = ptrtoint i8* %2 to i64 
-  %4 = inttoptr i64 %3 to i64* 
-  store  i64 %0, i64* %4 
-  %5 = add   i64 %3, 8 
-  %6 = inttoptr i64 %5 to i64* 
-  store  i64 %"st##0", i64* %6 
-  %7 = add   i64 %3, 16 
-  %8 = inttoptr i64 %7 to i64* 
-  store  i64 %"en##0", i64* %8 
-  %9 = insertvalue {i64, i64, i1} undef, i64 %"s##0", 0 
-  %10 = insertvalue {i64, i64, i1} %9, i64 %3, 1 
-  %11 = insertvalue {i64, i64, i1} %10, i1 1, 2 
-  ret {i64, i64, i1} %11 
 }
 
 

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -38,20 +38,20 @@ foobar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_if.gen#1<0>(_:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp#11##0:stmt_if.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7
+        stmt_if.foobar#cont#1<0>(~tmp#11##0:stmt_if.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7
 
     1:
         wybe.string.print<0>("lookup succeeds when it should":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #9 @string:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_if.gen#1<0>(_:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp#11##0:stmt_if.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
+        stmt_if.foobar#cont#1<0>(~tmp#11##0:stmt_if.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5
 
 
 
-gen#1 > (2 calls)
-0: stmt_if.gen#1<0>
-gen#1([tmp#0##0:stmt_if.tree], [tmp#1##0:stmt_if.tree], [tmp#2##0:stmt_if.tree], tr##0:stmt_if.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+foobar#cont#1 > (2 calls)
+0: stmt_if.foobar#cont#1<0>
+foobar#cont#1(tr##0:stmt_if.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     stmt_if.lookup<0>(3:wybe.int, ~tr##0:stmt_if.tree, ?tmp#3##0:wybe.bool) #0 @stmt_if:nn:nn
@@ -163,17 +163,17 @@ entry:
 if.then:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_if.gen#1<0>"(i64  %2)  
+  tail call fastcc  void  @"stmt_if.foobar#cont#1<0>"(i64  %2)  
   ret void 
 if.else:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_if.gen#1<0>"(i64  %2)  
+  tail call fastcc  void  @"stmt_if.foobar#cont#1<0>"(i64  %2)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_if.gen#1<0>"(i64  %"tr##0")    {
+define external fastcc  void @"stmt_if.foobar#cont#1<0>"(i64  %"tr##0")    {
 entry:
   %0 = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  3, i64  %"tr##0")  
   br i1 %0, label %if.then, label %if.else 

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -41,14 +41,6 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-gen#1 > {inline} (3 calls)
-0: stmt_if2.gen#1<0>
-gen#1([k##0:wybe.int], [key##0:wybe.int], [l##0:stmt_if2.tree], [r##0:stmt_if2.tree], tmp#4##0:wybe.bool, [tree##0:stmt_if2.tree], ?#result##0:wybe.bool)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(~tmp#4##0:wybe.bool, ?#result##0:wybe.bool) @stmt_if2:nn:nn
-
-
 lookup > public (5 calls)
 0: stmt_if2.lookup<0>
 lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?#result##0:wybe.bool)<{}; {}>:
@@ -86,6 +78,14 @@ lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?#result##0:wybe.bool)<{}; {}>:
     1:
         foreign llvm move(0:wybe.bool, ?#result##0:wybe.bool) @stmt_if2:nn:nn
 
+
+
+lookup#cont#1 > {inline} (3 calls)
+0: stmt_if2.lookup#cont#1<0>
+lookup#cont#1(tmp#4##0:wybe.bool, ?#result##0:wybe.bool)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(~tmp#4##0:wybe.bool, ?#result##0:wybe.bool) @stmt_if2:nn:nn
 
   LLVM code       :
 
@@ -133,12 +133,6 @@ if.else:
 }
 
 
-define external fastcc  i1 @"stmt_if2.gen#1<0>"(i1  %"tmp#4##0") alwaysinline   {
-entry:
-  ret i1 %"tmp#4##0" 
-}
-
-
 define external fastcc  i1 @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %"tree##0")    {
 entry:
   %0 = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"tree##0", i64  0)  
@@ -172,6 +166,12 @@ if.then3:
 if.else3:
   %13 = musttail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %9)  
   ret i1 %13 
+}
+
+
+define external fastcc  i1 @"stmt_if2.lookup#cont#1<0>"(i1  %"tmp#4##0") alwaysinline   {
+entry:
+  ret i1 %"tmp#4##0" 
 }
 --------------------------------------------------
  Module stmt_if2.tree

--- a/test-cases/final-dump/stmt_unless.exp
+++ b/test-cases/final-dump/stmt_unless.exp
@@ -15,12 +15,12 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    stmt_unless.gen#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @stmt_unless:nn:nn
+    stmt_unless.#cont#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @stmt_unless:nn:nn
 
 
-gen#1 > (3 calls)
-0: stmt_unless.gen#1<0>
-gen#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (3 calls)
+0: stmt_unless.#cont#1<0>
+#cont#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
@@ -28,13 +28,13 @@ gen#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     0:
 
     1:
-        stmt_unless.gen#2<0>(~n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1
+        stmt_unless.#cont#2<0>(~n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1
 
 
 
-gen#2 > (1 calls)
-0: stmt_unless.gen#2<0>
-gen#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#2 > (1 calls)
+0: stmt_unless.#cont#2<0>
+#cont#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
@@ -46,10 +46,10 @@ gen#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
         foreign c print_int(tmp#0##0:wybe.int, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @int:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_unless.gen#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_unless:nn:nn
+        stmt_unless.#cont#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_unless:nn:nn
 
     1:
-        stmt_unless.gen#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_unless:nn:nn
+        stmt_unless.#cont#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @stmt_unless:nn:nn
 
 
 
@@ -82,36 +82,36 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"stmt_unless.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"stmt_unless.gen#1<0>"(i64  10)  
+  tail call fastcc  void  @"stmt_unless.#cont#1<0>"(i64  10)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_unless.gen#1<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_unless.#cont#1<0>"(i64  %"n##0")    {
 entry:
   %0 = icmp sgt i64 %"n##0", 0 
   br i1 %0, label %if.then, label %if.else 
 if.then:
-  musttail call fastcc  void  @"stmt_unless.gen#2<0>"(i64  %"n##0")  
+  musttail call fastcc  void  @"stmt_unless.#cont#2<0>"(i64  %"n##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_unless.gen#2<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_unless.#cont#2<0>"(i64  %"n##0")    {
 entry:
   %0 = sub   i64 %"n##0", 1 
   %1 = urem i64 %0, 2 
   %2 = icmp eq i64 %1, 0 
   br i1 %2, label %if.then, label %if.else 
 if.then:
-  musttail call fastcc  void  @"stmt_unless.gen#1<0>"(i64  %0)  
+  musttail call fastcc  void  @"stmt_unless.#cont#1<0>"(i64  %0)  
   ret void 
 if.else:
   tail call ccc  void  @print_int(i64  %0)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_unless.gen#1<0>"(i64  %0)  
+  musttail call fastcc  void  @"stmt_unless.#cont#1<0>"(i64  %0)  
   ret void 
 }
 

--- a/test-cases/final-dump/stmt_until.exp
+++ b/test-cases/final-dump/stmt_until.exp
@@ -14,12 +14,12 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    stmt_until.gen#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @stmt_until:nn:nn
+    stmt_until.#cont#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @stmt_until:nn:nn
 
 
-gen#1 > (2 calls)
-0: stmt_until.gen#1<0>
-gen#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (2 calls)
+0: stmt_until.#cont#1<0>
+#cont#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_slt(n##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
@@ -30,15 +30,15 @@ gen#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
         foreign c print_int(tmp#5##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @int:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_until.gen#1<0>(~tmp#5##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_until:nn:nn
+        stmt_until.#cont#1<0>(~tmp#5##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_until:nn:nn
 
     1:
 
 
 
-gen#2 > {inline} (1 calls)
-0: stmt_until.gen#2<0>
-gen#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#2 > {inline} (1 calls)
+0: stmt_until.#cont#2<0>
+#cont#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
@@ -46,7 +46,7 @@ gen#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign c print_int(tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    stmt_until.gen#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_until:nn:nn
+    stmt_until.#cont#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_until:nn:nn
 
   LLVM code       :
 
@@ -70,12 +70,12 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"stmt_until.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"stmt_until.gen#1<0>"(i64  10)  
+  tail call fastcc  void  @"stmt_until.#cont#1<0>"(i64  10)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_until.gen#1<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_until.#cont#1<0>"(i64  %"n##0")    {
 entry:
   %0 = icmp slt i64 %"n##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -85,16 +85,16 @@ if.else:
   %1 = sub   i64 %"n##0", 1 
   tail call ccc  void  @print_int(i64  %1)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_until.gen#1<0>"(i64  %1)  
+  musttail call fastcc  void  @"stmt_until.#cont#1<0>"(i64  %1)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_until.gen#2<0>"(i64  %"n##0") alwaysinline   {
+define external fastcc  void @"stmt_until.#cont#2<0>"(i64  %"n##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"n##0", 1 
   tail call ccc  void  @print_int(i64  %0)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_until.gen#1<0>"(i64  %0)  
+  musttail call fastcc  void  @"stmt_until.#cont#1<0>"(i64  %0)  
   ret void 
 }

--- a/test-cases/final-dump/stmt_when.exp
+++ b/test-cases/final-dump/stmt_when.exp
@@ -15,12 +15,12 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    stmt_when.gen#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @stmt_when:nn:nn
+    stmt_when.#cont#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @stmt_when:nn:nn
 
 
-gen#1 > (3 calls)
-0: stmt_when.gen#1<0>
-gen#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (3 calls)
+0: stmt_when.#cont#1<0>
+#cont#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
@@ -28,13 +28,13 @@ gen#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     0:
 
     1:
-        stmt_when.gen#2<0>(~n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1
+        stmt_when.#cont#2<0>(~n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1
 
 
 
-gen#2 > (1 calls)
-0: stmt_when.gen#2<0>
-gen#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#2 > (1 calls)
+0: stmt_when.#cont#2<0>
+#cont#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
@@ -42,14 +42,14 @@ gen#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
     case ~tmp#2##0:wybe.bool of
     0:
-        stmt_when.gen#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_when:nn:nn
+        stmt_when.#cont#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #5 @stmt_when:nn:nn
 
     1:
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @int:nn:nn
         foreign c print_int(tmp#0##0:wybe.int, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @int:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_when.gen#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_when:nn:nn
+        stmt_when.#cont#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @stmt_when:nn:nn
 
 
 
@@ -82,24 +82,24 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"stmt_when.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"stmt_when.gen#1<0>"(i64  10)  
+  tail call fastcc  void  @"stmt_when.#cont#1<0>"(i64  10)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_when.gen#1<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_when.#cont#1<0>"(i64  %"n##0")    {
 entry:
   %0 = icmp sgt i64 %"n##0", 0 
   br i1 %0, label %if.then, label %if.else 
 if.then:
-  musttail call fastcc  void  @"stmt_when.gen#2<0>"(i64  %"n##0")  
+  musttail call fastcc  void  @"stmt_when.#cont#2<0>"(i64  %"n##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_when.gen#2<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_when.#cont#2<0>"(i64  %"n##0")    {
 entry:
   %0 = sub   i64 %"n##0", 1 
   %1 = urem i64 %0, 2 
@@ -108,10 +108,10 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %0)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_when.gen#1<0>"(i64  %0)  
+  musttail call fastcc  void  @"stmt_when.#cont#1<0>"(i64  %0)  
   ret void 
 if.else:
-  musttail call fastcc  void  @"stmt_when.gen#1<0>"(i64  %0)  
+  musttail call fastcc  void  @"stmt_when.#cont#1<0>"(i64  %0)  
   ret void 
 }
 

--- a/test-cases/final-dump/stmt_while.exp
+++ b/test-cases/final-dump/stmt_while.exp
@@ -14,12 +14,12 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    stmt_while.gen#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @stmt_while:nn:nn
+    stmt_while.#cont#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @stmt_while:nn:nn
 
 
-gen#1 > (2 calls)
-0: stmt_while.gen#1<0>
-gen#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#1 > (2 calls)
+0: stmt_while.#cont#1<0>
+#cont#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
@@ -32,13 +32,13 @@ gen#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
         foreign c print_int(tmp#5##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @int:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        stmt_while.gen#1<0>(~tmp#5##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_while:nn:nn
+        stmt_while.#cont#1<0>(~tmp#5##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_while:nn:nn
 
 
 
-gen#2 > {inline} (1 calls)
-0: stmt_while.gen#2<0>
-gen#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#2 > {inline} (1 calls)
+0: stmt_while.#cont#2<0>
+#cont#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
@@ -46,7 +46,7 @@ gen#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     foreign c print_int(tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @int:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    stmt_while.gen#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_while:nn:nn
+    stmt_while.#cont#1<0>(~tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @stmt_while:nn:nn
 
   LLVM code       :
 
@@ -70,12 +70,12 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"stmt_while.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"stmt_while.gen#1<0>"(i64  10)  
+  tail call fastcc  void  @"stmt_while.#cont#1<0>"(i64  10)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_while.gen#1<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_while.#cont#1<0>"(i64  %"n##0")    {
 entry:
   %0 = icmp sgt i64 %"n##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -83,18 +83,18 @@ if.then:
   %1 = sub   i64 %"n##0", 1 
   tail call ccc  void  @print_int(i64  %1)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_while.gen#1<0>"(i64  %1)  
+  musttail call fastcc  void  @"stmt_while.#cont#1<0>"(i64  %1)  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_while.gen#2<0>"(i64  %"n##0") alwaysinline   {
+define external fastcc  void @"stmt_while.#cont#2<0>"(i64  %"n##0") alwaysinline   {
 entry:
   %0 = sub   i64 %"n##0", 1 
   tail call ccc  void  @print_int(i64  %0)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"stmt_while.gen#1<0>"(i64  %0)  
+  musttail call fastcc  void  @"stmt_while.#cont#1<0>"(i64  %0)  
   ret void 
 }

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -14,6 +14,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(65,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(68,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(70,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(72,(string.print_loop#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @c_string:nn:nn
     foreign c print_string(c"TESTING CONSTRUCTION":wybe.c_string, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @c_string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
@@ -31,7 +32,7 @@ module top-level code > public {semipure} (0 calls)
     foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
     wybe.string.,,<0>("abc":wybe.string, "abc":wybe.string, ?tmp#0##0:wybe.string) #4 @string:nn:nn
-    wybe.string.print<0>(~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #65 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #65 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
@@ -44,14 +45,14 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#53##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
     wybe.range.construct<0>(1:wybe.int, 3:wybe.int, 100:wybe.int, ?tmp#3##0:wybe.range) #67 @range:nn:nn
     wybe.string.[]<1>("abcdefghi":wybe.string, tmp#3##0:wybe.range, ?tmp#2##0:wybe.string) #9 @string:nn:nn
-    wybe.string.print<0>(~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #68 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #68 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#58##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#58##0:wybe.phantom, ?tmp#59##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#59##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
     wybe.string.[]<1>("abcdefghi":wybe.string, ~tmp#3##0:wybe.range, ?tmp#5##0:wybe.string) #12 @string:nn:nn
     wybe.range...<0>(1:wybe.int, 3:wybe.int, ?tmp#7##0:wybe.range) #13 @string:nn:nn
     wybe.string.[]<1>(~tmp#5##0:wybe.string, ~tmp#7##0:wybe.range, ?tmp#4##0:wybe.string) #14 @string:nn:nn
-    wybe.string.print<0>(~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #70 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #70 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#64##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#64##0:wybe.phantom, ?tmp#65##0:wybe.phantom) @io:nn:nn
     foreign c print_string(c"\nTESTING CONVERSION TO c_string":wybe.c_string, ~tmp#65##0:wybe.phantom, ?tmp#68##0:wybe.phantom) @c_string:nn:nn
@@ -73,10 +74,10 @@ module top-level code > public {semipure} (0 calls)
     foreign c print_string(c"\nTESTING LOOPS":wybe.c_string, ~tmp#79##0:wybe.phantom, ?tmp#82##0:wybe.phantom) @c_string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#82##0:wybe.phantom, ?tmp#83##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#83##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-    string.gen#1<0>("abc":wybe.string, "abc":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #71 @string:nn:nn
+    string.print_loop#cont#1<0>("abc":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #71 @string:nn:nn
     wybe.range.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.range) #28 @string:nn:nn
     wybe.string.[]<1>("abcdefghijkl":wybe.string, ~tmp#14##0:wybe.range, ?tmp#13##0:wybe.string) #29 @string:nn:nn
-    string.gen#1<0>(~tmp#13##0:wybe.string, ~tmp#13##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #72 @string:nn:nn
+    string.print_loop#cont#1<0>[410bae77d3](~tmp#13##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #72 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#87##0:wybe.phantom) @c_string:nn:nn
     foreign c print_string(c"\nTESTING INDEXING":wybe.c_string, ~tmp#87##0:wybe.phantom, ?tmp#88##0:wybe.phantom) @c_string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#88##0:wybe.phantom, ?tmp#89##0:wybe.phantom) @io:nn:nn
@@ -112,12 +113,20 @@ module top-level code > public {semipure} (0 calls)
     string.test_index<0>(~tmp#25##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #61 @string:nn:nn
 
 
-gen#1 > (2 calls)
-0: string.gen#1<0>
-gen#1(s##0:wybe.string, tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+print_loop > {inline} (2 calls)
+0: string.print_loop<0>
+print_loop(s##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 1]
-  MultiSpeczDepInfo: [(0,(wybe.string.[|]<0>,fromList [NonAliasedParamCond 2 [1]])),(2,(string.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
+  InterestingCallProperties: []
+    string.print_loop#cont#1<0>(~s##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @string:nn:nn
+
+
+print_loop#cont#1 > (2 calls)
+0: string.print_loop#cont#1<0>[410bae77d3]
+print_loop#cont#1(tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: [InterestingUnaliased 0]
+  MultiSpeczDepInfo: [(0,(wybe.string.[|]<0>,fromList [NonAliasedParamCond 2 [0]])),(2,(string.print_loop#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.[|]<0>(?c##0:wybe.char, ?tmp#0##1:wybe.string, ~tmp#0##0:wybe.string, ?tmp#1##0:wybe.bool) #0 @string:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -129,9 +138,9 @@ gen#1(s##0:wybe.string, tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @char:nn:nn
         foreign c putchar(~c##0:wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @char:nn:nn
         foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
-        string.gen#1<0>[6dacb8fd25](~s##0:wybe.string, ~tmp#0##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
+        string.print_loop#cont#1<0>[410bae77d3](~tmp#0##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
 
- [6dacb8fd25] [NonAliasedParam 1] :
+ [410bae77d3] [NonAliasedParam 0] :
     wybe.string.[|]<0>[785a827a1b](?c##0:wybe.char, ?tmp#0##1:wybe.string, ~tmp#0##0:wybe.string, ?tmp#1##0:wybe.bool) #0 @string:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -143,16 +152,8 @@ gen#1(s##0:wybe.string, tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @char:nn:nn
         foreign c putchar(~c##0:wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @char:nn:nn
         foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
-        string.gen#1<0>[6dacb8fd25](~s##0:wybe.string, ~tmp#0##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
+        string.print_loop#cont#1<0>[410bae77d3](~tmp#0##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @string:nn:nn
 
-
-
-print_loop > {inline} (2 calls)
-0: string.print_loop<0>
-print_loop(s##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    string.gen#1<0>(~s##0:wybe.string, ~s##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @string:nn:nn
 
 
 test_index > (13 calls)
@@ -294,6 +295,9 @@ declare external fastcc  void @"wybe.string.print<0>"(i64)
 declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)    
 
 
+declare external fastcc  void @"wybe.string.print<0>[410bae77d3]"(i64)    
+
+
 declare external ccc  i8* @wybe_malloc(i32)    
 
 
@@ -311,7 +315,7 @@ entry:
   tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %0 = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.6, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.6, i32 0, i32 0) to i64))  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %0)  
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %0)  
   tail call ccc  void  @putchar(i8  10)  
   %1 = shl   i64 97, 2 
   %2 = or i64 %1, 1024 
@@ -320,12 +324,12 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %4 = tail call fastcc  i64  @"wybe.range.construct<0>"(i64  1, i64  3, i64  100)  
   %5 = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.8, i32 0, i32 0) to i64), i64  %4)  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %5)  
   tail call ccc  void  @putchar(i8  10)  
   %6 = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.8, i32 0, i32 0) to i64), i64  %4)  
   %7 = tail call fastcc  i64  @"wybe.range...<0>"(i64  1, i64  3)  
   %8 = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %6, i64  %7)  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  %8)  
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %8)  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
@@ -343,10 +347,10 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.12, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"string.gen#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.6, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.6, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"string.print_loop#cont#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.6, i32 0, i32 0) to i64))  
   %17 = tail call fastcc  i64  @"wybe.range.irange<0>"(i64  10, i64  -1, i64  1)  
   %18 = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.14, i32 0, i32 0) to i64), i64  %17)  
-  tail call fastcc  void  @"string.gen#1<0>"(i64  %18, i64  %18)  
+  tail call fastcc  void  @"string.print_loop#cont#1<0>[410bae77d3]"(i64  %18)  
   tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.15, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.6, i32 0, i32 0) to i64), i64  0)  
@@ -382,7 +386,14 @@ entry:
 }
 
 
-define external fastcc  void @"string.gen#1<0>"(i64  %"s##0", i64  %"tmp#0##0")    {
+define external fastcc  void @"string.print_loop<0>"(i64  %"s##0") alwaysinline   {
+entry:
+  musttail call fastcc  void  @"string.print_loop#cont#1<0>"(i64  %"s##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"string.print_loop#cont#1<0>"(i64  %"tmp#0##0")    {
 entry:
   %0 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>"(i64  %"tmp#0##0")  
   %1 = extractvalue {i8, i64, i1} %0, 0 
@@ -391,7 +402,7 @@ entry:
   br i1 %3, label %if.then, label %if.else 
 if.then:
   tail call ccc  void  @putchar(i8  %1)  
-  musttail call fastcc  void  @"string.gen#1<0>[6dacb8fd25]"(i64  %"s##0", i64  %2)  
+  musttail call fastcc  void  @"string.print_loop#cont#1<0>[410bae77d3]"(i64  %2)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  10)  
@@ -399,7 +410,7 @@ if.else:
 }
 
 
-define external fastcc  void @"string.gen#1<0>[6dacb8fd25]"(i64  %"s##0", i64  %"tmp#0##0")    {
+define external fastcc  void @"string.print_loop#cont#1<0>[410bae77d3]"(i64  %"tmp#0##0")    {
 entry:
   %0 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
   %1 = extractvalue {i8, i64, i1} %0, 0 
@@ -408,17 +419,10 @@ entry:
   br i1 %3, label %if.then, label %if.else 
 if.then:
   tail call ccc  void  @putchar(i8  %1)  
-  musttail call fastcc  void  @"string.gen#1<0>[6dacb8fd25]"(i64  %"s##0", i64  %2)  
+  musttail call fastcc  void  @"string.print_loop#cont#1<0>[410bae77d3]"(i64  %2)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  10)  
-  ret void 
-}
-
-
-define external fastcc  void @"string.print_loop<0>"(i64  %"s##0") alwaysinline   {
-entry:
-  tail call fastcc  void  @"string.gen#1<0>"(i64  %"s##0", i64  %"s##0")  
   ret void 
 }
 

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -35,20 +35,22 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(2,(student.printStudent<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course) @student:nn:nn
     foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int) @student:nn:nn
     foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string) @student:nn:nn
     foreign lpvm alloc(16:wybe.int, ?tmp#9##0:student.student) @student:nn:nn
     foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int) @student:nn:nn
     foreign lpvm mutate(~tmp#10##0:student.student, ?tmp#11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:student.course) @student:nn:nn
-    student.printStudent<0>(~tmp#11##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @student:nn:nn
+    student.printStudent<0>[410bae77d3](~tmp#11##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @student:nn:nn
 
 
 printStudent > public (1 calls)
-0: student.printStudent<0>
+0: student.printStudent<0>[410bae77d3]
 printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
-  InterestingCallProperties: []
+  InterestingCallProperties: [InterestingUnaliased 0]
+  MultiSpeczDepInfo: [(10,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 [0]]))]
     wybe.string.print<0>("student id: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @student:nn:nn
     foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @student:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @int:nn:nn
@@ -65,6 +67,26 @@ printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
     wybe.string.print<0>("course name: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @student:nn:nn
     foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @student:nn:nn
     wybe.string.print<0>(~tmp#3##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+ [410bae77d3] [NonAliasedParam 0] :
+    wybe.string.print<0>("student id: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #0 @student:nn:nn
+    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @student:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:student.course) @student:nn:nn
+    wybe.string.print<0>("course code: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @student:nn:nn
+    foreign lpvm access(tmp#1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @student:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+    wybe.string.print<0>("course name: ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7 @student:nn:nn
+    foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string) @student:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#3##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #10 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
     foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
@@ -104,6 +126,9 @@ printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
 declare external ccc  void @putchar(i8)    
 
 
+declare external fastcc  void @"wybe.string.print<0>[410bae77d3]"(i64)    
+
+
 declare external fastcc  void @"wybe.string.print<0>"(i64)    
 
 
@@ -134,7 +159,7 @@ entry:
   %10 = add   i64 %8, 8 
   %11 = inttoptr i64 %10 to i64* 
   store  i64 %2, i64* %11 
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %8)  
+  tail call fastcc  void  @"student.printStudent<0>[410bae77d3]"(i64  %8)  
   ret void 
 }
 
@@ -159,6 +184,31 @@ entry:
   %8 = inttoptr i64 %7 to i64* 
   %9 = load  i64, i64* %8 
   tail call fastcc  void  @"wybe.string.print<0>"(i64  %9)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"student.printStudent<0>[410bae77d3]"(i64  %"stu##0")    {
+entry:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.3, i32 0, i32 0) to i64))  
+  %0 = inttoptr i64 %"stu##0" to i64* 
+  %1 = load  i64, i64* %0 
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  %2 = add   i64 %"stu##0", 8 
+  %3 = inttoptr i64 %2 to i64* 
+  %4 = load  i64, i64* %3 
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.5, i32 0, i32 0) to i64))  
+  %5 = inttoptr i64 %4 to i64* 
+  %6 = load  i64, i64* %5 
+  tail call ccc  void  @print_int(i64  %6)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.7, i32 0, i32 0) to i64))  
+  %7 = add   i64 %4, 8 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = load  i64, i64* %8 
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %9)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -195,7 +245,8 @@ entry:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ?#success##0:wybe.bool) #3
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ?tmp#9##0:wybe.comparison) #4 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -260,7 +311,8 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string)<{};
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        wybe.string.=<0>(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#0##0:wybe.bool) #1
+        wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#8##0:wybe.comparison) #1 @string:nn:nn
+        foreign llvm icmp_eq(~tmp#8##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
         foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -272,7 +324,7 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string)<{};
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -296,8 +348,9 @@ entry:
   %10 = icmp eq i64 %1, %6 
   br i1 %10, label %if.then, label %if.else 
 if.then:
-  %11 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  ret i1 %11 
+  %11 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %12 = icmp eq i2 %11, 1 
+  ret i1 %12 
 if.else:
   ret i1 0 
 }
@@ -393,12 +446,13 @@ entry:
   %10 = icmp eq i64 %1, %6 
   br i1 %10, label %if.then, label %if.else 
 if.then:
-  %11 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %4, i64  %9)  
-  %12 = xor i1 %11, 1 
-  ret i1 %12 
-if.else:
-  %13 = xor i1 0, 1 
+  %11 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %4, i64  %9, i64  %4, i64  %9)  
+  %12 = icmp eq i2 %11, 1 
+  %13 = xor i1 %12, 1 
   ret i1 %13 
+if.else:
+  %14 = xor i1 0, 1 
+  ret i1 %14 
 }
 --------------------------------------------------
  Module student.student
@@ -443,7 +497,8 @@ if.else:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            wybe.string.=<0>(~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ?#success##0:wybe.bool) #4
+            wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ?tmp#14##0:wybe.comparison) #4 @string:nn:nn
+            foreign llvm icmp_eq(~tmp#14##0:wybe.comparison, 1:wybe.comparison, ?#success##0:wybe.bool) @comparison:nn:nn
 
 
 
@@ -520,7 +575,8 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student)<{
             foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            wybe.string.=<0>(~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#0##0:wybe.bool) #1
+            wybe.string.<=>#cont#2<0>(1:wybe.comparison, ~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#13##0:wybe.comparison) #1 @string:nn:nn
+            foreign llvm icmp_eq(~tmp#13##0:wybe.comparison, 1:wybe.comparison, ?tmp#0##0:wybe.bool) @comparison:nn:nn
             foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -533,7 +589,7 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student)<{
  
 
 
-declare external fastcc  i1 @"wybe.string.=<0>"(i64, i64)    
+declare external fastcc  i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -572,8 +628,9 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %22 = musttail call fastcc  i1  @"wybe.string.=<0>"(i64  %15, i64  %20)  
-  ret i1 %22 
+  %22 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %15, i64  %20, i64  %15, i64  %20)  
+  %23 = icmp eq i2 %22, 1 
+  ret i1 %23 
 if.else1:
   ret i1 0 
 }
@@ -682,13 +739,14 @@ if.then:
   %21 = icmp eq i64 %17, %12 
   br i1 %21, label %if.then1, label %if.else1 
 if.else:
+  %26 = xor i1 0, 1 
+  ret i1 %26 
+if.then1:
+  %22 = tail call fastcc  i2  @"wybe.string.<=>#cont#2<0>"(i2  1, i64  %15, i64  %20, i64  %15, i64  %20)  
+  %23 = icmp eq i2 %22, 1 
+  %24 = xor i1 %23, 1 
+  ret i1 %24 
+if.else1:
   %25 = xor i1 0, 1 
   ret i1 %25 
-if.then1:
-  %22 = tail call fastcc  i1  @"wybe.string.=<0>"(i64  %15, i64  %20)  
-  %23 = xor i1 %22, 1 
-  ret i1 %23 
-if.else1:
-  %24 = xor i1 0, 1 
-  ret i1 %24 
 }

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -36,47 +36,15 @@ find_modulo > {inline} (3 calls)
 find_modulo(seq##0:test_loop.int_seq, modulus##0:wybe.int, ?i##0:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    test_loop.gen#1<0>(~modulus##0:wybe.int, ~seq##0:test_loop.int_seq, ?i##0:wybe.int, ?#success##0:wybe.bool) #0 @test_loop:nn:nn
+    test_loop.find_modulo#cont#1<0>(~modulus##0:wybe.int, ~seq##0:test_loop.int_seq, ?i##0:wybe.int, ?#success##0:wybe.bool) #0 @test_loop:nn:nn
 
 
-find_test > (2 calls)
-0: test_loop.find_test<0>
-find_test(modulus##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-  MultiSpeczDepInfo: [(8,(test_loop.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(24:wybe.int, ?tmp#5##0:test_loop.int_seq) @test_loop:nn:nn
-    foreign lpvm mutate(~tmp#5##0:test_loop.int_seq, ?tmp#6##0:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @test_loop:nn:nn
-    foreign lpvm mutate(~tmp#6##0:test_loop.int_seq, ?tmp#7##0:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @test_loop:nn:nn
-    foreign lpvm mutate(~tmp#7##0:test_loop.int_seq, ?tmp#8##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 10:wybe.int) @test_loop:nn:nn
-    test_loop.gen#1<0>[6dacb8fd25](modulus##0:wybe.int, ~tmp#8##0:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #8 @test_loop:nn:nn
-    case ~tmp#1##0:wybe.bool of
-    0:
-        wybe.string.print<0>("Couldn't find even number divisible by ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @test_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~modulus##0:wybe.int, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
-    1:
-        wybe.string.print<0>("First even number divisible by ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @test_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~modulus##0:wybe.int, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int:nn:nn
-        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
-        wybe.string.print<0>(" is ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @test_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
-
-
-gen#1 > (2 calls)
-0: test_loop.gen#1<0>[6dacb8fd25]
-gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
+find_modulo#cont#1 > (2 calls)
+0: test_loop.find_modulo#cont#1<0>[6dacb8fd25]
+find_modulo#cont#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 1]
-  MultiSpeczDepInfo: [(0,(test_loop.int_seq.seq_next<0>,fromList [NonAliasedParamCond 0 [1]])),(3,(test_loop.gen#1<0>,fromList [NonAliasedParamCond 1 [1]]))]
+  MultiSpeczDepInfo: [(0,(test_loop.int_seq.seq_next<0>,fromList [NonAliasedParamCond 0 [1]])),(3,(test_loop.find_modulo#cont#1<0>,fromList [NonAliasedParamCond 1 [1]]))]
     test_loop.int_seq.seq_next<0>(~seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #0 @test_loop:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
@@ -88,7 +56,7 @@ gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?#success##
         foreign llvm icmp_eq(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            test_loop.gen#1<0>(~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool) #3 @test_loop:nn:nn
+            test_loop.find_modulo#cont#1<0>(~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool) #3 @test_loop:nn:nn
 
         1:
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
@@ -107,12 +75,44 @@ gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?#success##
         foreign llvm icmp_eq(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            test_loop.gen#1<0>[6dacb8fd25](~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool) #3 @test_loop:nn:nn
+            test_loop.find_modulo#cont#1<0>[6dacb8fd25](~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool) #3 @test_loop:nn:nn
 
         1:
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
+
+
+
+find_test > (2 calls)
+0: test_loop.find_test<0>
+find_test(modulus##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+  MultiSpeczDepInfo: [(8,(test_loop.find_modulo#cont#1<0>,fromList [NonAliasedParamCond 1 []]))]
+    foreign lpvm alloc(24:wybe.int, ?tmp#5##0:test_loop.int_seq) @test_loop:nn:nn
+    foreign lpvm mutate(~tmp#5##0:test_loop.int_seq, ?tmp#6##0:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @test_loop:nn:nn
+    foreign lpvm mutate(~tmp#6##0:test_loop.int_seq, ?tmp#7##0:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int) @test_loop:nn:nn
+    foreign lpvm mutate(~tmp#7##0:test_loop.int_seq, ?tmp#8##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 10:wybe.int) @test_loop:nn:nn
+    test_loop.find_modulo#cont#1<0>[6dacb8fd25](modulus##0:wybe.int, ~tmp#8##0:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #8 @test_loop:nn:nn
+    case ~tmp#1##0:wybe.bool of
+    0:
+        wybe.string.print<0>("Couldn't find even number divisible by ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #6 @test_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~modulus##0:wybe.int, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+
+    1:
+        wybe.string.print<0>("First even number divisible by ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2 @test_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~modulus##0:wybe.int, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int:nn:nn
+        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+        wybe.string.print<0>(" is ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #4 @test_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
   LLVM code       :
@@ -166,7 +166,7 @@ entry:
 
 define external fastcc  {i64, i1} @"test_loop.find_modulo<0>"(i64  %"seq##0", i64  %"modulus##0") alwaysinline   {
 entry:
-  %0 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %"seq##0")  
+  %0 = tail call fastcc  {i64, i1}  @"test_loop.find_modulo#cont#1<0>"(i64  %"modulus##0", i64  %"seq##0")  
   %1 = extractvalue {i64, i1} %0, 0 
   %2 = extractvalue {i64, i1} %0, 1 
   %3 = insertvalue {i64, i1} undef, i64 %1, 0 
@@ -175,39 +175,7 @@ entry:
 }
 
 
-define external fastcc  void @"test_loop.find_test<0>"(i64  %"modulus##0")    {
-entry:
-  %0 = trunc i64 24 to i32  
-  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
-  %2 = ptrtoint i8* %1 to i64 
-  %3 = inttoptr i64 %2 to i64* 
-  store  i64 2, i64* %3 
-  %4 = add   i64 %2, 8 
-  %5 = inttoptr i64 %4 to i64* 
-  store  i64 2, i64* %5 
-  %6 = add   i64 %2, 16 
-  %7 = inttoptr i64 %6 to i64* 
-  store  i64 10, i64* %7 
-  %8 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %2)  
-  %9 = extractvalue {i64, i1} %8, 0 
-  %10 = extractvalue {i64, i1} %8, 1 
-  br i1 %10, label %if.then, label %if.else 
-if.then:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.1, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %"modulus##0")  
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.3, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %9)  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-if.else:
-  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.5, i32 0, i32 0) to i64))  
-  tail call ccc  void  @print_int(i64  %"modulus##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-}
-
-
-define external fastcc  {i64, i1} @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %"seq##0")    {
+define external fastcc  {i64, i1} @"test_loop.find_modulo#cont#1<0>"(i64  %"modulus##0", i64  %"seq##0")    {
 entry:
   %0 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>"(i64  %"seq##0")  
   %1 = extractvalue {i64, i64, i1} %0, 0 
@@ -227,7 +195,7 @@ if.then1:
   %7 = insertvalue {i64, i1} %6, i1 1, 1 
   ret {i64, i1} %7 
 if.else1:
-  %8 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %1)  
+  %8 = tail call fastcc  {i64, i1}  @"test_loop.find_modulo#cont#1<0>"(i64  %"modulus##0", i64  %1)  
   %9 = extractvalue {i64, i1} %8, 0 
   %10 = extractvalue {i64, i1} %8, 1 
   %11 = insertvalue {i64, i1} undef, i64 %9, 0 
@@ -236,7 +204,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %"seq##0")    {
+define external fastcc  {i64, i1} @"test_loop.find_modulo#cont#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %"seq##0")    {
 entry:
   %0 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq##0")  
   %1 = extractvalue {i64, i64, i1} %0, 0 
@@ -256,12 +224,44 @@ if.then1:
   %7 = insertvalue {i64, i1} %6, i1 1, 1 
   ret {i64, i1} %7 
 if.else1:
-  %8 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %1)  
+  %8 = tail call fastcc  {i64, i1}  @"test_loop.find_modulo#cont#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %1)  
   %9 = extractvalue {i64, i1} %8, 0 
   %10 = extractvalue {i64, i1} %8, 1 
   %11 = insertvalue {i64, i1} undef, i64 %9, 0 
   %12 = insertvalue {i64, i1} %11, i1 %10, 1 
   ret {i64, i1} %12 
+}
+
+
+define external fastcc  void @"test_loop.find_test<0>"(i64  %"modulus##0")    {
+entry:
+  %0 = trunc i64 24 to i32  
+  %1 = tail call ccc  i8*  @wybe_malloc(i32  %0)  
+  %2 = ptrtoint i8* %1 to i64 
+  %3 = inttoptr i64 %2 to i64* 
+  store  i64 2, i64* %3 
+  %4 = add   i64 %2, 8 
+  %5 = inttoptr i64 %4 to i64* 
+  store  i64 2, i64* %5 
+  %6 = add   i64 %2, 16 
+  %7 = inttoptr i64 %6 to i64* 
+  store  i64 10, i64* %7 
+  %8 = tail call fastcc  {i64, i1}  @"test_loop.find_modulo#cont#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %2)  
+  %9 = extractvalue {i64, i1} %8, 0 
+  %10 = extractvalue {i64, i1} %8, 1 
+  br i1 %10, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.1, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %"modulus##0")  
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.3, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %9)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+if.else:
+  tail call fastcc  void  @"wybe.string.print<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.5, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %"modulus##0")  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
 }
 --------------------------------------------------
  Module test_loop.int_seq

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -21,14 +21,107 @@ module top-level code > public {semipure} (0 calls)
     type_generics.foo2<0>(1:wybe.int, ?y##0:wybe.int, ?tmp#7##0:wybe.bool) #5 @type_generics:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
-        type_generics.gen#1<0>(_:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8
+        type_generics.#cont#1<0>(_:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #8
 
     1:
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @int:nn:nn
         foreign c print_int(~y##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @int:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
         foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        type_generics.gen#1<0>(_:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7
+        type_generics.#cont#1<0>(_:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #7
+
+
+
+#cont#1 > (2 calls)
+0: type_generics.#cont#1<0>
+#cont#1([x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    type_generics.foo2<0>(1:wybe.int, ?y##0:wybe.int, ?tmp#6##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp#6##0:wybe.bool of
+    0:
+        type_generics.#cont#2<0>(_:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @int:nn:nn
+        foreign c print_int(~y##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @int:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        type_generics.#cont#2<0>(_:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#2 > (2 calls)
+0: type_generics.#cont#2<0>
+#cont#2([x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    type_generics.foo2<0>(1.0:wybe.float, ?fx##0:wybe.float, ?tmp#5##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp#5##0:wybe.bool of
+    0:
+        type_generics.#cont#3<0>(_:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#7##0:wybe.phantom) @float:nn:nn
+        foreign c print_float(~fx##0:wybe.float, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @float:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        type_generics.#cont#3<0>(_:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#3 > (2 calls)
+0: type_generics.#cont#3<0>
+#cont#3([x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    type_generics.foo2<0>(1.0:wybe.float, ?x##1:wybe.float, ?tmp#4##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp#4##0:wybe.bool of
+    0:
+        type_generics.#cont#4<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @float:nn:nn
+        foreign c print_float(~x##1:wybe.float, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @float:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        type_generics.#cont#4<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#4 > (2 calls)
+0: type_generics.#cont#4<0>
+#cont#4()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    type_generics.foo2<0>('a':wybe.char, ?z##0:wybe.char, ?tmp#3##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp#3##0:wybe.bool of
+    0:
+        type_generics.#cont#5<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
+
+    1:
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @char:nn:nn
+        foreign c putchar(~z##0:wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @char:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
+        type_generics.#cont#5<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
+
+
+
+#cont#5 > (2 calls)
+0: type_generics.#cont#5<0>
+#cont#5()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    type_generics.foo2<0>(0:wybe.bool, ?b##0:wybe.bool, ?tmp#2##0:wybe.bool) #1 @type_generics:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+
+    1:
+        wybe.bool.print<0>(~b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @bool:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
 
@@ -66,99 +159,6 @@ foo2(x##0:T0, ?y##0:T0, ?#success##0:wybe.bool)<{}; {}>:
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-
-gen#1 > (2 calls)
-0: type_generics.gen#1<0>
-gen#1([tmp#0##0:wybe.bool], [x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    type_generics.foo2<0>(1:wybe.int, ?y##0:wybe.int, ?tmp#6##0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp#6##0:wybe.bool of
-    0:
-        type_generics.gen#2<0>(_:wybe.int, _:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @int:nn:nn
-        foreign c print_int(~y##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @int:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        type_generics.gen#2<0>(_:wybe.int, _:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#2 > (2 calls)
-0: type_generics.gen#2<0>
-gen#2([i##0:wybe.int], [tmp#0##0:wybe.bool], [x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:wybe.float, ?fx##0:wybe.float, ?tmp#5##0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp#5##0:wybe.bool of
-    0:
-        type_generics.gen#3<0>(_:wybe.float, _:wybe.int, _:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#7##0:wybe.phantom) @float:nn:nn
-        foreign c print_float(~fx##0:wybe.float, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @float:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        type_generics.gen#3<0>(_:wybe.float, _:wybe.int, _:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#3 > (2 calls)
-0: type_generics.gen#3<0>
-gen#3([f##0:wybe.float], [i##0:wybe.int], [tmp#0##0:wybe.bool], [x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:wybe.float, ?x##1:wybe.float, ?tmp#4##0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp#4##0:wybe.bool of
-    0:
-        type_generics.gen#4<0>(_:wybe.float, _:wybe.int, _:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @float:nn:nn
-        foreign c print_float(~x##1:wybe.float, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @float:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        type_generics.gen#4<0>(_:wybe.float, _:wybe.int, _:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#4 > (2 calls)
-0: type_generics.gen#4<0>
-gen#4([f##0:wybe.float], [i##0:wybe.int], [tmp#0##0:wybe.bool], [x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    type_generics.foo2<0>('a':wybe.char, ?z##0:wybe.char, ?tmp#3##0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp#3##0:wybe.bool of
-    0:
-        type_generics.gen#5<0>(_:wybe.float, _:wybe.int, _:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3
-
-    1:
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @char:nn:nn
-        foreign c putchar(~z##0:wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @char:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-        type_generics.gen#5<0>(_:wybe.float, _:wybe.int, _:wybe.bool, _:wybe.float)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #2
-
-
-
-gen#5 > (2 calls)
-0: type_generics.gen#5<0>
-gen#5([f##0:wybe.float], [i##0:wybe.int], [tmp#0##0:wybe.bool], [x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    type_generics.foo2<0>(0:wybe.bool, ?b##0:wybe.bool, ?tmp#2##0:wybe.bool) #1 @type_generics:nn:nn
-    case ~tmp#2##0:wybe.bool of
-    0:
-
-    1:
-        wybe.bool.print<0>(~b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #3 @bool:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
-        foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
-
-
   LLVM code       :
 
 ; ModuleID = 'type_generics'
@@ -170,16 +170,16 @@ gen#5([f##0:wybe.float], [i##0:wybe.int], [tmp#0##0:wybe.bool], [x##0:wybe.float
 declare external ccc  void @putchar(i8)    
 
 
-declare external fastcc  void @"wybe.bool.print<0>"(i1)    
-
-
-declare external ccc  void @print_float(double)    
-
-
 declare external ccc  void @print_int(i64)    
 
 
 declare external fastcc  i64 @"wybe.list.length1<0>"(i64, i64)    
+
+
+declare external fastcc  void @"wybe.bool.print<0>"(i1)    
+
+
+declare external ccc  void @print_float(double)    
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -201,10 +201,97 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %1)  
   tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"type_generics.gen#1<0>"()  
+  musttail call fastcc  void  @"type_generics.#cont#1<0>"()  
   ret void 
 if.else:
-  musttail call fastcc  void  @"type_generics.gen#1<0>"()  
+  musttail call fastcc  void  @"type_generics.#cont#1<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"type_generics.#cont#1<0>"()    {
+entry:
+  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  1)  
+  %1 = extractvalue {i64, i1} %0, 0 
+  %2 = extractvalue {i64, i1} %0, 1 
+  br i1 %2, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"type_generics.#cont#2<0>"()  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"type_generics.#cont#2<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"type_generics.#cont#2<0>"()    {
+entry:
+  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  bitcast (double 1.000000e0 to i64))  
+  %1 = extractvalue {i64, i1} %0, 0 
+  %2 = extractvalue {i64, i1} %0, 1 
+  br i1 %2, label %if.then, label %if.else 
+if.then:
+  %3 = bitcast i64 %1 to double 
+  tail call ccc  void  @print_float(double  %3)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"type_generics.#cont#3<0>"()  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"type_generics.#cont#3<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"type_generics.#cont#3<0>"()    {
+entry:
+  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  bitcast (double 1.000000e0 to i64))  
+  %1 = extractvalue {i64, i1} %0, 0 
+  %2 = extractvalue {i64, i1} %0, 1 
+  br i1 %2, label %if.then, label %if.else 
+if.then:
+  %3 = bitcast i64 %1 to double 
+  tail call ccc  void  @print_float(double  %3)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"type_generics.#cont#4<0>"()  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"type_generics.#cont#4<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"type_generics.#cont#4<0>"()    {
+entry:
+  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  97)  
+  %1 = extractvalue {i64, i1} %0, 0 
+  %2 = extractvalue {i64, i1} %0, 1 
+  br i1 %2, label %if.then, label %if.else 
+if.then:
+  %3 = trunc i64 %1 to i8  
+  tail call ccc  void  @putchar(i8  %3)  
+  tail call ccc  void  @putchar(i8  10)  
+  musttail call fastcc  void  @"type_generics.#cont#5<0>"()  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"type_generics.#cont#5<0>"()  
+  ret void 
+}
+
+
+define external fastcc  void @"type_generics.#cont#5<0>"()    {
+entry:
+  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  0)  
+  %1 = extractvalue {i64, i1} %0, 0 
+  %2 = extractvalue {i64, i1} %0, 1 
+  br i1 %2, label %if.then, label %if.else 
+if.then:
+  %3 = trunc i64 %1 to i1  
+  tail call fastcc  void  @"wybe.bool.print<0>"(i1  %3)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+if.else:
   ret void 
 }
 
@@ -248,91 +335,4 @@ if.else:
   %11 = insertvalue {i64, i1} undef, i64 undef, 0 
   %12 = insertvalue {i64, i1} %11, i1 0, 1 
   ret {i64, i1} %12 
-}
-
-
-define external fastcc  void @"type_generics.gen#1<0>"()    {
-entry:
-  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  1)  
-  %1 = extractvalue {i64, i1} %0, 0 
-  %2 = extractvalue {i64, i1} %0, 1 
-  br i1 %2, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %1)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"type_generics.gen#2<0>"()  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"type_generics.gen#2<0>"()  
-  ret void 
-}
-
-
-define external fastcc  void @"type_generics.gen#2<0>"()    {
-entry:
-  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  bitcast (double 1.000000e0 to i64))  
-  %1 = extractvalue {i64, i1} %0, 0 
-  %2 = extractvalue {i64, i1} %0, 1 
-  br i1 %2, label %if.then, label %if.else 
-if.then:
-  %3 = bitcast i64 %1 to double 
-  tail call ccc  void  @print_float(double  %3)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"type_generics.gen#3<0>"()  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"type_generics.gen#3<0>"()  
-  ret void 
-}
-
-
-define external fastcc  void @"type_generics.gen#3<0>"()    {
-entry:
-  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  bitcast (double 1.000000e0 to i64))  
-  %1 = extractvalue {i64, i1} %0, 0 
-  %2 = extractvalue {i64, i1} %0, 1 
-  br i1 %2, label %if.then, label %if.else 
-if.then:
-  %3 = bitcast i64 %1 to double 
-  tail call ccc  void  @print_float(double  %3)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"type_generics.gen#4<0>"()  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"type_generics.gen#4<0>"()  
-  ret void 
-}
-
-
-define external fastcc  void @"type_generics.gen#4<0>"()    {
-entry:
-  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  97)  
-  %1 = extractvalue {i64, i1} %0, 0 
-  %2 = extractvalue {i64, i1} %0, 1 
-  br i1 %2, label %if.then, label %if.else 
-if.then:
-  %3 = trunc i64 %1 to i8  
-  tail call ccc  void  @putchar(i8  %3)  
-  tail call ccc  void  @putchar(i8  10)  
-  musttail call fastcc  void  @"type_generics.gen#5<0>"()  
-  ret void 
-if.else:
-  musttail call fastcc  void  @"type_generics.gen#5<0>"()  
-  ret void 
-}
-
-
-define external fastcc  void @"type_generics.gen#5<0>"()    {
-entry:
-  %0 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  0)  
-  %1 = extractvalue {i64, i1} %0, 0 
-  %2 = extractvalue {i64, i1} %0, 1 
-  br i1 %2, label %if.then, label %if.else 
-if.then:
-  %3 = trunc i64 %1 to i1  
-  tail call fastcc  void  @"wybe.bool.print<0>"(i1  %3)  
-  tail call ccc  void  @putchar(i8  10)  
-  ret void 
-if.else:
-  ret void 
 }

--- a/test-cases/final-dump/unbranch_bug.exp
+++ b/test-cases/final-dump/unbranch_bug.exp
@@ -14,26 +14,26 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    unbranch_bug.gen#3<0>(0:wybe.list(5), 0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
+    unbranch_bug.#cont#3<0>(0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
 
 
-gen#1 > {inline} (1 calls)
-0: unbranch_bug.gen#1<0>
-gen#1([tmp#0##0:wybe.list(5)], [tmp#1##0:wybe.list(5)])<{}; {}>:
+#cont#1 > {inline} (1 calls)
+0: unbranch_bug.#cont#1<0>
+#cont#1()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-gen#2 > {inline} (1 calls)
-0: unbranch_bug.gen#2<0>
-gen#2([tmp#0##0:wybe.list(5)], [tmp#1##0:wybe.list(5)])<{}; {}>:
+#cont#2 > {inline} (1 calls)
+0: unbranch_bug.#cont#2<0>
+#cont#2()<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-gen#3 > (2 calls)
-0: unbranch_bug.gen#3<0>
-gen#3(tmp#0##0:wybe.list(5), tmp#1##0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+#cont#3 > (2 calls)
+0: unbranch_bug.#cont#3<0>
+#cont#3(tmp#0##0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
@@ -42,7 +42,7 @@ gen#3(tmp#0##0:wybe.list(5), tmp#1##0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io
 
     1:
         foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(5)) @list:nn:nn
-        unbranch_bug.gen#3<0>(~tmp#0##1:wybe.list(5), ~tmp#1##0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
+        unbranch_bug.#cont#3<0>(~tmp#0##1:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}> #1 @unbranch_bug:nn:nn
 
 
   LLVM code       :
@@ -61,24 +61,24 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 define external fastcc  void @"unbranch_bug.<0>"() alwaysinline   {
 entry:
-  tail call fastcc  void  @"unbranch_bug.gen#3<0>"(i64  0, i64  0)  
+  tail call fastcc  void  @"unbranch_bug.#cont#3<0>"(i64  0)  
   ret void 
 }
 
 
-define external fastcc  void @"unbranch_bug.gen#1<0>"() alwaysinline   {
+define external fastcc  void @"unbranch_bug.#cont#1<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"unbranch_bug.gen#2<0>"() alwaysinline   {
+define external fastcc  void @"unbranch_bug.#cont#2<0>"() alwaysinline   {
 entry:
   ret void 
 }
 
 
-define external fastcc  void @"unbranch_bug.gen#3<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
+define external fastcc  void @"unbranch_bug.#cont#3<0>"(i64  %"tmp#0##0")    {
 entry:
   %0 = icmp ne i64 %"tmp#0##0", 0 
   br i1 %0, label %if.then, label %if.else 
@@ -86,7 +86,7 @@ if.then:
   %1 = add   i64 %"tmp#0##0", 8 
   %2 = inttoptr i64 %1 to i64* 
   %3 = load  i64, i64* %2 
-  musttail call fastcc  void  @"unbranch_bug.gen#3<0>"(i64  %3, i64  %"tmp#1##0")  
+  musttail call fastcc  void  @"unbranch_bug.#cont#3<0>"(i64  %3)  
   ret void 
 if.else:
   ret void 

--- a/test-cases/final-dump/uneeded_closure_args.exp
+++ b/test-cases/final-dump/uneeded_closure_args.exp
@@ -14,10 +14,18 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
   AliasPairs: []
   InterestingCallProperties: []
-    uneeded_closure_args.call<0>(uneeded_closure_args.gen#1<0><_:A>:(wybe.int, ?wybe.int), 2:wybe.int, ?tmp#0##0:wybe.int) #0 @uneeded_closure_args:nn:nn
+    uneeded_closure_args.call<0>(uneeded_closure_args.#closure#1<0><_:A>:(wybe.int, ?wybe.int), 2:wybe.int, ?tmp#0##0:wybe.int) #0 @uneeded_closure_args:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @int:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @int:nn:nn
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+
+
+#closure#1 > {inline} (1 calls)
+0: uneeded_closure_args.#closure#1<0>
+#closure#1([^a##0:A], b##0:B, ?#result##0:B)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(~b##0:B, ?#result##0:B) @uneeded_closure_args:nn:nn
 
 
 call > {noinline} (1 calls)
@@ -26,14 +34,6 @@ call(f##0:(A, ?A), a##0:A, ?#result##0:A)<{}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~f##0:(A, ?A)(~a##0:A, ?#result##0:A) #0 @uneeded_closure_args:nn:nn
-
-
-gen#1 > {inline} (1 calls)
-0: uneeded_closure_args.gen#1<0>
-gen#1([^a##0:A], b##0:B, ?#result##0:B)<{}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(~b##0:B, ?#result##0:B) @uneeded_closure_args:nn:nn
 
 
 second > {inline} (1 calls)
@@ -51,7 +51,7 @@ second([a##0:A], b##0:B, ?#result##0:B)<{}; {}>:
  
 
 
-@uneeded_closure_args.0 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"uneeded_closure_args.gen#1<0>" to i64)]
+@uneeded_closure_args.0 =    constant [1 x i64] [i64 ptrtoint (i64 (i64, i64)* @"uneeded_closure_args.#closure#1<0>" to i64)]
 
 
 declare external ccc  void @print_int(i64)    
@@ -71,6 +71,12 @@ entry:
 }
 
 
+define external fastcc  i64 @"uneeded_closure_args.#closure#1<0>"(i64  %"#env##0", i64  %"b##0") alwaysinline   {
+entry:
+  ret i64 %"b##0" 
+}
+
+
 define external fastcc  i64 @"uneeded_closure_args.call<0>"(i64  %"f##0", i64  %"a##0") noinline   {
 entry:
   %0 = inttoptr i64 %"f##0" to i64* 
@@ -78,12 +84,6 @@ entry:
   %2 = inttoptr i64 %1 to i64 (i64, i64)* 
   %3 = tail call fastcc  i64  %2(i64  %"f##0", i64  %"a##0")  
   ret i64 %3 
-}
-
-
-define external fastcc  i64 @"uneeded_closure_args.gen#1<0>"(i64  %"#env##0", i64  %"b##0") alwaysinline   {
-entry:
-  ret i64 %"b##0" 
 }
 
 


### PR DESCRIPTION
This PR removes definitely unneeded parameters from continuation procs, as mentioned in #87 

I also took the liberty of changing names that are generated for continuations to make it a little easier to know where they came from. The format is now ***proc***`#cont#`***N*** where ***proc*** is the name of the current proc and ***N*** is a monotonic number for the given combination of ***proc***`#cont`. Anonymous procedures and closures have also been given nicer names, being `anon` and `closure`, respectively, with similar increasing numbers