### PR TITLE
Fix bug where tmp vars were not defined, leading to flattening issues

### DIFF
--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -183,8 +183,10 @@ tempVar :: Flattener VarName
 tempVar = do
     ctr <- gets tempCtr
     modify (\s -> s { tempCtr = ctr + 1 })
-    return $ mkTempName ctr
-
+    let name = mkTempName ctr
+    noteVarIntro name
+    return name
+    
 
 -- |Run a flattener, ignoring its state changes except for the temp variable
 --  counter.  If transparent is True, also keep changes to the set of defined

--- a/test-cases/final-dump/bug_var_def.exp
+++ b/test-cases/final-dump/bug_var_def.exp
@@ -1,0 +1,35 @@
+======================================================================
+AFTER EVERYTHING:
+ Module bug_var_def
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : bug_var_def.<0>
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+module top-level code > public {inline,semipure} (0 calls)
+0: bug_var_def.<0>
+()<{}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+
+  LLVM code       :
+
+; ModuleID = 'bug_var_def'
+
+
+ 
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"bug_var_def.<0>"() alwaysinline   {
+entry:
+  ret void 
+}

--- a/test-cases/final-dump/bug_var_def.wybe
+++ b/test-cases/final-dump/bug_var_def.wybe
@@ -1,0 +1,3 @@
+case 1+1 in {
+    3 :: !println("f")
+}


### PR DESCRIPTION
Previously the added test case raised this error:

```
Error detected during type checking of module(s) tmp
Higher order call to tmp#0 in module top-level code has a type/flow error.
```

This PR fixes that