### PR TITLE
Allow calls to impure functions within expressions

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -3979,7 +3979,7 @@ instance Show Exp where
   show (CondExp cond thn els) =
     "if {" ++ show cond ++ ":: " ++ show thn ++ " | " ++ show els ++ "}"
   show (Fncall maybeMod fn resourceful args) =
-    flowPrefix (if resourceful then ParamInOut else ParamIn) ++ maybeModPrefix maybeMod ++ fn ++ showArguments args
+    (if resourceful then "!" else "") ++ maybeModPrefix maybeMod ++ fn ++ showArguments args
   show (ForeignFn lang fn flags args) =
     "foreign " ++ lang ++ " " ++ fn
     ++ (if List.null flags then "" else " " ++ unwords flags)

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -68,7 +68,7 @@ module AST (
   setPrimParamType, setTypeFlowType,
   flowsIn, flowsOut, primFlowToFlowDir, isInputFlow, isOutputFlow,
   foldStmts, foldExps, foldBodyPrims, foldBodyDistrib,
-  seqToStmt, stmtsImpurity, stmtImpurity, procCallToExp,
+  seqToStmt, stmtsImpurity, stmtImpurity,
   stmtsInputs, expOutputs, pexpListOutputs, expInputs, pexpListInputs,
   setExpTypeFlow, setPExpTypeFlow,
   Prim(..), primArgs, replacePrimArgs, argIsVar, argIsConst, argIntegerValue,
@@ -2960,8 +2960,8 @@ data Exp
       | DisjExp (Placed Exp) (Placed Exp)
       | CondExp (Placed Stmt) (Placed Exp) (Placed Exp)
       | Fncall ModSpec ProcName Bool [Placed Exp]
-        -- ^ Bool flag indicates whether the call is allowed to use resources
-        -- (! marker)
+        --                      ^ Bool flag indicates whether the call
+        --                        is allowed to use resources (! prefix)
       | ForeignFn Ident ProcName [Ident] [Placed Exp]
       --- | An expression that matches the first expression against each of the
       --  fst expressions in the list, returning the value of the snd expression
@@ -3337,28 +3337,6 @@ trustArgInt :: PrimArg -> Integer
 trustArgInt arg = trustFromJust
                   "LPVM instruction argument must be an integer constant."
                   $ argIntVal arg
-
-
--- |Convert a statement read as an expression to a Stmt.
--- expToStmt :: Exp -> Stmt
--- expToStmt (Fncall [] "&" _ args) = And $ List.map (fmap expToStmt) args
--- expToStmt (Fncall [] "|" _ args) = Or (List.map (fmap expToStmt) args) Nothing Nothing
--- expToStmt (Fncall [] "~" _ [arg]) = Not $ fmap expToStmt arg
--- expToStmt (Fncall [] "~" _ args) = shouldnt $ "non-unary 'not' " ++ show args
--- expToStmt (Fncall maybeMod name resourceful args) =
---     ProcCall (First maybeMod name Nothing) Det resourceful args
--- expToStmt (ForeignFn lang name flags args) =
---     ForeignCall lang name flags args
--- expToStmt (Var name ParamIn _) = ProcCall (First [] name Nothing) Det False []
--- expToStmt (Var name ParamInOut _) = ProcCall (First [] name Nothing) Det True []
--- expToStmt expr = shouldnt $ "non-Fncall expr " ++ show expr
-
-
-procCallToExp :: Stmt -> Exp
-procCallToExp (ProcCall (First maybeMod name Nothing) _ resourceful args) =
-    Fncall maybeMod name resourceful args
-procCallToExp stmt =
-    shouldnt $ "converting non-proccall to expr " ++ showStmt 4 stmt
 
 
 -- |Return all input variables to each statement in a list of statements

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -458,9 +458,7 @@ loadModuleFromSrcFile mspec srcfile maybeDir = do
     Informational <!> "Loading module " ++ showModSpec mspec
                       ++ " from " ++ srcfile
     tokens <- (liftIO . fileTokens) srcfile
-    logBuild $ "Tokens: " ++ show tokens
-    parseTree <- parseWybe tokens srcfile
-    logBuild $ "Parsed source " ++ show parseTree
+    let parseTree = parseWybe tokens srcfile
     mods <- either
             (\er -> errmsg
                     (Just $ errorPos er)

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -458,7 +458,9 @@ loadModuleFromSrcFile mspec srcfile maybeDir = do
     Informational <!> "Loading module " ++ showModSpec mspec
                       ++ " from " ++ srcfile
     tokens <- (liftIO . fileTokens) srcfile
-    let parseTree = parseWybe tokens srcfile
+    logBuild $ "Tokens: " ++ show tokens
+    parseTree <- parseWybe tokens srcfile
+    logBuild $ "Parsed source " ++ show parseTree
     mods <- either
             (\er -> errmsg
                     (Just $ errorPos er)

--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -282,14 +282,14 @@ flattenStmt' stmt@(ProcCall fn@(First [] "=" id) callDetism res [arg1,arg2]) pos
     logFlatten $ "Flattening assignment with arg1 outputs? " ++ show arg1outs
                  ++ " and arg2 outputs? " ++ show arg2outs
     case (arg1content, arg2content) of
-      (Fncall mod name args, _)
+      (Fncall mod name resourceful args, _)
         | not arg1outs && arg2outs -> do
-        let stmt' = ProcCall (First mod name Nothing) Det False (args++[arg2])
+        let stmt' = ProcCall (First mod name Nothing) Det resourceful (args++[arg2])
         flattenStmt stmt' pos detism
-      (_, Fncall mod name args)
+      (_, Fncall mod name resourceful args)
         | not arg2outs && arg1outs -> do
         (arg1':args') <- flattenStmtArgs (arg1:args) pos
-        emit pos $ ProcCall (First mod name Nothing) Det False (args'++[arg1'])
+        emit pos $ ProcCall (First mod name Nothing) Det resourceful (args'++[arg1'])
         flushPostponed
       (_,_) | callDetism == Det
                 && (varCheck arg1content arg2outs || varCheck arg2content arg1outs)
@@ -596,8 +596,8 @@ flattenExp (CaseExp pexpr cases deflt) ty castFrom pos = do
     pexpr' <- flattenPExp pexpr
     flattenStmt (translateExpCases pexpr' resultName cases deflt) pos Det
     return $ maybePlace (Var resultName ParamIn Ordinary) pos
-flattenExp (Fncall mod name exps) ty castFrom pos = do
-    let stmtBuilder = ProcCall (First mod name Nothing) Det False
+flattenExp (Fncall mod name resourceful exps) ty castFrom pos = do
+    let stmtBuilder = ProcCall (First mod name Nothing) Det resourceful
     flattenCall stmtBuilder False ty castFrom pos exps
 flattenExp (ForeignFn lang name flags exps) ty castFrom pos = do
     flattenCall (ForeignCall lang name flags) True ty castFrom pos exps

--- a/src/Unique.hs
+++ b/src/Unique.hs
@@ -335,7 +335,7 @@ uniquenessCheckExp (CondExp stmt e1 e2) pos =
     (placedApply uniquenessCheckStmt stmt `withDetism` SemiDet
      >> placedApply uniquenessCheckExp e1)
     `joinUniqueness` placedApply uniquenessCheckExp e2
-uniquenessCheckExp (Fncall _ _ exps) pos =
+uniquenessCheckExp (Fncall _ _ _ exps) pos =
     mapM_  (placedApply uniquenessCheckExp) exps
 uniquenessCheckExp (ForeignFn _ _ _ exps) pos =
     mapM_  (placedApply uniquenessCheckExp) exps

--- a/test-cases/final-dump/impure_call_in_expression.exp
+++ b/test-cases/final-dump/impure_call_in_expression.exp
@@ -1,0 +1,91 @@
+======================================================================
+AFTER EVERYTHING:
+ Module impure_call_in_expression
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : impure_call_in_expression.<0>
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+module top-level code > public {inline,semipure} (0 calls)
+0: impure_call_in_expression.<0>
+()<{<<wybe.io.io>>}; {<<wybe.io.io>>}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    impure_call_in_expression.fib<0>(10:wybe.int, ?tmp#0##0:wybe.int) #0 @impure_call_in_expression:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @int:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @int:nn:nn
+    foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
+
+
+fib > {impure} (3 calls)
+0: impure_call_in_expression.fib<0>
+fib(x##0:wybe.int, ?#result##0:wybe.int)<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_eq(x##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
+    0:
+        foreign llvm icmp_eq(x##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+        case ~tmp#7##0:wybe.bool of
+        0:
+            foreign llvm sub(x##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+            impure_call_in_expression.fib<0>(~tmp#4##0:wybe.int, ?tmp#3##0:wybe.int) #3 @impure_call_in_expression:nn:nn
+            foreign llvm sub(~x##0:wybe.int, 2:wybe.int, ?tmp#6##0:wybe.int) @int:nn:nn
+            impure_call_in_expression.fib<0>(~tmp#6##0:wybe.int, ?tmp#5##0:wybe.int) #5 @impure_call_in_expression:nn:nn
+            foreign llvm add(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
+
+        1:
+            foreign llvm move(1:wybe.int, ?#result##0:wybe.int) @impure_call_in_expression:nn:nn
+
+
+    1:
+        foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @impure_call_in_expression:nn:nn
+
+
+  LLVM code       :
+
+; ModuleID = 'impure_call_in_expression'
+
+
+ 
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"impure_call_in_expression.<0>"() alwaysinline   {
+entry:
+  %0 = tail call fastcc  i64  @"impure_call_in_expression.fib<0>"(i64  10)  
+  tail call ccc  void  @print_int(i64  %0)  
+  ret void 
+}
+
+
+define external fastcc  i64 @"impure_call_in_expression.fib<0>"(i64  %"x##0")    {
+entry:
+  %0 = icmp eq i64 %"x##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  ret i64 0 
+if.else:
+  %1 = icmp eq i64 %"x##0", 1 
+  br i1 %1, label %if.then1, label %if.else1 
+if.then1:
+  ret i64 1 
+if.else1:
+  %2 = sub   i64 %"x##0", 1 
+  %3 = tail call fastcc  i64  @"impure_call_in_expression.fib<0>"(i64  %2)  
+  %4 = sub   i64 %"x##0", 2 
+  %5 = tail call fastcc  i64  @"impure_call_in_expression.fib<0>"(i64  %4)  
+  %6 = add   i64 %3, %5 
+  ret i64 %6 
+}

--- a/test-cases/final-dump/impure_call_in_expression.wybe
+++ b/test-cases/final-dump/impure_call_in_expression.wybe
@@ -1,0 +1,13 @@
+
+def {impure} fib(x: int) = if {
+    x = 0 ::
+        0
+    | else :: if {
+        x = 1 ::
+            1
+        | else ::
+            !fib(x-1) + !fib(x-2)
+    }
+}
+
+!print(!fib(10))


### PR DESCRIPTION
While I was trying to work on https://github.com/pschachte/wybe/pull/304, I discovered what I think is a bug in the parser? You can write `!function_name()` as part of an expression, but by the time it gets to typechecking the `!` is silently lost, and you get this error:

```
testing/impure_fib.wybe:9:14: Calling impure proc impure_fib.fib<0> without ! non-purity marker
```

which I was very confused by, since I *did* use the `!` non-purity marker.

This PR adds a "uses resources" boolean flag to the `Fncall` Exp variant, mimicking the "uses resources" boolean flag on the `ProcCall` Stmt variant. This means the `!` marker is no-longer silently lost before typechecking the expression.

I also found a couple more functions in AST.hs which weren't used, which I removed since they're not actively being tested. I can revert this though if you'd prefer.