### PR TITLE
Added warning when type constraint is of the current type

### DIFF
--- a/src/Clause.hs
+++ b/src/Clause.hs
@@ -143,7 +143,7 @@ compileProc proc procID =
         let ProcDefSrc body = procImpln proc
         let proto = procProto proc
         let procName = procProtoName proto
-        let params = procProtoParams proto
+        let params = content <$> procProtoParams proto
         modify (\st -> st {nextCallSiteID=procCallSiteCount proc})
         logClause $ "--------------\nCompiling proc " ++ show proto
         mapM_ (nextVar . paramName) $ List.filter (flowsIn . paramFlow) params

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -239,7 +239,8 @@ fromUseItemParser v = do
 -- 'visibility' 'determinism'.
 procOrFuncItem :: Visibility -> Parser Item
 procOrFuncItem vis = do
-    pos <- tokenPosition <$> ident "def"
+    ident "def"
+    pos <- getPosition 
     mods <- modifierList >>= parseWith (processProcModifiers pos "procedure or function declaration")
     (proto, returnType) <- limitedTerm prototypePrecedence
                             >>= parseWith termToPrototype

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -1288,12 +1288,12 @@ termToProto other =
 
 
 -- | Translate a Term to a proc or func parameter
-termToParam :: TranslateTo Param
-termToParam (Call _ [] ":" ParamIn [Call _ [] name flow [],ty]) = do
+termToParam :: TranslateTo (Placed Param)
+termToParam (Call pos [] ":" ParamIn [Call _ [] name flow [],ty]) = do
     ty' <- termToTypeSpec ty
-    return $ Param name ty' flow Ordinary
+    return $ Param name ty' flow Ordinary `maybePlace` Just pos
 termToParam (Call pos [] name flow []) =
-    return $ Param name AnyType flow Ordinary
+    return $ Param name AnyType flow Ordinary `maybePlace` Just pos
 termToParam other =
     syntaxError (termPos other) $ "invalid parameter " ++ show other
 
@@ -1309,17 +1309,19 @@ termToCtorDecl other =
 
 
 -- | Translate a Term to a ctor field
-termToCtorField :: TranslateTo Param
-termToCtorField (Call _ [] ":" ParamIn [Call _ [] name ParamIn [],ty]) = do
+termToCtorField :: TranslateTo (Placed Param)
+termToCtorField (Call pos [] ":" ParamIn [Call _ [] name ParamIn [],ty]) = do
     ty' <- termToTypeSpec ty
-    return $ Param name ty' ParamIn Ordinary
+    return $ Param name ty' ParamIn Ordinary `maybePlace` Just pos
 termToCtorField (Call pos [] name ParamIn [])
   | isTypeVar name = do
     return $ Param "" (TypeVariable $ RealTypeVar name) ParamIn Ordinary
+                `maybePlace` Just pos
 termToCtorField (Call pos mod name ParamIn params)
   | not $ isTypeVar name = do
     tyParams <- mapM termToTypeSpec params
     return $ Param "" (TypeSpec mod name tyParams) ParamIn Ordinary
+                `maybePlace` Just pos
 termToCtorField other =
     syntaxError (termPos other) $ "invalid constructor field " ++ show other
 

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -3207,9 +3207,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
-[93mint_list.wybe:4:31: Explicit specification of current type int_list,
-  it is recommended to specify type as _
-[0m[93mint_list.wybe:4:46: Explicit specification of current type int_list,
+[93mint_list.wybe:4:46: Explicit specification of current type int_list,
   it is recommended to specify type as _
 [0m
 ----------------------------------------------------------------------

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -3207,7 +3207,11 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
-
+[93mint_list.wybe:4:31: Explicit specification of current type int_list,
+  it is recommended to specify type as _
+[0m[93mint_list.wybe:4:46: Explicit specification of current type int_list,
+  it is recommended to specify type as _
+[0m
 ----------------------------------------------------------------------
 
 

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -801,3 +801,10 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/mytree.wybe:1:29: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/mytree.wybe:1:54: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -801,9 +801,7 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/mytree.wybe:1:29: Explicit specification of current type tree,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
+[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
   it is recommended to specify type as _
 [0m[93mfinal-dump/mytree.wybe:1:54: Explicit specification of current type tree,
   it is recommended to specify type as _

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -788,9 +788,7 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/mytree.wybe:1:29: Explicit specification of current type tree,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
+[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
   it is recommended to specify type as _
 [0m[93mfinal-dump/mytree.wybe:1:54: Explicit specification of current type tree,
   it is recommended to specify type as _

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -788,3 +788,10 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/mytree.wybe:1:29: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/mytree.wybe:1:54: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -727,9 +727,7 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/mytree.wybe:1:29: Explicit specification of current type tree,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
+[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
   it is recommended to specify type as _
 [0m[93mfinal-dump/mytree.wybe:1:54: Explicit specification of current type tree,
   it is recommended to specify type as _

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -727,3 +727,10 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/mytree.wybe:1:29: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/mytree.wybe:1:54: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/alias_recursion2.exp
+++ b/test-cases/final-dump/alias_recursion2.exp
@@ -1,7 +1,5 @@
 Error detected during type checking of module(s) alias_recursion2, alias_recursion2.mynode
-[93mfinal-dump/alias_recursion2.wybe:1:31: Explicit specification of current type mynode,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/alias_recursion2.wybe:1:48: Explicit specification of current type mynode,
+[93mfinal-dump/alias_recursion2.wybe:1:48: Explicit specification of current type mynode,
   it is recommended to specify type as _
 [0m[91mfinal-dump/alias_recursion2.wybe:18:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion2.wybe:19:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context

--- a/test-cases/final-dump/alias_recursion2.exp
+++ b/test-cases/final-dump/alias_recursion2.exp
@@ -1,4 +1,8 @@
 Error detected during type checking of module(s) alias_recursion2, alias_recursion2.mynode
-[91mfinal-dump/alias_recursion2.wybe:18:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
+[93mfinal-dump/alias_recursion2.wybe:1:31: Explicit specification of current type mynode,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/alias_recursion2.wybe:1:48: Explicit specification of current type mynode,
+  it is recommended to specify type as _
+[0m[91mfinal-dump/alias_recursion2.wybe:18:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion2.wybe:19:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
 [0m

--- a/test-cases/final-dump/alias_recursion3.exp
+++ b/test-cases/final-dump/alias_recursion3.exp
@@ -1,9 +1,7 @@
 Error detected during type checking of module(s) alias_recursion3, alias_recursion3.mynode
-[93mfinal-dump/alias_recursion3.wybe:1:31: Explicit specification of current type mynode,
+[93mfinal-dump/alias_recursion3.wybe:1:48: Explicit specification of current type mynode,
   it is recommended to specify type as _
-[0m[93mfinal-dump/alias_recursion3.wybe:1:48: Explicit specification of current type mynode,
-  it is recommended to specify type as _
-[0m[91mfinal-dump/alias_recursion3.wybe:12:5: Output parameter resutl1 not defined by proc foo
+[0m[91mfinal-dump/alias_recursion3.wybe:12:9: Output parameter resutl1 not defined by proc foo
 [0m[91mfinal-dump/alias_recursion3.wybe:15:17: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion3.wybe:16:13: Calling test proc alias_recursion3.mynode.next<1> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion3.wybe:16:28: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context

--- a/test-cases/final-dump/alias_recursion3.exp
+++ b/test-cases/final-dump/alias_recursion3.exp
@@ -1,5 +1,9 @@
 Error detected during type checking of module(s) alias_recursion3, alias_recursion3.mynode
-[91mfinal-dump/alias_recursion3.wybe:12:5: Output parameter resutl1 not defined by proc foo
+[93mfinal-dump/alias_recursion3.wybe:1:31: Explicit specification of current type mynode,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/alias_recursion3.wybe:1:48: Explicit specification of current type mynode,
+  it is recommended to specify type as _
+[0m[91mfinal-dump/alias_recursion3.wybe:12:5: Output parameter resutl1 not defined by proc foo
 [0m[91mfinal-dump/alias_recursion3.wybe:15:17: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion3.wybe:16:13: Calling test proc alias_recursion3.mynode.next<1> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion3.wybe:16:28: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context

--- a/test-cases/final-dump/detism_error.exp
+++ b/test-cases/final-dump/detism_error.exp
@@ -1,4 +1,4 @@
 Error detected during type checking of module(s) detism_error
 [91mfinal-dump/detism_error.wybe:4:6: Calling test proc wybe.int.=<0> in a normal (total) context
-[0m[91mfinal-dump/detism_error.wybe:16:5: not_really_terminal has normal (total) determinism, but declared terminal
+[0m[91mfinal-dump/detism_error.wybe:16:9: not_really_terminal has normal (total) determinism, but declared terminal
 [0m

--- a/test-cases/final-dump/error_mode.exp
+++ b/test-cases/final-dump/error_mode.exp
@@ -1,7 +1,5 @@
 Error detected during type checking of module(s) error_mode, error_mode.tree
-[93mfinal-dump/error_mode.wybe:3:29: Explicit specification of current type tree,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/error_mode.wybe:3:34: Explicit specification of current type tree,
+[93mfinal-dump/error_mode.wybe:3:34: Explicit specification of current type tree,
   it is recommended to specify type as _
 [0m[93mfinal-dump/error_mode.wybe:3:54: Explicit specification of current type tree,
   it is recommended to specify type as _

--- a/test-cases/final-dump/error_mode.exp
+++ b/test-cases/final-dump/error_mode.exp
@@ -1,4 +1,10 @@
 Error detected during type checking of module(s) error_mode, error_mode.tree
-[91mfinal-dump/error_mode.wybe:8:40: Calling test proc error_mode.tree.left<0> in a normal (total) context
+[93mfinal-dump/error_mode.wybe:3:29: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/error_mode.wybe:3:34: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/error_mode.wybe:3:54: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[91mfinal-dump/error_mode.wybe:8:40: Calling test proc error_mode.tree.left<0> in a normal (total) context
 [0m[91mfinal-dump/error_mode.wybe:9:30: Calling test proc error_mode.tree.right<0> in a normal (total) context
 [0m

--- a/test-cases/final-dump/error_mode2.exp
+++ b/test-cases/final-dump/error_mode2.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) error_mode2
-[91mfinal-dump/error_mode2.wybe:3:5: non_terminal has normal (total) determinism, but declared terminal
-[0m[91mfinal-dump/error_mode2.wybe:7:5: non_terminal2 has failing determinism, but declared terminal
-[0m[91mfinal-dump/error_mode2.wybe:15:5: non_failing has normal (total) determinism, but declared failing
+[91mfinal-dump/error_mode2.wybe:3:9: non_terminal has normal (total) determinism, but declared terminal
+[0m[91mfinal-dump/error_mode2.wybe:7:9: non_terminal2 has failing determinism, but declared terminal
+[0m[91mfinal-dump/error_mode2.wybe:15:9: non_failing has normal (total) determinism, but declared failing
 [0m

--- a/test-cases/final-dump/func_no_types.exp
+++ b/test-cases/final-dump/func_no_types.exp
@@ -1,3 +1,3 @@
 Error detected during checking parameter type declarations in module(s) func_no_types
-[91mfinal-dump/func_no_types.wybe:1:5: Public proc 'double' with undeclared parameter or return type
+[91mfinal-dump/func_no_types.wybe:1:9: Public proc 'double' with undeclared parameter or return type
 [0m

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -348,23 +348,13 @@ define external fastcc  i64 @"generic_list.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
-[93mExplicit specification of current type generic_list(T),
+[93mfinal-dump/generic_list.wybe:1:40: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:1:27: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:1:40: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:3:5: Explicit specification of current type generic_list(T),
+[0m[93mfinal-dump/generic_list.wybe:3:9: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _
 [0m[93mfinal-dump/generic_list.wybe:3:16: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _
 [0m[93mfinal-dump/generic_list.wybe:3:35: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:4:9: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:4:28: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:5:17: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _
 [0m[93mfinal-dump/generic_list.wybe:8:16: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -348,3 +348,26 @@ define external fastcc  i64 @"generic_list.nil<0>"() alwaysinline   {
 entry:
   ret i64 0 
 }
+[93mExplicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:1:27: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:1:40: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:3:5: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:3:16: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:3:35: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:4:9: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:4:28: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:5:17: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:8:16: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:10:13: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -871,3 +871,26 @@ if.then:
 if.else:
   ret i64 %"suffix##0" 
 }
+[93mExplicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:1:27: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:1:40: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:3:5: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:3:16: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:3:35: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:4:9: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:4:28: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:5:17: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:8:16: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m[93mfinal-dump/generic_list.wybe:10:13: Explicit specification of current type generic_list(T),
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -871,23 +871,13 @@ if.then:
 if.else:
   ret i64 %"suffix##0" 
 }
-[93mExplicit specification of current type generic_list(T),
+[93mfinal-dump/generic_list.wybe:1:40: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:1:27: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:1:40: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:3:5: Explicit specification of current type generic_list(T),
+[0m[93mfinal-dump/generic_list.wybe:3:9: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _
 [0m[93mfinal-dump/generic_list.wybe:3:16: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _
 [0m[93mfinal-dump/generic_list.wybe:3:35: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:4:9: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:4:28: Explicit specification of current type generic_list(T),
-  it is recommended to specify type as _
-[0m[93mfinal-dump/generic_list.wybe:5:17: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _
 [0m[93mfinal-dump/generic_list.wybe:8:16: Explicit specification of current type generic_list(T),
   it is recommended to specify type as _

--- a/test-cases/final-dump/in_before_out.exp
+++ b/test-cases/final-dump/in_before_out.exp
@@ -1,4 +1,4 @@
 Error detected during type checking of module(s) in_before_out
-[91mfinal-dump/in_before_out.wybe:1:5: Output parameter result not defined by proc in_before_out
+[91mfinal-dump/in_before_out.wybe:1:9: Output parameter result not defined by proc in_before_out
 [0m[91mfinal-dump/in_before_out.wybe:2:8: Uninitialised argument in call to incr, argument 1
 [0m

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -487,3 +487,8 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/int_list.wybe:1:31: Explicit specification of current type int_list,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/int_list.wybe:1:46: Explicit specification of current type int_list,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -487,8 +487,6 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/int_list.wybe:1:31: Explicit specification of current type int_list,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/int_list.wybe:1:46: Explicit specification of current type int_list,
+[93mfinal-dump/int_list.wybe:1:46: Explicit specification of current type int_list,
   it is recommended to specify type as _
 [0m

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -576,3 +576,8 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/list_loop.wybe:1:30: Explicit specification of current type intlist,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/list_loop.wybe:1:45: Explicit specification of current type intlist,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -576,8 +576,6 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/list_loop.wybe:1:30: Explicit specification of current type intlist,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/list_loop.wybe:1:45: Explicit specification of current type intlist,
+[93mfinal-dump/list_loop.wybe:1:45: Explicit specification of current type intlist,
   it is recommended to specify type as _
 [0m

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -490,3 +490,8 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/loop_bug.wybe:1:31: Explicit specification of current type int_list,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/loop_bug.wybe:1:46: Explicit specification of current type int_list,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -490,8 +490,6 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/loop_bug.wybe:1:31: Explicit specification of current type int_list,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/loop_bug.wybe:1:46: Explicit specification of current type int_list,
+[93mfinal-dump/loop_bug.wybe:1:46: Explicit specification of current type int_list,
   it is recommended to specify type as _
 [0m

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -485,7 +485,7 @@ entry:
                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access(#left##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#85##0:16 bit unsigned)
+                                        foreign lpvm access(#left##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#85##0:16 bit unsigned) @multictr:nn:nn
                                         foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#86##0:wybe.bool)
                                         case ~tmp#86##0:wybe.bool of
                                         0:
@@ -533,7 +533,7 @@ entry:
                                                                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                     1:
-                                                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#145##0:16 bit unsigned)
+                                                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#145##0:16 bit unsigned) @multictr:nn:nn
                                                                                         foreign llvm icmp_eq(~tmp#145##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#146##0:wybe.bool)
                                                                                         case ~tmp#146##0:wybe.bool of
                                                                                         0:
@@ -562,7 +562,7 @@ entry:
                                                                                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                 1:
-                                                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#139##0:16 bit unsigned)
+                                                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#139##0:16 bit unsigned) @multictr:nn:nn
                                                                                     foreign llvm icmp_eq(~tmp#139##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#140##0:wybe.bool)
                                                                                     case ~tmp#140##0:wybe.bool of
                                                                                     0:
@@ -591,7 +591,7 @@ entry:
                                                                                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#133##0:16 bit unsigned)
+                                                                                foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#133##0:16 bit unsigned) @multictr:nn:nn
                                                                                 foreign llvm icmp_eq(~tmp#133##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#134##0:wybe.bool)
                                                                                 case ~tmp#134##0:wybe.bool of
                                                                                 0:
@@ -620,7 +620,7 @@ entry:
                                                                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                         1:
-                                                                            foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#127##0:16 bit unsigned)
+                                                                            foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#127##0:16 bit unsigned) @multictr:nn:nn
                                                                             foreign llvm icmp_eq(~tmp#127##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#128##0:wybe.bool)
                                                                             case ~tmp#128##0:wybe.bool of
                                                                             0:
@@ -649,7 +649,7 @@ entry:
                                                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                     1:
-                                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#121##0:16 bit unsigned)
+                                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#121##0:16 bit unsigned) @multictr:nn:nn
                                                                         foreign llvm icmp_eq(~tmp#121##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#122##0:wybe.bool)
                                                                         case ~tmp#122##0:wybe.bool of
                                                                         0:
@@ -678,7 +678,7 @@ entry:
                                                                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                 1:
-                                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#115##0:16 bit unsigned)
+                                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#115##0:16 bit unsigned) @multictr:nn:nn
                                                                     foreign llvm icmp_eq(~tmp#115##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#116##0:wybe.bool)
                                                                     case ~tmp#116##0:wybe.bool of
                                                                     0:
@@ -707,7 +707,7 @@ entry:
                                                                 foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                             1:
-                                                                foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#109##0:16 bit unsigned)
+                                                                foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#109##0:16 bit unsigned) @multictr:nn:nn
                                                                 foreign llvm icmp_eq(~tmp#109##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#110##0:wybe.bool)
                                                                 case ~tmp#110##0:wybe.bool of
                                                                 0:
@@ -736,7 +736,7 @@ entry:
                                                             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                         1:
-                                                            foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#103##0:16 bit unsigned)
+                                                            foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#103##0:16 bit unsigned) @multictr:nn:nn
                                                             foreign llvm icmp_eq(~tmp#103##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#104##0:wybe.bool)
                                                             case ~tmp#104##0:wybe.bool of
                                                             0:
@@ -765,7 +765,7 @@ entry:
                                                         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                     1:
-                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#97##0:16 bit unsigned)
+                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#97##0:16 bit unsigned) @multictr:nn:nn
                                                         foreign llvm icmp_eq(~tmp#97##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#98##0:wybe.bool)
                                                         case ~tmp#98##0:wybe.bool of
                                                         0:
@@ -794,7 +794,7 @@ entry:
                                                     foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                 1:
-                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#91##0:16 bit unsigned)
+                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#91##0:16 bit unsigned) @multictr:nn:nn
                                                     foreign llvm icmp_eq(~tmp#91##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#92##0:wybe.bool)
                                                     case ~tmp#92##0:wybe.bool of
                                                     0:
@@ -1232,7 +1232,7 @@ c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1276,7 +1276,7 @@ c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1320,7 +1320,7 @@ c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1364,7 +1364,7 @@ c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1408,7 +1408,7 @@ c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1452,7 +1452,7 @@ c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1496,7 +1496,7 @@ c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1540,7 +1540,7 @@ c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1584,7 +1584,7 @@ c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1628,7 +1628,7 @@ c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
             foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
         1:
-            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2013,7 +2013,7 @@ f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2046,7 +2046,7 @@ f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2081,7 +2081,7 @@ f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2114,7 +2114,7 @@ f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2149,7 +2149,7 @@ f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2182,7 +2182,7 @@ f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2217,7 +2217,7 @@ f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2250,7 +2250,7 @@ f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2285,7 +2285,7 @@ f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2318,7 +2318,7 @@ f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2353,7 +2353,7 @@ f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2386,7 +2386,7 @@ f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2421,7 +2421,7 @@ f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2454,7 +2454,7 @@ f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2489,7 +2489,7 @@ f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2522,7 +2522,7 @@ f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2557,7 +2557,7 @@ f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2590,7 +2590,7 @@ f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2625,7 +2625,7 @@ f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -2658,7 +2658,7 @@ f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned) @multictr:nn:nn
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -568,3 +568,10 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/mytree.wybe:1:29: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/mytree.wybe:1:54: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -568,9 +568,7 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/mytree.wybe:1:29: Explicit specification of current type tree,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
+[93mfinal-dump/mytree.wybe:1:34: Explicit specification of current type tree,
   it is recommended to specify type as _
 [0m[93mfinal-dump/mytree.wybe:1:54: Explicit specification of current type tree,
   it is recommended to specify type as _

--- a/test-cases/final-dump/representation.exp
+++ b/test-cases/final-dump/representation.exp
@@ -35,3 +35,14 @@ entry:
   %0 = add   i16 %"x##0", %"y##0" 
   ret i16 %0 
 }
+[93mExplicit specification of current type representation,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/representation.wybe:4:5: Explicit specification of current type representation,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/representation.wybe:4:13: Explicit specification of current type representation,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/representation.wybe:4:31: Explicit specification of current type representation,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/representation.wybe:5:5: Explicit specification of current type representation,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/representation.exp
+++ b/test-cases/final-dump/representation.exp
@@ -35,14 +35,10 @@ entry:
   %0 = add   i16 %"x##0", %"y##0" 
   ret i16 %0 
 }
-[93mExplicit specification of current type representation,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/representation.wybe:4:5: Explicit specification of current type representation,
+[93mfinal-dump/representation.wybe:4:9: Explicit specification of current type representation,
   it is recommended to specify type as _
 [0m[93mfinal-dump/representation.wybe:4:13: Explicit specification of current type representation,
   it is recommended to specify type as _
 [0m[93mfinal-dump/representation.wybe:4:31: Explicit specification of current type representation,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/representation.wybe:5:5: Explicit specification of current type representation,
   it is recommended to specify type as _
 [0m

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -2093,3 +2093,8 @@ if.else1:
   %20 = xor i1 0, 1 
   ret i1 %20 
 }
+[93mfinal-dump/stmt_for.wybe:91:40: Explicit specification of current type int_sequence,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/stmt_for.wybe:91:60: Explicit specification of current type int_sequence,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -663,3 +663,10 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/stmt_if.wybe:3:29: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/stmt_if.wybe:3:34: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/stmt_if.wybe:3:54: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -663,9 +663,7 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/stmt_if.wybe:3:29: Explicit specification of current type tree,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/stmt_if.wybe:3:34: Explicit specification of current type tree,
+[93mfinal-dump/stmt_if.wybe:3:34: Explicit specification of current type tree,
   it is recommended to specify type as _
 [0m[93mfinal-dump/stmt_if.wybe:3:54: Explicit specification of current type tree,
   it is recommended to specify type as _

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -619,3 +619,10 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/stmt_if2.wybe:3:29: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/stmt_if2.wybe:3:34: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/stmt_if2.wybe:3:54: Explicit specification of current type tree,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -619,9 +619,7 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/stmt_if2.wybe:3:29: Explicit specification of current type tree,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/stmt_if2.wybe:3:34: Explicit specification of current type tree,
+[93mfinal-dump/stmt_if2.wybe:3:34: Explicit specification of current type tree,
   it is recommended to specify type as _
 [0m[93mfinal-dump/stmt_if2.wybe:3:54: Explicit specification of current type tree,
   it is recommended to specify type as _

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -690,3 +690,6 @@ if.else1:
   %20 = xor i1 0, 1 
   ret i1 %20 
 }
+[93mfinal-dump/test_loop.wybe:6:33: Explicit specification of current type int_seq,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -728,3 +728,10 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/tests.wybe:19:28: Explicit specification of current type map,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/tests.wybe:19:33: Explicit specification of current type map,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/tests.wybe:19:63: Explicit specification of current type map,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -728,9 +728,7 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/tests.wybe:19:28: Explicit specification of current type map,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/tests.wybe:19:33: Explicit specification of current type map,
+[93mfinal-dump/tests.wybe:19:33: Explicit specification of current type map,
   it is recommended to specify type as _
 [0m[93mfinal-dump/tests.wybe:19:63: Explicit specification of current type map,
   it is recommended to specify type as _

--- a/test-cases/final-dump/type_error2.exp
+++ b/test-cases/final-dump/type_error2.exp
@@ -1,3 +1,3 @@
 Error detected during final normalisation of module(s) type_error2, type_error2.foo
-[91mfinal-dump/type_error2.wybe:1:12: In constructor parameter, unknown type notatype
+[91mfinal-dump/type_error2.wybe:1:16: In constructor parameter, unknown type notatype
 [0m

--- a/test-cases/final-dump/type_int.exp
+++ b/test-cases/final-dump/type_int.exp
@@ -274,15 +274,11 @@ entry:
   %0 = icmp ne i64 %"x##0", %"y##0" 
   ret i1 %0 
 }
-[93mExplicit specification of current type myint,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/type_int.wybe:2:9: Explicit specification of current type myint,
+[93mfinal-dump/type_int.wybe:2:13: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:2:17: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:2:25: Explicit specification of current type myint,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/type_int.wybe:2:42: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:3:18: Explicit specification of current type myint,
   it is recommended to specify type as _
@@ -296,13 +292,11 @@ entry:
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:4:34: Explicit specification of current type myint,
   it is recommended to specify type as _
-[0m[93mfinal-dump/type_int.wybe:5:9: Explicit specification of current type myint,
+[0m[93mfinal-dump/type_int.wybe:5:13: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:5:17: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:5:25: Explicit specification of current type myint,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/type_int.wybe:5:42: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:6:18: Explicit specification of current type myint,
   it is recommended to specify type as _
@@ -316,21 +310,17 @@ entry:
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:7:34: Explicit specification of current type myint,
   it is recommended to specify type as _
-[0m[93mfinal-dump/type_int.wybe:8:9: Explicit specification of current type myint,
+[0m[93mfinal-dump/type_int.wybe:8:13: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:8:17: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:8:25: Explicit specification of current type myint,
   it is recommended to specify type as _
-[0m[93mfinal-dump/type_int.wybe:8:42: Explicit specification of current type myint,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/type_int.wybe:9:9: Explicit specification of current type myint,
+[0m[93mfinal-dump/type_int.wybe:9:13: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:9:17: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:9:25: Explicit specification of current type myint,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/type_int.wybe:9:42: Explicit specification of current type myint,
   it is recommended to specify type as _
 [0m[93mfinal-dump/type_int.wybe:10:17: Explicit specification of current type myint,
   it is recommended to specify type as _

--- a/test-cases/final-dump/type_int.exp
+++ b/test-cases/final-dump/type_int.exp
@@ -274,3 +274,86 @@ entry:
   %0 = icmp ne i64 %"x##0", %"y##0" 
   ret i1 %0 
 }
+[93mExplicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:2:9: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:2:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:2:25: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:2:42: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:3:18: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:3:26: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:3:34: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:4:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:4:26: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:4:34: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:5:9: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:5:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:5:25: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:5:42: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:6:18: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:6:26: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:6:34: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:7:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:7:26: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:7:34: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:8:9: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:8:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:8:25: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:8:42: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:9:9: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:9:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:9:25: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:9:42: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:10:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:10:25: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:11:18: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:11:26: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:12:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:12:25: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:13:18: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:13:26: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:14:17: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:14:25: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:15:18: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_int.wybe:15:26: Explicit specification of current type myint,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -563,8 +563,6 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
-[93mfinal-dump/type_list.wybe:1:30: Explicit specification of current type intlist,
-  it is recommended to specify type as _
-[0m[93mfinal-dump/type_list.wybe:1:45: Explicit specification of current type intlist,
+[93mfinal-dump/type_list.wybe:1:45: Explicit specification of current type intlist,
   it is recommended to specify type as _
 [0m

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -563,3 +563,8 @@ entry:
   %1 = xor i1 %0, 1 
   ret i1 %1 
 }
+[93mfinal-dump/type_list.wybe:1:30: Explicit specification of current type intlist,
+  it is recommended to specify type as _
+[0m[93mfinal-dump/type_list.wybe:1:45: Explicit specification of current type intlist,
+  it is recommended to specify type as _
+[0m

--- a/test-cases/final-dump/unexported_type_overload.exp
+++ b/test-cases/final-dump/unexported_type_overload.exp
@@ -1,3 +1,3 @@
 Error detected during checking parameter type declarations in module(s) unexported_type_overload, unexported_type_overload.sub, unexported_type_overload.sub.hidden
-[91mfinal-dump/unexported_type_overload.wybe:8:5: Public proc 'proc2' with undeclared parameter or return type
+[91mfinal-dump/unexported_type_overload.wybe:8:9: Public proc 'proc2' with undeclared parameter or return type
 [0m

--- a/test-cases/final-dump/unique_generic.exp
+++ b/test-cases/final-dump/unique_generic.exp
@@ -3,7 +3,7 @@ Error detected during uniqueness checking of module(s) unique_generic, unique_ge
 [0m[91mfinal-dump/unique_generic.wybe:7:11: Call to wybe.list.[|] binds type variable T to unique type unique_generic.u
 [0m[91mfinal-dump/unique_generic.wybe:7:14: Call to wybe.list.[] binds type variable T to unique type unique_generic.u
 [0m[91mfinal-dump/unique_generic.wybe:8:9: Call to wybe.list.reverse binds type variable T to unique type unique_generic.u
-[0m[91mfinal-dump/unique_generic.wybe:10:1: Parameter lst of bla has type with unique type parameter unique_generic.u
+[0m[91mfinal-dump/unique_generic.wybe:10:9: Parameter lst of bla has type with unique type parameter unique_generic.u
 [0m[91mfinal-dump/unique_generic.wybe:11:9: Call to wybe.list.[|] binds type variable T to unique type unique_generic.u
 [0m[91mfinal-dump/unique_generic.wybe:11:17: Unique variable h:unique_generic.u assigned in a test context
 [0m[91mfinal-dump/unique_generic.wybe:18:1: Call to unique_generic.foo binds inferred variable type to unique type unique_generic.u

--- a/test-cases/final-dump/unique_member.exp
+++ b/test-cases/final-dump/unique_member.exp
@@ -1,3 +1,3 @@
 Error detected during uniqueness checking of module(s) unique_member, unique_member.ty
-[91mfinal-dump/unique_member.wybe:3:15: Unique constructor argument uniq of non-unique type
+[91mfinal-dump/unique_member.wybe:3:20: Unique constructor argument uniq of non-unique type
 [0m

--- a/test-cases/final-dump/use_before_def.exp
+++ b/test-cases/final-dump/use_before_def.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) use_before_def
-[91mfinal-dump/use_before_def.wybe:1:5: Output parameter result not defined by proc use_before_def
+[91mfinal-dump/use_before_def.wybe:1:9: Output parameter result not defined by proc use_before_def
 [0m[91mfinal-dump/use_before_def.wybe:2:9: Uninitialised argument in call to =, argument 2
 [0m[91mfinal-dump/use_before_def.wybe:2:18: Uninitialised argument in call to +, argument 1
 [0m

--- a/wybelibs/wybe/float.wybe
+++ b/wybelibs/wybe/float.wybe
@@ -10,10 +10,10 @@ representation is 64 bit float
 ## Constants
 
 # The ratio of a circle's circumference to its diameter.
-pub def pi:float = 3.14159265358979323846264338327950288
+pub def pi:_ = 3.14159265358979323846264338327950288
 
 # The base of natural logarithms.  e = exp(1.0).
-pub def e:float = 2.71828182845904523536028747135266250
+pub def e:_ = 2.71828182845904523536028747135266250
 
 
 ## Common floating point operations


### PR DESCRIPTION
Fixes #135 

This was one of the first issues I attempted to tackle. It turns out the issue is quite deep-rooted. 

This also adds a lot of positioning to auto-generated procs, which is useful for these warnings. If not, these warnings that arise from (de)constructors/getters/mutators are unplaced.