### PR TITLE
 Be more consistent in showing proc names in error messages and logging

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -111,7 +111,8 @@ module AST (
   specialChar, specialName, specialName2,
   outputVariableName, outputStatusName,
   envParamName, envPrimParam, makeGlobalResourceName,
-  showBody, showPlacedPrims, showStmt, showBlock, showProcDef, showProcName,
+  showBody, showPlacedPrims, showStmt, showBlock, showProcDef,
+  showProcIdentifier, showProcName,
   showModSpec, showModSpecs, showResources, showOptPos, showProcDefs, showUse,
   shouldnt, nyi, checkError, checkValue, trustFromJust, trustFromJustM,
   flowPrefix, showProcModifiers, showProcModifiers', showFlags, showFlags',
@@ -3856,10 +3857,17 @@ showProcDef thisID
     ++ show def
 
 
+-- | A printable version of a proc name or HO term or foreign proc name.  First
+-- argument specifies what kind of proc it is.  Handles special empty proc
+-- name.
+showProcIdentifier :: String -> ProcName -> String
+showProcIdentifier _ ""       = "module top-level code"
+showProcIdentifier kind name = kind ++ " " ++ name
+
+
 -- | A printable version of a proc name; handles special empty proc name.
 showProcName :: ProcName -> String
-showProcName "" = "module top-level code"
-showProcName name = name
+showProcName = showProcIdentifier "proc"
 
 
 -- |How to show a type specification.

--- a/src/Unique.hs
+++ b/src/Unique.hs
@@ -84,9 +84,9 @@ initUniquenessState = UniquenessState Map.empty [] False
 -- | Check correctness of uniqueness for a procedure
 uniquenessCheckProc :: ProcDef -> Int -> Compiler ProcDef
 uniquenessCheckProc def _ = do
-    let name = showProcName $ procName def
+    let name = procName def
     let pos = procPos def
-    logMsg Uniqueness $ "Uniqueness checking proc: " ++ showProcName name
+    logMsg Uniqueness $ "Uniqueness checking " ++ showProcName name
     let detism = procDetism def
     let params = procProtoParams $ procProto def
     let ress = procProtoResources $ procProto def

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -111,7 +111,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-set_exit_code > public {inline} (0 calls)
+proc set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
 set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}; {}>:
   AliasPairs: []
@@ -232,7 +232,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: drone.#cont#1<0>
 #cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -245,7 +245,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-do_action > (2 calls)
+proc do_action > (2 calls)
 0: drone.do_action<0>
 do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?success##2:wybe.bool)<{}; {}; {}>:
   AliasPairs: [(d##0,d##2)]
@@ -321,7 +321,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
 
 
 
-do_action#cont#1 > (7 calls)
+proc do_action#cont#1 > (7 calls)
 0: drone.do_action#cont#1<0>
 do_action#cont#1(d##0:drone.drone_info, success##0:wybe.bool, ?d##1:drone.drone_info, [?success##0:wybe.bool])<{}; {}; {}>:
   AliasPairs: [(d##0,d##1)]
@@ -337,7 +337,7 @@ do_action#cont#1(d##0:drone.drone_info, success##0:wybe.bool, ?d##1:drone.drone_
 
 
 
-drone_init > (3 calls)
+proc drone_init > (3 calls)
 0: drone.drone_init<0>
 drone_init(?#result##0:drone.drone_info)<{}; {}; {}>:
   AliasPairs: []
@@ -349,7 +349,7 @@ drone_init(?#result##0:drone.drone_info)<{}; {}; {}>:
     foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
 
 
-loop > (2 calls)
+proc loop > (2 calls)
 0: drone.loop<0>
 loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -407,7 +407,7 @@ loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>};
 
 
 
-loop#cont#1 > (4 calls)
+proc loop#cont#1 > (4 calls)
 0: drone.loop#cont#1<0>
 loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -426,7 +426,7 @@ loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.
 
 
 
-print_info > {inline} (1 calls)
+proc print_info > {inline} (1 calls)
 0: drone.print_info<0>
 print_info(d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -477,7 +477,7 @@ LLVM code       : None
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: drone.drone_info.=<0>
 =(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -514,13 +514,13 @@ LLVM code       : None
 
 
 
-count > public {inline} (0 calls)
+proc count > public {inline} (0 calls)
 0: drone.drone_info.count<0>
 count(#rec##0:drone.drone_info, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
-count > public {inline} (0 calls)
+proc count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
 count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -528,7 +528,7 @@ count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{
     foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
-drone_info > public {inline} (0 calls)
+proc drone_info > public {inline} (0 calls)
 0: drone.drone_info.drone_info<0>
 drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?#result##0:drone.drone_info)<{}; {}; {}>:
   AliasPairs: []
@@ -538,7 +538,7 @@ drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?#res
     foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int) @drone:nn:nn
     foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int) @drone:nn:nn
     foreign lpvm mutate(~#rec##3:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int) @drone:nn:nn
-drone_info > public {inline} (14 calls)
+proc drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
 drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, #result##0:drone.drone_info)<{}; {}; {}>:
   AliasPairs: []
@@ -549,13 +549,13 @@ drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, #
     foreign lpvm access(~#result##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int) @drone:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: drone.drone_info.x<0>
 x(#rec##0:drone.drone_info, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
 x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -563,13 +563,13 @@ x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {
     foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: drone.drone_info.y<0>
 y(#rec##0:drone.drone_info, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
 y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -577,13 +577,13 @@ y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {
     foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
-z > public {inline} (0 calls)
+proc z > public {inline} (0 calls)
 0: drone.drone_info.z<0>
 z(#rec##0:drone.drone_info, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
-z > public {inline} (0 calls)
+proc z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
 z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -591,7 +591,7 @@ z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {
     foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: drone.drone_info.~=<0>
 ~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -767,7 +767,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-set_exit_code > public {inline} (0 calls)
+proc set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
 set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}; {}>:
   AliasPairs: []
@@ -888,7 +888,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: drone.#cont#1<0>
 #cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -901,7 +901,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-do_action > (2 calls)
+proc do_action > (2 calls)
 0: drone.do_action<0>[410bae77d3]
 do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?success##2:wybe.bool)<{}; {}; {}>:
   AliasPairs: [(d##0,d##2)]
@@ -1046,7 +1046,7 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
 
 
 
-do_action#cont#1 > (7 calls)
+proc do_action#cont#1 > (7 calls)
 0: drone.do_action#cont#1<0>[410bae77d3]
 do_action#cont#1(d##0:drone.drone_info, success##0:wybe.bool, ?d##1:drone.drone_info, [?success##0:wybe.bool])<{}; {}; {}>:
   AliasPairs: [(d##0,d##1)]
@@ -1072,7 +1072,7 @@ do_action#cont#1(d##0:drone.drone_info, success##0:wybe.bool, ?d##1:drone.drone_
 
 
 
-drone_init > (3 calls)
+proc drone_init > (3 calls)
 0: drone.drone_init<0>
 drone_init(?#result##0:drone.drone_info)<{}; {}; {}>:
   AliasPairs: []
@@ -1084,7 +1084,7 @@ drone_init(?#result##0:drone.drone_info)<{}; {}; {}>:
     foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @drone:nn:nn
 
 
-loop > (2 calls)
+proc loop > (2 calls)
 0: drone.loop<0>[410bae77d3]
 loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -1193,7 +1193,7 @@ loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>};
 
 
 
-loop#cont#1 > (4 calls)
+proc loop#cont#1 > (4 calls)
 0: drone.loop#cont#1<0>[6dacb8fd25]
 loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -1224,7 +1224,7 @@ loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.
 
 
 
-print_info > {inline} (1 calls)
+proc print_info > {inline} (1 calls)
 0: drone.print_info<0>
 print_info(d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -1805,7 +1805,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: drone.drone_info.=<0>
 =(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1842,13 +1842,13 @@ entry:
 
 
 
-count > public {inline} (0 calls)
+proc count > public {inline} (0 calls)
 0: drone.drone_info.count<0>
 count(#rec##0:drone.drone_info, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
-count > public {inline} (0 calls)
+proc count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
 count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1856,7 +1856,7 @@ count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{
     foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
-drone_info > public {inline} (0 calls)
+proc drone_info > public {inline} (0 calls)
 0: drone.drone_info.drone_info<0>
 drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?#result##0:drone.drone_info)<{}; {}; {}>:
   AliasPairs: []
@@ -1866,7 +1866,7 @@ drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?#res
     foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int) @drone:nn:nn
     foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int) @drone:nn:nn
     foreign lpvm mutate(~#rec##3:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int) @drone:nn:nn
-drone_info > public {inline} (14 calls)
+proc drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
 drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, #result##0:drone.drone_info)<{}; {}; {}>:
   AliasPairs: []
@@ -1877,13 +1877,13 @@ drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, #
     foreign lpvm access(~#result##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int) @drone:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: drone.drone_info.x<0>
 x(#rec##0:drone.drone_info, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
 x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1891,13 +1891,13 @@ x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {
     foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: drone.drone_info.y<0>
 y(#rec##0:drone.drone_info, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
 y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1905,13 +1905,13 @@ y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {
     foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
-z > public {inline} (0 calls)
+proc z > public {inline} (0 calls)
 0: drone.drone_info.z<0>
 z(#rec##0:drone.drone_info, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @drone:nn:nn
-z > public {inline} (0 calls)
+proc z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
 z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1919,7 +1919,7 @@ z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int)<{}; {
     foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @drone:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: drone.drone_info.~=<0>
 ~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -180,7 +180,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-set_exit_code > public {inline} (0 calls)
+proc set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
 set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}; {}>:
   AliasPairs: []
@@ -298,7 +298,7 @@ entry:
   submodules      : int_list.int_list
   procs           : 
 
-append > public (0 calls)
+proc append > public (0 calls)
 0: int_list.append<0>
 append(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -310,7 +310,7 @@ append(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list)<{
     int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, outByReference #result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
-count > public (3 calls)
+proc count > public (3 calls)
 0: int_list.count<0>
 count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -335,7 +335,7 @@ count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>
 
 
 
-count#cont#1 > {inline} (2 calls)
+proc count#cont#1 > {inline} (2 calls)
 0: int_list.count#cont#1<0>
 count#cont#1(tmp#2##0:wybe.int, tmp#3##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -343,7 +343,7 @@ count#cont#1(tmp#2##0:wybe.int, tmp#3##0:wybe.int, ?#result##0:wybe.int)<{}; {};
     foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
-extend > public (3 calls)
+proc extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
 extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst2##0)]
@@ -364,7 +364,7 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, outByReference #res
 
 
 
-greater > (3 calls)
+proc greater > (3 calls)
 0: int_list.greater<0>
 greater(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -392,7 +392,7 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_l
 
 
 
-index > public {inline} (0 calls)
+proc index > public {inline} (0 calls)
 0: int_list.index<0>
 index(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -400,7 +400,7 @@ index(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>
     int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?#result##0:wybe.int) #0 @int_list:nn:nn
 
 
-index_helper > (2 calls)
+proc index_helper > (2 calls)
 0: int_list.index_helper<0>
 index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -425,7 +425,7 @@ index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?#result#
 
 
 
-insert > public (2 calls)
+proc insert > public (2 calls)
 0: int_list.insert<0>[410bae77d3]
 insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst##0)]
@@ -457,7 +457,7 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, outByReference 
 
 
 
-lesser > (3 calls)
+proc lesser > (3 calls)
 0: int_list.lesser<0>
 lesser(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -485,7 +485,7 @@ lesser(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_li
 
 
 
-pop > public (1 calls)
+proc pop > public (1 calls)
 0: int_list.pop<0>[410bae77d3]
 pop(lst##0:int_list.int_list, idx##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst##0)]
@@ -514,7 +514,7 @@ pop(lst##0:int_list.int_list, idx##0:wybe.int, outByReference #result##0:int_lis
 
 
 
-print > public (2 calls)
+proc print > public (2 calls)
 0: int_list.print<0>
 print(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -534,7 +534,7 @@ print(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-println > public {inline} (0 calls)
+proc println > public {inline} (0 calls)
 0: int_list.println<0>
 println(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -545,7 +545,7 @@ println(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#1##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-range > public {inline} (0 calls)
+proc range > public {inline} (0 calls)
 0: int_list.range<0>
 range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -553,7 +553,7 @@ range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list
     int_list.range#cont#1<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##1:int_list.int_list) #1 @int_list:nn:nn
 
 
-range#cont#1 > (2 calls)
+proc range#cont#1 > (2 calls)
 0: int_list.range#cont#1<0>[410bae77d3]
 range#cont#1(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, ?result##1:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -573,7 +573,7 @@ range#cont#1(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, s
 
 
 
-range#cont#2 > {inline} (1 calls)
+proc range#cont#2 > {inline} (1 calls)
 0: int_list.range#cont#2<0>
 range#cont#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, ?result##2:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -585,7 +585,7 @@ range#cont#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, s
     int_list.range#cont#1<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
-remove > public (1 calls)
+proc remove > public (1 calls)
 0: int_list.remove<0>[410bae77d3]
 remove(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst##0)]
@@ -613,7 +613,7 @@ remove(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_li
 
 
 
-reverse > public {inline} (1 calls)
+proc reverse > public {inline} (1 calls)
 0: int_list.reverse<0>
 reverse(lst##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -621,7 +621,7 @@ reverse(lst##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
     int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?#result##0:int_list.int_list) #1 @int_list:nn:nn
 
 
-reverse_helper > (2 calls)
+proc reverse_helper > (2 calls)
 0: int_list.reverse_helper<0>
 reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,acc##0)]
@@ -642,7 +642,7 @@ reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:i
 
 
 
-sort > public (2 calls)
+proc sort > public (2 calls)
 0: int_list.sort<0>[410bae77d3]
 sort(lst##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -687,7 +687,7 @@ LLVM code       : None
   resources       : 
   procs           : 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: int_list.int_list.=<0>
 =(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -720,7 +720,7 @@ LLVM code       : None
 
 
 
-cons > public {inline} (0 calls)
+proc cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
 cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -728,7 +728,7 @@ cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list) @int_list:nn:nn
     foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @int_list:nn:nn
     foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list) @int_list:nn:nn
-cons > public {inline} (12 calls)
+proc cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
 cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -747,7 +747,7 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list
 
 
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
 head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -762,7 +762,7 @@ head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}
         foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
 head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -779,7 +779,7 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
 nil(?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -787,7 +787,7 @@ nil(?#result##0:int_list.int_list)<{}; {}; {}>:
     foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list)
 
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
 tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -802,7 +802,7 @@ tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe
         foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
 tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -819,7 +819,7 @@ tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.i
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
 ~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -934,7 +934,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#74##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-test_int_list > (2 calls)
+proc test_int_list > (2 calls)
 0: int_list_test.test_int_list<0>
 test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -1127,7 +1127,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-set_exit_code > public {inline} (0 calls)
+proc set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
 set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}; {}>:
   AliasPairs: []
@@ -1245,7 +1245,7 @@ entry:
   submodules      : int_list.int_list
   procs           : 
 
-append > public (0 calls)
+proc append > public (0 calls)
 0: int_list.append<0>[410bae77d3]
 append(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -1262,7 +1262,7 @@ append(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list)<{
     int_list.extend<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, outByReference #result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
-count > public (3 calls)
+proc count > public (3 calls)
 0: int_list.count<0>
 count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1287,7 +1287,7 @@ count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>
 
 
 
-count#cont#1 > {inline} (2 calls)
+proc count#cont#1 > {inline} (2 calls)
 0: int_list.count#cont#1<0>
 count#cont#1(tmp#2##0:wybe.int, tmp#3##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1295,7 +1295,7 @@ count#cont#1(tmp#2##0:wybe.int, tmp#3##0:wybe.int, ?#result##0:wybe.int)<{}; {};
     foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
-extend > public (3 calls)
+proc extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
 extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst2##0)]
@@ -1327,7 +1327,7 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, outByReference #res
 
 
 
-greater > (3 calls)
+proc greater > (3 calls)
 0: int_list.greater<0>[410bae77d3]
 greater(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -1374,7 +1374,7 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_l
 
 
 
-index > public {inline} (0 calls)
+proc index > public {inline} (0 calls)
 0: int_list.index<0>
 index(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1382,7 +1382,7 @@ index(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>
     int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?#result##0:wybe.int) #0 @int_list:nn:nn
 
 
-index_helper > (2 calls)
+proc index_helper > (2 calls)
 0: int_list.index_helper<0>
 index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1407,7 +1407,7 @@ index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?#result#
 
 
 
-insert > public (2 calls)
+proc insert > public (2 calls)
 0: int_list.insert<0>[410bae77d3]
 insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst##0)]
@@ -1461,7 +1461,7 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, outByReference 
 
 
 
-lesser > (3 calls)
+proc lesser > (3 calls)
 0: int_list.lesser<0>
 lesser(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -1489,7 +1489,7 @@ lesser(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_li
 
 
 
-pop > public (1 calls)
+proc pop > public (1 calls)
 0: int_list.pop<0>[410bae77d3]
 pop(lst##0:int_list.int_list, idx##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst##0)]
@@ -1537,7 +1537,7 @@ pop(lst##0:int_list.int_list, idx##0:wybe.int, outByReference #result##0:int_lis
 
 
 
-print > public (2 calls)
+proc print > public (2 calls)
 0: int_list.print<0>
 print(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -1557,7 +1557,7 @@ print(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-println > public {inline} (0 calls)
+proc println > public {inline} (0 calls)
 0: int_list.println<0>
 println(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -1568,7 +1568,7 @@ println(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#1##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-range > public {inline} (0 calls)
+proc range > public {inline} (0 calls)
 0: int_list.range<0>
 range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -1576,7 +1576,7 @@ range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list
     int_list.range#cont#1<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##1:int_list.int_list) #1 @int_list:nn:nn
 
 
-range#cont#1 > (2 calls)
+proc range#cont#1 > (2 calls)
 0: int_list.range#cont#1<0>
 range#cont#1(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, ?result##1:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -1609,7 +1609,7 @@ range#cont#1(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, s
 
 
 
-range#cont#2 > {inline} (1 calls)
+proc range#cont#2 > {inline} (1 calls)
 0: int_list.range#cont#2<0>
 range#cont#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, ?result##2:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -1621,7 +1621,7 @@ range#cont#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, s
     int_list.range#cont#1<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
-remove > public (1 calls)
+proc remove > public (1 calls)
 0: int_list.remove<0>[410bae77d3]
 remove(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst##0)]
@@ -1668,7 +1668,7 @@ remove(lst##0:int_list.int_list, v##0:wybe.int, outByReference #result##0:int_li
 
 
 
-reverse > public {inline} (1 calls)
+proc reverse > public {inline} (1 calls)
 0: int_list.reverse<0>
 reverse(lst##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -1676,7 +1676,7 @@ reverse(lst##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
     int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?#result##0:int_list.int_list) #1 @int_list:nn:nn
 
 
-reverse_helper > (2 calls)
+proc reverse_helper > (2 calls)
 0: int_list.reverse_helper<0>[410bae77d3]
 reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: [(#result##0,acc##0)]
@@ -1708,7 +1708,7 @@ reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:i
 
 
 
-sort > public (2 calls)
+proc sort > public (2 calls)
 0: int_list.sort<0>[410bae77d3]
 sort(lst##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -2419,7 +2419,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: int_list.int_list.=<0>
 =(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2452,7 +2452,7 @@ if.else:
 
 
 
-cons > public {inline} (0 calls)
+proc cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
 cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -2460,7 +2460,7 @@ cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list) @int_list:nn:nn
     foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @int_list:nn:nn
     foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list) @int_list:nn:nn
-cons > public {inline} (12 calls)
+proc cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
 cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2479,7 +2479,7 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list
 
 
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
 head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2494,7 +2494,7 @@ head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}
         foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
 head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2511,7 +2511,7 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
 nil(?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -2519,7 +2519,7 @@ nil(?#result##0:int_list.int_list)<{}; {}; {}>:
     foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list)
 
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
 tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2534,7 +2534,7 @@ tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe
         foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
 tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2551,7 +2551,7 @@ tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.i
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
 ~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2843,7 +2843,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#74##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-test_int_list > (2 calls)
+proc test_int_list > (2 calls)
 0: int_list_test.test_int_list<0>[9e35cb823b]
 test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/afterbreak.exp
+++ b/test-cases/final-dump/afterbreak.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     afterbreak.#cont#1<0>(1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @afterbreak:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: afterbreak.#cont#1<0>
 #cont#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-#cont#2 > {inline} (1 calls)
+proc #cont#2 > {inline} (1 calls)
 0: afterbreak.#cont#2<0>
 #cont#2([x##0:wybe.int], y##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -36,7 +36,7 @@ module top-level code > public {semipure} (0 calls)
     alias1.baz<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @alias1:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: alias1.bar<0>
 bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -64,7 +64,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~p2##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias1:nn:nn
 
 
-baz > public (1 calls)
+proc baz > public (1 calls)
 0: alias1.baz<0>
 baz()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -100,7 +100,7 @@ baz()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~tmp#1##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #18 @alias1:nn:nn
 
 
-foo > public (1 calls)
+proc foo > public (1 calls)
 0: alias1.foo<0>
 foo()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -128,7 +128,7 @@ foo()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias1:nn:nn
 
 
-replicate > public (3 calls)
+proc replicate > public (3 calls)
 0: alias1.replicate<0>
 replicate(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -435,7 +435,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -529,7 +529,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -548,7 +548,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -556,7 +556,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -565,13 +565,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -579,13 +579,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -593,7 +593,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -33,7 +33,7 @@ module top-level code > public {semipure} (0 calls)
     position.printPosition<0>(~r##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @alias2:nn:nn
 
 
-fcopy > public (0 calls)
+proc fcopy > public (0 calls)
 0: alias2.fcopy<0>
 fcopy(p1##0:position.position, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -47,7 +47,7 @@ fcopy(p1##0:position.position, ?#result##0:position.position)<{}; {}; {}>:
     foreign lpvm {noalias} mutate(~p2##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int) @position:nn:nn
 
 
-pcopy > public (1 calls)
+proc pcopy > public (1 calls)
 0: alias2.pcopy<0>
 pcopy(p1##0:position.position, ?p2##2:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -210,7 +210,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -304,7 +304,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -323,7 +323,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -331,7 +331,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -340,13 +340,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -354,13 +354,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -368,7 +368,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
     alias3.bar<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @alias3:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: alias3.bar<0>
 bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -48,7 +48,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias3:nn:nn
 
 
-replicate1 > public (1 calls)
+proc replicate1 > public (1 calls)
 0: alias3.replicate1<0>
 replicate1(p1##0:position.position, ?p2##2:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -205,7 +205,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -299,7 +299,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -318,7 +318,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -326,7 +326,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -335,13 +335,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -349,13 +349,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -363,7 +363,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
     alias4.bar<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @alias4:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: alias4.bar<0>
 bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -48,7 +48,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias4:nn:nn
 
 
-replicate1 > public (1 calls)
+proc replicate1 > public (1 calls)
 0: alias4.replicate1<0>
 replicate1(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -210,7 +210,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -304,7 +304,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -323,7 +323,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -331,7 +331,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -340,13 +340,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -354,13 +354,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -368,7 +368,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias5.exp
+++ b/test-cases/final-dump/alias5.exp
@@ -19,7 +19,7 @@ module top-level code > public {inline,semipure} (0 calls)
     alias5.bar<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @alias5:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: alias5.bar<0>
 bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -48,7 +48,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-replicate1 > public (2 calls)
+proc replicate1 > public (2 calls)
 0: alias5.replicate1<0>
 replicate1(v1##0:wybe.int, ?v2##0:wybe.int, v3##0:wybe.int, ?v4##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -21,7 +21,7 @@ module top-level code > public {inline,semipure} (0 calls)
     alias_cyclic.bar<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @alias_cyclic:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: alias_cyclic.bar<0>
 bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @alias_cyclic:nn:nn
 
 
-updateX > public (2 calls)
+proc updateX > public (2 calls)
 0: alias_cyclic.updateX<0>[410bae77d3]
 updateX(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -67,7 +67,7 @@ updateX(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<
 
 
 
-updateY > public (1 calls)
+proc updateY > public (1 calls)
 0: alias_cyclic.updateY<0>[410bae77d3]
 updateY(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -259,7 +259,7 @@ if.else:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -353,7 +353,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -372,7 +372,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -380,7 +380,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -389,13 +389,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -403,13 +403,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -417,7 +417,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
     alias_data.bar<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @alias_data:nn:nn
 
 
-backup > public {inline} (1 calls)
+proc backup > public {inline} (1 calls)
 0: alias_data.backup<0>
 backup(student1##0:student.student, ?student2##0:student.student)<{}; {}; {}>:
   AliasPairs: []
@@ -28,7 +28,7 @@ backup(student1##0:student.student, ?student2##0:student.student)<{}; {}; {}>:
     foreign llvm move(~student1##0:student.student, ?student2##0:student.student) @alias_data:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: alias_data.bar<0>
 bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -180,7 +180,7 @@ module top-level code > public {semipure} (0 calls)
     student.printStudent<0>[410bae77d3](~tmp#11##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @student:nn:nn
 
 
-printStudent > public (1 calls)
+proc printStudent > public (1 calls)
 0: student.printStudent<0>[410bae77d3]
 printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -365,7 +365,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: student.course.=<0>
 =(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -385,13 +385,13 @@ entry:
 
 
 
-code > public {inline} (0 calls)
+proc code > public {inline} (0 calls)
 0: student.course.code<0>
 code(#rec##0:student.course, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @student:nn:nn
-code > public {inline} (0 calls)
+proc code > public {inline} (0 calls)
 1: student.course.code<1>
 code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -399,7 +399,7 @@ code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int)<{}; {}
     foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @student:nn:nn
 
 
-course > public {inline} (0 calls)
+proc course > public {inline} (0 calls)
 0: student.course.course<0>
 course(code##0:wybe.int, name##0:wybe.string, ?#result##0:student.course)<{}; {}; {}>:
   AliasPairs: []
@@ -407,7 +407,7 @@ course(code##0:wybe.int, name##0:wybe.string, ?#result##0:student.course)<{}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course) @student:nn:nn
     foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int) @student:nn:nn
     foreign lpvm mutate(~#rec##1:student.course, ?#result##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string) @student:nn:nn
-course > public {inline} (6 calls)
+proc course > public {inline} (6 calls)
 1: student.course.course<1>
 course(?code##0:wybe.int, ?name##0:wybe.string, #result##0:student.course)<{}; {}; {}>:
   AliasPairs: []
@@ -416,13 +416,13 @@ course(?code##0:wybe.int, ?name##0:wybe.string, #result##0:student.course)<{}; {
     foreign lpvm access(~#result##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string) @student:nn:nn
 
 
-name > public {inline} (0 calls)
+proc name > public {inline} (0 calls)
 0: student.course.name<0>
 name(#rec##0:student.course, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @student:nn:nn
-name > public {inline} (0 calls)
+proc name > public {inline} (0 calls)
 1: student.course.name<1>
 name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -430,7 +430,7 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string)<{};
     foreign lpvm {noalias} mutate(~#rec##0:student.course, ?#rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @student:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: student.course.~=<0>
 ~=(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -607,7 +607,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: student.student.=<0>
 =(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -638,13 +638,13 @@ if.else:
 
 
 
-id > public {inline} (0 calls)
+proc id > public {inline} (0 calls)
 0: student.student.id<0>
 id(#rec##0:student.student, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @student:nn:nn
-id > public {inline} (0 calls)
+proc id > public {inline} (0 calls)
 1: student.student.id<1>
 id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -652,13 +652,13 @@ id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int)<{}; {}
     foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @student:nn:nn
 
 
-major > public {inline} (0 calls)
+proc major > public {inline} (0 calls)
 0: student.student.major<0>
 major(#rec##0:student.student, ?#result##0:student.course)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:student.course) @student:nn:nn
-major > public {inline} (0 calls)
+proc major > public {inline} (0 calls)
 1: student.student.major<1>
 major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.course)<{}; {}; {}>:
   AliasPairs: []
@@ -666,7 +666,7 @@ major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.cours
     foreign lpvm {noalias} mutate(~#rec##0:student.student, ?#rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:student.course) @student:nn:nn
 
 
-student > public {inline} (0 calls)
+proc student > public {inline} (0 calls)
 0: student.student.student<0>
 student(id##0:wybe.int, major##0:student.course, ?#result##0:student.student)<{}; {}; {}>:
   AliasPairs: []
@@ -674,7 +674,7 @@ student(id##0:wybe.int, major##0:student.course, ?#result##0:student.student)<{}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student) @student:nn:nn
     foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int) @student:nn:nn
     foreign lpvm mutate(~#rec##1:student.student, ?#result##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course) @student:nn:nn
-student > public {inline} (6 calls)
+proc student > public {inline} (6 calls)
 1: student.student.student<1>
 student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student)<{}; {}; {}>:
   AliasPairs: []
@@ -683,7 +683,7 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student)<{
     foreign lpvm access(~#result##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course) @student:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: student.student.~=<0>
 ~=(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
     alias_des.foo<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @alias_des:nn:nn
 
 
-foo > public (1 calls)
+proc foo > public (1 calls)
 0: alias_des.foo<0>
 foo()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -31,7 +31,7 @@ foo()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~p2##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @alias_des:nn:nn
 
 
-replicate > public (1 calls)
+proc replicate > public (1 calls)
 0: alias_des.replicate<0>
 replicate(?p2##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -163,7 +163,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -257,7 +257,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -276,7 +276,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -284,7 +284,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -293,13 +293,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -307,13 +307,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -321,7 +321,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -84,7 +84,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -178,7 +178,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -197,7 +197,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -205,7 +205,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -214,13 +214,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -228,13 +228,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -242,7 +242,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -32,7 +32,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-simpleMerge > public (1 calls)
+proc simpleMerge > public (1 calls)
 0: alias_fork1.simpleMerge<0>
 simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: [(#result##0,tl##0),(#result##0,tr##0),(tl##0,tr##0)]
@@ -77,7 +77,7 @@ simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?#result##0:mytree.tree)<{}; {
 
 
 
-simpleMerge#cont#1 > {inline} (2 calls)
+proc simpleMerge#cont#1 > {inline} (2 calls)
 0: alias_fork1.simpleMerge#cont#1<0>
 simpleMerge#cont#1(tmp#2##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -256,7 +256,7 @@ entry:
   submodules      : mytree.tree
   procs           : 
 
-printTree > public {inline} (0 calls)
+proc printTree > public {inline} (0 calls)
 0: mytree.printTree<0>
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -265,7 +265,7 @@ printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
 
 
-printTree1 > public (3 calls)
+proc printTree1 > public (3 calls)
 0: mytree.printTree1<0>
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(prefix##0,prefix##3)]
@@ -376,7 +376,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public (7 calls)
+proc = > public (7 calls)
 0: mytree.tree.=<0>
 =(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -418,7 +418,7 @@ if.else:
 
 
 
-empty > public {inline} (0 calls)
+proc empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
 empty(?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -426,7 +426,7 @@ empty(?#result##0:mytree.tree)<{}; {}; {}>:
     foreign llvm move(0:mytree.tree, ?#result##0:mytree.tree)
 
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 0: mytree.tree.key<0>
 key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -441,7 +441,7 @@ key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 1: mytree.tree.key<1>
 key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -458,7 +458,7 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:
 
 
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 0: mytree.tree.left<0>
 left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -473,7 +473,7 @@ left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {
         foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 1: mytree.tree.left<1>
 left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -490,7 +490,7 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success
 
 
 
-node > public {inline} (0 calls)
+proc node > public {inline} (0 calls)
 0: mytree.tree.node<0>
 node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -499,7 +499,7 @@ node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:myt
     foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree) @mytree:nn:nn
     foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @mytree:nn:nn
     foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree) @mytree:nn:nn
-node > public {inline} (16 calls)
+proc node > public {inline} (16 calls)
 1: mytree.tree.node<1>
 node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -520,7 +520,7 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
 
 
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 0: mytree.tree.right<0>
 right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -535,7 +535,7 @@ right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; 
         foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 1: mytree.tree.right<1>
 right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -552,7 +552,7 @@ right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#succes
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
 ~=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -46,7 +46,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: alias_fork2.#cont#1<0>
 #cont#1(t##0:mytree.tree, t1##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -73,7 +73,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-simpleMerge > public (3 calls)
+proc simpleMerge > public (3 calls)
 0: alias_fork2.simpleMerge<0>
 simpleMerge(tl##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: [(#result##0,tl##0)]
@@ -243,7 +243,7 @@ entry:
   submodules      : mytree.tree
   procs           : 
 
-printTree > public {inline} (0 calls)
+proc printTree > public {inline} (0 calls)
 0: mytree.printTree<0>
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -252,7 +252,7 @@ printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
 
 
-printTree1 > public (3 calls)
+proc printTree1 > public (3 calls)
 0: mytree.printTree1<0>
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(prefix##0,prefix##3)]
@@ -363,7 +363,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public (7 calls)
+proc = > public (7 calls)
 0: mytree.tree.=<0>
 =(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -405,7 +405,7 @@ if.else:
 
 
 
-empty > public {inline} (0 calls)
+proc empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
 empty(?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -413,7 +413,7 @@ empty(?#result##0:mytree.tree)<{}; {}; {}>:
     foreign llvm move(0:mytree.tree, ?#result##0:mytree.tree)
 
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 0: mytree.tree.key<0>
 key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -428,7 +428,7 @@ key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 1: mytree.tree.key<1>
 key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -445,7 +445,7 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:
 
 
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 0: mytree.tree.left<0>
 left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -460,7 +460,7 @@ left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {
         foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 1: mytree.tree.left<1>
 left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -477,7 +477,7 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success
 
 
 
-node > public {inline} (0 calls)
+proc node > public {inline} (0 calls)
 0: mytree.tree.node<0>
 node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -486,7 +486,7 @@ node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:myt
     foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree) @mytree:nn:nn
     foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @mytree:nn:nn
     foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree) @mytree:nn:nn
-node > public {inline} (16 calls)
+proc node > public {inline} (16 calls)
 1: mytree.tree.node<1>
 node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -507,7 +507,7 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
 
 
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 0: mytree.tree.right<0>
 right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -522,7 +522,7 @@ right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; 
         foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 1: mytree.tree.right<1>
 right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -539,7 +539,7 @@ right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#succes
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
 ~=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -37,7 +37,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-simpleSlice > public (1 calls)
+proc simpleSlice > public (1 calls)
 0: alias_fork3.simpleSlice<0>
 simpleSlice(tr##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: [(#result##0,tr##0)]
@@ -182,7 +182,7 @@ if.else:
   submodules      : mytree.tree
   procs           : 
 
-printTree > public {inline} (0 calls)
+proc printTree > public {inline} (0 calls)
 0: mytree.printTree<0>
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -191,7 +191,7 @@ printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
 
 
-printTree1 > public (3 calls)
+proc printTree1 > public (3 calls)
 0: mytree.printTree1<0>
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(prefix##0,prefix##3)]
@@ -302,7 +302,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public (7 calls)
+proc = > public (7 calls)
 0: mytree.tree.=<0>
 =(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -344,7 +344,7 @@ if.else:
 
 
 
-empty > public {inline} (0 calls)
+proc empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
 empty(?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -352,7 +352,7 @@ empty(?#result##0:mytree.tree)<{}; {}; {}>:
     foreign llvm move(0:mytree.tree, ?#result##0:mytree.tree)
 
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 0: mytree.tree.key<0>
 key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -367,7 +367,7 @@ key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 1: mytree.tree.key<1>
 key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -384,7 +384,7 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:
 
 
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 0: mytree.tree.left<0>
 left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -399,7 +399,7 @@ left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {
         foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 1: mytree.tree.left<1>
 left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -416,7 +416,7 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success
 
 
 
-node > public {inline} (0 calls)
+proc node > public {inline} (0 calls)
 0: mytree.tree.node<0>
 node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -425,7 +425,7 @@ node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:myt
     foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree) @mytree:nn:nn
     foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @mytree:nn:nn
     foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree) @mytree:nn:nn
-node > public {inline} (16 calls)
+proc node > public {inline} (16 calls)
 1: mytree.tree.node<1>
 node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -446,7 +446,7 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
 
 
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 0: mytree.tree.right<0>
 right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -461,7 +461,7 @@ right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; 
         foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 1: mytree.tree.right<1>
 right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -478,7 +478,7 @@ right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#succes
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
 ~=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -101,7 +101,7 @@ entry:
   resources       : 
   procs           : 
 
-bar > public (0 calls)
+proc bar > public (0 calls)
 0: alias_mbar.bar<0>[410bae77d3]
 bar(p1##0:position.position, ?p3##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p3##1)]
@@ -207,7 +207,7 @@ if.else:
   resources       : 
   procs           : 
 
-foo > public (0 calls)
+proc foo > public (0 calls)
 0: alias_mfoo.foo<0>[410bae77d3]
 foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -387,7 +387,7 @@ if.else:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -481,7 +481,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -500,7 +500,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -508,7 +508,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -517,13 +517,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -531,13 +531,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -545,7 +545,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -11,7 +11,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-bar > public (0 calls)
+proc bar > public (0 calls)
 0: alias_mbar.bar<0>[410bae77d3]
 bar(p1##0:position.position, ?p3##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p3##1)]
@@ -117,7 +117,7 @@ if.else:
   resources       : 
   procs           : 
 
-foo > public (0 calls)
+proc foo > public (0 calls)
 0: alias_mfoo.foo<0>[410bae77d3]
 foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -297,7 +297,7 @@ if.else:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -391,7 +391,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -410,7 +410,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -418,7 +418,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -427,13 +427,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -441,13 +441,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -455,7 +455,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -11,7 +11,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-bar > public (0 calls)
+proc bar > public (0 calls)
 0: alias_mbar.bar<0>[410bae77d3]
 bar(p1##0:position.position, ?p3##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p3##1)]
@@ -117,7 +117,7 @@ if.else:
   resources       : 
   procs           : 
 
-foo > public (0 calls)
+proc foo > public (0 calls)
 0: alias_mfoo.foo<0>[410bae77d3]
 foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -297,7 +297,7 @@ if.else:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -391,7 +391,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -410,7 +410,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -418,7 +418,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -427,13 +427,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -441,13 +441,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -455,7 +455,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -24,7 +24,7 @@ module top-level code > public {semipure} (0 calls)
     position.printPosition<0>(~tmp#0##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @alias_mod_param:nn:nn
 
 
-foo > public (1 calls)
+proc foo > public (1 calls)
 0: alias_mod_param.foo<0>
 foo(pa##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -117,7 +117,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -211,7 +211,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -230,7 +230,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -238,7 +238,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -247,13 +247,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -261,13 +261,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -275,7 +275,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -21,7 +21,7 @@ module top-level code > public {inline,semipure} (0 calls)
     alias_multifunc.bar<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @alias_multifunc:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: alias_multifunc.bar<0>
 bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ bar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @alias_multifunc:nn:nn
 
 
-replicate1 > public (1 calls)
+proc replicate1 > public (1 calls)
 0: alias_multifunc.replicate1<0>
 replicate1(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0),(p1##0,p3##0),(p2##0,p3##0)]
@@ -71,7 +71,7 @@ replicate1(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.po
     alias_multifunc.replicate2<0>(~p1##0:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @alias_multifunc:nn:nn
 
 
-replicate2 > public (1 calls)
+proc replicate2 > public (1 calls)
 0: alias_multifunc.replicate2<0>
 replicate2(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -269,7 +269,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -363,7 +363,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -382,7 +382,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -390,7 +390,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -399,13 +399,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -413,13 +413,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -427,7 +427,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -49,7 +49,7 @@ module top-level code > public {semipure} (0 calls)
     position.printPosition<0>(~p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #18 @alias_multifunc1:nn:nn
 
 
-replicate1 > public (1 calls)
+proc replicate1 > public (1 calls)
 0: alias_multifunc1.replicate1<0>
 replicate1(p1##0:position.position, ?p2##1:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p3##0)]
@@ -59,7 +59,7 @@ replicate1(p1##0:position.position, ?p2##1:position.position, ?p3##0:position.po
     foreign lpvm {noalias} mutate(~p2##0:position.position, ?p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int) @position:nn:nn
 
 
-replicate2 > public (2 calls)
+proc replicate2 > public (2 calls)
 0: alias_multifunc1.replicate2<0>
 replicate2(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -257,7 +257,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -351,7 +351,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -370,7 +370,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -378,7 +378,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -387,13 +387,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -401,13 +401,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -415,7 +415,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -44,7 +44,7 @@ module top-level code > public {semipure} (0 calls)
     position.printPosition<0>(~p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @alias_multifunc2:nn:nn
 
 
-replicate1 > public (1 calls)
+proc replicate1 > public (1 calls)
 0: alias_multifunc2.replicate1<0>
 replicate1(p1##0:position.position, ?p2##1:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p3##0)]
@@ -54,7 +54,7 @@ replicate1(p1##0:position.position, ?p2##1:position.position, ?p3##0:position.po
     foreign lpvm {noalias} mutate(~p2##0:position.position, ?p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int) @position:nn:nn
 
 
-replicate2 > public (2 calls)
+proc replicate2 > public (2 calls)
 0: alias_multifunc2.replicate2<0>
 replicate2(p1##0:position.position, ?p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -236,7 +236,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -330,7 +330,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -349,7 +349,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -357,7 +357,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -366,13 +366,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -380,13 +380,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -394,7 +394,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -39,7 +39,7 @@ module top-level code > public {semipure} (0 calls)
     position.printPosition<0>(~p2##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_multifunc3:nn:nn
 
 
-replicate1 > public (1 calls)
+proc replicate1 > public (1 calls)
 0: alias_multifunc3.replicate1<0>
 replicate1(pa##0:position.position, ?pb##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(pa##0,pb##0)]
@@ -201,7 +201,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -295,7 +295,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -314,7 +314,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -322,7 +322,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -331,13 +331,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -345,13 +345,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -359,7 +359,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -50,7 +50,7 @@ module top-level code > public {semipure} (0 calls)
     position.printPosition<0>(~p7##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #18 @alias_multifunc4:nn:nn
 
 
-replicate1 > public (1 calls)
+proc replicate1 > public (1 calls)
 0: alias_multifunc4.replicate1<0>
 replicate1(pa##0:position.position, ?pb##1:position.position, ?pc##0:position.position)<{}; {}; {}>:
   AliasPairs: [(pa##0,pc##0)]
@@ -63,7 +63,7 @@ replicate1(pa##0:position.position, ?pb##1:position.position, ?pc##0:position.po
     foreign lpvm {noalias} mutate(~pa##0:position.position, ?pb##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int) @position:nn:nn
 
 
-replicate21 > public (1 calls)
+proc replicate21 > public (1 calls)
 0: alias_multifunc4.replicate21<0>
 replicate21(?pb##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -77,7 +77,7 @@ replicate21(?pb##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     position.printPosition<0>(~pc##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @alias_multifunc4:nn:nn
 
 
-replicate22 > public (1 calls)
+proc replicate22 > public (1 calls)
 0: alias_multifunc4.replicate22<0>
 replicate22(?pb##0:position.position, ?pc##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -325,7 +325,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -419,7 +419,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -438,7 +438,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -446,7 +446,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -455,13 +455,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -469,13 +469,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -483,7 +483,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -56,7 +56,7 @@ module top-level code > public {semipure} (0 calls)
     position.printPosition<0>(~r##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @alias_recursion1:nn:nn
 
 
-if_test > public (2 calls)
+proc if_test > public (2 calls)
 0: alias_recursion1.if_test<0>
 if_test(a##0:position.position, b##0:position.position, ?r##0:position.position)<{}; {}; {}>:
   AliasPairs: [(a##0,b##0),(a##0,r##0),(b##0,r##0)]
@@ -234,7 +234,7 @@ if.else:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -328,7 +328,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -347,7 +347,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -355,7 +355,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -364,13 +364,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -378,13 +378,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -392,7 +392,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -33,7 +33,7 @@ module top-level code > public {semipure} (0 calls)
     position.printPosition<0>(~p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @alias_scc_proc:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: alias_scc_proc.bar<0>[410bae77d3]
 bar(p1##0:position.position, ?p3##1:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p3##1)]
@@ -64,7 +64,7 @@ bar(p1##0:position.position, ?p3##1:position.position)<{<<wybe.io.io>>}; {<<wybe
 
 
 
-foo > public (2 calls)
+proc foo > public (2 calls)
 0: alias_scc_proc.foo<0>[410bae77d3]
 foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(p1##0,p2##0)]
@@ -342,7 +342,7 @@ if.else:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -436,7 +436,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -455,7 +455,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -463,7 +463,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -472,13 +472,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -486,13 +486,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -500,7 +500,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -125,7 +125,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: alias_type1.position.=<0>
 =(#left##0:alias_type1.position, #right##0:alias_type1.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -144,7 +144,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: alias_type1.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type1.position)<{}; {}; {}>:
   AliasPairs: []
@@ -152,7 +152,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type1.position)<{}; {};
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.position) @alias_type1:nn:nn
     foreign lpvm mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @alias_type1:nn:nn
     foreign lpvm mutate(~#rec##1:alias_type1.position, ?#result##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @alias_type1:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: alias_type1.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type1.position)<{}; {}; {}>:
   AliasPairs: []
@@ -161,13 +161,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type1.position)<{}; {}
     foreign lpvm access(~#result##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @alias_type1:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: alias_type1.position.x<0>
 x(#rec##0:alias_type1.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type1:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: alias_type1.position.x<1>
 x(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -175,13 +175,13 @@ x(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.in
     foreign lpvm {noalias} mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type1:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: alias_type1.position.y<0>
 y(#rec##0:alias_type1.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type1:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: alias_type1.position.y<1>
 y(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -189,7 +189,7 @@ y(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.in
     foreign lpvm {noalias} mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type1:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: alias_type1.position.~=<0>
 ~=(#left##0:alias_type1.position, #right##0:alias_type1.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -360,7 +360,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: alias_type1.posrec.=<0>
 =(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -390,13 +390,13 @@ if.else:
 
 
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 0: alias_type1.posrec.a<0>
 a(#rec##0:alias_type1.posrec, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type1:nn:nn
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 1: alias_type1.posrec.a<1>
 a(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -404,13 +404,13 @@ a(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:wybe.int)<{
     foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type1:nn:nn
 
 
-p > public {inline} (0 calls)
+proc p > public {inline} (0 calls)
 0: alias_type1.posrec.p<0>
 p(#rec##0:alias_type1.posrec, ?#result##0:alias_type1.position)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type1.position) @alias_type1:nn:nn
-p > public {inline} (0 calls)
+proc p > public {inline} (0 calls)
 1: alias_type1.posrec.p<1>
 p(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:alias_type1.position)<{}; {}; {}>:
   AliasPairs: []
@@ -418,7 +418,7 @@ p(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:alias_type1
     foreign lpvm {noalias} mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type1.position) @alias_type1:nn:nn
 
 
-posrec > public {inline} (0 calls)
+proc posrec > public {inline} (0 calls)
 0: alias_type1.posrec.posrec<0>
 posrec(a##0:wybe.int, p##0:alias_type1.position, ?#result##0:alias_type1.posrec)<{}; {}; {}>:
   AliasPairs: []
@@ -426,7 +426,7 @@ posrec(a##0:wybe.int, p##0:alias_type1.position, ?#result##0:alias_type1.posrec)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.posrec) @alias_type1:nn:nn
     foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @alias_type1:nn:nn
     foreign lpvm mutate(~#rec##1:alias_type1.posrec, ?#result##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type1.position) @alias_type1:nn:nn
-posrec > public {inline} (6 calls)
+proc posrec > public {inline} (6 calls)
 1: alias_type1.posrec.posrec<1>
 posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec)<{}; {}; {}>:
   AliasPairs: []
@@ -435,7 +435,7 @@ posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec
     foreign lpvm access(~#result##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type1.position) @alias_type1:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: alias_type1.posrec.~=<0>
 ~=(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -139,7 +139,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: alias_type2.position.=<0>
 =(#left##0:alias_type2.position, #right##0:alias_type2.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -158,7 +158,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: alias_type2.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type2.position)<{}; {}; {}>:
   AliasPairs: []
@@ -166,7 +166,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type2.position)<{}; {};
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.position) @alias_type2:nn:nn
     foreign lpvm mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @alias_type2:nn:nn
     foreign lpvm mutate(~#rec##1:alias_type2.position, ?#result##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @alias_type2:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: alias_type2.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type2.position)<{}; {}; {}>:
   AliasPairs: []
@@ -175,13 +175,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type2.position)<{}; {}
     foreign lpvm access(~#result##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @alias_type2:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: alias_type2.position.x<0>
 x(#rec##0:alias_type2.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type2:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: alias_type2.position.x<1>
 x(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -189,13 +189,13 @@ x(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.in
     foreign lpvm {noalias} mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type2:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: alias_type2.position.y<0>
 y(#rec##0:alias_type2.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type2:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: alias_type2.position.y<1>
 y(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -203,7 +203,7 @@ y(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.in
     foreign lpvm {noalias} mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type2:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: alias_type2.position.~=<0>
 ~=(#left##0:alias_type2.position, #right##0:alias_type2.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -374,7 +374,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: alias_type2.posrec.=<0>
 =(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -404,13 +404,13 @@ if.else:
 
 
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 0: alias_type2.posrec.a<0>
 a(#rec##0:alias_type2.posrec, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type2:nn:nn
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 1: alias_type2.posrec.a<1>
 a(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -418,13 +418,13 @@ a(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:wybe.int)<{
     foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type2:nn:nn
 
 
-p > public {inline} (0 calls)
+proc p > public {inline} (0 calls)
 0: alias_type2.posrec.p<0>
 p(#rec##0:alias_type2.posrec, ?#result##0:alias_type2.position)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type2.position) @alias_type2:nn:nn
-p > public {inline} (0 calls)
+proc p > public {inline} (0 calls)
 1: alias_type2.posrec.p<1>
 p(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:alias_type2.position)<{}; {}; {}>:
   AliasPairs: []
@@ -432,7 +432,7 @@ p(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:alias_type2
     foreign lpvm {noalias} mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type2.position) @alias_type2:nn:nn
 
 
-posrec > public {inline} (0 calls)
+proc posrec > public {inline} (0 calls)
 0: alias_type2.posrec.posrec<0>
 posrec(p##0:alias_type2.position, a##0:wybe.int, ?#result##0:alias_type2.posrec)<{}; {}; {}>:
   AliasPairs: []
@@ -440,7 +440,7 @@ posrec(p##0:alias_type2.position, a##0:wybe.int, ?#result##0:alias_type2.posrec)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.posrec) @alias_type2:nn:nn
     foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type2.position) @alias_type2:nn:nn
     foreign lpvm mutate(~#rec##1:alias_type2.posrec, ?#result##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @alias_type2:nn:nn
-posrec > public {inline} (6 calls)
+proc posrec > public {inline} (6 calls)
 1: alias_type2.posrec.posrec<1>
 posrec(?p##0:alias_type2.position, ?a##0:wybe.int, #result##0:alias_type2.posrec)<{}; {}; {}>:
   AliasPairs: []
@@ -449,7 +449,7 @@ posrec(?p##0:alias_type2.position, ?a##0:wybe.int, #result##0:alias_type2.posrec
     foreign lpvm access(~#result##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int) @alias_type2:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: alias_type2.posrec.~=<0>
 ~=(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -142,7 +142,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: alias_type3.position.=<0>
 =(#left##0:alias_type3.position, #right##0:alias_type3.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -161,7 +161,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: alias_type3.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type3.position)<{}; {}; {}>:
   AliasPairs: []
@@ -169,7 +169,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type3.position)<{}; {};
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.position) @alias_type3:nn:nn
     foreign lpvm mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @alias_type3:nn:nn
     foreign lpvm mutate(~#rec##1:alias_type3.position, ?#result##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @alias_type3:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: alias_type3.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type3.position)<{}; {}; {}>:
   AliasPairs: []
@@ -178,13 +178,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type3.position)<{}; {}
     foreign lpvm access(~#result##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @alias_type3:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: alias_type3.position.x<0>
 x(#rec##0:alias_type3.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type3:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: alias_type3.position.x<1>
 x(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -192,13 +192,13 @@ x(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.in
     foreign lpvm {noalias} mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type3:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: alias_type3.position.y<0>
 y(#rec##0:alias_type3.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type3:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: alias_type3.position.y<1>
 y(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -206,7 +206,7 @@ y(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.in
     foreign lpvm {noalias} mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type3:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: alias_type3.position.~=<0>
 ~=(#left##0:alias_type3.position, #right##0:alias_type3.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -377,7 +377,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: alias_type3.posrec.=<0>
 =(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -407,13 +407,13 @@ if.else:
 
 
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 0: alias_type3.posrec.a<0>
 a(#rec##0:alias_type3.posrec, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type3:nn:nn
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 1: alias_type3.posrec.a<1>
 a(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -421,13 +421,13 @@ a(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:wybe.int)<{
     foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type3:nn:nn
 
 
-p > public {inline} (0 calls)
+proc p > public {inline} (0 calls)
 0: alias_type3.posrec.p<0>
 p(#rec##0:alias_type3.posrec, ?#result##0:alias_type3.position)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type3.position) @alias_type3:nn:nn
-p > public {inline} (0 calls)
+proc p > public {inline} (0 calls)
 1: alias_type3.posrec.p<1>
 p(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:alias_type3.position)<{}; {}; {}>:
   AliasPairs: []
@@ -435,7 +435,7 @@ p(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:alias_type3
     foreign lpvm {noalias} mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type3.position) @alias_type3:nn:nn
 
 
-posrec > public {inline} (0 calls)
+proc posrec > public {inline} (0 calls)
 0: alias_type3.posrec.posrec<0>
 posrec(p##0:alias_type3.position, a##0:wybe.int, ?#result##0:alias_type3.posrec)<{}; {}; {}>:
   AliasPairs: []
@@ -443,7 +443,7 @@ posrec(p##0:alias_type3.position, a##0:wybe.int, ?#result##0:alias_type3.posrec)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.posrec) @alias_type3:nn:nn
     foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type3.position) @alias_type3:nn:nn
     foreign lpvm mutate(~#rec##1:alias_type3.posrec, ?#result##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @alias_type3:nn:nn
-posrec > public {inline} (6 calls)
+proc posrec > public {inline} (6 calls)
 1: alias_type3.posrec.posrec<1>
 posrec(?p##0:alias_type3.position, ?a##0:wybe.int, #result##0:alias_type3.posrec)<{}; {}; {}>:
   AliasPairs: []
@@ -452,7 +452,7 @@ posrec(?p##0:alias_type3.position, ?a##0:wybe.int, #result##0:alias_type3.posrec
     foreign lpvm access(~#result##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int) @alias_type3:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: alias_type3.posrec.~=<0>
 ~=(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -45,7 +45,7 @@ module top-level code > public {semipure} (0 calls)
     alias_type4.foo<0>[410bae77d3](~tmp#11##0:alias_type4.posrec)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @alias_type4:nn:nn
 
 
-foo > public (1 calls)
+proc foo > public (1 calls)
 0: alias_type4.foo<0>[410bae77d3]
 foo(r1##0:alias_type4.posrec)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -160,7 +160,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: alias_type4.position.=<0>
 =(#left##0:alias_type4.position, #right##0:alias_type4.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -179,7 +179,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: alias_type4.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type4.position)<{}; {}; {}>:
   AliasPairs: []
@@ -187,7 +187,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type4.position)<{}; {};
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.position) @alias_type4:nn:nn
     foreign lpvm mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @alias_type4:nn:nn
     foreign lpvm mutate(~#rec##1:alias_type4.position, ?#result##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @alias_type4:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: alias_type4.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type4.position)<{}; {}; {}>:
   AliasPairs: []
@@ -196,13 +196,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type4.position)<{}; {}
     foreign lpvm access(~#result##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @alias_type4:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: alias_type4.position.x<0>
 x(#rec##0:alias_type4.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type4:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: alias_type4.position.x<1>
 x(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -210,13 +210,13 @@ x(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.in
     foreign lpvm {noalias} mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type4:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: alias_type4.position.y<0>
 y(#rec##0:alias_type4.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type4:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: alias_type4.position.y<1>
 y(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -224,7 +224,7 @@ y(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.in
     foreign lpvm {noalias} mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type4:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: alias_type4.position.~=<0>
 ~=(#left##0:alias_type4.position, #right##0:alias_type4.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -395,7 +395,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: alias_type4.posrec.=<0>
 =(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -425,13 +425,13 @@ if.else:
 
 
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 0: alias_type4.posrec.a<0>
 a(#rec##0:alias_type4.posrec, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @alias_type4:nn:nn
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 1: alias_type4.posrec.a<1>
 a(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -439,13 +439,13 @@ a(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:wybe.int)<{
     foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @alias_type4:nn:nn
 
 
-p > public {inline} (0 calls)
+proc p > public {inline} (0 calls)
 0: alias_type4.posrec.p<0>
 p(#rec##0:alias_type4.posrec, ?#result##0:alias_type4.position)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type4.position) @alias_type4:nn:nn
-p > public {inline} (0 calls)
+proc p > public {inline} (0 calls)
 1: alias_type4.posrec.p<1>
 p(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:alias_type4.position)<{}; {}; {}>:
   AliasPairs: []
@@ -453,7 +453,7 @@ p(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:alias_type4
     foreign lpvm {noalias} mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type4.position) @alias_type4:nn:nn
 
 
-posrec > public {inline} (0 calls)
+proc posrec > public {inline} (0 calls)
 0: alias_type4.posrec.posrec<0>
 posrec(p##0:alias_type4.position, a##0:wybe.int, ?#result##0:alias_type4.posrec)<{}; {}; {}>:
   AliasPairs: []
@@ -461,7 +461,7 @@ posrec(p##0:alias_type4.position, a##0:wybe.int, ?#result##0:alias_type4.posrec)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.posrec) @alias_type4:nn:nn
     foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type4.position) @alias_type4:nn:nn
     foreign lpvm mutate(~#rec##1:alias_type4.posrec, ?#result##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @alias_type4:nn:nn
-posrec > public {inline} (6 calls)
+proc posrec > public {inline} (6 calls)
 1: alias_type4.posrec.posrec<1>
 posrec(?p##0:alias_type4.position, ?a##0:wybe.int, #result##0:alias_type4.posrec)<{}; {}; {}>:
   AliasPairs: []
@@ -470,7 +470,7 @@ posrec(?p##0:alias_type4.position, ?a##0:wybe.int, #result##0:alias_type4.posrec
     foreign lpvm access(~#result##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int) @alias_type4:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: alias_type4.posrec.~=<0>
 ~=(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/alloc_args.exp
+++ b/test-cases/final-dump/alloc_args.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     alloc_args.foo<0>(1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @alloc_args:nn:nn
 
 
-foo > {noinline} (1 calls)
+proc foo > {noinline} (1 calls)
 0: alloc_args.foo<0>
 foo(size##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -45,7 +45,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: anon_field.#cont#1<0>
 #cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -69,7 +69,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#2 > (3 calls)
+proc #cont#2 > (3 calls)
 0: anon_field.#cont#2<0>
 #cont#2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -96,7 +96,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#3 > (2 calls)
+proc #cont#3 > (2 calls)
 0: anon_field.#cont#3<0>
 #cont#3()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -124,7 +124,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-= > public (7 calls)
+proc = > public (7 calls)
 0: anon_field.=<0>
 =(#left##0:anon_field, #right##0:anon_field, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -190,7 +190,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-bar > {inline} (3 calls)
+proc bar > {inline} (3 calls)
 0: anon_field.bar<0>
 bar(bar#1##0:wybe.int, ?#result##0:anon_field)<{}; {}; {}>:
   AliasPairs: []
@@ -198,7 +198,7 @@ bar(bar#1##0:wybe.int, ?#result##0:anon_field)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field) @anon_field:nn:nn
     foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int) @anon_field:nn:nn
     foreign llvm or(~#rec##1:anon_field, 1:wybe.int, ?#result##0:anon_field) @anon_field:nn:nn
-bar > {inline} (7 calls)
+proc bar > {inline} (7 calls)
 1: anon_field.bar<1>
 bar(?bar#1##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -216,7 +216,7 @@ bar(?bar#1##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool)<{}; {}; {
 
 
 
-baz > {inline} (5 calls)
+proc baz > {inline} (5 calls)
 0: anon_field.baz<0>
 baz(field##0:wybe.int, ?#result##0:anon_field)<{}; {}; {}>:
   AliasPairs: []
@@ -224,7 +224,7 @@ baz(field##0:wybe.int, ?#result##0:anon_field)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field) @anon_field:nn:nn
     foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~field##0:wybe.int) @anon_field:nn:nn
     foreign llvm or(~#rec##1:anon_field, 2:wybe.int, ?#result##0:anon_field) @anon_field:nn:nn
-baz > {inline} (5 calls)
+proc baz > {inline} (5 calls)
 1: anon_field.baz<1>
 baz(?field##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -242,7 +242,7 @@ baz(?field##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool)<{}; {}; {
 
 
 
-field > {inline} (5 calls)
+proc field > {inline} (5 calls)
 0: anon_field.field<0>
 field(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -258,7 +258,7 @@ field(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; 
         foreign lpvm access(~#rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-field > {inline} (0 calls)
+proc field > {inline} (0 calls)
 1: anon_field.field<1>
 field(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -276,7 +276,7 @@ field(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:
 
 
 
-foo > {inline} (14 calls)
+proc foo > {inline} (14 calls)
 0: anon_field.foo<0>
 foo(foo#1##0:wybe.int, foo#2##0:wybe.bool, i##0:wybe.int, ?#result##0:anon_field)<{}; {}; {}>:
   AliasPairs: []
@@ -285,7 +285,7 @@ foo(foo#1##0:wybe.int, foo#2##0:wybe.bool, i##0:wybe.int, ?#result##0:anon_field
     foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#2##0:wybe.bool) @anon_field:nn:nn
     foreign lpvm mutate(~#rec##1:anon_field, ?#rec##2:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#1##0:wybe.int) @anon_field:nn:nn
     foreign lpvm mutate(~#rec##2:anon_field, ?#result##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int) @anon_field:nn:nn
-foo > {inline} (20 calls)
+proc foo > {inline} (20 calls)
 1: anon_field.foo<1>
 foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -307,7 +307,7 @@ foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_fie
 
 
 
-i > {inline} (5 calls)
+proc i > {inline} (5 calls)
 0: anon_field.i<0>
 i(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -323,7 +323,7 @@ i(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
         foreign lpvm access(~#rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @anon_field:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-i > {inline} (0 calls)
+proc i > {inline} (0 calls)
 1: anon_field.i<1>
 i(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -341,7 +341,7 @@ i(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:wybe
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: anon_field.~=<0>
 ~=(#left##0:anon_field, #right##0:anon_field, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -810,7 +810,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: anon_field.quux.=<0>
 =(#left##0:anon_field.quux, #right##0:anon_field.quux, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -829,13 +829,13 @@ entry:
 
 
 
-j > public {inline} (0 calls)
+proc j > public {inline} (0 calls)
 0: anon_field.quux.j<0>
 j(#rec##0:anon_field.quux, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @anon_field:nn:nn
-j > public {inline} (0 calls)
+proc j > public {inline} (0 calls)
 1: anon_field.quux.j<1>
 j(#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -843,7 +843,7 @@ j(#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, #field##0:wybe.int)<{}; {};
     foreign lpvm {noalias} mutate(~#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @anon_field:nn:nn
 
 
-quuz > public {inline} (0 calls)
+proc quuz > public {inline} (0 calls)
 0: anon_field.quux.quuz<0>
 quuz(quuz#1##0:wybe.int, j##0:wybe.int, ?#result##0:anon_field.quux)<{}; {}; {}>:
   AliasPairs: []
@@ -851,7 +851,7 @@ quuz(quuz#1##0:wybe.int, j##0:wybe.int, ?#result##0:anon_field.quux)<{}; {}; {}>
     foreign lpvm alloc(16:wybe.int, ?#rec##0:anon_field.quux) @anon_field:nn:nn
     foreign lpvm mutate(~#rec##0:anon_field.quux, ?#rec##1:anon_field.quux, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~quuz#1##0:wybe.int) @anon_field:nn:nn
     foreign lpvm mutate(~#rec##1:anon_field.quux, ?#result##0:anon_field.quux, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~j##0:wybe.int) @anon_field:nn:nn
-quuz > public {inline} (6 calls)
+proc quuz > public {inline} (6 calls)
 1: anon_field.quux.quuz<1>
 quuz(?quuz#1##0:wybe.int, ?j##0:wybe.int, #result##0:anon_field.quux)<{}; {}; {}>:
   AliasPairs: []
@@ -860,7 +860,7 @@ quuz(?quuz#1##0:wybe.int, ?j##0:wybe.int, #result##0:anon_field.quux)<{}; {}; {}
     foreign lpvm access(~#result##0:anon_field.quux, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int) @anon_field:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: anon_field.quux.~=<0>
 ~=(#left##0:anon_field.quux, #right##0:anon_field.quux, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/anon_field_variable.exp
+++ b/test-cases/final-dump/anon_field_variable.exp
@@ -29,7 +29,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-bar > {inline} (0 calls)
+proc bar > {inline} (0 calls)
 0: anon_field_variable.bar<0>
 bar(bar#1##0:wybe.int, field##0:T <{}; {}; {1}>, bar#3##0:T <{}; {}; {2}>, ?#result##0:anon_field_variable(T) <{}; {}; {1, 2}>)<{}; {}; {}>:
   AliasPairs: []
@@ -39,7 +39,7 @@ bar(bar#1##0:wybe.int, field##0:T <{}; {}; {1}>, bar#3##0:T <{}; {}; {2}>, ?#res
     foreign lpvm mutate(~#rec##1:anon_field_variable(T), ?#rec##2:anon_field_variable(T), 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~field##0:T) @anon_field_variable:nn:nn
     foreign lpvm mutate(~#rec##2:anon_field_variable(T), ?#rec##3:anon_field_variable(T), 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#3##0:T) @anon_field_variable:nn:nn
     foreign llvm or(~#rec##3:anon_field_variable(T), 1:wybe.int, ?#result##0:anon_field_variable(T)) @anon_field_variable:nn:nn
-bar > {inline} (0 calls)
+proc bar > {inline} (0 calls)
 1: anon_field_variable.bar<1>
 bar(?bar#1##0:wybe.int, ?field##0:T <{}; {}; {3}>, ?bar#3##0:T <{}; {}; {3}>, #result##0:anon_field_variable(T) <{}; {}; {3}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -61,7 +61,7 @@ bar(?bar#1##0:wybe.int, ?field##0:T <{}; {}; {3}>, ?bar#3##0:T <{}; {}; {3}>, #r
 
 
 
-field > {inline} (0 calls)
+proc field > {inline} (0 calls)
 0: anon_field_variable.field<0>
 field(#rec##0:anon_field_variable(T) <{}; {}; {0}>, ?#result##0:T <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -77,7 +77,7 @@ field(#rec##0:anon_field_variable(T) <{}; {}; {0}>, ?#result##0:T <{}; {}; {0}>,
         foreign lpvm access(~#rec##0:anon_field_variable(T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:T) @anon_field_variable:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-field > {inline} (0 calls)
+proc field > {inline} (0 calls)
 1: anon_field_variable.field<1>
 field(#rec##0:anon_field_variable(T) <{}; {}; {0}>, ?#rec##1:anon_field_variable(T) <{}; {}; {0, 2}>, #field##0:T <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -95,14 +95,14 @@ field(#rec##0:anon_field_variable(T) <{}; {}; {0}>, ?#rec##1:anon_field_variable
 
 
 
-foo > {inline} (3 calls)
+proc foo > {inline} (3 calls)
 0: anon_field_variable.foo<0>
 foo(foo#1##0:T <{}; {}; {0}>, ?#result##0:anon_field_variable(T) <{}; {}; {0}>)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field_variable(T)) @anon_field_variable:nn:nn
     foreign lpvm mutate(~#rec##0:anon_field_variable(T), ?#result##0:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~foo#1##0:T) @anon_field_variable:nn:nn
-foo > {inline} (3 calls)
+proc foo > {inline} (3 calls)
 1: anon_field_variable.foo<1>
 foo(?foo#1##0:T <{}; {}; {1}>, #result##0:anon_field_variable(T) <{}; {}; {1}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/backquote_OK.exp
+++ b/test-cases/final-dump/backquote_OK.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-OK backquote use! > {inline} (0 calls)
+proc OK backquote use! > {inline} (0 calls)
 0: backquote_OK.OK backquote use!<0>
 OK backquote use!(?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/backwards_assign.exp
+++ b/test-cases/final-dump/backwards_assign.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     backwards_assign.#cont#1<0>(0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @backwards_assign:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: backwards_assign.#cont#1<0>
 #cont#1(i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-backwards_assign > {inline} (3 calls)
+proc backwards_assign > {inline} (3 calls)
 0: backwards_assign.backwards_assign<0>
 backwards_assign(?output##0:wybe.int, input##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/bad_assign.exp
+++ b/test-cases/final-dump/bad_assign.exp
@@ -1,3 +1,3 @@
 Error detected during type checking of module(s) bad_assign
-[91mfinal-dump/bad_assign.wybe:5:1: 'l' unknown in module top-level code
+[91mfinal-dump/bad_assign.wybe:5:1: proc l unknown in module top-level code
 [0m

--- a/test-cases/final-dump/bar.exp
+++ b/test-cases/final-dump/bar.exp
@@ -81,7 +81,7 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-factorial > public (1 calls)
+proc factorial > public (1 calls)
 0: numbers.factorial<0>
 factorial(n##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -98,7 +98,7 @@ factorial(n##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
 
 
 
-toCelsius > public {inline} (0 calls)
+proc toCelsius > public {inline} (0 calls)
 0: numbers.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/break_in_loop_in_do.exp
+++ b/test-cases/final-dump/break_in_loop_in_do.exp
@@ -21,7 +21,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#cont#1 > {inline} (2 calls)
+proc #cont#1 > {inline} (2 calls)
 0: break_in_loop_in_do.#cont#1<0>
 #cont#1([counter##0:wybe.int])<{<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -33,7 +33,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#cont#2 > {inline} (1 calls)
+proc #cont#2 > {inline} (1 calls)
 0: break_in_loop_in_do.#cont#2<0>
 #cont#2([tmp#0##0:wybe.int], tmp#1##0:wybe.int)<{<<wybe.io.io>>}; {<<break_in_loop_in_do.counter>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/bug214.exp
+++ b/test-cases/final-dump/bug214.exp
@@ -28,7 +28,7 @@ module top-level code > public {semipure} (0 calls)
     bug214.#cont#2<0>[7477e50a09](~tmp#0##0:bug214.position, ~tmp#1##0:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @bug214:nn:nn
 
 
-#cont#1 > {inline} (0 calls)
+proc #cont#1 > {inline} (0 calls)
 0: bug214.#cont#1<0>
 #cont#1(pos##0:bug214.position, sub##0:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -56,7 +56,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#38##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#cont#2 > (3 calls)
+proc #cont#2 > (3 calls)
 0: bug214.#cont#2<0>[7477e50a09]
 #cont#2(pos##0:bug214.position, sub##0:bug214)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -118,7 +118,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: bug214.=<0>
 =(#left##0:bug214, #right##0:bug214, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -146,13 +146,13 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-aim > {inline} (3 calls)
+proc aim > {inline} (3 calls)
 0: bug214.aim<0>
 aim(#rec##0:bug214, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:bug214, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @bug214:nn:nn
-aim > {inline} (2 calls)
+proc aim > {inline} (2 calls)
 1: bug214.aim<1>
 aim(#rec##0:bug214, ?#rec##1:bug214, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -160,7 +160,7 @@ aim(#rec##0:bug214, ?#rec##1:bug214, #field##0:wybe.int)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:bug214, ?#rec##1:bug214, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @bug214:nn:nn
 
 
-move > (1 calls)
+proc move > (1 calls)
 0: bug214.move<0>[410bae77d3]
 move(pos##0:bug214.position, ?pos##1:bug214.position, dir##0:bug214.direction, units##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -198,7 +198,7 @@ move(pos##0:bug214.position, ?pos##1:bug214.position, dir##0:bug214.direction, u
         foreign llvm sub(~tmp#8##0:wybe.int, ~units##0:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~pos##0:bug214.position, ?pos##1:bug214.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int) @bug214:nn:nn
 
-move > (1 calls)
+proc move > (1 calls)
 1: bug214.move<1>[410bae77d3]
 move(sub##0:bug214, ?sub##2:bug214, dir##0:bug214.direction, units##0:wybe.int)<{}; {}; {}>:
   AliasPairs: [(sub##0,sub##2)]
@@ -256,13 +256,13 @@ move(sub##0:bug214, ?sub##2:bug214, dir##0:bug214.direction, units##0:wybe.int)<
 
 
 
-sub_pos > {inline} (7 calls)
+proc sub_pos > {inline} (7 calls)
 0: bug214.sub_pos<0>
 sub_pos(#rec##0:bug214, ?#result##0:bug214.position)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:bug214, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:bug214.position) @bug214:nn:nn
-sub_pos > {inline} (2 calls)
+proc sub_pos > {inline} (2 calls)
 1: bug214.sub_pos<1>
 sub_pos(#rec##0:bug214, ?#rec##1:bug214, #field##0:bug214.position)<{}; {}; {}>:
   AliasPairs: []
@@ -270,7 +270,7 @@ sub_pos(#rec##0:bug214, ?#rec##1:bug214, #field##0:bug214.position)<{}; {}; {}>:
     foreign lpvm {noalias} mutate(~#rec##0:bug214, ?#rec##1:bug214, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:bug214.position) @bug214:nn:nn
 
 
-submarine > {inline} (1 calls)
+proc submarine > {inline} (1 calls)
 0: bug214.submarine<0>
 submarine(sub_pos##0:bug214.position, aim##0:wybe.int, ?#result##0:bug214)<{}; {}; {}>:
   AliasPairs: []
@@ -278,7 +278,7 @@ submarine(sub_pos##0:bug214.position, aim##0:wybe.int, ?#result##0:bug214)<{}; {
     foreign lpvm alloc(16:wybe.int, ?#rec##0:bug214) @bug214:nn:nn
     foreign lpvm mutate(~#rec##0:bug214, ?#rec##1:bug214, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sub_pos##0:bug214.position) @bug214:nn:nn
     foreign lpvm mutate(~#rec##1:bug214, ?#result##0:bug214, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~aim##0:wybe.int) @bug214:nn:nn
-submarine > {inline} (6 calls)
+proc submarine > {inline} (6 calls)
 1: bug214.submarine<1>
 submarine(?sub_pos##0:bug214.position, ?aim##0:wybe.int, #result##0:bug214)<{}; {}; {}>:
   AliasPairs: []
@@ -287,7 +287,7 @@ submarine(?sub_pos##0:bug214.position, ?aim##0:wybe.int, #result##0:bug214)<{}; 
     foreign lpvm access(~#result##0:bug214, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?aim##0:wybe.int) @bug214:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: bug214.~=<0>
 ~=(#left##0:bug214, #right##0:bug214, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -864,7 +864,7 @@ if.else1:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: bug214.direction.=<0>
 =(#left##0:bug214.direction, #right##0:bug214.direction, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -872,7 +872,7 @@ if.else1:
     foreign llvm icmp_eq(~#left##0:bug214.direction, ~#right##0:bug214.direction, ?#success##0:wybe.bool)
 
 
-down > public {inline} (1 calls)
+proc down > public {inline} (1 calls)
 0: bug214.direction.down<0>
 down(?#result##0:bug214.direction)<{}; {}; {}>:
   AliasPairs: []
@@ -880,7 +880,7 @@ down(?#result##0:bug214.direction)<{}; {}; {}>:
     foreign llvm move(1:bug214.direction, ?#result##0:bug214.direction)
 
 
-fwd > public {inline} (1 calls)
+proc fwd > public {inline} (1 calls)
 0: bug214.direction.fwd<0>
 fwd(?#result##0:bug214.direction)<{}; {}; {}>:
   AliasPairs: []
@@ -888,7 +888,7 @@ fwd(?#result##0:bug214.direction)<{}; {}; {}>:
     foreign llvm move(0:bug214.direction, ?#result##0:bug214.direction)
 
 
-parse_direction > public (0 calls)
+proc parse_direction > public (0 calls)
 0: bug214.direction.parse_direction<0>
 parse_direction(str##0:wybe.string, ?dir##0:bug214.direction, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -924,7 +924,7 @@ parse_direction(str##0:wybe.string, ?dir##0:bug214.direction, ?#success##0:wybe.
 
 
 
-up > public {inline} (1 calls)
+proc up > public {inline} (1 calls)
 0: bug214.direction.up<0>
 up(?#result##0:bug214.direction)<{}; {}; {}>:
   AliasPairs: []
@@ -932,7 +932,7 @@ up(?#result##0:bug214.direction)<{}; {}; {}>:
     foreign llvm move(2:bug214.direction, ?#result##0:bug214.direction)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: bug214.direction.~=<0>
 ~=(#left##0:bug214.direction, #right##0:bug214.direction, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1058,7 +1058,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: bug214.position.=<0>
 =(#left##0:bug214.position, #right##0:bug214.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1077,7 +1077,7 @@ entry:
 
 
 
-origin > public (0 calls)
+proc origin > public (0 calls)
 0: bug214.position.origin<0>
 origin(?#result##0:bug214.position)<{}; {}; {}>:
   AliasPairs: []
@@ -1087,7 +1087,7 @@ origin(?#result##0:bug214.position)<{}; {}; {}>:
     foreign lpvm mutate(~tmp#4##0:bug214.position, ?#result##0:bug214.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int) @bug214:nn:nn
 
 
-position > public {inline} (1 calls)
+proc position > public {inline} (1 calls)
 0: bug214.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:bug214.position)<{}; {}; {}>:
   AliasPairs: []
@@ -1095,7 +1095,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:bug214.position)<{}; {}; {}>:
     foreign lpvm alloc(16:wybe.int, ?#rec##0:bug214.position) @bug214:nn:nn
     foreign lpvm mutate(~#rec##0:bug214.position, ?#rec##1:bug214.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @bug214:nn:nn
     foreign lpvm mutate(~#rec##1:bug214.position, ?#result##0:bug214.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @bug214:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: bug214.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:bug214.position)<{}; {}; {}>:
   AliasPairs: []
@@ -1104,7 +1104,7 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:bug214.position)<{}; {}; {}>
     foreign lpvm access(~#result##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @bug214:nn:nn
 
 
-print > public (0 calls)
+proc print > public (0 calls)
 0: bug214.position.print<0>
 print(pos##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -1122,13 +1122,13 @@ print(pos##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @bug214:nn:nn
 
 
-x > public {inline} (1 calls)
+proc x > public {inline} (1 calls)
 0: bug214.position.x<0>
 x(#rec##0:bug214.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @bug214:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: bug214.position.x<1>
 x(#rec##0:bug214.position, ?#rec##1:bug214.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1136,13 +1136,13 @@ x(#rec##0:bug214.position, ?#rec##1:bug214.position, #field##0:wybe.int)<{}; {};
     foreign lpvm {noalias} mutate(~#rec##0:bug214.position, ?#rec##1:bug214.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @bug214:nn:nn
 
 
-y > public {inline} (1 calls)
+proc y > public {inline} (1 calls)
 0: bug214.position.y<0>
 y(#rec##0:bug214.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @bug214:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: bug214.position.y<1>
 y(#rec##0:bug214.position, ?#rec##1:bug214.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1150,7 +1150,7 @@ y(#rec##0:bug214.position, ?#rec##1:bug214.position, #field##0:wybe.int)<{}; {};
     foreign lpvm {noalias} mutate(~#rec##0:bug214.position, ?#rec##1:bug214.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @bug214:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: bug214.position.~=<0>
 ~=(#left##0:bug214.position, #right##0:bug214.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/bug217.exp
+++ b/test-cases/final-dump/bug217.exp
@@ -38,7 +38,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   submodules      : bug217.foo.bar
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: bug217.foo.=<0>
 =([#left##0:bug217.foo], [#right##0:bug217.foo], ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -46,7 +46,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-foo > {inline} (0 calls)
+proc foo > {inline} (0 calls)
 0: bug217.foo.foo<0>
 foo(?#result##0:bug217.foo)<{}; {}; {}>:
   AliasPairs: []
@@ -54,7 +54,7 @@ foo(?#result##0:bug217.foo)<{}; {}; {}>:
     foreign llvm move(0:bug217.foo, ?#result##0:bug217.foo)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: bug217.foo.~=<0>
 ~=([#left##0:bug217.foo], [#right##0:bug217.foo], ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -103,7 +103,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: bug217.foo.bar.=<0>
 =([#left##0:bug217.foo.bar], [#right##0:bug217.foo.bar], ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -111,7 +111,7 @@ entry:
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-bar > {inline} (0 calls)
+proc bar > {inline} (0 calls)
 0: bug217.foo.bar.bar<0>
 bar(?#result##0:bug217.foo.bar)<{}; {}; {}>:
   AliasPairs: []
@@ -119,7 +119,7 @@ bar(?#result##0:bug217.foo.bar)<{}; {}; {}>:
     foreign llvm move(0:bug217.foo.bar, ?#result##0:bug217.foo.bar)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: bug217.foo.bar.~=<0>
 ~=([#left##0:bug217.foo.bar], [#right##0:bug217.foo.bar], ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/bug228-okay.exp
+++ b/test-cases/final-dump/bug228-okay.exp
@@ -22,7 +22,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-bar > {inline} (1 calls)
+proc bar > {inline} (1 calls)
 0: bug228-okay.bar<0>
 bar(?out1##0:wybe.int, ?out2##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -33,7 +33,7 @@ bar(?out1##0:wybe.int, ?out2##0:wybe.int)<{}; {}; {}>:
     foreign llvm move(1:wybe.int, ?out1##0:wybe.int) @bug228-okay:11:6
 
 
-init_res > {inline} (1 calls)
+proc init_res > {inline} (1 calls)
 0: bug228-okay.init_res<0>
 init_res()<{}; {<<bug228-okay.res>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/bug228-type.exp
+++ b/test-cases/final-dump/bug228-type.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) bug228-type
-[91mfinal-dump/bug228-type.wybe:5:2: Type error in call to =, argument 1
-[0m[91mfinal-dump/bug228-type.wybe:5:2: Type error in call to =, argument 2
+[91mfinal-dump/bug228-type.wybe:5:2: Type error in call to proc =, argument 1
+[0m[91mfinal-dump/bug228-type.wybe:5:2: Type error in call to proc =, argument 2
 [0m[91mfinal-dump/bug228-type.wybe:5:2: Type of "1.0" incompatible with ?bar
 [0m

--- a/test-cases/final-dump/bug228-undefined.exp
+++ b/test-cases/final-dump/bug228-undefined.exp
@@ -1,3 +1,3 @@
 Error detected during type checking of module(s) bug228-undefined
-[91mfinal-dump/bug228-undefined.wybe:10:10: 'res' unknown in module top-level code
+[91mfinal-dump/bug228-undefined.wybe:10:10: proc res unknown in module top-level code
 [0m

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -49,7 +49,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-bar > public {inline} (9 calls)
+proc bar > public {inline} (9 calls)
 0: call_site_id.bar<0>
 bar(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -57,7 +57,7 @@ bar(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     call_site_id.foo<0>(~x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @call_site_id:nn:nn
 
 
-foo > public (1 calls)
+proc foo > public (1 calls)
 0: call_site_id.foo<0>
 foo(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/call_unknown.exp
+++ b/test-cases/final-dump/call_unknown.exp
@@ -1,3 +1,3 @@
 Error detected during type checking of module(s) call_unknown
-[91mfinal-dump/call_unknown.wybe:1:26: 'nonexistent_proc' unknown in foo
+[91mfinal-dump/call_unknown.wybe:1:26: proc nonexistent_proc unknown in proc foo
 [0m

--- a/test-cases/final-dump/card.exp
+++ b/test-cases/final-dump/card.exp
@@ -58,7 +58,7 @@ module top-level code > public {inline,semipure} (0 calls)
     card.#cont#1<0>(~tmp#1##0:wybe.list(card.suit))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @card:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: card.#cont#1<0>
 #cont#1(tmp#0##0:wybe.list(card.suit))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -75,7 +75,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-#cont#2 > (2 calls)
+proc #cont#2 > (2 calls)
 0: card.#cont#2<0>
 #cont#2(s##0:card.suit, tmp#0##0:wybe.list(card.suit), tmp#2##0:wybe.list(card.rank))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -98,7 +98,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: card.=<0>
 =(#left##0:card, #right##0:card, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -106,14 +106,14 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm icmp_eq(~#left##0:card, ~#right##0:card, ?#success##0:wybe.bool)
 
 
-card > public {inline} (1 calls)
+proc card > public {inline} (1 calls)
 0: card.card<0>
 card(rank##0:card.rank, suit##0:card.suit, ?#result##3:card)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm shl(~rank##0:card, 2:card, ?#temp##0:card) @card:nn:nn
     foreign llvm or(~#temp##0:card, ~suit##0:card, ?#result##3:card) @card:nn:nn
-card > public {inline} (0 calls)
+proc card > public {inline} (0 calls)
 1: card.card<1>
 card(?rank##0:card.rank, ?suit##0:card.suit, #result##0:card)<{}; {}; {}>:
   AliasPairs: []
@@ -125,7 +125,7 @@ card(?rank##0:card.rank, ?suit##0:card.suit, #result##0:card)<{}; {}; {}>:
     foreign lpvm cast(~#temp2##1:card, ?suit##0:card.suit) @card:nn:nn
 
 
-print > public (1 calls)
+proc print > public (1 calls)
 0: card.print<0>
 print(c##0:card)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -139,7 +139,7 @@ print(c##0:card)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     card.suit.print<0>(~tmp#1##0:card.suit)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @card:nn:nn
 
 
-rank > public {inline} (1 calls)
+proc rank > public {inline} (1 calls)
 0: card.rank<0>
 rank(#rec##0:card, ?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -147,7 +147,7 @@ rank(#rec##0:card, ?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm lshr(~#rec##0:card, 2:card, ?#rec##1:card) @card:nn:nn
     foreign llvm and(~#rec##1:card, 15:card, ?#field##0:card) @card:nn:nn
     foreign lpvm cast(~#field##0:card, ?#result##0:card.rank) @card:nn:nn
-rank > public {inline} (0 calls)
+proc rank > public {inline} (0 calls)
 1: card.rank<1>
 rank(#rec##0:card, ?#rec##2:card, #field##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -157,14 +157,14 @@ rank(#rec##0:card, ?#rec##2:card, #field##0:card.rank)<{}; {}; {}>:
     foreign llvm or(~#rec##1:card, ~#temp##0:card, ?#rec##2:card) @card:nn:nn
 
 
-suit > public {inline} (1 calls)
+proc suit > public {inline} (1 calls)
 0: card.suit<0>
 suit(#rec##0:card, ?#result##0:card.suit)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm and(~#rec##0:card, 3:card, ?#field##0:card) @card:nn:nn
     foreign lpvm cast(~#field##0:card, ?#result##0:card.suit) @card:nn:nn
-suit > public {inline} (0 calls)
+proc suit > public {inline} (0 calls)
 1: card.suit<1>
 suit(#rec##0:card, ?#rec##2:card, #field##0:card.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -173,7 +173,7 @@ suit(#rec##0:card, ?#rec##2:card, #field##0:card.suit)<{}; {}; {}>:
     foreign llvm or(~#field##0:card, ~#rec##1:card, ?#rec##2:card) @card:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: card.~=<0>
 ~=(#left##0:card, #right##0:card, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -361,7 +361,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (106 calls)
+proc = > public {inline} (106 calls)
 0: card.rank.=<0>
 =(#left##0:card.rank, #right##0:card.rank, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -369,7 +369,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:card.rank, ~#right##0:card.rank, ?#success##0:wybe.bool)
 
 
-ace > public {inline} (3 calls)
+proc ace > public {inline} (3 calls)
 0: card.rank.ace<0>
 ace(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -377,7 +377,7 @@ ace(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(12:card.rank, ?#result##0:card.rank)
 
 
-char > public (1 calls)
+proc char > public (1 calls)
 0: card.rank.char<0>
 char(r##0:card.rank, ?#result##0:wybe.char)<{}; {}; {}>:
   AliasPairs: []
@@ -424,7 +424,7 @@ char(r##0:card.rank, ?#result##0:wybe.char)<{}; {}; {}>:
 
 
 
-jack > public {inline} (6 calls)
+proc jack > public {inline} (6 calls)
 0: card.rank.jack<0>
 jack(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -432,7 +432,7 @@ jack(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(9:card.rank, ?#result##0:card.rank)
 
 
-king > public {inline} (4 calls)
+proc king > public {inline} (4 calls)
 0: card.rank.king<0>
 king(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -440,7 +440,7 @@ king(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(11:card.rank, ?#result##0:card.rank)
 
 
-print > public {inline} (0 calls)
+proc print > public {inline} (0 calls)
 0: card.rank.print<0>
 print(r##0:card.rank)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -451,7 +451,7 @@ print(r##0:card.rank)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
 
 
-queen > public {inline} (5 calls)
+proc queen > public {inline} (5 calls)
 0: card.rank.queen<0>
 queen(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -459,7 +459,7 @@ queen(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(10:card.rank, ?#result##0:card.rank)
 
 
-r10 > public {inline} (7 calls)
+proc r10 > public {inline} (7 calls)
 0: card.rank.r10<0>
 r10(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -467,7 +467,7 @@ r10(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(8:card.rank, ?#result##0:card.rank)
 
 
-r2 > public {inline} (16 calls)
+proc r2 > public {inline} (16 calls)
 0: card.rank.r2<0>
 r2(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -475,7 +475,7 @@ r2(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(0:card.rank, ?#result##0:card.rank)
 
 
-r3 > public {inline} (14 calls)
+proc r3 > public {inline} (14 calls)
 0: card.rank.r3<0>
 r3(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -483,7 +483,7 @@ r3(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(1:card.rank, ?#result##0:card.rank)
 
 
-r4 > public {inline} (13 calls)
+proc r4 > public {inline} (13 calls)
 0: card.rank.r4<0>
 r4(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -491,7 +491,7 @@ r4(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(2:card.rank, ?#result##0:card.rank)
 
 
-r5 > public {inline} (12 calls)
+proc r5 > public {inline} (12 calls)
 0: card.rank.r5<0>
 r5(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -499,7 +499,7 @@ r5(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(3:card.rank, ?#result##0:card.rank)
 
 
-r6 > public {inline} (11 calls)
+proc r6 > public {inline} (11 calls)
 0: card.rank.r6<0>
 r6(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -507,7 +507,7 @@ r6(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(4:card.rank, ?#result##0:card.rank)
 
 
-r7 > public {inline} (10 calls)
+proc r7 > public {inline} (10 calls)
 0: card.rank.r7<0>
 r7(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -515,7 +515,7 @@ r7(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(5:card.rank, ?#result##0:card.rank)
 
 
-r8 > public {inline} (9 calls)
+proc r8 > public {inline} (9 calls)
 0: card.rank.r8<0>
 r8(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -523,7 +523,7 @@ r8(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(6:card.rank, ?#result##0:card.rank)
 
 
-r9 > public {inline} (8 calls)
+proc r9 > public {inline} (8 calls)
 0: card.rank.r9<0>
 r9(?#result##0:card.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -531,7 +531,7 @@ r9(?#result##0:card.rank)<{}; {}; {}>:
     foreign llvm move(7:card.rank, ?#result##0:card.rank)
 
 
-ranks > public (0 calls)
+proc ranks > public (0 calls)
 0: card.rank.ranks<0>
 ranks(?#result##0:wybe.list(card.rank))<{}; {}; {}>:
   AliasPairs: []
@@ -577,7 +577,7 @@ ranks(?#result##0:wybe.list(card.rank))<{}; {}; {}>:
     foreign lpvm mutate(~tmp#78##0:wybe.list(T), ?#result##0:wybe.list(card.rank), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: card.rank.~=<0>
 ~=(#left##0:card.rank, #right##0:card.rank, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -862,7 +862,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (16 calls)
+proc = > public {inline} (16 calls)
 0: card.suit.=<0>
 =(#left##0:card.suit, #right##0:card.suit, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -870,7 +870,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:card.suit, ~#right##0:card.suit, ?#success##0:wybe.bool)
 
 
-char > public (1 calls)
+proc char > public (1 calls)
 0: card.suit.char<0>
 char(s##0:card.suit, ?#result##0:wybe.char)<{}; {}; {}>:
   AliasPairs: []
@@ -890,7 +890,7 @@ char(s##0:card.suit, ?#result##0:wybe.char)<{}; {}; {}>:
 
 
 
-clubs > public {inline} (7 calls)
+proc clubs > public {inline} (7 calls)
 0: card.suit.clubs<0>
 clubs(?#result##0:card.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -898,7 +898,7 @@ clubs(?#result##0:card.suit)<{}; {}; {}>:
     foreign llvm move(0:card.suit, ?#result##0:card.suit)
 
 
-diamonds > public {inline} (5 calls)
+proc diamonds > public {inline} (5 calls)
 0: card.suit.diamonds<0>
 diamonds(?#result##0:card.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -906,7 +906,7 @@ diamonds(?#result##0:card.suit)<{}; {}; {}>:
     foreign llvm move(1:card.suit, ?#result##0:card.suit)
 
 
-hearts > public {inline} (4 calls)
+proc hearts > public {inline} (4 calls)
 0: card.suit.hearts<0>
 hearts(?#result##0:card.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -914,7 +914,7 @@ hearts(?#result##0:card.suit)<{}; {}; {}>:
     foreign llvm move(2:card.suit, ?#result##0:card.suit)
 
 
-print > public {inline} (0 calls)
+proc print > public {inline} (0 calls)
 0: card.suit.print<0>
 print(r##0:card.suit)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -925,7 +925,7 @@ print(r##0:card.suit)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @char:nn:nn
 
 
-spades > public {inline} (3 calls)
+proc spades > public {inline} (3 calls)
 0: card.suit.spades<0>
 spades(?#result##0:card.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -933,7 +933,7 @@ spades(?#result##0:card.suit)<{}; {}; {}>:
     foreign llvm move(3:card.suit, ?#result##0:card.suit)
 
 
-suits > public (0 calls)
+proc suits > public (0 calls)
 0: card.suit.suits<0>
 suits(?#result##0:wybe.list(card.suit))<{}; {}; {}>:
   AliasPairs: []
@@ -952,7 +952,7 @@ suits(?#result##0:wybe.list(card.suit))<{}; {}; {}>:
     foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?#result##0:wybe.list(card.suit), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.list(T)) @list:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: card.suit.~=<0>
 ~=(#left##0:card.suit, #right##0:card.suit, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -37,7 +37,7 @@ module top-level code > public {semipure} (0 calls)
     caret.#cont#1<0>[410bae77d3](~tmp#24##0:caret.region)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: caret.#cont#1<0>[410bae77d3]
 #cont#1(reg##0:caret.region)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -65,7 +65,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-expand_region > public (0 calls)
+proc expand_region > public (0 calls)
 0: caret.expand_region<0>
 expand_region(reg##0:caret.region, ?reg##4:caret.region, point##0:position.position)<{}; {}; {}>:
   AliasPairs: [(reg##0,reg##4)]
@@ -335,7 +335,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: caret.region.=<0>
 =(#left##0:caret.region, #right##0:caret.region, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -376,13 +376,13 @@ entry:
 
 
 
-lower_left > public {inline} (0 calls)
+proc lower_left > public {inline} (0 calls)
 0: caret.region.lower_left<0>
 lower_left(#rec##0:caret.region, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:position.position) @caret:nn:nn
-lower_left > public {inline} (0 calls)
+proc lower_left > public {inline} (0 calls)
 1: caret.region.lower_left<1>
 lower_left(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -390,7 +390,7 @@ lower_left(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.posit
     foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:position.position) @caret:nn:nn
 
 
-region > public {inline} (0 calls)
+proc region > public {inline} (0 calls)
 0: caret.region.region<0>
 region(lower_left##0:position.position, upper_right##0:position.position, ?#result##0:caret.region)<{}; {}; {}>:
   AliasPairs: []
@@ -398,7 +398,7 @@ region(lower_left##0:position.position, upper_right##0:position.position, ?#resu
     foreign lpvm alloc(16:wybe.int, ?#rec##0:caret.region) @caret:nn:nn
     foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower_left##0:position.position) @caret:nn:nn
     foreign lpvm mutate(~#rec##1:caret.region, ?#result##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right##0:position.position) @caret:nn:nn
-region > public {inline} (6 calls)
+proc region > public {inline} (6 calls)
 1: caret.region.region<1>
 region(?lower_left##0:position.position, ?upper_right##0:position.position, #result##0:caret.region)<{}; {}; {}>:
   AliasPairs: []
@@ -407,13 +407,13 @@ region(?lower_left##0:position.position, ?upper_right##0:position.position, #res
     foreign lpvm access(~#result##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right##0:position.position) @caret:nn:nn
 
 
-upper_right > public {inline} (0 calls)
+proc upper_right > public {inline} (0 calls)
 0: caret.region.upper_right<0>
 upper_right(#rec##0:caret.region, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:position.position) @caret:nn:nn
-upper_right > public {inline} (0 calls)
+proc upper_right > public {inline} (0 calls)
 1: caret.region.upper_right<1>
 upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -421,7 +421,7 @@ upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.posi
     foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:position.position) @caret:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: caret.region.~=<0>
 ~=(#left##0:caret.region, #right##0:caret.region, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -680,7 +680,7 @@ if.else2:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -774,7 +774,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -793,7 +793,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -801,7 +801,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -810,13 +810,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -824,13 +824,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -838,7 +838,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/cases.exp
+++ b/test-cases/final-dump/cases.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-len > (1 calls)
+proc len > (1 calls)
 0: cases.len<0>
 len(lst##0:wybe.list(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -26,7 +26,7 @@ len(lst##0:wybe.list(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
 
 
 
-len2 > (1 calls)
+proc len2 > (1 calls)
 0: cases.len2<0>
 len2(lst##0:wybe.list(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/chain_assign.exp
+++ b/test-cases/final-dump/chain_assign.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-chain > {inline} (0 calls)
+proc chain > {inline} (0 calls)
 0: chain_assign.chain<0>
 chain(?z##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/char-escape.exp
+++ b/test-cases/final-dump/char-escape.exp
@@ -27,7 +27,7 @@ module top-level code > public {semipure} (0 calls)
     wybe.string.print<0>("\astring with hex character escapes!\n":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @char-escape:23:2
 
 
-test > (10 calls)
+proc test > (10 calls)
 0: char-escape.test<0>
 test(ch##0:wybe.char, code##0:wybe.int, name##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/common_fields.exp
+++ b/test-cases/final-dump/common_fields.exp
@@ -87,7 +87,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: common_fields.=<0>
 =(#left##0:common_fields, #right##0:common_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -237,7 +237,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-DVD > public {inline} (0 calls)
+proc DVD > public {inline} (0 calls)
 0: common_fields.DVD<0>
 DVD(title##0:wybe.string, director##0:wybe.string, genre##0:wybe.string, id##0:wybe.int, ?#result##0:common_fields)<{}; {}; {}>:
   AliasPairs: []
@@ -248,7 +248,7 @@ DVD(title##0:wybe.string, director##0:wybe.string, genre##0:wybe.string, id##0:w
     foreign lpvm mutate(~#rec##2:common_fields, ?#rec##3:common_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~genre##0:wybe.string) @common_fields:nn:nn
     foreign lpvm mutate(~#rec##3:common_fields, ?#rec##4:common_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~id##0:wybe.int) @common_fields:nn:nn
     foreign llvm or(~#rec##4:common_fields, 2:wybe.int, ?#result##0:common_fields) @common_fields:nn:nn
-DVD > public {inline} (14 calls)
+proc DVD > public {inline} (14 calls)
 1: common_fields.DVD<1>
 DVD(?title##0:wybe.string, ?director##0:wybe.string, ?genre##0:wybe.string, ?id##0:wybe.int, #result##0:common_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -272,7 +272,7 @@ DVD(?title##0:wybe.string, ?director##0:wybe.string, ?genre##0:wybe.string, ?id#
 
 
 
-author > public {inline} (0 calls)
+proc author > public {inline} (0 calls)
 0: common_fields.author<0>
 author(#rec##0:common_fields, ?#result##0:wybe.string, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -288,7 +288,7 @@ author(#rec##0:common_fields, ?#result##0:wybe.string, ?#success##0:wybe.bool)<{
         foreign lpvm access(~#rec##0:common_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @common_fields:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-author > public {inline} (0 calls)
+proc author > public {inline} (0 calls)
 1: common_fields.author<1>
 author(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.string, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -306,7 +306,7 @@ author(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.string, ?#s
 
 
 
-book > public {inline} (7 calls)
+proc book > public {inline} (7 calls)
 0: common_fields.book<0>
 book(title##0:wybe.string, author##0:wybe.string, genre##0:wybe.string, id##0:wybe.int, ?#result##0:common_fields)<{}; {}; {}>:
   AliasPairs: []
@@ -316,7 +316,7 @@ book(title##0:wybe.string, author##0:wybe.string, genre##0:wybe.string, id##0:wy
     foreign lpvm mutate(~#rec##1:common_fields, ?#rec##2:common_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~author##0:wybe.string) @common_fields:nn:nn
     foreign lpvm mutate(~#rec##2:common_fields, ?#rec##3:common_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~genre##0:wybe.string) @common_fields:nn:nn
     foreign lpvm mutate(~#rec##3:common_fields, ?#result##0:common_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~id##0:wybe.int) @common_fields:nn:nn
-book > public {inline} (32 calls)
+proc book > public {inline} (32 calls)
 1: common_fields.book<1>
 book(?title##0:wybe.string, ?author##0:wybe.string, ?genre##0:wybe.string, ?id##0:wybe.int, #result##0:common_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -340,7 +340,7 @@ book(?title##0:wybe.string, ?author##0:wybe.string, ?genre##0:wybe.string, ?id##
 
 
 
-director > public {inline} (0 calls)
+proc director > public {inline} (0 calls)
 0: common_fields.director<0>
 director(#rec##0:common_fields, ?#result##0:wybe.string, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -356,7 +356,7 @@ director(#rec##0:common_fields, ?#result##0:wybe.string, ?#success##0:wybe.bool)
         foreign lpvm access(~#rec##0:common_fields, 6:wybe.int, 32:wybe.int, 2:wybe.int, ?#result##0:wybe.string) @common_fields:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-director > public {inline} (0 calls)
+proc director > public {inline} (0 calls)
 1: common_fields.director<1>
 director(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.string, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -374,7 +374,7 @@ director(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.string, ?
 
 
 
-frequency > public {inline} (0 calls)
+proc frequency > public {inline} (0 calls)
 0: common_fields.frequency<0>
 frequency(#rec##0:common_fields, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -390,7 +390,7 @@ frequency(#rec##0:common_fields, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{
         foreign lpvm access(~#rec##0:common_fields, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @common_fields:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-frequency > public {inline} (0 calls)
+proc frequency > public {inline} (0 calls)
 1: common_fields.frequency<1>
 frequency(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -408,7 +408,7 @@ frequency(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.int, ?#s
 
 
 
-genre > public (10 calls)
+proc genre > public (10 calls)
 0: common_fields.genre<0>
 genre(#rec##0:common_fields, ?#result##0:wybe.string, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: [(#rec##0,#result##0)]
@@ -432,7 +432,7 @@ genre(#rec##0:common_fields, ?#result##0:wybe.string, ?#success##0:wybe.bool)<{}
         foreign lpvm access(~#rec##0:common_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @common_fields:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-genre > public (5 calls)
+proc genre > public (5 calls)
 1: common_fields.genre<1>
 genre(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.string, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: [(#field##0,#rec##0),(#field##0,#rec##1),(#rec##0,#rec##1)]
@@ -458,7 +458,7 @@ genre(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.string, ?#su
 
 
 
-id > public (14 calls)
+proc id > public (14 calls)
 0: common_fields.id<0>
 id(#rec##0:common_fields, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -474,7 +474,7 @@ id(#rec##0:common_fields, ?#result##0:wybe.int)<{}; {}; {}>:
     2:
         foreign lpvm access(~#rec##0:common_fields, 22:wybe.int, 32:wybe.int, 2:wybe.int, ?#result##0:wybe.int) @common_fields:nn:nn
 
-id > public (7 calls)
+proc id > public (7 calls)
 1: common_fields.id<1>[410bae77d3]
 id(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: [(#rec##0,#rec##1)]
@@ -504,7 +504,7 @@ id(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.int)<{}; {}; {}
 
 
 
-magazine > public {inline} (7 calls)
+proc magazine > public {inline} (7 calls)
 0: common_fields.magazine<0>
 magazine(title##0:wybe.string, frequency##0:wybe.int, id##0:wybe.int, ?#result##0:common_fields)<{}; {}; {}>:
   AliasPairs: []
@@ -514,7 +514,7 @@ magazine(title##0:wybe.string, frequency##0:wybe.int, id##0:wybe.int, ?#result##
     foreign lpvm mutate(~#rec##1:common_fields, ?#rec##2:common_fields, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~frequency##0:wybe.int) @common_fields:nn:nn
     foreign lpvm mutate(~#rec##2:common_fields, ?#rec##3:common_fields, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~id##0:wybe.int) @common_fields:nn:nn
     foreign llvm or(~#rec##3:common_fields, 1:wybe.int, ?#result##0:common_fields) @common_fields:nn:nn
-magazine > public {inline} (17 calls)
+proc magazine > public {inline} (17 calls)
 1: common_fields.magazine<1>
 magazine(?title##0:wybe.string, ?frequency##0:wybe.int, ?id##0:wybe.int, #result##0:common_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -536,7 +536,7 @@ magazine(?title##0:wybe.string, ?frequency##0:wybe.int, ?id##0:wybe.int, #result
 
 
 
-other > public {inline} (0 calls)
+proc other > public {inline} (0 calls)
 0: common_fields.other<0>
 other(title##0:wybe.string, id##0:wybe.int, ?#result##0:common_fields)<{}; {}; {}>:
   AliasPairs: []
@@ -545,7 +545,7 @@ other(title##0:wybe.string, id##0:wybe.int, ?#result##0:common_fields)<{}; {}; {
     foreign lpvm mutate(~#rec##0:common_fields, ?#rec##1:common_fields, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~title##0:wybe.string) @common_fields:nn:nn
     foreign lpvm mutate(~#rec##1:common_fields, ?#rec##2:common_fields, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int) @common_fields:nn:nn
     foreign llvm or(~#rec##2:common_fields, 3:wybe.int, ?#result##0:common_fields) @common_fields:nn:nn
-other > public {inline} (7 calls)
+proc other > public {inline} (7 calls)
 1: common_fields.other<1>
 other(?title##0:wybe.string, ?id##0:wybe.int, #result##0:common_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -565,7 +565,7 @@ other(?title##0:wybe.string, ?id##0:wybe.int, #result##0:common_fields, ?#succes
 
 
 
-title > public (7 calls)
+proc title > public (7 calls)
 0: common_fields.title<0>
 title(#rec##0:common_fields, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: [(#rec##0,#result##0)]
@@ -581,7 +581,7 @@ title(#rec##0:common_fields, ?#result##0:wybe.string)<{}; {}; {}>:
     2:
         foreign lpvm access(~#rec##0:common_fields, -2:wybe.int, 32:wybe.int, 2:wybe.int, ?#result##0:wybe.string) @common_fields:nn:nn
 
-title > public (0 calls)
+proc title > public (0 calls)
 1: common_fields.title<1>
 title(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: [(#field##0,#rec##0),(#field##0,#rec##1),(#rec##0,#rec##1)]
@@ -599,7 +599,7 @@ title(#rec##0:common_fields, ?#rec##1:common_fields, #field##0:wybe.string)<{}; 
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: common_fields.~=<0>
 ~=(#left##0:common_fields, #right##0:common_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/commonsubexpr.exp
+++ b/test-cases/final-dump/commonsubexpr.exp
@@ -24,7 +24,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-common_subexpr > {inline} (1 calls)
+proc common_subexpr > {inline} (1 calls)
 0: commonsubexpr.common_subexpr<0>
 common_subexpr(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/compute.exp
+++ b/test-cases/final-dump/compute.exp
@@ -97,7 +97,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   resources       : 
   procs           : 
 
-toCelsius > public {inline} (0 calls)
+proc toCelsius > public {inline} (0 calls)
 0: math.temperature.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -147,7 +147,7 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-factorial > public (1 calls)
+proc factorial > public (1 calls)
 0: math.utils.factorial<0>
 factorial(n##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/constfold.exp
+++ b/test-cases/final-dump/constfold.exp
@@ -12,7 +12,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-fold_add > public {inline} (3 calls)
+proc fold_add > public {inline} (3 calls)
 0: constfold.fold_add<0>
 fold_add(?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -20,7 +20,7 @@ fold_add(?#result##0:wybe.int)<{}; {}; {}>:
     foreign llvm move(42:wybe.int, ?#result##0:wybe.int) @constfold:nn:nn
 
 
-fold_mult > public {inline} (3 calls)
+proc fold_mult > public {inline} (3 calls)
 0: constfold.fold_mult<0>
 fold_mult(?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -28,7 +28,7 @@ fold_mult(?#result##0:wybe.int)<{}; {}; {}>:
     foreign llvm move(42:wybe.int, ?#result##0:wybe.int) @constfold:nn:nn
 
 
-fold_test > public {inline} (0 calls)
+proc fold_test > public {inline} (0 calls)
 0: constfold.fold_test<0>
 fold_test(?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ fold_test(?#result##0:wybe.int)<{}; {}; {}>:
     foreign llvm move(42:wybe.int, ?#result##0:wybe.int) @constfold:nn:nn
 
 
-fortytwo > public {inline} (0 calls)
+proc fortytwo > public {inline} (0 calls)
 0: constfold.fortytwo<0>
 fortytwo(?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -15,7 +15,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: constructors.=<0>
 =(#left##0:constructors, #right##0:constructors, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -39,14 +39,14 @@ AFTER EVERYTHING:
 
 
 
-just > public {inline} (0 calls)
+proc just > public {inline} (0 calls)
 0: constructors.just<0>
 just(value##0:wybe.int, ?#result##0:constructors)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:constructors) @constructors:nn:nn
     foreign lpvm mutate(~#rec##0:constructors, ?#result##0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int) @constructors:nn:nn
-just > public {inline} (8 calls)
+proc just > public {inline} (8 calls)
 1: constructors.just<1>
 just(?value##0:wybe.int, #result##0:constructors, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -63,7 +63,7 @@ just(?value##0:wybe.int, #result##0:constructors, ?#success##0:wybe.bool)<{}; {}
 
 
 
-nothing > public {inline} (0 calls)
+proc nothing > public {inline} (0 calls)
 0: constructors.nothing<0>
 nothing(?#result##0:constructors)<{}; {}; {}>:
   AliasPairs: []
@@ -71,7 +71,7 @@ nothing(?#result##0:constructors)<{}; {}; {}>:
     foreign llvm move(0:constructors, ?#result##0:constructors)
 
 
-value > public {inline} (0 calls)
+proc value > public {inline} (0 calls)
 0: constructors.value<0>
 value(#rec##0:constructors, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -86,7 +86,7 @@ value(#rec##0:constructors, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}
         foreign lpvm access(~#rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @constructors:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-value > public {inline} (0 calls)
+proc value > public {inline} (0 calls)
 1: constructors.value<1>
 value(#rec##0:constructors, ?#rec##1:constructors, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -103,7 +103,7 @@ value(#rec##0:constructors, ?#rec##1:constructors, #field##0:wybe.int, ?#success
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: constructors.~=<0>
 ~=(#left##0:constructors, #right##0:constructors, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -45,7 +45,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-fcopy > public {inline} (1 calls)
+proc fcopy > public {inline} (1 calls)
 0: coordinate.fcopy<0>
 fcopy(crd1##0:coordinate.Coordinate, ?#result##0:coordinate.Coordinate)<{}; {}; {}>:
   AliasPairs: []
@@ -140,7 +140,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: coordinate.Coordinate.=<0>
 =(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -168,7 +168,7 @@ entry:
 
 
 
-Coordinate > public {inline} (0 calls)
+proc Coordinate > public {inline} (0 calls)
 0: coordinate.Coordinate.Coordinate<0>
 Coordinate(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, ?#result##0:coordinate.Coordinate)<{}; {}; {}>:
   AliasPairs: []
@@ -177,7 +177,7 @@ Coordinate(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, ?#result##0:coordinate.C
     foreign lpvm mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~x##0:wybe.int) @coordinate:nn:nn
     foreign lpvm mutate(~#rec##1:coordinate.Coordinate, ?#rec##2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y##0:wybe.int) @coordinate:nn:nn
     foreign lpvm mutate(~#rec##2:coordinate.Coordinate, ?#result##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z##0:wybe.int) @coordinate:nn:nn
-Coordinate > public {inline} (10 calls)
+proc Coordinate > public {inline} (10 calls)
 1: coordinate.Coordinate.Coordinate<1>
 Coordinate(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, #result##0:coordinate.Coordinate)<{}; {}; {}>:
   AliasPairs: []
@@ -187,13 +187,13 @@ Coordinate(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, #result##0:coordinate
     foreign lpvm access(~#result##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z##0:wybe.int) @coordinate:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: coordinate.Coordinate.x<0>
 x(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @coordinate:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: coordinate.Coordinate.x<1>
 x(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -201,13 +201,13 @@ x(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.
     foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @coordinate:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: coordinate.Coordinate.y<0>
 y(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @coordinate:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: coordinate.Coordinate.y<1>
 y(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -215,13 +215,13 @@ y(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.
     foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @coordinate:nn:nn
 
 
-z > public {inline} (0 calls)
+proc z > public {inline} (0 calls)
 0: coordinate.Coordinate.z<0>
 z(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @coordinate:nn:nn
-z > public {inline} (0 calls)
+proc z > public {inline} (0 calls)
 1: coordinate.Coordinate.z<1>
 z(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -229,7 +229,7 @@ z(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.
     foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @coordinate:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: coordinate.Coordinate.~=<0>
 ~=(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -25,7 +25,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: ctor_char.=<0>
 =(#left##0:ctor_char, #right##0:ctor_char, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -93,7 +93,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-c > {inline} (0 calls)
+proc c > {inline} (0 calls)
 0: ctor_char.c<0>
 c(#rec##0:ctor_char, ?#result##0:wybe.char, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -119,7 +119,7 @@ c(#rec##0:ctor_char, ?#result##0:wybe.char, ?#success##0:wybe.bool)<{}; {}; {}>:
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-c > {inline} (0 calls)
+proc c > {inline} (0 calls)
 1: ctor_char.c<1>
 c(#rec##0:ctor_char, ?#rec##2:ctor_char, #field##0:wybe.char, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -147,7 +147,7 @@ c(#rec##0:ctor_char, ?#rec##2:ctor_char, #field##0:wybe.char, ?#success##0:wybe.
 
 
 
-const > {inline} (0 calls)
+proc const > {inline} (0 calls)
 0: ctor_char.const<0>
 const(?#result##0:ctor_char)<{}; {}; {}>:
   AliasPairs: []
@@ -155,14 +155,14 @@ const(?#result##0:ctor_char)<{}; {}; {}>:
     foreign llvm move(0:ctor_char, ?#result##0:ctor_char)
 
 
-ctor > {inline} (1 calls)
+proc ctor > {inline} (1 calls)
 0: ctor_char.ctor<0>
 ctor(c##0:wybe.char, ?#result##3:ctor_char)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm shl(~c##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char) @ctor_char:nn:nn
     foreign llvm or(~#temp##0:ctor_char, 512:ctor_char, ?#result##3:ctor_char) @ctor_char:nn:nn
-ctor > {inline} (13 calls)
+proc ctor > {inline} (13 calls)
 1: ctor_char.ctor<1>
 ctor(?c##0:wybe.char, #result##0:ctor_char, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -190,7 +190,7 @@ ctor(?c##0:wybe.char, #result##0:ctor_char, ?#success##0:wybe.bool)<{}; {}; {}>:
 
 
 
-foo > (1 calls)
+proc foo > (1 calls)
 0: ctor_char.foo<0>
 foo(this##0:ctor_char, ?#result##0:wybe.char)<{}; {}; {}>:
   AliasPairs: []
@@ -215,7 +215,7 @@ foo(this##0:ctor_char, ?#result##0:wybe.char)<{}; {}; {}>:
 
 
 
-other_ctor > {inline} (0 calls)
+proc other_ctor > {inline} (0 calls)
 0: ctor_char.other_ctor<0>
 other_ctor(other_ctor#1##0:ctor_char, ?#result##0:ctor_char)<{}; {}; {}>:
   AliasPairs: []
@@ -223,7 +223,7 @@ other_ctor(other_ctor#1##0:ctor_char, ?#result##0:ctor_char)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char) @ctor_char:nn:nn
     foreign lpvm mutate(~#rec##0:ctor_char, ?#rec##1:ctor_char, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char) @ctor_char:nn:nn
     foreign llvm or(~#rec##1:ctor_char, 1:wybe.int, ?#result##0:ctor_char) @ctor_char:nn:nn
-other_ctor > {inline} (5 calls)
+proc other_ctor > {inline} (5 calls)
 1: ctor_char.other_ctor<1>
 other_ctor(?other_ctor#1##0:ctor_char, #result##0:ctor_char, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -249,7 +249,7 @@ other_ctor(?other_ctor#1##0:ctor_char, #result##0:ctor_char, ?#success##0:wybe.b
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_char.~=<0>
 ~=(#left##0:ctor_char, #right##0:ctor_char, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -25,7 +25,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-= > public (3 calls)
+proc = > public (3 calls)
 0: ctor_char2.=<0>
 =(#left##0:ctor_char2, #right##0:ctor_char2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -105,7 +105,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-another_ctor > {inline} (0 calls)
+proc another_ctor > {inline} (0 calls)
 0: ctor_char2.another_ctor<0>
 another_ctor(another_ctor#1##0:ctor_char2, ?#result##0:ctor_char2)<{}; {}; {}>:
   AliasPairs: []
@@ -113,7 +113,7 @@ another_ctor(another_ctor#1##0:ctor_char2, ?#result##0:ctor_char2)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2) @ctor_char2:nn:nn
     foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~another_ctor#1##0:ctor_char2) @ctor_char2:nn:nn
     foreign llvm or(~#rec##1:ctor_char2, 2:wybe.int, ?#result##0:ctor_char2) @ctor_char2:nn:nn
-another_ctor > {inline} (5 calls)
+proc another_ctor > {inline} (5 calls)
 1: ctor_char2.another_ctor<1>
 another_ctor(?another_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -139,7 +139,7 @@ another_ctor(?another_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:
 
 
 
-c > {inline} (0 calls)
+proc c > {inline} (0 calls)
 0: ctor_char2.c<0>
 c(#rec##0:ctor_char2, ?#result##0:wybe.char, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -165,7 +165,7 @@ c(#rec##0:ctor_char2, ?#result##0:wybe.char, ?#success##0:wybe.bool)<{}; {}; {}>
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-c > {inline} (0 calls)
+proc c > {inline} (0 calls)
 1: ctor_char2.c<1>
 c(#rec##0:ctor_char2, ?#rec##2:ctor_char2, #field##0:wybe.char, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -193,7 +193,7 @@ c(#rec##0:ctor_char2, ?#rec##2:ctor_char2, #field##0:wybe.char, ?#success##0:wyb
 
 
 
-const > {inline} (0 calls)
+proc const > {inline} (0 calls)
 0: ctor_char2.const<0>
 const(?#result##0:ctor_char2)<{}; {}; {}>:
   AliasPairs: []
@@ -201,14 +201,14 @@ const(?#result##0:ctor_char2)<{}; {}; {}>:
     foreign llvm move(0:ctor_char2, ?#result##0:ctor_char2)
 
 
-ctor > {inline} (1 calls)
+proc ctor > {inline} (1 calls)
 0: ctor_char2.ctor<0>
 ctor(c##0:wybe.char, ?#result##3:ctor_char2)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm shl(~c##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2) @ctor_char2:nn:nn
     foreign llvm or(~#temp##0:ctor_char2, 1024:ctor_char2, ?#result##3:ctor_char2) @ctor_char2:nn:nn
-ctor > {inline} (15 calls)
+proc ctor > {inline} (15 calls)
 1: ctor_char2.ctor<1>
 ctor(?c##0:wybe.char, #result##0:ctor_char2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -236,7 +236,7 @@ ctor(?c##0:wybe.char, #result##0:ctor_char2, ?#success##0:wybe.bool)<{}; {}; {}>
 
 
 
-foo > (1 calls)
+proc foo > (1 calls)
 0: ctor_char2.foo<0>
 foo(this##0:ctor_char2, ?#result##0:wybe.char)<{}; {}; {}>:
   AliasPairs: []
@@ -261,7 +261,7 @@ foo(this##0:ctor_char2, ?#result##0:wybe.char)<{}; {}; {}>:
 
 
 
-other_ctor > {inline} (0 calls)
+proc other_ctor > {inline} (0 calls)
 0: ctor_char2.other_ctor<0>
 other_ctor(other_ctor#1##0:ctor_char2, ?#result##0:ctor_char2)<{}; {}; {}>:
   AliasPairs: []
@@ -269,7 +269,7 @@ other_ctor(other_ctor#1##0:ctor_char2, ?#result##0:ctor_char2)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2) @ctor_char2:nn:nn
     foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char2) @ctor_char2:nn:nn
     foreign llvm or(~#rec##1:ctor_char2, 1:wybe.int, ?#result##0:ctor_char2) @ctor_char2:nn:nn
-other_ctor > {inline} (7 calls)
+proc other_ctor > {inline} (7 calls)
 1: ctor_char2.other_ctor<1>
 other_ctor(?other_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -295,7 +295,7 @@ other_ctor(?other_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:wybe
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_char2.~=<0>
 ~=(#left##0:ctor_char2, #right##0:ctor_char2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/ctor_visibility.exp
+++ b/test-cases/final-dump/ctor_visibility.exp
@@ -43,7 +43,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: ctor_visibility.all_priv.=<0>
 =(#left##0:ctor_visibility.all_priv, #right##0:ctor_visibility.all_priv, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -51,7 +51,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm icmp_eq(~#left##0:ctor_visibility.all_priv, ~#right##0:ctor_visibility.all_priv, ?#success##0:wybe.bool)
 
 
-bar > {inline} (0 calls)
+proc bar > {inline} (0 calls)
 0: ctor_visibility.all_priv.bar<0>
 bar(?#result##0:ctor_visibility.all_priv)<{}; {}; {}>:
   AliasPairs: []
@@ -59,7 +59,7 @@ bar(?#result##0:ctor_visibility.all_priv)<{}; {}; {}>:
     foreign llvm move(1:ctor_visibility.all_priv, ?#result##0:ctor_visibility.all_priv)
 
 
-foo > {inline} (0 calls)
+proc foo > {inline} (0 calls)
 0: ctor_visibility.all_priv.foo<0>
 foo(?#result##0:ctor_visibility.all_priv)<{}; {}; {}>:
   AliasPairs: []
@@ -67,7 +67,7 @@ foo(?#result##0:ctor_visibility.all_priv)<{}; {}; {}>:
     foreign llvm move(0:ctor_visibility.all_priv, ?#result##0:ctor_visibility.all_priv)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_visibility.all_priv.~=<0>
 ~=(#left##0:ctor_visibility.all_priv, #right##0:ctor_visibility.all_priv, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -128,7 +128,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: ctor_visibility.all_public_long.=<0>
 =(#left##0:ctor_visibility.all_public_long, #right##0:ctor_visibility.all_public_long, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -136,7 +136,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:ctor_visibility.all_public_long, ~#right##0:ctor_visibility.all_public_long, ?#success##0:wybe.bool)
 
 
-bar > public {inline} (0 calls)
+proc bar > public {inline} (0 calls)
 0: ctor_visibility.all_public_long.bar<0>
 bar(?#result##0:ctor_visibility.all_public_long)<{}; {}; {}>:
   AliasPairs: []
@@ -144,7 +144,7 @@ bar(?#result##0:ctor_visibility.all_public_long)<{}; {}; {}>:
     foreign llvm move(1:ctor_visibility.all_public_long, ?#result##0:ctor_visibility.all_public_long)
 
 
-foo > public {inline} (0 calls)
+proc foo > public {inline} (0 calls)
 0: ctor_visibility.all_public_long.foo<0>
 foo(?#result##0:ctor_visibility.all_public_long)<{}; {}; {}>:
   AliasPairs: []
@@ -152,7 +152,7 @@ foo(?#result##0:ctor_visibility.all_public_long)<{}; {}; {}>:
     foreign llvm move(0:ctor_visibility.all_public_long, ?#result##0:ctor_visibility.all_public_long)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_visibility.all_public_long.~=<0>
 ~=(#left##0:ctor_visibility.all_public_long, #right##0:ctor_visibility.all_public_long, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -213,7 +213,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: ctor_visibility.all_public_short.=<0>
 =(#left##0:ctor_visibility.all_public_short, #right##0:ctor_visibility.all_public_short, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -221,7 +221,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:ctor_visibility.all_public_short, ~#right##0:ctor_visibility.all_public_short, ?#success##0:wybe.bool)
 
 
-bar > public {inline} (0 calls)
+proc bar > public {inline} (0 calls)
 0: ctor_visibility.all_public_short.bar<0>
 bar(?#result##0:ctor_visibility.all_public_short)<{}; {}; {}>:
   AliasPairs: []
@@ -229,7 +229,7 @@ bar(?#result##0:ctor_visibility.all_public_short)<{}; {}; {}>:
     foreign llvm move(1:ctor_visibility.all_public_short, ?#result##0:ctor_visibility.all_public_short)
 
 
-foo > public {inline} (0 calls)
+proc foo > public {inline} (0 calls)
 0: ctor_visibility.all_public_short.foo<0>
 foo(?#result##0:ctor_visibility.all_public_short)<{}; {}; {}>:
   AliasPairs: []
@@ -237,7 +237,7 @@ foo(?#result##0:ctor_visibility.all_public_short)<{}; {}; {}>:
     foreign llvm move(0:ctor_visibility.all_public_short, ?#result##0:ctor_visibility.all_public_short)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_visibility.all_public_short.~=<0>
 ~=(#left##0:ctor_visibility.all_public_short, #right##0:ctor_visibility.all_public_short, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -296,7 +296,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: ctor_visibility.ctor_keyword.=<0>
 =(#left##0:ctor_visibility.ctor_keyword, #right##0:ctor_visibility.ctor_keyword, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -304,7 +304,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:ctor_visibility.ctor_keyword, ~#right##0:ctor_visibility.ctor_keyword, ?#success##0:wybe.bool)
 
 
-bar > {inline} (0 calls)
+proc bar > {inline} (0 calls)
 0: ctor_visibility.ctor_keyword.bar<0>
 bar(?#result##0:ctor_visibility.ctor_keyword)<{}; {}; {}>:
   AliasPairs: []
@@ -312,7 +312,7 @@ bar(?#result##0:ctor_visibility.ctor_keyword)<{}; {}; {}>:
     foreign llvm move(1:ctor_visibility.ctor_keyword, ?#result##0:ctor_visibility.ctor_keyword)
 
 
-foo > {inline} (0 calls)
+proc foo > {inline} (0 calls)
 0: ctor_visibility.ctor_keyword.foo<0>
 foo(?#result##0:ctor_visibility.ctor_keyword)<{}; {}; {}>:
   AliasPairs: []
@@ -320,7 +320,7 @@ foo(?#result##0:ctor_visibility.ctor_keyword)<{}; {}; {}>:
     foreign llvm move(0:ctor_visibility.ctor_keyword, ?#result##0:ctor_visibility.ctor_keyword)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_visibility.ctor_keyword.~=<0>
 ~=(#left##0:ctor_visibility.ctor_keyword, #right##0:ctor_visibility.ctor_keyword, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -380,7 +380,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: ctor_visibility.one_pub.=<0>
 =(#left##0:ctor_visibility.one_pub, #right##0:ctor_visibility.one_pub, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -388,7 +388,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:ctor_visibility.one_pub, ~#right##0:ctor_visibility.one_pub, ?#success##0:wybe.bool)
 
 
-bar > {inline} (0 calls)
+proc bar > {inline} (0 calls)
 0: ctor_visibility.one_pub.bar<0>
 bar(?#result##0:ctor_visibility.one_pub)<{}; {}; {}>:
   AliasPairs: []
@@ -396,7 +396,7 @@ bar(?#result##0:ctor_visibility.one_pub)<{}; {}; {}>:
     foreign llvm move(1:ctor_visibility.one_pub, ?#result##0:ctor_visibility.one_pub)
 
 
-foo > public {inline} (0 calls)
+proc foo > public {inline} (0 calls)
 0: ctor_visibility.one_pub.foo<0>
 foo(?#result##0:ctor_visibility.one_pub)<{}; {}; {}>:
   AliasPairs: []
@@ -404,7 +404,7 @@ foo(?#result##0:ctor_visibility.one_pub)<{}; {}; {}>:
     foreign llvm move(0:ctor_visibility.one_pub, ?#result##0:ctor_visibility.one_pub)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_visibility.one_pub.~=<0>
 ~=(#left##0:ctor_visibility.one_pub, #right##0:ctor_visibility.one_pub, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -464,7 +464,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: ctor_visibility.one_pub2.=<0>
 =(#left##0:ctor_visibility.one_pub2, #right##0:ctor_visibility.one_pub2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -472,7 +472,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:ctor_visibility.one_pub2, ~#right##0:ctor_visibility.one_pub2, ?#success##0:wybe.bool)
 
 
-bar > public {inline} (0 calls)
+proc bar > public {inline} (0 calls)
 0: ctor_visibility.one_pub2.bar<0>
 bar(?#result##0:ctor_visibility.one_pub2)<{}; {}; {}>:
   AliasPairs: []
@@ -480,7 +480,7 @@ bar(?#result##0:ctor_visibility.one_pub2)<{}; {}; {}>:
     foreign llvm move(1:ctor_visibility.one_pub2, ?#result##0:ctor_visibility.one_pub2)
 
 
-foo > {inline} (0 calls)
+proc foo > {inline} (0 calls)
 0: ctor_visibility.one_pub2.foo<0>
 foo(?#result##0:ctor_visibility.one_pub2)<{}; {}; {}>:
   AliasPairs: []
@@ -488,7 +488,7 @@ foo(?#result##0:ctor_visibility.one_pub2)<{}; {}; {}>:
     foreign llvm move(0:ctor_visibility.one_pub2, ?#result##0:ctor_visibility.one_pub2)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_visibility.one_pub2.~=<0>
 ~=(#left##0:ctor_visibility.one_pub2, #right##0:ctor_visibility.one_pub2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -555,7 +555,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: ctor_visibility.with_fields.=<0>
 =(#left##0:ctor_visibility.with_fields, #right##0:ctor_visibility.with_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -607,7 +607,7 @@ entry:
 
 
 
-a > public (0 calls)
+proc a > public (0 calls)
 0: ctor_visibility.with_fields.a<0>
 a(#rec##0:ctor_visibility.with_fields, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -621,7 +621,7 @@ a(#rec##0:ctor_visibility.with_fields, ?#result##0:wybe.int)<{}; {}; {}>:
     1:
         foreign lpvm access(~#rec##0:ctor_visibility.with_fields, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @ctor_visibility:nn:nn
 
-a > public (0 calls)
+proc a > public (0 calls)
 1: ctor_visibility.with_fields.a<1>
 a(#rec##0:ctor_visibility.with_fields, ?#rec##1:ctor_visibility.with_fields, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -637,7 +637,7 @@ a(#rec##0:ctor_visibility.with_fields, ?#rec##1:ctor_visibility.with_fields, #fi
 
 
 
-b > public {inline} (0 calls)
+proc b > public {inline} (0 calls)
 0: ctor_visibility.with_fields.b<0>
 b(#rec##0:ctor_visibility.with_fields, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -653,7 +653,7 @@ b(#rec##0:ctor_visibility.with_fields, ?#result##0:wybe.int, ?#success##0:wybe.b
         foreign lpvm access(~#rec##0:ctor_visibility.with_fields, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @ctor_visibility:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-b > public {inline} (0 calls)
+proc b > public {inline} (0 calls)
 1: ctor_visibility.with_fields.b<1>
 b(#rec##0:ctor_visibility.with_fields, ?#rec##1:ctor_visibility.with_fields, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -671,7 +671,7 @@ b(#rec##0:ctor_visibility.with_fields, ?#rec##1:ctor_visibility.with_fields, #fi
 
 
 
-bar > public {inline} (0 calls)
+proc bar > public {inline} (0 calls)
 0: ctor_visibility.with_fields.bar<0>
 bar(a##0:wybe.int, b##0:wybe.int, ?#result##0:ctor_visibility.with_fields)<{}; {}; {}>:
   AliasPairs: []
@@ -680,7 +680,7 @@ bar(a##0:wybe.int, b##0:wybe.int, ?#result##0:ctor_visibility.with_fields)<{}; {
     foreign lpvm mutate(~#rec##0:ctor_visibility.with_fields, ?#rec##1:ctor_visibility.with_fields, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int) @ctor_visibility:nn:nn
     foreign lpvm mutate(~#rec##1:ctor_visibility.with_fields, ?#rec##2:ctor_visibility.with_fields, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~b##0:wybe.int) @ctor_visibility:nn:nn
     foreign llvm or(~#rec##2:ctor_visibility.with_fields, 1:wybe.int, ?#result##0:ctor_visibility.with_fields) @ctor_visibility:nn:nn
-bar > public {inline} (7 calls)
+proc bar > public {inline} (7 calls)
 1: ctor_visibility.with_fields.bar<1>
 bar(?a##0:wybe.int, ?b##0:wybe.int, #result##0:ctor_visibility.with_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -700,14 +700,14 @@ bar(?a##0:wybe.int, ?b##0:wybe.int, #result##0:ctor_visibility.with_fields, ?#su
 
 
 
-foo > public {inline} (0 calls)
+proc foo > public {inline} (0 calls)
 0: ctor_visibility.with_fields.foo<0>
 foo(a##0:wybe.int, ?#result##0:ctor_visibility.with_fields)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_visibility.with_fields) @ctor_visibility:nn:nn
     foreign lpvm mutate(~#rec##0:ctor_visibility.with_fields, ?#result##0:ctor_visibility.with_fields, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int) @ctor_visibility:nn:nn
-foo > public {inline} (11 calls)
+proc foo > public {inline} (11 calls)
 1: ctor_visibility.with_fields.foo<1>
 foo(?a##0:wybe.int, #result##0:ctor_visibility.with_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -725,7 +725,7 @@ foo(?a##0:wybe.int, #result##0:ctor_visibility.with_fields, ?#success##0:wybe.bo
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_visibility.with_fields.~=<0>
 ~=(#left##0:ctor_visibility.with_fields, #right##0:ctor_visibility.with_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -986,7 +986,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: ctor_visibility.with_fields2.=<0>
 =(#left##0:ctor_visibility.with_fields2, #right##0:ctor_visibility.with_fields2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1029,7 +1029,7 @@ entry:
 
 
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 0: ctor_visibility.with_fields2.a<0>
 a(#rec##0:ctor_visibility.with_fields2, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1045,7 +1045,7 @@ a(#rec##0:ctor_visibility.with_fields2, ?#result##0:wybe.int, ?#success##0:wybe.
         foreign lpvm access(~#rec##0:ctor_visibility.with_fields2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @ctor_visibility:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 1: ctor_visibility.with_fields2.a<1>
 a(#rec##0:ctor_visibility.with_fields2, ?#rec##1:ctor_visibility.with_fields2, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1063,7 +1063,7 @@ a(#rec##0:ctor_visibility.with_fields2, ?#rec##1:ctor_visibility.with_fields2, #
 
 
 
-b > {inline} (0 calls)
+proc b > {inline} (0 calls)
 0: ctor_visibility.with_fields2.b<0>
 b(#rec##0:ctor_visibility.with_fields2, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1079,7 +1079,7 @@ b(#rec##0:ctor_visibility.with_fields2, ?#result##0:wybe.int, ?#success##0:wybe.
         foreign lpvm access(~#rec##0:ctor_visibility.with_fields2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @ctor_visibility:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-b > {inline} (0 calls)
+proc b > {inline} (0 calls)
 1: ctor_visibility.with_fields2.b<1>
 b(#rec##0:ctor_visibility.with_fields2, ?#rec##1:ctor_visibility.with_fields2, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1097,7 +1097,7 @@ b(#rec##0:ctor_visibility.with_fields2, ?#rec##1:ctor_visibility.with_fields2, #
 
 
 
-bar > {inline} (0 calls)
+proc bar > {inline} (0 calls)
 0: ctor_visibility.with_fields2.bar<0>
 bar(b##0:wybe.int, ?#result##0:ctor_visibility.with_fields2)<{}; {}; {}>:
   AliasPairs: []
@@ -1105,7 +1105,7 @@ bar(b##0:wybe.int, ?#result##0:ctor_visibility.with_fields2)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_visibility.with_fields2) @ctor_visibility:nn:nn
     foreign lpvm mutate(~#rec##0:ctor_visibility.with_fields2, ?#rec##1:ctor_visibility.with_fields2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~b##0:wybe.int) @ctor_visibility:nn:nn
     foreign llvm or(~#rec##1:ctor_visibility.with_fields2, 1:wybe.int, ?#result##0:ctor_visibility.with_fields2) @ctor_visibility:nn:nn
-bar > {inline} (5 calls)
+proc bar > {inline} (5 calls)
 1: ctor_visibility.with_fields2.bar<1>
 bar(?b##0:wybe.int, #result##0:ctor_visibility.with_fields2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1123,14 +1123,14 @@ bar(?b##0:wybe.int, #result##0:ctor_visibility.with_fields2, ?#success##0:wybe.b
 
 
 
-foo > public {inline} (0 calls)
+proc foo > public {inline} (0 calls)
 0: ctor_visibility.with_fields2.foo<0>
 foo(a##0:wybe.int, ?#result##0:ctor_visibility.with_fields2)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_visibility.with_fields2) @ctor_visibility:nn:nn
     foreign lpvm mutate(~#rec##0:ctor_visibility.with_fields2, ?#result##0:ctor_visibility.with_fields2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int) @ctor_visibility:nn:nn
-foo > public {inline} (10 calls)
+proc foo > public {inline} (10 calls)
 1: ctor_visibility.with_fields2.foo<1>
 foo(?a##0:wybe.int, #result##0:ctor_visibility.with_fields2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1148,7 +1148,7 @@ foo(?a##0:wybe.int, #result##0:ctor_visibility.with_fields2, ?#success##0:wybe.b
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: ctor_visibility.with_fields2.~=<0>
 ~=(#left##0:ctor_visibility.with_fields2, #right##0:ctor_visibility.with_fields2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/current_module_alias.exp
+++ b/test-cases/final-dump/current_module_alias.exp
@@ -23,7 +23,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-toCelsius > public {noinline} (1 calls)
+proc toCelsius > public {noinline} (1 calls)
 0: current_module_alias.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -76,7 +76,7 @@ entry:
   resources       : 
   procs           : 
 
-toCelsius > public {inline} (0 calls)
+proc toCelsius > public {inline} (0 calls)
 0: math.temperature.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/current_module_alias_fail.exp
+++ b/test-cases/final-dump/current_module_alias_fail.exp
@@ -23,7 +23,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-toCelsius > public {noinline} (1 calls)
+proc toCelsius > public {noinline} (1 calls)
 0: current_module_alias_fail.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -76,7 +76,7 @@ entry:
   resources       : 
   procs           : 
 
-toCelsius > public {inline} (0 calls)
+proc toCelsius > public {inline} (0 calls)
 0: math.temperature.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/current_module_alias_warning.exp
+++ b/test-cases/final-dump/current_module_alias_warning.exp
@@ -24,14 +24,14 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-toCelsius > public {noinline} (1 calls)
+proc toCelsius > public {noinline} (1 calls)
 0: current_module_alias_warning.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp#1##0:wybe.float) @float:nn:nn
     foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?#result##0:wybe.float) @float:nn:nn
-toCelsius > public {noinline} (0 calls)
+proc toCelsius > public {noinline} (0 calls)
 1: current_module_alias_warning.toCelsius<1>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -92,7 +92,7 @@ entry:
   resources       : 
   procs           : 
 
-toCelsius > public {inline} (0 calls)
+proc toCelsius > public {inline} (0 calls)
 0: math.temperature.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -64,7 +64,7 @@ module top-level code > public {semipure} (0 calls)
     dead_cell_size.print_t2<0>(~tmp#4##0:dead_cell_size.t2)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @dead_cell_size:nn:nn
 
 
-bar > public (1 calls)
+proc bar > public (1 calls)
 0: dead_cell_size.bar<0>[410bae77d3]
 bar(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)<{}; {}; {}>:
   AliasPairs: [(x##0,x##1)]
@@ -107,7 +107,7 @@ bar(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)<{}; {}; {}>:
 
 
 
-diff_type > public (1 calls)
+proc diff_type > public (1 calls)
 0: dead_cell_size.diff_type<0>[410bae77d3]
 diff_type(x##0:dead_cell_size.t, ?y##0:dead_cell_size.t2)<{}; {}; {}>:
   AliasPairs: []
@@ -153,7 +153,7 @@ diff_type(x##0:dead_cell_size.t, ?y##0:dead_cell_size.t2)<{}; {}; {}>:
 
 
 
-foo > public (1 calls)
+proc foo > public (1 calls)
 0: dead_cell_size.foo<0>
 foo(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)<{}; {}; {}>:
   AliasPairs: [(x##0,x##1)]
@@ -181,7 +181,7 @@ foo(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)<{}; {}; {}>:
 
 
 
-print_t > public (2 calls)
+proc print_t > public (2 calls)
 0: dead_cell_size.print_t<0>
 print_t(x##0:dead_cell_size.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -252,7 +252,7 @@ print_t(x##0:dead_cell_size.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-print_t2 > public (1 calls)
+proc print_t2 > public (1 calls)
 0: dead_cell_size.print_t2<0>
 print_t2(x##0:dead_cell_size.t2)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -627,7 +627,7 @@ if.else1:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: dead_cell_size.t.=<0>
 =(#left##0:dead_cell_size.t, #right##0:dead_cell_size.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -721,7 +721,7 @@ if.else1:
 
 
 
-ta > public {inline} (0 calls)
+proc ta > public {inline} (0 calls)
 0: dead_cell_size.t.ta<0>
 ta(?#result##0:dead_cell_size.t)<{}; {}; {}>:
   AliasPairs: []
@@ -729,14 +729,14 @@ ta(?#result##0:dead_cell_size.t)<{}; {}; {}>:
     foreign llvm move(0:dead_cell_size.t, ?#result##0:dead_cell_size.t)
 
 
-tb > public {inline} (0 calls)
+proc tb > public {inline} (0 calls)
 0: dead_cell_size.t.tb<0>
 tb(tb1##0:wybe.int, ?#result##0:dead_cell_size.t)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t) @dead_cell_size:nn:nn
     foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#result##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int) @dead_cell_size:nn:nn
-tb > public {inline} (14 calls)
+proc tb > public {inline} (14 calls)
 1: dead_cell_size.t.tb<1>
 tb(?tb1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -762,7 +762,7 @@ tb(?tb1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool)<{}; {}
 
 
 
-tb1 > public {inline} (0 calls)
+proc tb1 > public {inline} (0 calls)
 0: dead_cell_size.t.tb1<0>
 tb1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -786,7 +786,7 @@ tb1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; 
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-tb1 > public {inline} (0 calls)
+proc tb1 > public {inline} (0 calls)
 1: dead_cell_size.t.tb1<1>
 tb1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -812,7 +812,7 @@ tb1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
 
 
 
-tc > public {inline} (0 calls)
+proc tc > public {inline} (0 calls)
 0: dead_cell_size.t.tc<0>
 tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?#result##0:dead_cell_size.t)<{}; {}; {}>:
   AliasPairs: []
@@ -822,7 +822,7 @@ tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?#result##0:dead_cell_size
     foreign lpvm mutate(~#rec##1:dead_cell_size.t, ?#rec##2:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc2##0:wybe.int) @dead_cell_size:nn:nn
     foreign lpvm mutate(~#rec##2:dead_cell_size.t, ?#rec##3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3##0:wybe.int) @dead_cell_size:nn:nn
     foreign llvm or(~#rec##3:dead_cell_size.t, 1:wybe.int, ?#result##0:dead_cell_size.t) @dead_cell_size:nn:nn
-tc > public {inline} (11 calls)
+proc tc > public {inline} (11 calls)
 1: dead_cell_size.t.tc<1>
 tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -854,7 +854,7 @@ tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_si
 
 
 
-tc1 > public {inline} (0 calls)
+proc tc1 > public {inline} (0 calls)
 0: dead_cell_size.t.tc1<0>
 tc1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -878,7 +878,7 @@ tc1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; 
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-tc1 > public {inline} (0 calls)
+proc tc1 > public {inline} (0 calls)
 1: dead_cell_size.t.tc1<1>
 tc1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -904,7 +904,7 @@ tc1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
 
 
 
-tc2 > public {inline} (0 calls)
+proc tc2 > public {inline} (0 calls)
 0: dead_cell_size.t.tc2<0>
 tc2(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -928,7 +928,7 @@ tc2(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; 
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-tc2 > public {inline} (0 calls)
+proc tc2 > public {inline} (0 calls)
 1: dead_cell_size.t.tc2<1>
 tc2(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -954,7 +954,7 @@ tc2(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
 
 
 
-tc3 > public {inline} (0 calls)
+proc tc3 > public {inline} (0 calls)
 0: dead_cell_size.t.tc3<0>
 tc3(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -978,7 +978,7 @@ tc3(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; 
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-tc3 > public {inline} (0 calls)
+proc tc3 > public {inline} (0 calls)
 1: dead_cell_size.t.tc3<1>
 tc3(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1004,7 +1004,7 @@ tc3(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
 
 
 
-td > public {inline} (0 calls)
+proc td > public {inline} (0 calls)
 0: dead_cell_size.t.td<0>
 td(td1##0:wybe.int, ?#result##0:dead_cell_size.t)<{}; {}; {}>:
   AliasPairs: []
@@ -1012,7 +1012,7 @@ td(td1##0:wybe.int, ?#result##0:dead_cell_size.t)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t) @dead_cell_size:nn:nn
     foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1##0:wybe.int) @dead_cell_size:nn:nn
     foreign llvm or(~#rec##1:dead_cell_size.t, 2:wybe.int, ?#result##0:dead_cell_size.t) @dead_cell_size:nn:nn
-td > public {inline} (5 calls)
+proc td > public {inline} (5 calls)
 1: dead_cell_size.t.td<1>
 td(?td1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1038,7 +1038,7 @@ td(?td1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool)<{}; {}
 
 
 
-td1 > public {inline} (0 calls)
+proc td1 > public {inline} (0 calls)
 0: dead_cell_size.t.td1<0>
 td1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1062,7 +1062,7 @@ td1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; 
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-td1 > public {inline} (0 calls)
+proc td1 > public {inline} (0 calls)
 1: dead_cell_size.t.td1<1>
 td1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1088,7 +1088,7 @@ td1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#s
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: dead_cell_size.t.~=<0>
 ~=(#left##0:dead_cell_size.t, #right##0:dead_cell_size.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1663,7 +1663,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: dead_cell_size.t2.=<0>
 =(#left##0:dead_cell_size.t2, #right##0:dead_cell_size.t2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1687,7 +1687,7 @@ entry:
 
 
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 0: dead_cell_size.t2.a<0>
 a(#rec##0:dead_cell_size.t2, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1702,7 +1702,7 @@ a(#rec##0:dead_cell_size.t2, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {
         foreign lpvm access(~#rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @dead_cell_size:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 1: dead_cell_size.t2.a<1>
 a(#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1719,7 +1719,7 @@ a(#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, #field##0:wybe.int, ?#s
 
 
 
-t2a > public {inline} (0 calls)
+proc t2a > public {inline} (0 calls)
 0: dead_cell_size.t2.t2a<0>
 t2a(?#result##0:dead_cell_size.t2)<{}; {}; {}>:
   AliasPairs: []
@@ -1727,14 +1727,14 @@ t2a(?#result##0:dead_cell_size.t2)<{}; {}; {}>:
     foreign llvm move(0:dead_cell_size.t2, ?#result##0:dead_cell_size.t2)
 
 
-t2b > public {inline} (0 calls)
+proc t2b > public {inline} (0 calls)
 0: dead_cell_size.t2.t2b<0>
 t2b(a##0:wybe.int, ?#result##0:dead_cell_size.t2)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t2) @dead_cell_size:nn:nn
     foreign lpvm mutate(~#rec##0:dead_cell_size.t2, ?#result##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int) @dead_cell_size:nn:nn
-t2b > public {inline} (8 calls)
+proc t2b > public {inline} (8 calls)
 1: dead_cell_size.t2.t2b<1>
 t2b(?a##0:wybe.int, #result##0:dead_cell_size.t2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1751,7 +1751,7 @@ t2b(?a##0:wybe.int, #result##0:dead_cell_size.t2, ?#success##0:wybe.bool)<{}; {}
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: dead_cell_size.t2.~=<0>
 ~=(#left##0:dead_cell_size.t2, #right##0:dead_cell_size.t2, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/det_for.exp
+++ b/test-cases/final-dump/det_for.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     det_for.#cont#1<0>(0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @det_for:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: det_for.#cont#1<0>
 #cont#1(tmp#0##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -30,7 +30,7 @@ module top-level code > public {inline,semipure} (0 calls)
     det_for.#cont#1<0>(~tmp#0##1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @det_for:nn:nn
 
 
-[|] > {inline} (1 calls)
+proc [|] > {inline} (1 calls)
 0: det_for.[|]<0>
 [|](?value##0:wybe.int, ?next##0:wybe.int, current##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/disjunction.exp
+++ b/test-cases/final-dump/disjunction.exp
@@ -12,7 +12,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-in > public (2 calls)
+proc in > public (2 calls)
 0: disjunction.in<0>
 in(e##0:wybe.int, lst##0:wybe.list(wybe.int), ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ in(e##0:wybe.int, lst##0:wybe.list(wybe.int), ?#success##0:wybe.bool)<{}; {}; {}
 
 
 
-member > public (1 calls)
+proc member > public (1 calls)
 0: disjunction.member<0>
 member(e##0:wybe.int, lst##0:wybe.list(wybe.int), ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -60,7 +60,7 @@ member(e##0:wybe.int, lst##0:wybe.list(wybe.int), ?#success##0:wybe.bool)<{}; {}
 
 
 
-saturating_tail > public (0 calls)
+proc saturating_tail > public (0 calls)
 0: disjunction.saturating_tail<0>
 saturating_tail(lst##0:wybe.list(T) <{}; {}; {0}>, ?tl##0:wybe.list(T) <{}; {}; {0}>)<{}; {}; {}>:
   AliasPairs: [(lst##0,tl##0)]
@@ -75,7 +75,7 @@ saturating_tail(lst##0:wybe.list(T) <{}; {}; {0}>, ?tl##0:wybe.list(T) <{}; {}; 
 
 
 
-saturating_tail2 > public (0 calls)
+proc saturating_tail2 > public (0 calls)
 0: disjunction.saturating_tail2<0>
 saturating_tail2(lst##0:wybe.list(T) <{}; {}; {0}>, ?#result##0:wybe.list(T) <{}; {}; {0}>)<{}; {}; {}>:
   AliasPairs: [(#result##0,lst##0)]

--- a/test-cases/final-dump/disjunctive-cond.exp
+++ b/test-cases/final-dump/disjunctive-cond.exp
@@ -21,7 +21,7 @@ module top-level code > public {semipure} (0 calls)
     disjunctive-cond.#cont#1<0>(1:wybe.bool, 0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9
 
 
-#cont#1 > (5 calls)
+proc #cont#1 > (5 calls)
 0: disjunctive-cond.#cont#1<0>
 #cont#1(a##0:wybe.bool, b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#2 > (3 calls)
+proc #cont#2 > (3 calls)
 0: disjunctive-cond.#cont#2<0>
 #cont#2(a##0:wybe.bool, b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -88,7 +88,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#3 > (7 calls)
+proc #cont#3 > (7 calls)
 0: disjunctive-cond.#cont#3<0>
 #cont#3(a##0:wybe.bool, b##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -22,7 +22,7 @@ module top-level code > public {semipure} (0 calls)
     foreign c {terminal,semipure} exit(1:wybe.int) @early_error:nn:nn
 
 
-my_error > {terminal,inline,semipure} (1 calls)
+proc my_error > {terminal,inline,semipure} (1 calls)
 0: early_error.my_error<0>
 my_error(msg##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/early_exit2.exp
+++ b/test-cases/final-dump/early_exit2.exp
@@ -21,7 +21,7 @@ module top-level code > public {semipure} (0 calls)
     foreign c {terminal,semipure} exit(1:wybe.int) @early_exit2:nn:nn
 
 
-my_exit > {terminal,inline} (1 calls)
+proc my_exit > {terminal,inline} (1 calls)
 0: early_exit2.my_exit<0>
 my_exit(code##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
     wybe.string.print<0>(~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @exp_if:nn:nn
 
 
-if_test > public (1 calls)
+proc if_test > public (1 calls)
 0: exp_if.if_test<0>
 if_test(x##0:wybe.int, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/exp_simple.exp
+++ b/test-cases/final-dump/exp_simple.exp
@@ -32,7 +32,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#33##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-foreign_add > {inline} (1 calls)
+proc foreign_add > {inline} (1 calls)
 0: exp_simple.foreign_add<0>
 foreign_add(?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/explicit_type_warning.exp
+++ b/test-cases/final-dump/explicit_type_warning.exp
@@ -10,7 +10,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: explicit_type_warning.=<0>
 =(#left##0:explicit_type_warning, #right##0:explicit_type_warning, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -43,7 +43,7 @@ AFTER EVERYTHING:
 
 
 
-h > {inline} (0 calls)
+proc h > {inline} (0 calls)
 0: explicit_type_warning.h<0>
 h(#rec##0:explicit_type_warning, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -58,7 +58,7 @@ h(#rec##0:explicit_type_warning, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{
         foreign lpvm access(~#rec##0:explicit_type_warning, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @explicit_type_warning:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-h > {inline} (0 calls)
+proc h > {inline} (0 calls)
 1: explicit_type_warning.h<1>
 h(#rec##0:explicit_type_warning, ?#rec##1:explicit_type_warning, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -75,7 +75,7 @@ h(#rec##0:explicit_type_warning, ?#rec##1:explicit_type_warning, #field##0:wybe.
 
 
 
-mt > {inline} (0 calls)
+proc mt > {inline} (0 calls)
 0: explicit_type_warning.mt<0>
 mt(?#result##0:explicit_type_warning)<{}; {}; {}>:
   AliasPairs: []
@@ -83,7 +83,7 @@ mt(?#result##0:explicit_type_warning)<{}; {}; {}>:
     foreign llvm move(0:explicit_type_warning, ?#result##0:explicit_type_warning)
 
 
-oops > {inline} (0 calls)
+proc oops > {inline} (0 calls)
 0: explicit_type_warning.oops<0>
 oops(h##0:wybe.int, t##0:explicit_type_warning, ?#result##0:explicit_type_warning)<{}; {}; {}>:
   AliasPairs: []
@@ -91,7 +91,7 @@ oops(h##0:wybe.int, t##0:explicit_type_warning, ?#result##0:explicit_type_warnin
     foreign lpvm alloc(16:wybe.int, ?#rec##0:explicit_type_warning) @explicit_type_warning:nn:nn
     foreign lpvm mutate(~#rec##0:explicit_type_warning, ?#rec##1:explicit_type_warning, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int) @explicit_type_warning:nn:nn
     foreign lpvm mutate(~#rec##1:explicit_type_warning, ?#result##0:explicit_type_warning, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~t##0:explicit_type_warning) @explicit_type_warning:nn:nn
-oops > {inline} (15 calls)
+proc oops > {inline} (15 calls)
 1: explicit_type_warning.oops<1>
 oops(?h##0:wybe.int, ?t##0:explicit_type_warning, #result##0:explicit_type_warning, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -110,7 +110,7 @@ oops(?h##0:wybe.int, ?t##0:explicit_type_warning, #result##0:explicit_type_warni
 
 
 
-oops2 > (1 calls)
+proc oops2 > (1 calls)
 0: explicit_type_warning.oops2<0>
 oops2(l##0:explicit_type_warning, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -127,7 +127,7 @@ oops2(l##0:explicit_type_warning, ?#result##0:wybe.int)<{}; {}; {}>:
 
 
 
-t > {inline} (0 calls)
+proc t > {inline} (0 calls)
 0: explicit_type_warning.t<0>
 t(#rec##0:explicit_type_warning, ?#result##0:explicit_type_warning, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -142,7 +142,7 @@ t(#rec##0:explicit_type_warning, ?#result##0:explicit_type_warning, ?#success##0
         foreign lpvm access(~#rec##0:explicit_type_warning, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:explicit_type_warning) @explicit_type_warning:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-t > {inline} (0 calls)
+proc t > {inline} (0 calls)
 1: explicit_type_warning.t<1>
 t(#rec##0:explicit_type_warning, ?#rec##1:explicit_type_warning, #field##0:explicit_type_warning, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -159,7 +159,7 @@ t(#rec##0:explicit_type_warning, ?#rec##1:explicit_type_warning, #field##0:expli
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: explicit_type_warning.~=<0>
 ~=(#left##0:explicit_type_warning, #right##0:explicit_type_warning, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/extern_anon_params_a.exp
+++ b/test-cases/final-dump/extern_anon_params_a.exp
@@ -10,7 +10,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-need > public {inline,semipure} (1 calls)
+proc need > public {inline,semipure} (1 calls)
 0: extern_anon_params_a.need<0>
 need(stmt##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
@@ -18,7 +18,7 @@ need(stmt##0:{impure}())<{}; {}; {}>:
     ~stmt##0:{impure}() #0 @extern_anon_params_a:nn:nn
 
 
-run > public {inline,impure} (0 calls)
+proc run > public {inline,impure} (0 calls)
 0: extern_anon_params_a.run<0>
 run(func##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
@@ -26,13 +26,13 @@ run(func##0:{impure}())<{}; {}; {}>:
     extern_anon_params_a.run#anon#1<0>(~^func##0:{impure}()) #0 @extern_anon_params_a:nn:nn
 
 
-run#anon#1 > {inline,impure} (1 calls)
+proc run#anon#1 > {inline,impure} (1 calls)
 0: extern_anon_params_a.run#anon#1<0>
 run#anon#1(^func##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~func##0:{impure}() #0 @extern_anon_params_a:nn:nn
-run#anon#1 > {inline,impure} (1 calls)
+proc run#anon#1 > {inline,impure} (1 calls)
 1: extern_anon_params_a.run#anon#1<1>
 run#anon#1(^func##0:{impure}())<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/extern_anon_params_b.exp
+++ b/test-cases/final-dump/extern_anon_params_b.exp
@@ -10,7 +10,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-need > public {inline,semipure} (1 calls)
+proc need > public {inline,semipure} (1 calls)
 0: extern_anon_params_a.need<0>
 need(stmt##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
@@ -18,7 +18,7 @@ need(stmt##0:{impure}())<{}; {}; {}>:
     ~stmt##0:{impure}() #0 @extern_anon_params_a:nn:nn
 
 
-run > public {inline,impure} (0 calls)
+proc run > public {inline,impure} (0 calls)
 0: extern_anon_params_a.run<0>
 run(func##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
@@ -26,13 +26,13 @@ run(func##0:{impure}())<{}; {}; {}>:
     extern_anon_params_a.run#anon#1<0>(~^func##0:{impure}()) #0 @extern_anon_params_a:nn:nn
 
 
-run#anon#1 > {inline,impure} (1 calls)
+proc run#anon#1 > {inline,impure} (1 calls)
 0: extern_anon_params_a.run#anon#1<0>
 run#anon#1(^func##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~func##0:{impure}() #0 @extern_anon_params_a:nn:nn
-run#anon#1 > {inline,impure} (1 calls)
+proc run#anon#1 > {inline,impure} (1 calls)
 1: extern_anon_params_a.run#anon#1<1>
 run#anon#1(^func##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
@@ -110,12 +110,12 @@ module top-level code > public {inline,semipure} (0 calls)
     extern_anon_params_a.run#anon#1<0>(extern_anon_params_b.#anon#1<1><>:{impure}()) #1 @extern_anon_params_a:nn:nn
 
 
-#anon#1 > {inline,impure} (1 calls)
+proc #anon#1 > {inline,impure} (1 calls)
 0: extern_anon_params_b.#anon#1<0>
 #anon#1()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-#anon#1 > {inline,impure} (1 calls)
+proc #anon#1 > {inline,impure} (1 calls)
 1: extern_anon_params_b.#anon#1<1>
 #anon#1()<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/failure_in_cond_test.exp
+++ b/test-cases/final-dump/failure_in_cond_test.exp
@@ -19,7 +19,7 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-foo > {inline} (3 calls)
+proc foo > {inline} (3 calls)
 0: failure_in_cond_test.foo<0>
 foo(?i##3:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/func_factorial.exp
+++ b/test-cases/final-dump/func_factorial.exp
@@ -22,7 +22,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-factorial > public (2 calls)
+proc factorial > public (2 calls)
 0: func_factorial.factorial<0>
 factorial(n##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/func_let.exp
+++ b/test-cases/final-dump/func_let.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-quad > public {inline} (1 calls)
+proc quad > public {inline} (1 calls)
 0: func_let.quad<0>
 quad(x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/func_no_types.exp
+++ b/test-cases/final-dump/func_no_types.exp
@@ -1,3 +1,3 @@
 Error detected during checking parameter type declarations in module(s) func_no_types
-[91mfinal-dump/func_no_types.wybe:1:5: Public proc 'double' with undeclared parameter or return type
+[91mfinal-dump/func_no_types.wybe:1:5: Public proc double with undeclared parameter or return type
 [0m

--- a/test-cases/final-dump/func_quadruple.exp
+++ b/test-cases/final-dump/func_quadruple.exp
@@ -10,7 +10,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-double > public {inline} (2 calls)
+proc double > public {inline} (2 calls)
 0: func_quadruple.double<0>
 double(a##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -18,7 +18,7 @@ double(a##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
     foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
-quadruple > public {inline} (0 calls)
+proc quadruple > public {inline} (0 calls)
 0: func_quadruple.quadruple<0>
 quadruple(a##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/func_typed.exp
+++ b/test-cases/final-dump/func_typed.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-plus > public {inline} (0 calls)
+proc plus > public {inline} (0 calls)
 0: func_typed.plus<0>
 plus(a##0:wybe.int, b##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/func_untyped.exp
+++ b/test-cases/final-dump/func_untyped.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-incr > {inline} (0 calls)
+proc incr > {inline} (0 calls)
 0: func_untyped.incr<0>
 incr(a##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/func_where.exp
+++ b/test-cases/final-dump/func_where.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-quad > public {inline} (0 calls)
+proc quad > public {inline} (0 calls)
 0: func_where.quad<0>
 quad(x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -17,7 +17,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-append > public (1 calls)
+proc append > public (1 calls)
 0: generic_list.append<0>
 append(x##0:generic_list(T) <{}; {}; {0}>, y##0:generic_list(T) <{}; {}; {1}>, outByReference #result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: [(#result##0,y##0)]
@@ -38,7 +38,7 @@ append(x##0:generic_list(T) <{}; {}; {0}>, y##0:generic_list(T) <{}; {}; {1}>, o
 
 
 
-car > public {inline} (0 calls)
+proc car > public {inline} (0 calls)
 0: generic_list.car<0>
 car(#rec##0:generic_list(T) <{}; {}; {0}>, ?#result##0:T <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ car(#rec##0:generic_list(T) <{}; {}; {0}>, ?#result##0:T <{}; {}; {0}>, ?#succes
         foreign lpvm access(~#rec##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-car > public {inline} (0 calls)
+proc car > public {inline} (0 calls)
 1: generic_list.car<1>
 car(#rec##0:generic_list(T) <{}; {}; {0}>, ?#rec##1:generic_list(T) <{}; {}; {0, 2}>, #field##0:T <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -70,7 +70,7 @@ car(#rec##0:generic_list(T) <{}; {}; {0}>, ?#rec##1:generic_list(T) <{}; {}; {0,
 
 
 
-cdr > public {inline} (0 calls)
+proc cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
 cdr(#rec##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -85,7 +85,7 @@ cdr(#rec##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; 
         foreign lpvm access(~#rec##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-cdr > public {inline} (0 calls)
+proc cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
 cdr(#rec##0:generic_list(T) <{}; {}; {0}>, ?#rec##1:generic_list(T) <{}; {}; {0, 2}>, #field##0:generic_list(T) <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -102,7 +102,7 @@ cdr(#rec##0:generic_list(T) <{}; {}; {0}>, ?#rec##1:generic_list(T) <{}; {}; {0,
 
 
 
-cons > public {inline} (1 calls)
+proc cons > public {inline} (1 calls)
 0: generic_list.cons<0>
 cons(car##0:T <{}; {}; {0}>, cdr##0:generic_list(T) <{}; {}; {1}>, ?#result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: []
@@ -110,7 +110,7 @@ cons(car##0:T <{}; {}; {0}>, cdr##0:generic_list(T) <{}; {}; {1}>, ?#result##0:g
     foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(T)) @generic_list:nn:nn
     foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T) @generic_list:nn:nn
     foreign lpvm mutate(~#rec##1:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(T)) @generic_list:nn:nn
-cons > public {inline} (6 calls)
+proc cons > public {inline} (6 calls)
 1: generic_list.cons<1>
 cons(?car##0:T <{}; {}; {2}>, ?cdr##0:generic_list(T) <{}; {}; {2}>, #result##0:generic_list(T) <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -129,7 +129,7 @@ cons(?car##0:T <{}; {}; {2}>, ?cdr##0:generic_list(T) <{}; {}; {2}>, #result##0:
 
 
 
-length > public {inline} (0 calls)
+proc length > public {inline} (0 calls)
 0: generic_list.length<0>
 length(x##0:generic_list(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -137,7 +137,7 @@ length(x##0:generic_list(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
     generic_list.length1<0>(~x##0:generic_list(T), 0:wybe.int, ?#result##0:wybe.int) #0 @generic_list:nn:nn
 
 
-length1 > (2 calls)
+proc length1 > (2 calls)
 0: generic_list.length1<0>
 length1(x##0:generic_list(T) <{}; {}; {0}>, acc##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -154,7 +154,7 @@ length1(x##0:generic_list(T) <{}; {}; {0}>, acc##0:wybe.int, ?#result##0:wybe.in
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: generic_list.nil<0>
 nil(?#result##0:generic_list(T))<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -17,7 +17,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-append > public (1 calls)
+proc append > public (1 calls)
 0: generic_list.append<0>
 append(x##0:generic_list(T) <{}; {}; {0}>, y##0:generic_list(T) <{}; {}; {1}>, outByReference #result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: [(#result##0,y##0)]
@@ -38,7 +38,7 @@ append(x##0:generic_list(T) <{}; {}; {0}>, y##0:generic_list(T) <{}; {}; {1}>, o
 
 
 
-car > public {inline} (0 calls)
+proc car > public {inline} (0 calls)
 0: generic_list.car<0>
 car(#rec##0:generic_list(T) <{}; {}; {0}>, ?#result##0:T <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ car(#rec##0:generic_list(T) <{}; {}; {0}>, ?#result##0:T <{}; {}; {0}>, ?#succes
         foreign lpvm access(~#rec##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-car > public {inline} (0 calls)
+proc car > public {inline} (0 calls)
 1: generic_list.car<1>
 car(#rec##0:generic_list(T) <{}; {}; {0}>, ?#rec##1:generic_list(T) <{}; {}; {0, 2}>, #field##0:T <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -70,7 +70,7 @@ car(#rec##0:generic_list(T) <{}; {}; {0}>, ?#rec##1:generic_list(T) <{}; {}; {0,
 
 
 
-cdr > public {inline} (0 calls)
+proc cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
 cdr(#rec##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -85,7 +85,7 @@ cdr(#rec##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; 
         foreign lpvm access(~#rec##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(T)) @generic_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-cdr > public {inline} (0 calls)
+proc cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
 cdr(#rec##0:generic_list(T) <{}; {}; {0}>, ?#rec##1:generic_list(T) <{}; {}; {0, 2}>, #field##0:generic_list(T) <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -102,7 +102,7 @@ cdr(#rec##0:generic_list(T) <{}; {}; {0}>, ?#rec##1:generic_list(T) <{}; {}; {0,
 
 
 
-cons > public {inline} (1 calls)
+proc cons > public {inline} (1 calls)
 0: generic_list.cons<0>
 cons(car##0:T <{}; {}; {0}>, cdr##0:generic_list(T) <{}; {}; {1}>, ?#result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: []
@@ -110,7 +110,7 @@ cons(car##0:T <{}; {}; {0}>, cdr##0:generic_list(T) <{}; {}; {1}>, ?#result##0:g
     foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(T)) @generic_list:nn:nn
     foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T) @generic_list:nn:nn
     foreign lpvm mutate(~#rec##1:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(T)) @generic_list:nn:nn
-cons > public {inline} (6 calls)
+proc cons > public {inline} (6 calls)
 1: generic_list.cons<1>
 cons(?car##0:T <{}; {}; {2}>, ?cdr##0:generic_list(T) <{}; {}; {2}>, #result##0:generic_list(T) <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -129,7 +129,7 @@ cons(?car##0:T <{}; {}; {2}>, ?cdr##0:generic_list(T) <{}; {}; {2}>, #result##0:
 
 
 
-length > public {inline} (0 calls)
+proc length > public {inline} (0 calls)
 0: generic_list.length<0>
 length(x##0:generic_list(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -137,7 +137,7 @@ length(x##0:generic_list(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
     generic_list.length1<0>(~x##0:generic_list(T), 0:wybe.int, ?#result##0:wybe.int) #0 @generic_list:nn:nn
 
 
-length1 > (2 calls)
+proc length1 > (2 calls)
 0: generic_list.length1<0>
 length1(x##0:generic_list(T) <{}; {}; {0}>, acc##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -154,7 +154,7 @@ length1(x##0:generic_list(T) <{}; {}; {0}>, acc##0:wybe.int, ?#result##0:wybe.in
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: generic_list.nil<0>
 nil(?#result##0:generic_list(T))<{}; {}; {}>:
   AliasPairs: []
@@ -398,7 +398,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-concat > public (3 calls)
+proc concat > public (3 calls)
 0: generic_use.concat<0>[410bae77d3]
 concat(l1##0:generic_list(T) <{}; {}; {0}>, l2##0:generic_list(T) <{}; {}; {1}>, outByReference #result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: [(#result##0,l2##0)]
@@ -430,7 +430,7 @@ concat(l1##0:generic_list(T) <{}; {}; {0}>, l2##0:generic_list(T) <{}; {}; {1}>,
 
 
 
-fromto > public {inline} (2 calls)
+proc fromto > public {inline} (2 calls)
 0: generic_use.fromto<0>
 fromto(lo##0:wybe.int, hi##0:wybe.int, ?#result##0:generic_list(wybe.int))<{}; {}; {}>:
   AliasPairs: []
@@ -438,7 +438,7 @@ fromto(lo##0:wybe.int, hi##0:wybe.int, ?#result##0:generic_list(wybe.int))<{}; {
     generic_use.fromto1<0>(~lo##0:wybe.int, ~hi##0:wybe.int, 0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
-fromto1 > (2 calls)
+proc fromto1 > (2 calls)
 0: generic_use.fromto1<0>
 fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int))<{}; {}; {}>:
   AliasPairs: [(#result##0,sofar##0)]
@@ -457,7 +457,7 @@ fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?#resul
 
 
 
-iota > public {inline} (1 calls)
+proc iota > public {inline} (1 calls)
 0: generic_use.iota<0>
 iota(n##0:wybe.int, ?#result##0:generic_list(wybe.int))<{}; {}; {}>:
   AliasPairs: []
@@ -465,7 +465,7 @@ iota(n##0:wybe.int, ?#result##0:generic_list(wybe.int))<{}; {}; {}>:
     generic_use.fromto1<0>(1:wybe.int, ~n##0:wybe.int, 0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
-nrev > public (2 calls)
+proc nrev > public (2 calls)
 0: generic_use.nrev<0>[410bae77d3]
 nrev(lst##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; {0}>)<{}; {}; {}>:
   AliasPairs: []
@@ -499,7 +499,7 @@ nrev(lst##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; 
 
 
 
-print > (1 calls)
+proc print > (1 calls)
 0: generic_use.print<0>
 print(lst##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -524,7 +524,7 @@ print(lst##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-print_tail > (2 calls)
+proc print_tail > (2 calls)
 0: generic_use.print_tail<0>
 print_tail(lst##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -544,7 +544,7 @@ print_tail(lst##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}
 
 
 
-println > {inline} (5 calls)
+proc println > {inline} (5 calls)
 0: generic_use.println<0>
 println(lst##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -555,7 +555,7 @@ println(lst##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#1##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-reverse > public {inline} (1 calls)
+proc reverse > public {inline} (1 calls)
 0: generic_use.reverse<0>
 reverse(lst##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; {0}>)<{}; {}; {}>:
   AliasPairs: []
@@ -563,7 +563,7 @@ reverse(lst##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {
     generic_use.reverse1<0>(~lst##0:generic_list(T), 0:generic_list(T), ?#result##0:generic_list(T)) #1 @generic_use:nn:nn
 
 
-reverse1 > public (2 calls)
+proc reverse1 > public (2 calls)
 0: generic_use.reverse1<0>[410bae77d3]
 reverse1(lst##0:generic_list(T) <{}; {}; {0}>, suffix##0:generic_list(T) <{}; {}; {1}>, ?#result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: [(#result##0,suffix##0)]

--- a/test-cases/final-dump/global_flow_inference.exp
+++ b/test-cases/final-dump/global_flow_inference.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(1:wybe.int, <<global_flow_inference.res>>:wybe.int) @global_flow_inference:nn:nn
 
 
-higher_order_branch > {noinline} (0 calls)
+proc higher_order_branch > {noinline} (0 calls)
 0: global_flow_inference.higher_order_branch<0>
 higher_order_branch(b##0:wybe.bool, f##0:{resource}() <{}; {}; {1}>)<{}; {}; {1}>:
   AliasPairs: []
@@ -30,7 +30,7 @@ higher_order_branch(b##0:wybe.bool, f##0:{resource}() <{}; {}; {1}>)<{}; {}; {1}
 
 
 
-higher_order_branch_no_use > {noinline} (0 calls)
+proc higher_order_branch_no_use > {noinline} (0 calls)
 0: global_flow_inference.higher_order_branch_no_use<0>
 higher_order_branch_no_use(b##0:wybe.bool, f##0:{resource}() <{}; {}; {1}>)<{}; {}; {1}>:
   AliasPairs: []
@@ -43,7 +43,7 @@ higher_order_branch_no_use(b##0:wybe.bool, f##0:{resource}() <{}; {}; {1}>)<{}; 
 
 
 
-higher_order_branch_use > {noinline} (0 calls)
+proc higher_order_branch_use > {noinline} (0 calls)
 0: global_flow_inference.higher_order_branch_use<0>
 higher_order_branch_use(b##0:wybe.bool, f##0:{resource}() <{}; {}; {1}>)<{<<global_flow_inference.res>>}; {<<global_flow_inference.res>>}; {1}>:
   AliasPairs: []
@@ -57,7 +57,7 @@ higher_order_branch_use(b##0:wybe.bool, f##0:{resource}() <{}; {}; {1}>)<{<<glob
 
 
 
-higher_order_in > {noinline} (0 calls)
+proc higher_order_in > {noinline} (0 calls)
 0: global_flow_inference.higher_order_in<0>
 higher_order_in(f##0:{resource}(wybe.int) <{}; {}; {0}>)<{<<global_flow_inference.res>>}; {}; {0}>:
   AliasPairs: []
@@ -66,7 +66,7 @@ higher_order_in(f##0:{resource}(wybe.int) <{}; {}; {0}>)<{<<global_flow_inferenc
     ~f##0:{resource}(wybe.int)(~res##0:wybe.int) #0 @global_flow_inference:nn:nn
 
 
-higher_order_inout > {noinline} (0 calls)
+proc higher_order_inout > {noinline} (0 calls)
 0: global_flow_inference.higher_order_inout<0>
 higher_order_inout(f##0:{resource}(wybe.int) <{}; {}; {0}>)<{<<global_flow_inference.res>>}; {<<global_flow_inference.res>>}; {0}>:
   AliasPairs: []
@@ -76,7 +76,7 @@ higher_order_inout(f##0:{resource}(wybe.int) <{}; {}; {0}>)<{<<global_flow_infer
     foreign lpvm store(1:wybe.int, <<global_flow_inference.res>>:wybe.int) @global_flow_inference:nn:nn
 
 
-higher_order_only_out > {noinline} (0 calls)
+proc higher_order_only_out > {noinline} (0 calls)
 0: global_flow_inference.higher_order_only_out<0>
 higher_order_only_out(f##0:{resource}(wybe.int) <{}; {}; {0}>)<{}; {<<global_flow_inference.res>>}; {0}>:
   AliasPairs: []
@@ -85,7 +85,7 @@ higher_order_only_out(f##0:{resource}(wybe.int) <{}; {}; {0}>)<{}; {<<global_flo
     ~f##0:{resource}(wybe.int)(1:wybe.int) #0 @global_flow_inference:nn:nn
 
 
-higher_order_out > {noinline} (0 calls)
+proc higher_order_out > {noinline} (0 calls)
 0: global_flow_inference.higher_order_out<0>
 higher_order_out(f##0:{resource}(?wybe.int) <{}; {}; {0}>)<{}; {<<global_flow_inference.res>>}; {0}>:
   AliasPairs: []
@@ -94,7 +94,7 @@ higher_order_out(f##0:{resource}(?wybe.int) <{}; {}; {0}>)<{}; {<<global_flow_in
     foreign lpvm store(~%res##0:wybe.int, <<global_flow_inference.res>>:wybe.int) @global_flow_inference:nn:nn
 
 
-inout > {noinline} (0 calls)
+proc inout > {noinline} (0 calls)
 0: global_flow_inference.inout<0>
 inout(b##0:wybe.bool)<{<<global_flow_inference.res>>}; {<<global_flow_inference.res>>}; {}>:
   AliasPairs: []
@@ -107,7 +107,7 @@ inout(b##0:wybe.bool)<{<<global_flow_inference.res>>}; {<<global_flow_inference.
 
 
 
-only_in > {noinline} (0 calls)
+proc only_in > {noinline} (0 calls)
 0: global_flow_inference.only_in<0>
 only_in(?x##0:wybe.int)<{<<global_flow_inference.res>>}; {}; {}>:
   AliasPairs: []
@@ -115,7 +115,7 @@ only_in(?x##0:wybe.int)<{<<global_flow_inference.res>>}; {}; {}>:
     foreign lpvm load(<<global_flow_inference.res>>:wybe.int, ?%x##0:wybe.int) @global_flow_inference:nn:nn
 
 
-only_out > {noinline} (1 calls)
+proc only_out > {noinline} (1 calls)
 0: global_flow_inference.only_out<0>
 only_out(b##0:wybe.bool)<{}; {<<global_flow_inference.res>>}; {}>:
   AliasPairs: []
@@ -129,7 +129,7 @@ only_out(b##0:wybe.bool)<{}; {<<global_flow_inference.res>>}; {}>:
 
 
 
-rec_out_only1 > {noinline} (1 calls)
+proc rec_out_only1 > {noinline} (1 calls)
 0: global_flow_inference.rec_out_only1<0>
 rec_out_only1()<{}; {<<global_flow_inference.res>>}; {}>:
   AliasPairs: []
@@ -137,7 +137,7 @@ rec_out_only1()<{}; {<<global_flow_inference.res>>}; {}>:
     global_flow_inference.rec_out_only2<0><{}; {<<global_flow_inference.res>>}; {}> #0 @global_flow_inference:nn:nn
 
 
-rec_out_only2 > {noinline} (1 calls)
+proc rec_out_only2 > {noinline} (1 calls)
 0: global_flow_inference.rec_out_only2<0>
 rec_out_only2()<{}; {<<global_flow_inference.res>>}; {}>:
   AliasPairs: []
@@ -145,7 +145,7 @@ rec_out_only2()<{}; {<<global_flow_inference.res>>}; {}>:
     global_flow_inference.rec_out_only1<0><{}; {<<global_flow_inference.res>>}; {}> #0 @global_flow_inference:nn:nn
 
 
-rec_out_only_notail1 > {noinline} (1 calls)
+proc rec_out_only_notail1 > {noinline} (1 calls)
 0: global_flow_inference.rec_out_only_notail1<0>
 rec_out_only_notail1()<{}; {<<global_flow_inference.res>>}; {}>:
   AliasPairs: []
@@ -153,7 +153,7 @@ rec_out_only_notail1()<{}; {<<global_flow_inference.res>>}; {}>:
     foreign lpvm store(1:wybe.int, <<global_flow_inference.res>>:wybe.int) @global_flow_inference:nn:nn
 
 
-rec_out_only_notail2 > {noinline} (1 calls)
+proc rec_out_only_notail2 > {noinline} (1 calls)
 0: global_flow_inference.rec_out_only_notail2<0>
 rec_out_only_notail2()<{}; {<<global_flow_inference.res>>}; {}>:
   AliasPairs: []
@@ -161,7 +161,7 @@ rec_out_only_notail2()<{}; {<<global_flow_inference.res>>}; {}>:
     foreign lpvm store(1:wybe.int, <<global_flow_inference.res>>:wybe.int) @global_flow_inference:nn:nn
 
 
-still_only_in > {noinline} (0 calls)
+proc still_only_in > {noinline} (0 calls)
 0: global_flow_inference.still_only_in<0>
 still_only_in(b##0:wybe.bool, ?x##0:wybe.int)<{<<global_flow_inference.res>>}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_anon.exp
+++ b/test-cases/final-dump/higher_order_anon.exp
@@ -16,13 +16,13 @@ module top-level code > public {inline,semipure} (0 calls)
   InterestingCallProperties: []
 
 
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 0: higher_order_anon.#anon#1<0>
 #anon#1(anon#1#1##0:wybe.int, ?anon#1#2##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~anon#1#1##0:wybe.int, 1:wybe.int, ?anon#1#2##0:wybe.int) @int:nn:nn
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 1: higher_order_anon.#anon#1<1>
 #anon#1(anon#1#1##0:wybe.int, ?anon#1#2##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -30,13 +30,13 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm add(~anon#1#1##0:wybe.int, 1:wybe.int, ?anon#1#2##0:wybe.int) @int:nn:nn
 
 
-#anon#2 > {inline} (1 calls)
+proc #anon#2 > {inline} (1 calls)
 0: higher_order_anon.#anon#2<0>
 #anon#2(anon#2#1##0:wybe.int, ?anon#2#2##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~anon#2#1##0:wybe.int, 1:wybe.int, ?anon#2#2##0:wybe.int) @int:nn:nn
-#anon#2 > {inline} (1 calls)
+proc #anon#2 > {inline} (1 calls)
 1: higher_order_anon.#anon#2<1>
 #anon#2(anon#2#1##0:wybe.int, ?anon#2#2##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -44,13 +44,13 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm add(~anon#2#1##0:wybe.int, 1:wybe.int, ?anon#2#2##0:wybe.int) @int:nn:nn
 
 
-#anon#3 > {inline} (1 calls)
+proc #anon#3 > {inline} (1 calls)
 0: higher_order_anon.#anon#3<0>
 #anon#3([anon#3#1##0:20 <{}; {}; {0}>], anon#3#2##0:2 <{}; {}; {1}>, ?anon#3#3##0:2 <{}; {}; {1}>)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#3#2##0:2, ?anon#3#3##0:2) @higher_order_anon:nn:nn
-#anon#3 > {inline} (1 calls)
+proc #anon#3 > {inline} (1 calls)
 1: higher_order_anon.#anon#3<1>
 #anon#3(anon#3#1##0:20 <{}; {}; {0}>, anon#3#2##0:2 <{}; {}; {1}>, ?anon#3#3##0:2 <{}; {}; {1}>)<{}; {}; {}>:
   AliasPairs: []
@@ -58,13 +58,13 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm move(~anon#3#2##0:2, ?anon#3#3##0:2) @higher_order_anon:nn:nn
 
 
-#anon#4 > {inline} (1 calls)
+proc #anon#4 > {inline} (1 calls)
 0: higher_order_anon.#anon#4<0>
 #anon#4([anon#4#1##0:20 <{}; {}; {0}>], anon#4#2##0:2 <{}; {}; {1}>, ?anon#4#3##0:2 <{}; {}; {1}>)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#4#2##0:2, ?anon#4#3##0:2) @higher_order_anon:nn:nn
-#anon#4 > {inline} (1 calls)
+proc #anon#4 > {inline} (1 calls)
 1: higher_order_anon.#anon#4<1>
 #anon#4(anon#4#1##0:20 <{}; {}; {0}>, anon#4#2##0:2 <{}; {}; {1}>, ?anon#4#3##0:2 <{}; {}; {1}>)<{}; {}; {}>:
   AliasPairs: []
@@ -72,13 +72,13 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm move(~anon#4#2##0:2, ?anon#4#3##0:2) @higher_order_anon:nn:nn
 
 
-#anon#5 > {inline} (1 calls)
+proc #anon#5 > {inline} (1 calls)
 0: higher_order_anon.#anon#5<0>
 #anon#5(anon#5#1##0:(wybe.int, ?wybe.int), ?anon#5#2##0:(wybe.int, ?wybe.int))<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#5#1##0:(wybe.int, ?wybe.int), ?anon#5#2##0:(wybe.int, ?wybe.int)) @higher_order_anon:nn:nn
-#anon#5 > {inline} (1 calls)
+proc #anon#5 > {inline} (1 calls)
 1: higher_order_anon.#anon#5<1>
 #anon#5(anon#5#1##0:(wybe.int, ?wybe.int), ?anon#5#2##0:(wybe.int, ?wybe.int))<{}; {}; {}>:
   AliasPairs: []
@@ -86,13 +86,13 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm move(~anon#5#1##0:(wybe.int, ?wybe.int), ?anon#5#2##0:(wybe.int, ?wybe.int)) @higher_order_anon:nn:nn
 
 
-#anon#6 > {inline} (1 calls)
+proc #anon#6 > {inline} (1 calls)
 0: higher_order_anon.#anon#6<0>
 #anon#6(anon#6#1##0:(wybe.int, ?wybe.int), ?anon#6#2##0:(wybe.int, ?wybe.int))<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#6#1##0:(wybe.int, ?wybe.int), ?anon#6#2##0:(wybe.int, ?wybe.int)) @higher_order_anon:nn:nn
-#anon#6 > {inline} (1 calls)
+proc #anon#6 > {inline} (1 calls)
 1: higher_order_anon.#anon#6<1>
 #anon#6(anon#6#1##0:(wybe.int, ?wybe.int), ?anon#6#2##0:(wybe.int, ?wybe.int))<{}; {}; {}>:
   AliasPairs: []
@@ -100,13 +100,13 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm move(~anon#6#1##0:(wybe.int, ?wybe.int), ?anon#6#2##0:(wybe.int, ?wybe.int)) @higher_order_anon:nn:nn
 
 
-#anon#7 > {inline} (1 calls)
+proc #anon#7 > {inline} (1 calls)
 0: higher_order_anon.#anon#7<0>
 #anon#7(^id##0:((wybe.int, ?wybe.int), ?(wybe.int, ?wybe.int)), ?anon#7#1##0:(wybe.int, ?wybe.int))<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~id##0:((wybe.int, ?wybe.int), ?(wybe.int, ?wybe.int))(higher_order_anon.#anon#7#anon#1<1><>:(wybe.int, ?wybe.int), ?anon#7#1##0:(wybe.int, ?wybe.int)) #0 @higher_order_anon:nn:nn
-#anon#7 > {inline} (1 calls)
+proc #anon#7 > {inline} (1 calls)
 1: higher_order_anon.#anon#7<1>
 #anon#7(^id##0:((wybe.int, ?wybe.int), ?(wybe.int, ?wybe.int)), ?anon#7#1##0:(wybe.int, ?wybe.int))<{}; {}; {}>:
   AliasPairs: []
@@ -114,13 +114,13 @@ module top-level code > public {inline,semipure} (0 calls)
     ~^id##0:((wybe.int, ?wybe.int), ?(wybe.int, ?wybe.int))(higher_order_anon.#anon#7#anon#1<1><>:(wybe.int, ?wybe.int), ?anon#7#1##0:(wybe.int, ?wybe.int)) #0 @higher_order_anon:nn:nn
 
 
-#anon#7#anon#1 > {inline} (1 calls)
+proc #anon#7#anon#1 > {inline} (1 calls)
 0: higher_order_anon.#anon#7#anon#1<0>
 #anon#7#anon#1(anon#8#1##0:wybe.int, ?anon#8#2##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~anon#8#1##0:wybe.int, 1:wybe.int, ?anon#8#2##0:wybe.int) @int:nn:nn
-#anon#7#anon#1 > {inline} (1 calls)
+proc #anon#7#anon#1 > {inline} (1 calls)
 1: higher_order_anon.#anon#7#anon#1<1>
 #anon#7#anon#1(anon#8#1##0:wybe.int, ?anon#8#2##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -128,13 +128,13 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm add(~anon#8#1##0:wybe.int, 1:wybe.int, ?anon#8#2##0:wybe.int) @int:nn:nn
 
 
-#anon#8 > {inline} (1 calls)
+proc #anon#8 > {inline} (1 calls)
 0: higher_order_anon.#anon#8<0>
 #anon#8(anon#9#1##0:wybe.float, [anon#9#2##0:29 <{}; {}; {1}>], anon#9#3##0:wybe.float, ?anon#9#4##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm fadd(~anon#9#1##0:wybe.float, ~anon#9#3##0:wybe.float, ?anon#9#4##0:wybe.float) @float:nn:nn
-#anon#8 > {inline} (1 calls)
+proc #anon#8 > {inline} (1 calls)
 1: higher_order_anon.#anon#8<1>
 #anon#8(anon#9#1##0:wybe.float, anon#9#2##0:29 <{}; {}; {1}>, anon#9#3##0:wybe.float, ?anon#9#4##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -142,13 +142,13 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign llvm fadd(~anon#9#1##0:wybe.float, ~anon#9#3##0:wybe.float, ?anon#9#4##0:wybe.float) @float:nn:nn
 
 
-#anon#9 > {inline} (1 calls)
+proc #anon#9 > {inline} (1 calls)
 0: higher_order_anon.#anon#9<0>
 #anon#9(anon#10#1##0:wybe.float, [anon#10#2##0:29 <{}; {}; {1}>], anon#10#3##0:wybe.float, ?anon#10#4##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm fadd(~anon#10#1##0:wybe.float, ~anon#10#3##0:wybe.float, ?anon#10#4##0:wybe.float) @float:nn:nn
-#anon#9 > {inline} (1 calls)
+proc #anon#9 > {inline} (1 calls)
 1: higher_order_anon.#anon#9<1>
 #anon#9(anon#10#1##0:wybe.float, anon#10#2##0:29 <{}; {}; {1}>, anon#10#3##0:wybe.float, ?anon#10#4##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_append.exp
+++ b/test-cases/final-dump/higher_order_append.exp
@@ -49,13 +49,13 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#54##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 0: higher_order_append.#anon#1<0>
 #anon#1(^cons##0:wybe.list(wybe.int), anon#1#1##0:wybe.list(wybe.int), ?anon#1#2##0:wybe.list(wybe.int))<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     higher_order_append.append<0>(~anon#1#1##0:wybe.list(wybe.int), ~cons##0:wybe.list(wybe.int), outByReference anon#1#2##0:wybe.list(wybe.int)) #0 @higher_order_append:nn:nn
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 1: higher_order_append.#anon#1<1>
 #anon#1(^cons##0:wybe.list(wybe.int), anon#1#1##0:wybe.list(wybe.int), ?anon#1#2##0:wybe.list(wybe.int))<{}; {}; {}>:
   AliasPairs: []
@@ -63,7 +63,7 @@ module top-level code > public {semipure} (0 calls)
     higher_order_append.append<0>(~anon#1#1##0:wybe.list(wybe.int), ~^cons##0:wybe.list(wybe.int), outByReference anon#1#2##0:wybe.list(wybe.int)) #1 @higher_order_append:nn:nn
 
 
-#closure#1 > {inline} (2 calls)
+proc #closure#1 > {inline} (2 calls)
 0: higher_order_append.#closure#1<0>
 #closure#1(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -71,7 +71,7 @@ module top-level code > public {semipure} (0 calls)
     wybe.list.print<0>(higher_order_append.print_list_of_ints#closure#1<0><>:{resource}(wybe.int), ~l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {0, 1}> #1 @higher_order_append:nn:nn
 
 
-append > (2 calls)
+proc append > (2 calls)
 0: higher_order_append.append<0>
 append(front##0:wybe.list(wybe.int), back##0:wybe.list(wybe.int), outByReference result##0:wybe.list(wybe.int))<{}; {}; {}>:
   AliasPairs: [(back##0,result##0)]
@@ -92,7 +92,7 @@ append(front##0:wybe.list(wybe.int), back##0:wybe.list(wybe.int), outByReference
 
 
 
-print_list_of_ints > {inline} (1 calls)
+proc print_list_of_ints > {inline} (1 calls)
 0: higher_order_append.print_list_of_ints<0>
 print_list_of_ints(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -100,7 +100,7 @@ print_list_of_ints(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>};
     wybe.list.print<0>(higher_order_append.print_list_of_ints#closure#1<0><>:{resource}(wybe.int), ~l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {0, 1}> #0 @higher_order_append:nn:nn
 
 
-print_list_of_ints#closure#1 > {inline} (1 calls)
+proc print_list_of_ints#closure#1 > {inline} (1 calls)
 0: higher_order_append.print_list_of_ints#closure#1<0>
 print_list_of_ints#closure#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_arity_error.exp
+++ b/test-cases/final-dump/higher_order_arity_error.exp
@@ -1,3 +1,3 @@
 Error detected during type checking of module(s) higher_order_arity_error
-[91mfinal-dump/higher_order_arity_error.wybe:2:5: Call from a to f with 1 argument(s), expected 2
+[91mfinal-dump/higher_order_arity_error.wybe:2:5: Call from proc a to proc f with 1 argument(s), expected 2
 [0m

--- a/test-cases/final-dump/higher_order_flow_error.exp
+++ b/test-cases/final-dump/higher_order_flow_error.exp
@@ -1,3 +1,3 @@
 Error detected during type checking of module(s) higher_order_flow_error
-[91mfinal-dump/higher_order_flow_error.wybe:2:5: Higher order call to f in foo has output (?) flow for argument 2, but expects input flow.
+[91mfinal-dump/higher_order_flow_error.wybe:2:5: Higher order call to proc f in proc foo has output (?) flow for argument 2, but expects input flow.
 [0m

--- a/test-cases/final-dump/higher_order_impure.exp
+++ b/test-cases/final-dump/higher_order_impure.exp
@@ -22,19 +22,19 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#anon#1 > {inline,impure} (1 calls)
+proc #anon#1 > {inline,impure} (1 calls)
 0: higher_order_impure.#anon#1<0>
 #anon#1([^l2##0:wybe.list(wybe.int)])<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-#anon#1 > {inline,impure} (1 calls)
+proc #anon#1 > {inline,impure} (1 calls)
 1: higher_order_impure.#anon#1<1>
 #anon#1([^l2##0:wybe.list(wybe.int)])<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-measure > public {inline,impure} (1 calls)
+proc measure > public {inline,impure} (1 calls)
 0: higher_order_impure.measure<0>
 measure(func##0:{impure}(), ?seconds_elapsed##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_inline.exp
+++ b/test-cases/final-dump/higher_order_inline.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#closure#1 > {inline} (1 calls)
+proc #closure#1 > {inline} (1 calls)
 0: higher_order_inline.#closure#1<0>
 #closure#1(a##0:A <{}; {}; {0}>, ?#result##0:A <{}; {}; {0}>)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_loop.exp
+++ b/test-cases/final-dump/higher_order_loop.exp
@@ -23,7 +23,7 @@ module top-level code > public {semipure} (0 calls)
     higher_order_loop.#cont#1<0>(~tmp#0##0:wybe.list({resource}(wybe.int)))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {0}> #3 @higher_order_loop:nn:nn
 
 
-#closure#1 > {inline} (1 calls)
+proc #closure#1 > {inline} (1 calls)
 0: higher_order_loop.#closure#1<0>
 #closure#1(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -34,7 +34,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#closure#2 > {inline} (1 calls)
+proc #closure#2 > {inline} (1 calls)
 0: higher_order_loop.#closure#2<0>
 #closure#2(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -44,7 +44,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: higher_order_loop.#cont#1<0>
 #cont#1(tmp#5##0:wybe.list({resource}(wybe.int)) <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {0}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_phantom.exp
+++ b/test-cases/final-dump/higher_order_phantom.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-a > {inline} (0 calls)
+proc a > {inline} (0 calls)
 0: higher_order_phantom.a<0>
 a(f##0:(wybe.phantom, ?wybe.phantom), x##0:wybe.phantom, ?#result##0:wybe.phantom)<{}; {}; {}>:
   AliasPairs: []
@@ -17,7 +17,7 @@ a(f##0:(wybe.phantom, ?wybe.phantom), x##0:wybe.phantom, ?#result##0:wybe.phanto
     ~f##0:(wybe.phantom, ?wybe.phantom)(~x##0:wybe.phantom, ?#result##0:wybe.phantom) #0 @higher_order_phantom:nn:nn
 
 
-b > {inline,semipure} (0 calls)
+proc b > {inline,semipure} (0 calls)
 0: higher_order_phantom.b<0>
 b(f##0:{impure}(wybe.phantom, ?wybe.phantom), x##0:wybe.phantom, [y##0:wybe.phantom])<{}; {}; {}>:
   AliasPairs: []
@@ -25,7 +25,7 @@ b(f##0:{impure}(wybe.phantom, ?wybe.phantom), x##0:wybe.phantom, [y##0:wybe.phan
     ~f##0:{impure}(wybe.phantom, ?wybe.phantom)(~x##0:wybe.phantom, ?y##1:wybe.phantom) #0 @higher_order_phantom:nn:nn
 
 
-c > {inline} (0 calls)
+proc c > {inline} (0 calls)
 0: higher_order_phantom.c<0>
 c(f##0:(wybe.phantom, ?X) <{}; {}; {0}>, x##0:wybe.phantom, ?#result##0:X <{}; {}; {0}>)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -36,13 +36,13 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#33##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 0: higher_order_refs.#anon#1<0>
 #anon#1(anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float) @higher_order_refs:nn:nn
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 1: higher_order_refs.#anon#1<1>
 #anon#1(anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -50,13 +50,13 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm move(~anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float) @higher_order_refs:nn:nn
 
 
-#anon#2 > {inline} (1 calls)
+proc #anon#2 > {inline} (1 calls)
 0: higher_order_refs.#anon#2<0>
 #anon#2(anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float) @higher_order_refs:nn:nn
-#anon#2 > {inline} (1 calls)
+proc #anon#2 > {inline} (1 calls)
 1: higher_order_refs.#anon#2<1>
 #anon#2(anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -64,13 +64,13 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm move(~anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float) @higher_order_refs:nn:nn
 
 
-#anon#3 > {inline} (1 calls)
+proc #anon#3 > {inline} (1 calls)
 0: higher_order_refs.#anon#3<0>
 #anon#3(^y##0:wybe.float, anon#3#1##0:wybe.float, ?anon#3#2##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm fsub(~anon#3#1##0:wybe.float, ~y##0:wybe.float, ?anon#3#2##0:wybe.float) @float:nn:nn
-#anon#3 > {inline} (1 calls)
+proc #anon#3 > {inline} (1 calls)
 1: higher_order_refs.#anon#3<1>
 #anon#3(^y##0:wybe.float, anon#3#1##0:wybe.float, ?anon#3#2##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -78,7 +78,7 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm fsub(~anon#3#1##0:wybe.float, ~^y##0:wybe.float, ?anon#3#2##0:wybe.float) @float:nn:nn
 
 
-#closure#1 > {inline} (1 calls)
+proc #closure#1 > {inline} (1 calls)
 0: higher_order_refs.#closure#1<0>
 #closure#1(a##0:A <{}; {}; {0}>, ?#result##0:A <{}; {}; {0}>)<{}; {}; {}>:
   AliasPairs: []
@@ -86,7 +86,7 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm move(~a##0:A, ?#result##0:A) @predicate:nn:nn
 
 
-#closure#2 > {inline} (1 calls)
+proc #closure#2 > {inline} (1 calls)
 0: higher_order_refs.#closure#2<0>
 #closure#2(i##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -94,7 +94,7 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
-#closure#3 > {inline} (1 calls)
+proc #closure#3 > {inline} (1 calls)
 0: higher_order_refs.#closure#3<0>
 #closure#3([^x##0:wybe.int], y##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -102,13 +102,13 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm add(~y##0:wybe.int, 10:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
-add_one > {inline} (1 calls)
+proc add_one > {inline} (1 calls)
 0: higher_order_refs.add_one<0>
 add_one(i##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
-add_one > {inline} (0 calls)
+proc add_one > {inline} (0 calls)
 1: higher_order_refs.add_one<1>
 add_one(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -116,7 +116,7 @@ add_one(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
     foreign llvm fadd(~f##0:wybe.float, 1.0:wybe.float, ?#result##0:wybe.float) @float:nn:nn
 
 
-app > {noinline} (6 calls)
+proc app > {noinline} (6 calls)
 0: higher_order_refs.app<0>
 app(f##0:(I, ?J) <{}; {}; {0}>, i##0:I <{}; {}; {1}>, ?#result##0:J <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -93,14 +93,14 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~tmp#29##0:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
 
 
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 0: higher_order_resources.#anon#1<0>
 #anon#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.list.length1<0>(~anon#1#1##0:wybe.list(T), 0:wybe.int, ?tmp#10##0:wybe.int) #2 @list:nn:nn
     higher_order_resources.take_max<0>(~tmp#10##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}> #1 @higher_order_resources:nn:nn
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 1: higher_order_resources.#anon#1<1>
 #anon#1(anon#1#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}>:
   AliasPairs: []
@@ -109,7 +109,7 @@ module top-level code > public {semipure} (0 calls)
     higher_order_resources.take_max<0>(~tmp#1##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}> #2 @higher_order_resources:nn:nn
 
 
-#anon#2 > {inline} (1 calls)
+proc #anon#2 > {inline} (1 calls)
 0: higher_order_resources.#anon#2<0>
 #anon#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -126,7 +126,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~tmp#32##0:wybe.int, <<higher_order_resources.maximum>>:wybe.int) @higher_order_resources:nn:nn
     wybe.list.length1<0>(~anon#2#1##0:wybe.list(T), 0:wybe.int, ?tmp#28##0:wybe.int) #6 @list:nn:nn
     higher_order_resources.take_max<0>(~tmp#28##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}> #4 @higher_order_resources:nn:nn
-#anon#2 > {inline} (1 calls)
+proc #anon#2 > {inline} (1 calls)
 1: higher_order_resources.#anon#2<1>
 #anon#2(anon#2#1##0:wybe.list(wybe.int))<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -145,7 +145,7 @@ module top-level code > public {semipure} (0 calls)
     higher_order_resources.take_max<0>(~tmp#6##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}> #4 @higher_order_resources:nn:nn
 
 
-#anon#2#closure#1 > {inline} (1 calls)
+proc #anon#2#closure#1 > {inline} (1 calls)
 0: higher_order_resources.#anon#2#closure#1<0>
 #anon#2#closure#1(i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}>:
   AliasPairs: []
@@ -153,7 +153,7 @@ module top-level code > public {semipure} (0 calls)
     higher_order_resources.take_max<0>(~i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}> #0
 
 
-take_max > (3 calls)
+proc take_max > (3 calls)
 0: higher_order_resources.take_max<0>
 take_max(i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/higher_order_sort.exp
+++ b/test-cases/final-dump/higher_order_sort.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-insert > (2 calls)
+proc insert > (2 calls)
 0: higher_order_sort.insert<0>
 insert(<=##0:(X, X, ?wybe.bool) <{}; {}; {0}>, x##0:X <{}; {}; {1}>, xs##0:wybe.list(X) <{}; {}; {2}>, outByReference xs##1:wybe.list(X) <{}; {}; {0, 1, 2}>)<{}; {}; {}>:
   AliasPairs: [(xs##0,xs##1)]
@@ -40,7 +40,7 @@ insert(<=##0:(X, X, ?wybe.bool) <{}; {}; {0}>, x##0:X <{}; {}; {1}>, xs##0:wybe.
 
 
 
-sort > {inline} (0 calls)
+proc sort > {inline} (0 calls)
 0: higher_order_sort.sort<0>
 sort(<=##0:(X, X, ?wybe.bool) <{}; {}; {0}>, xs##0:wybe.list(X) <{}; {}; {1}>, ?sorted##1:wybe.list(X) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: []
@@ -48,7 +48,7 @@ sort(<=##0:(X, X, ?wybe.bool) <{}; {}; {0}>, xs##0:wybe.list(X) <{}; {}; {1}>, ?
     higher_order_sort.sort#cont#1<0>(~<=##0:(X, X, ?wybe.bool), 0:wybe.list(X), ~xs##0:wybe.list(X), ?sorted##1:wybe.list(X)) #1 @higher_order_sort:nn:nn
 
 
-sort#cont#1 > (2 calls)
+proc sort#cont#1 > (2 calls)
 0: higher_order_sort.sort#cont#1<0>
 sort#cont#1(<=##0:(X, X, ?wybe.bool) <{}; {}; {0}>, sorted##0:wybe.list(X) <{}; {}; {1}>, tmp#1##0:wybe.list(X) <{}; {}; {2}>, ?sorted##2:wybe.list(X) <{}; {}; {0, 1, 2}>)<{}; {}; {}>:
   AliasPairs: [(sorted##0,sorted##2)]

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -28,13 +28,13 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#anon#1 > {inline} (1 calls)
+proc #anon#1 > {inline} (1 calls)
 0: higher_order_tests.#anon#1<0>
 #anon#1([anon#1#1##0:wybe.int], ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
-#anon#1 > {inline} (3 calls)
+proc #anon#1 > {inline} (3 calls)
 1: higher_order_tests.#anon#1<1>
 #anon#1(anon#1#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -42,13 +42,13 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-#anon#2 > {inline} (1 calls)
+proc #anon#2 > {inline} (1 calls)
 0: higher_order_tests.#anon#2<0>
 #anon#2(anon#2#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_eq(~anon#2#1##0:wybe.int, 1:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
-#anon#2 > {inline} (3 calls)
+proc #anon#2 > {inline} (3 calls)
 1: higher_order_tests.#anon#2<1>
 #anon#2(anon#2#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -56,7 +56,7 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm icmp_eq(~anon#2#1##0:wybe.int, 1:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: higher_order_tests.#cont#1<0>
 #cont#1(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -75,7 +75,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#2 > (2 calls)
+proc #cont#2 > (2 calls)
 0: higher_order_tests.#cont#2<0>
 #cont#2(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -94,7 +94,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#3 > (2 calls)
+proc #cont#3 > (2 calls)
 0: higher_order_tests.#cont#3<0>
 #cont#3(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -113,7 +113,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#4 > (2 calls)
+proc #cont#4 > (2 calls)
 0: higher_order_tests.#cont#4<0>
 #cont#4([t##0:(wybe.int, ?wybe.bool)])<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -136,7 +136,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#5 > (2 calls)
+proc #cont#5 > (2 calls)
 0: higher_order_tests.#cont#5<0>
 #cont#5(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -155,7 +155,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#6 > (2 calls)
+proc #cont#6 > (2 calls)
 0: higher_order_tests.#cont#6<0>
 #cont#6(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -174,7 +174,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#7 > (2 calls)
+proc #cont#7 > (2 calls)
 0: higher_order_tests.#cont#7<0>
 #cont#7(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -191,7 +191,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-do_test > {inline} (12 calls)
+proc do_test > {inline} (12 calls)
 0: higher_order_tests.do_test<0>
 do_test(f##0:(I, ?wybe.bool) <{}; {}; {0}>, i##0:I <{}; {}; {1}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -199,7 +199,7 @@ do_test(f##0:(I, ?wybe.bool) <{}; {}; {0}>, i##0:I <{}; {}; {1}>, ?#success##0:w
     ~f##0:(I, ?wybe.bool)(~i##0:I, ?#success##0:wybe.bool) #0 @higher_order_tests:nn:nn
 
 
-do_test2 > {inline} (12 calls)
+proc do_test2 > {inline} (12 calls)
 0: higher_order_tests.do_test2<0>
 do_test2(f##0:(I, ?wybe.bool) <{}; {}; {0}>, i##0:I <{}; {}; {1}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/hypot.exp
+++ b/test-cases/final-dump/hypot.exp
@@ -103,7 +103,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#114##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-area > {inline} (1 calls)
+proc area > {inline} (1 calls)
 0: hypot.area<0>
 area(r##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -112,7 +112,7 @@ area(r##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
     foreign llvm fmul(3.141592653589793:wybe.float, ~tmp#2##0:wybe.float, ?#result##0:wybe.float) @float:nn:nn
 
 
-hypot > {inline} (1 calls)
+proc hypot > {inline} (1 calls)
 0: hypot.hypot<0>
 hypot(s1##0:wybe.float, s2##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -29,7 +29,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-distance > public (1 calls)
+proc distance > public (1 calls)
 0: import.distance<0>
 distance(p1##0:position.position, p2##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -136,7 +136,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -230,7 +230,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -249,7 +249,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -257,7 +257,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -266,13 +266,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -280,13 +280,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -294,7 +294,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/import_in_sub_mod_lib.exp
+++ b/test-cases/final-dump/import_in_sub_mod_lib.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-foo > public {inline} (0 calls)
+proc foo > public {inline} (0 calls)
 0: import_in_sub_mod_lib.foo<0>
 foo(v##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/import_in_sub_mod_main.exp
+++ b/test-cases/final-dump/import_in_sub_mod_main.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-foo > public {inline} (0 calls)
+proc foo > public {inline} (0 calls)
 0: import_in_sub_mod_lib.foo<0>
 foo(v##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -105,7 +105,7 @@ entry:
   resources       : 
   procs           : 
 
-bar > public {inline} (0 calls)
+proc bar > public {inline} (0 calls)
 0: import_in_sub_mod_main.sub.bar<0>
 bar(v##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/in_before_out.exp
+++ b/test-cases/final-dump/in_before_out.exp
@@ -1,4 +1,4 @@
 Error detected during type checking of module(s) in_before_out
 [91mfinal-dump/in_before_out.wybe:1:5: Output parameter result not defined by proc in_before_out
-[0m[91mfinal-dump/in_before_out.wybe:2:8: Uninitialised argument in call to incr, argument 1
+[0m[91mfinal-dump/in_before_out.wybe:2:8: Uninitialised argument in call to proc incr, argument 1
 [0m

--- a/test-cases/final-dump/incompatible_generics.exp
+++ b/test-cases/final-dump/incompatible_generics.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) incompatible_generics
-[91mfinal-dump/incompatible_generics.wybe:1:23: Type error in call to =, argument 1
-[0m[91mfinal-dump/incompatible_generics.wybe:1:23: Type error in call to =, argument 2
+[91mfinal-dump/incompatible_generics.wybe:1:23: Type error in call to proc =, argument 1
+[0m[91mfinal-dump/incompatible_generics.wybe:1:23: Type error in call to proc =, argument 2
 [0m[91mfinal-dump/incompatible_generics.wybe:1:23: Type of i incompatible with ?j
 [0m

--- a/test-cases/final-dump/incompatible_generics_2.exp
+++ b/test-cases/final-dump/incompatible_generics_2.exp
@@ -1,4 +1,4 @@
 Error detected during type checking of module(s) incompatible_generics_2
-[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to +, argument 1
-[0m[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to +, argument 2
+[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to proc +, argument 1
+[0m[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to proc +, argument 2
 [0m

--- a/test-cases/final-dump/inline_decl.exp
+++ b/test-cases/final-dump/inline_decl.exp
@@ -33,7 +33,7 @@ module top-level code > public {semipure} (0 calls)
     inline_decl.finish<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @inline_decl:nn:nn
 
 
-finish > public {noinline} (1 calls)
+proc finish > public {noinline} (1 calls)
 0: inline_decl.finish<0>
 finish()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -43,7 +43,7 @@ finish()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#1##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-long > public {inline} (1 calls)
+proc long > public {inline} (1 calls)
 0: inline_decl.long<0>
 long()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/inline_rename.exp
+++ b/test-cases/final-dump/inline_rename.exp
@@ -23,7 +23,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-eq > {noinline} (1 calls)
+proc eq > {noinline} (1 calls)
 0: inline_rename.eq<0>
 eq(x##0:wybe.int, ?y##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -31,7 +31,7 @@ eq(x##0:wybe.int, ?y##0:wybe.int)<{}; {}; {}>:
     foreign llvm move(~x##0:wybe.int, ?y##0:wybe.int) @inline_rename:nn:nn
 
 
-foo > {inline} (1 calls)
+proc foo > {inline} (1 calls)
 0: inline_rename.foo<0>
 foo(?bar##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -42,7 +42,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-print > public (2 calls)
+proc print > public (2 calls)
 0: int_list.print<0>
 print(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -62,7 +62,7 @@ print(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-println > public {inline} (1 calls)
+proc println > public {inline} (1 calls)
 0: int_list.println<0>
 println(x##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -168,7 +168,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: int_list.int_list.=<0>
 =(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -201,7 +201,7 @@ entry:
 
 
 
-cons > public {inline} (0 calls)
+proc cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
 cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -209,7 +209,7 @@ cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list) @int_list:nn:nn
     foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @int_list:nn:nn
     foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list) @int_list:nn:nn
-cons > public {inline} (12 calls)
+proc cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
 cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -228,7 +228,7 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list
 
 
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
 head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -243,7 +243,7 @@ head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}
         foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
 head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -260,7 +260,7 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
 nil(?#result##0:int_list.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -268,7 +268,7 @@ nil(?#result##0:int_list.int_list)<{}; {}; {}>:
     foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list)
 
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
 tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -283,7 +283,7 @@ tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe
         foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list) @int_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
 tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -300,7 +300,7 @@ tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.i
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
 ~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -30,7 +30,7 @@ module top-level code > public {semipure} (0 calls)
     int_sequence.#cont#1<0>[410bae77d3](~tmp#1##0:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @int_sequence:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: int_sequence.#cont#1<0>[410bae77d3]
 #cont#1(tmp#0##0:int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -61,7 +61,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-.. > public {inline} (2 calls)
+proc .. > public {inline} (2 calls)
 0: int_sequence...<0>
 ..(lower##0:wybe.int, upper##0:wybe.int, ?#result##0:int_sequence)<{}; {}; {}>:
   AliasPairs: []
@@ -69,7 +69,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:int_sequence) @int_sequence:nn:nn
     foreign lpvm mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower##0:wybe.int) @int_sequence:nn:nn
     foreign lpvm mutate(~#rec##1:int_sequence, ?#result##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper##0:wybe.int) @int_sequence:nn:nn
-.. > public {inline} (6 calls)
+proc .. > public {inline} (6 calls)
 1: int_sequence...<1>
 ..(?lower##0:wybe.int, ?upper##0:wybe.int, #result##0:int_sequence)<{}; {}; {}>:
   AliasPairs: []
@@ -78,7 +78,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm access(~#result##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper##0:wybe.int) @int_sequence:nn:nn
 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: int_sequence.=<0>
 =(#left##0:int_sequence, #right##0:int_sequence, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -97,7 +97,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-[|] > public (3 calls)
+proc [|] > public (3 calls)
 0: int_sequence.[|]<0>[785a827a1b]
 [|](?head##0:wybe.int, ?tail##0:int_sequence, seq##0:int_sequence, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -138,13 +138,13 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-lower > public {inline} (5 calls)
+proc lower > public {inline} (5 calls)
 0: int_sequence.lower<0>
 lower(#rec##0:int_sequence, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_sequence:nn:nn
-lower > public {inline} (0 calls)
+proc lower > public {inline} (0 calls)
 1: int_sequence.lower<1>
 lower(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -152,13 +152,13 @@ lower(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int)<{}; {}; {
     foreign lpvm {noalias} mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @int_sequence:nn:nn
 
 
-upper > public {inline} (4 calls)
+proc upper > public {inline} (4 calls)
 0: int_sequence.upper<0>
 upper(#rec##0:int_sequence, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @int_sequence:nn:nn
-upper > public {inline} (0 calls)
+proc upper > public {inline} (0 calls)
 1: int_sequence.upper<1>
 upper(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -166,7 +166,7 @@ upper(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int)<{}; {}; {
     foreign lpvm {noalias} mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @int_sequence:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: int_sequence.~=<0>
 ~=(#left##0:int_sequence, #right##0:int_sequence, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/io.exp
+++ b/test-cases/final-dump/io.exp
@@ -24,7 +24,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-myprint_a > public {inline} (1 calls)
+proc myprint_a > public {inline} (1 calls)
 0: io.myprint_a<0>
 myprint_a(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -35,7 +35,7 @@ myprint_a(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-myprint_b > public {inline} (1 calls)
+proc myprint_b > public {inline} (1 calls)
 0: io.myprint_b<0>
 myprint_b(x##0:wybe.int, ?y##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/io_flow_ok.exp
+++ b/test-cases/final-dump/io_flow_ok.exp
@@ -42,7 +42,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-aok > {inline} (5 calls)
+proc aok > {inline} (5 calls)
 0: io_flow_ok.aok<0>
 aok()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ aok()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-unknown > {noinline} (3 calls)
+proc unknown > {noinline} (3 calls)
 0: io_flow_ok.unknown<0>
 unknown(?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -37,7 +37,7 @@ module top-level code > public {semipure} (0 calls)
     list_loop.#cont#1<0>(~tmp#20##0:list_loop.intlist, ~tmp#20##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: list_loop.#cont#1<0>
 #cont#1(l##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -57,7 +57,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#2 > {inline} (1 calls)
+proc #cont#2 > {inline} (1 calls)
 0: list_loop.#cont#2<0>
 #cont#2(h##0:wybe.int, l##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -69,7 +69,7 @@ module top-level code > public {semipure} (0 calls)
     list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~x##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @list_loop:nn:nn
 
 
-#cont#3 > (2 calls)
+proc #cont#3 > (2 calls)
 0: list_loop.#cont#3<0>
 #cont#3(h##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -95,7 +95,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#4 > {inline} (1 calls)
+proc #cont#4 > {inline} (1 calls)
 0: list_loop.#cont#4<0>
 #cont#4(h##0:wybe.int, h2##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -257,7 +257,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: list_loop.intlist.=<0>
 =(#left##0:list_loop.intlist, #right##0:list_loop.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -290,7 +290,7 @@ entry:
 
 
 
-cons > public {inline} (0 calls)
+proc cons > public {inline} (0 calls)
 0: list_loop.intlist.cons<0>
 cons(head##0:wybe.int, tail##0:list_loop.intlist, ?#result##0:list_loop.intlist)<{}; {}; {}>:
   AliasPairs: []
@@ -298,7 +298,7 @@ cons(head##0:wybe.int, tail##0:list_loop.intlist, ?#result##0:list_loop.intlist)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:list_loop.intlist) @list_loop:nn:nn
     foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @list_loop:nn:nn
     foreign lpvm mutate(~#rec##1:list_loop.intlist, ?#result##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist) @list_loop:nn:nn
-cons > public {inline} (12 calls)
+proc cons > public {inline} (12 calls)
 1: list_loop.intlist.cons<1>
 cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, #result##0:list_loop.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -317,7 +317,7 @@ cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, #result##0:list_loop.intlist
 
 
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 0: list_loop.intlist.head<0>
 head(#rec##0:list_loop.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -332,7 +332,7 @@ head(#rec##0:list_loop.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}
         foreign lpvm access(~#rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @list_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 1: list_loop.intlist.head<1>
 head(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -349,7 +349,7 @@ head(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:wybe.int, 
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: list_loop.intlist.nil<0>
 nil(?#result##0:list_loop.intlist)<{}; {}; {}>:
   AliasPairs: []
@@ -357,7 +357,7 @@ nil(?#result##0:list_loop.intlist)<{}; {}; {}>:
     foreign llvm move(0:list_loop.intlist, ?#result##0:list_loop.intlist)
 
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 0: list_loop.intlist.tail<0>
 tail(#rec##0:list_loop.intlist, ?#result##0:list_loop.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -372,7 +372,7 @@ tail(#rec##0:list_loop.intlist, ?#result##0:list_loop.intlist, ?#success##0:wybe
         foreign lpvm access(~#rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_loop.intlist) @list_loop:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 1: list_loop.intlist.tail<1>
 tail(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:list_loop.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -389,7 +389,7 @@ tail(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:list_loop.
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: list_loop.intlist.~=<0>
 ~=(#left##0:list_loop.intlist, #right##0:list_loop.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -17,7 +17,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-append > public (1 calls)
+proc append > public (1 calls)
 0: list_this.append<0>
 append(x##0:list_this(T) <{}; {}; {0}>, y##0:list_this(T) <{}; {}; {1}>, outByReference #result##0:list_this(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: [(#result##0,y##0)]
@@ -38,7 +38,7 @@ append(x##0:list_this(T) <{}; {}; {0}>, y##0:list_this(T) <{}; {}; {1}>, outByRe
 
 
 
-car > public {inline} (0 calls)
+proc car > public {inline} (0 calls)
 0: list_this.car<0>
 car(#rec##0:list_this(T) <{}; {}; {0}>, ?#result##0:T <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ car(#rec##0:list_this(T) <{}; {}; {0}>, ?#result##0:T <{}; {}; {0}>, ?#success##
         foreign lpvm access(~#rec##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T) @list_this:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-car > public {inline} (0 calls)
+proc car > public {inline} (0 calls)
 1: list_this.car<1>
 car(#rec##0:list_this(T) <{}; {}; {0}>, ?#rec##1:list_this(T) <{}; {}; {0, 2}>, #field##0:T <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -70,7 +70,7 @@ car(#rec##0:list_this(T) <{}; {}; {0}>, ?#rec##1:list_this(T) <{}; {}; {0, 2}>, 
 
 
 
-cdr > public {inline} (0 calls)
+proc cdr > public {inline} (0 calls)
 0: list_this.cdr<0>
 cdr(#rec##0:list_this(T) <{}; {}; {0}>, ?#result##0:list_this(T) <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -85,7 +85,7 @@ cdr(#rec##0:list_this(T) <{}; {}; {0}>, ?#result##0:list_this(T) <{}; {}; {0}>, 
         foreign lpvm access(~#rec##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_this(T)) @list_this:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-cdr > public {inline} (0 calls)
+proc cdr > public {inline} (0 calls)
 1: list_this.cdr<1>
 cdr(#rec##0:list_this(T) <{}; {}; {0}>, ?#rec##1:list_this(T) <{}; {}; {0, 2}>, #field##0:list_this(T) <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -102,7 +102,7 @@ cdr(#rec##0:list_this(T) <{}; {}; {0}>, ?#rec##1:list_this(T) <{}; {}; {0, 2}>, 
 
 
 
-cons > public {inline} (1 calls)
+proc cons > public {inline} (1 calls)
 0: list_this.cons<0>
 cons(car##0:T <{}; {}; {0}>, cdr##0:list_this(T) <{}; {}; {1}>, ?#result##0:list_this(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: []
@@ -110,7 +110,7 @@ cons(car##0:T <{}; {}; {0}>, cdr##0:list_this(T) <{}; {}; {1}>, ?#result##0:list
     foreign lpvm alloc(16:wybe.int, ?#rec##0:list_this(T)) @list_this:nn:nn
     foreign lpvm mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T) @list_this:nn:nn
     foreign lpvm mutate(~#rec##1:list_this(T), ?#result##0:list_this(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(T)) @list_this:nn:nn
-cons > public {inline} (6 calls)
+proc cons > public {inline} (6 calls)
 1: list_this.cons<1>
 cons(?car##0:T <{}; {}; {2}>, ?cdr##0:list_this(T) <{}; {}; {2}>, #result##0:list_this(T) <{}; {}; {2}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -129,7 +129,7 @@ cons(?car##0:T <{}; {}; {2}>, ?cdr##0:list_this(T) <{}; {}; {2}>, #result##0:lis
 
 
 
-length > public {inline} (0 calls)
+proc length > public {inline} (0 calls)
 0: list_this.length<0>
 length(x##0:list_this(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -137,7 +137,7 @@ length(x##0:list_this(T) <{}; {}; {0}>, ?#result##0:wybe.int)<{}; {}; {}>:
     list_this.length1<0>(~x##0:list_this(T), 0:wybe.int, ?#result##0:wybe.int) #0 @list_this:nn:nn
 
 
-length1 > (2 calls)
+proc length1 > (2 calls)
 0: list_this.length1<0>
 length1(x##0:list_this(T) <{}; {}; {0}>, acc##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -154,7 +154,7 @@ length1(x##0:list_this(T) <{}; {}; {0}>, acc##0:wybe.int, ?#result##0:wybe.int)<
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: list_this.nil<0>
 nil(?#result##0:list_this(T))<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -20,7 +20,7 @@ AFTER EVERYTHING:
   submodules      : loop_bug.int_list
   procs           : 
 
-print > public (0 calls)
+proc print > public (0 calls)
 0: loop_bug.print<0>
 print(lst##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -42,7 +42,7 @@ print(lst##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-print#cont#1 > (2 calls)
+proc print#cont#1 > (2 calls)
 0: loop_bug.print#cont#1<0>
 print#cont#1([h##0:wybe.int], t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -65,7 +65,7 @@ print#cont#1([h##0:wybe.int], t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.
 
 
 
-print#cont#2 > {inline} (1 calls)
+proc print#cont#2 > {inline} (1 calls)
 0: loop_bug.print#cont#2<0>
 print#cont#2(h##0:wybe.int, t##0:loop_bug.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -171,7 +171,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: loop_bug.int_list.=<0>
 =(#left##0:loop_bug.int_list, #right##0:loop_bug.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -204,7 +204,7 @@ entry:
 
 
 
-cons > public {inline} (0 calls)
+proc cons > public {inline} (0 calls)
 0: loop_bug.int_list.cons<0>
 cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?#result##0:loop_bug.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -212,7 +212,7 @@ cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?#result##0:loop_bug.int_list)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:loop_bug.int_list) @loop_bug:nn:nn
     foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @loop_bug:nn:nn
     foreign lpvm mutate(~#rec##1:loop_bug.int_list, ?#result##0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list) @loop_bug:nn:nn
-cons > public {inline} (12 calls)
+proc cons > public {inline} (12 calls)
 1: loop_bug.int_list.cons<1>
 cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, #result##0:loop_bug.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -231,7 +231,7 @@ cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, #result##0:loop_bug.int_list
 
 
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 0: loop_bug.int_list.head<0>
 head(#rec##0:loop_bug.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -246,7 +246,7 @@ head(#rec##0:loop_bug.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}
         foreign lpvm access(~#rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @loop_bug:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 1: loop_bug.int_list.head<1>
 head(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -263,7 +263,7 @@ head(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:wybe.int, 
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: loop_bug.int_list.nil<0>
 nil(?#result##0:loop_bug.int_list)<{}; {}; {}>:
   AliasPairs: []
@@ -271,7 +271,7 @@ nil(?#result##0:loop_bug.int_list)<{}; {}; {}>:
     foreign llvm move(0:loop_bug.int_list, ?#result##0:loop_bug.int_list)
 
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 0: loop_bug.int_list.tail<0>
 tail(#rec##0:loop_bug.int_list, ?#result##0:loop_bug.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -286,7 +286,7 @@ tail(#rec##0:loop_bug.int_list, ?#result##0:loop_bug.int_list, ?#success##0:wybe
         foreign lpvm access(~#rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:loop_bug.int_list) @loop_bug:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 1: loop_bug.int_list.tail<1>
 tail(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:loop_bug.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -303,7 +303,7 @@ tail(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:loop_bug.i
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: loop_bug.int_list.~=<0>
 ~=(#left##0:loop_bug.int_list, #right##0:loop_bug.int_list, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/loop_exit.exp
+++ b/test-cases/final-dump/loop_exit.exp
@@ -1,3 +1,3 @@
 Error detected during type checking of module(s) loop_exit
-[91mfinal-dump/loop_exit.wybe:5:2: Uninitialised argument in call to println, argument 1
+[91mfinal-dump/loop_exit.wybe:5:2: Uninitialised argument in call to proc println, argument 1
 [0m

--- a/test-cases/final-dump/loop_terminators.exp
+++ b/test-cases/final-dump/loop_terminators.exp
@@ -9,49 +9,49 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-loop0 > {inline} (0 calls)
+proc loop0 > {inline} (0 calls)
 0: loop_terminators.loop0<0>
 loop0()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-loop0#cont#1 > {inline} (2 calls)
+proc loop0#cont#1 > {inline} (2 calls)
 0: loop_terminators.loop0#cont#1<0>
 loop0#cont#1()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-loop1 > {inline} (0 calls)
+proc loop1 > {inline} (0 calls)
 0: loop_terminators.loop1<0>
 loop1()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-loop1#cont#1 > {inline} (2 calls)
+proc loop1#cont#1 > {inline} (2 calls)
 0: loop_terminators.loop1#cont#1<0>
 loop1#cont#1()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-loop2 > {inline} (0 calls)
+proc loop2 > {inline} (0 calls)
 0: loop_terminators.loop2<0>
 loop2()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-loop2#cont#1 > {inline} (1 calls)
+proc loop2#cont#1 > {inline} (1 calls)
 0: loop_terminators.loop2#cont#1<0>
 loop2#cont#1()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-loop3 > {inline} (0 calls)
+proc loop3 > {inline} (0 calls)
 0: loop_terminators.loop3<0>
 loop3()<{}; {}; {}>:
   AliasPairs: []
@@ -60,7 +60,7 @@ loop3()<{}; {}; {}>:
     foreign c {terminal,semipure} error_exit(c"loop_terminators:14:11":wybe.c_string, ~tmp#0##0:wybe.c_string) @control:nn:nn
 
 
-loop3#cont#1 > {inline} (1 calls)
+proc loop3#cont#1 > {inline} (1 calls)
 0: loop_terminators.loop3#cont#1<0>
 loop3#cont#1()<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -43,7 +43,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-set_exit_code > public {inline} (0 calls)
+proc set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
 set_exit_code(code##0:wybe.int)<{}; {<<command_line.exit_code>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/mainless.exp
+++ b/test-cases/final-dump/mainless.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-nothing_interesting > public {inline} (0 calls)
+proc nothing_interesting > public {inline} (0 calls)
 0: mainless.nothing_interesting<0>
 nothing_interesting(?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -41,7 +41,7 @@ module top-level code > public {semipure} (0 calls)
     mixed_fields.printit<0>(~tmp#0##0:mixed_fields)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @mixed_fields:nn:nn
 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: mixed_fields.=<0>
 =(#left##0:mixed_fields, #right##0:mixed_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -96,13 +96,13 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-f1 > public {inline} (1 calls)
+proc f1 > public {inline} (1 calls)
 0: mixed_fields.f1<0>
 f1(#rec##0:mixed_fields, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mixed_fields:nn:nn
-f1 > public {inline} (0 calls)
+proc f1 > public {inline} (0 calls)
 1: mixed_fields.f1<1>
 f1(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -110,13 +110,13 @@ f1(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int)<{}; {}; {}>:
     foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mixed_fields:nn:nn
 
 
-f2 > public {inline} (1 calls)
+proc f2 > public {inline} (1 calls)
 0: mixed_fields.f2<0>
 f2(#rec##0:mixed_fields, ?#result##0:wybe.char)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.char) @mixed_fields:nn:nn
-f2 > public {inline} (0 calls)
+proc f2 > public {inline} (0 calls)
 1: mixed_fields.f2<1>
 f2(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char)<{}; {}; {}>:
   AliasPairs: []
@@ -124,13 +124,13 @@ f2(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char)<{}; {}; {}>
     foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.char) @mixed_fields:nn:nn
 
 
-f3 > public {inline} (1 calls)
+proc f3 > public {inline} (1 calls)
 0: mixed_fields.f3<0>
 f3(#rec##0:mixed_fields, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mixed_fields:nn:nn
-f3 > public {inline} (0 calls)
+proc f3 > public {inline} (0 calls)
 1: mixed_fields.f3<1>
 f3(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -138,13 +138,13 @@ f3(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int)<{}; {}; {}>:
     foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mixed_fields:nn:nn
 
 
-f4 > public {inline} (1 calls)
+proc f4 > public {inline} (1 calls)
 0: mixed_fields.f4<0>
 f4(#rec##0:mixed_fields, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.bool) @mixed_fields:nn:nn
-f4 > public {inline} (0 calls)
+proc f4 > public {inline} (0 calls)
 1: mixed_fields.f4<1>
 f4(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -152,13 +152,13 @@ f4(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.bool)<{}; {}; {}>
     foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 1:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.bool) @mixed_fields:nn:nn
 
 
-f5 > public {inline} (1 calls)
+proc f5 > public {inline} (1 calls)
 0: mixed_fields.f5<0>
 f5(#rec##0:mixed_fields, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mixed_fields:nn:nn
-f5 > public {inline} (0 calls)
+proc f5 > public {inline} (0 calls)
 1: mixed_fields.f5<1>
 f5(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -166,13 +166,13 @@ f5(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int)<{}; {}; {}>:
     foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @mixed_fields:nn:nn
 
 
-f6 > public {inline} (1 calls)
+proc f6 > public {inline} (1 calls)
 0: mixed_fields.f6<0>
 f6(#rec##0:mixed_fields, ?#result##0:wybe.char)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.char) @mixed_fields:nn:nn
-f6 > public {inline} (0 calls)
+proc f6 > public {inline} (0 calls)
 1: mixed_fields.f6<1>
 f6(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char)<{}; {}; {}>:
   AliasPairs: []
@@ -180,7 +180,7 @@ f6(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char)<{}; {}; {}>
     foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 2:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.char) @mixed_fields:nn:nn
 
 
-mixed > public {inline} (1 calls)
+proc mixed > public {inline} (1 calls)
 0: mixed_fields.mixed<0>
 mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wybe.int, f6##0:wybe.char, ?#result##0:mixed_fields)<{}; {}; {}>:
   AliasPairs: []
@@ -192,7 +192,7 @@ mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wy
     foreign lpvm mutate(~#rec##3:mixed_fields, ?#rec##4:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f1##0:wybe.int) @mixed_fields:nn:nn
     foreign lpvm mutate(~#rec##4:mixed_fields, ?#rec##5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3##0:wybe.int) @mixed_fields:nn:nn
     foreign lpvm mutate(~#rec##5:mixed_fields, ?#result##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5##0:wybe.int) @mixed_fields:nn:nn
-mixed > public {inline} (22 calls)
+proc mixed > public {inline} (22 calls)
 1: mixed_fields.mixed<1>
 mixed(?f1##0:wybe.int, ?f2##0:wybe.char, ?f3##0:wybe.int, ?f4##0:wybe.bool, ?f5##0:wybe.int, ?f6##0:wybe.char, #result##0:mixed_fields)<{}; {}; {}>:
   AliasPairs: []
@@ -205,7 +205,7 @@ mixed(?f1##0:wybe.int, ?f2##0:wybe.char, ?f3##0:wybe.int, ?f4##0:wybe.bool, ?f5#
     foreign lpvm access(~#result##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5##0:wybe.int) @mixed_fields:nn:nn
 
 
-printit > public (1 calls)
+proc printit > public (1 calls)
 0: mixed_fields.printit<0>
 printit(ob##0:mixed_fields)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -234,7 +234,7 @@ printit(ob##0:mixed_fields)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: mixed_fields.~=<0>
 ~=(#left##0:mixed_fields, #right##0:mixed_fields, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/multi_out.exp
+++ b/test-cases/final-dump/multi_out.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
   InterestingCallProperties: []
 
 
-onetwothree > public {inline} (1 calls)
+proc onetwothree > public {inline} (1 calls)
 0: multi_out.onetwothree<0>
 onetwothree(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -23,7 +23,7 @@ module top-level code > public {inline,semipure} (0 calls)
     multi_specz.bar2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @multi_specz:nn:nn
 
 
-bar1 > public (1 calls)
+proc bar1 > public (1 calls)
 0: multi_specz.bar1<0>
 bar1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -58,7 +58,7 @@ bar1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-bar2 > public (1 calls)
+proc bar2 > public (1 calls)
 0: multi_specz.bar2<0>
 bar2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -94,7 +94,7 @@ bar2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-foo > public (2 calls)
+proc foo > public (2 calls)
 0: multi_specz.foo<0>
 foo(x1##0:position.position, x2##0:position.position, x3##0:position.position, x4##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -111,7 +111,7 @@ foo(x1##0:position.position, x2##0:position.position, x3##0:position.position, x
     multi_specz.modifyAndPrint<0>(~x4##0:position.position, 444:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multi_specz:nn:nn
 
 
-modifyAndPrint > public (4 calls)
+proc modifyAndPrint > public (4 calls)
 0: multi_specz.modifyAndPrint<0>
 modifyAndPrint(pos##0:position.position, v##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -324,7 +324,7 @@ entry:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -418,7 +418,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -437,7 +437,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -445,7 +445,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -454,13 +454,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -468,13 +468,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -482,7 +482,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -19,7 +19,7 @@ module top-level code > public {inline,semipure} (0 calls)
     multi_specz_cyclic_exe.main<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @multi_specz_cyclic_exe:nn:nn
 
 
-main > public (1 calls)
+proc main > public (1 calls)
 0: multi_specz_cyclic_exe.main<0>
 main()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -166,7 +166,7 @@ entry:
   submodules      : multi_specz_cyclic_lib.position
   procs           : 
 
-foo1 > public (0 calls)
+proc foo1 > public (0 calls)
 0: multi_specz_cyclic_lib.foo1<0>[7477e50a09]
 foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -213,7 +213,7 @@ foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
 
 
 
-modifyAndPrint > public (4 calls)
+proc modifyAndPrint > public (4 calls)
 0: multi_specz_cyclic_lib.modifyAndPrint<0>
 modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -225,7 +225,7 @@ modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int)<{<<wybe.io
     multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @multi_specz_cyclic_lib:nn:nn
 
 
-printPosition > public (1 calls)
+proc printPosition > public (1 calls)
 0: multi_specz_cyclic_lib.printPosition<0>
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -404,7 +404,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
 =(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -423,7 +423,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position)<{}; {}; {}>:
   AliasPairs: []
@@ -431,7 +431,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.positi
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
     foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position)<{}; {}; {}>:
   AliasPairs: []
@@ -440,13 +440,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.posit
     foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -454,13 +454,13 @@ x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -468,7 +468,7 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
 ~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -632,7 +632,7 @@ if.else:
   resources       : 
   procs           : 
 
-foo2 > public (0 calls)
+proc foo2 > public (0 calls)
 0: multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]
 foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -22,7 +22,7 @@ AFTER EVERYTHING:
   submodules      : multi_specz_cyclic_lib.position
   procs           : 
 
-foo1 > public (0 calls)
+proc foo1 > public (0 calls)
 0: multi_specz_cyclic_lib.foo1<0>
 foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -42,7 +42,7 @@ foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
 
 
 
-modifyAndPrint > public (4 calls)
+proc modifyAndPrint > public (4 calls)
 0: multi_specz_cyclic_lib.modifyAndPrint<0>
 modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -51,7 +51,7 @@ modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int)<{<<wybe.io
     multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @multi_specz_cyclic_lib:nn:nn
 
 
-printPosition > public (1 calls)
+proc printPosition > public (1 calls)
 0: multi_specz_cyclic_lib.printPosition<0>
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -181,7 +181,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
 =(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -200,7 +200,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position)<{}; {}; {}>:
   AliasPairs: []
@@ -208,7 +208,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.positi
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
     foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position)<{}; {}; {}>:
   AliasPairs: []
@@ -217,13 +217,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.posit
     foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -231,13 +231,13 @@ x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -245,7 +245,7 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
 ~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -409,7 +409,7 @@ if.else:
   resources       : 
   procs           : 
 
-foo2 > public (0 calls)
+proc foo2 > public (0 calls)
 0: multi_specz_cyclic_lib2.foo2<0>
 foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -22,7 +22,7 @@ AFTER EVERYTHING:
   submodules      : multi_specz_cyclic_lib.position
   procs           : 
 
-foo1 > public (0 calls)
+proc foo1 > public (0 calls)
 0: multi_specz_cyclic_lib.foo1<0>
 foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -42,7 +42,7 @@ foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
 
 
 
-modifyAndPrint > public (4 calls)
+proc modifyAndPrint > public (4 calls)
 0: multi_specz_cyclic_lib.modifyAndPrint<0>
 modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -51,7 +51,7 @@ modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int)<{<<wybe.io
     multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @multi_specz_cyclic_lib:nn:nn
 
 
-printPosition > public (1 calls)
+proc printPosition > public (1 calls)
 0: multi_specz_cyclic_lib.printPosition<0>
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -181,7 +181,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
 =(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -200,7 +200,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position)<{}; {}; {}>:
   AliasPairs: []
@@ -208,7 +208,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.positi
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position) @multi_specz_cyclic_lib:nn:nn
     foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
     foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position)<{}; {}; {}>:
   AliasPairs: []
@@ -217,13 +217,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.posit
     foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -231,13 +231,13 @@ x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -245,7 +245,7 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
 ~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -409,7 +409,7 @@ if.else:
   resources       : 
   procs           : 
 
-foo2 > public (0 calls)
+proc foo2 > public (0 calls)
 0: multi_specz_cyclic_lib2.foo2<0>
 foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -207,7 +207,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multictr.card.=<0>
 =(#left##0:multictr.card, #right##0:multictr.card, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -215,14 +215,14 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm icmp_eq(~#left##0:multictr.card, ~#right##0:multictr.card, ?#success##0:wybe.bool)
 
 
-card > public {inline} (0 calls)
+proc card > public {inline} (0 calls)
 0: multictr.card.card<0>
 card(rank##0:multictr.rank, suit##0:multictr.suit, ?#result##3:multictr.card)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm shl(~rank##0:multictr.card, 2:multictr.card, ?#temp##0:multictr.card) @multictr:nn:nn
     foreign llvm or(~#temp##0:multictr.card, ~suit##0:multictr.card, ?#result##3:multictr.card) @multictr:nn:nn
-card > public {inline} (0 calls)
+proc card > public {inline} (0 calls)
 1: multictr.card.card<1>
 card(?rank##0:multictr.rank, ?suit##0:multictr.suit, #result##0:multictr.card)<{}; {}; {}>:
   AliasPairs: []
@@ -234,7 +234,7 @@ card(?rank##0:multictr.rank, ?suit##0:multictr.suit, #result##0:multictr.card)<{
     foreign lpvm cast(~#temp2##1:multictr.card, ?suit##0:multictr.suit) @multictr:nn:nn
 
 
-rank > public {inline} (0 calls)
+proc rank > public {inline} (0 calls)
 0: multictr.card.rank<0>
 rank(#rec##0:multictr.card, ?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -242,7 +242,7 @@ rank(#rec##0:multictr.card, ?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm lshr(~#rec##0:multictr.card, 2:multictr.card, ?#rec##1:multictr.card) @multictr:nn:nn
     foreign llvm and(~#rec##1:multictr.card, 15:multictr.card, ?#field##0:multictr.card) @multictr:nn:nn
     foreign lpvm cast(~#field##0:multictr.card, ?#result##0:multictr.rank) @multictr:nn:nn
-rank > public {inline} (0 calls)
+proc rank > public {inline} (0 calls)
 1: multictr.card.rank<1>
 rank(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -252,14 +252,14 @@ rank(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.rank)<{};
     foreign llvm or(~#rec##1:multictr.card, ~#temp##0:multictr.card, ?#rec##2:multictr.card) @multictr:nn:nn
 
 
-suit > public {inline} (0 calls)
+proc suit > public {inline} (0 calls)
 0: multictr.card.suit<0>
 suit(#rec##0:multictr.card, ?#result##0:multictr.suit)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm and(~#rec##0:multictr.card, 3:multictr.card, ?#field##0:multictr.card) @multictr:nn:nn
     foreign lpvm cast(~#field##0:multictr.card, ?#result##0:multictr.suit) @multictr:nn:nn
-suit > public {inline} (0 calls)
+proc suit > public {inline} (0 calls)
 1: multictr.card.suit<1>
 suit(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -268,7 +268,7 @@ suit(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.suit)<{};
     foreign llvm or(~#field##0:multictr.card, ~#rec##1:multictr.card, ?#rec##2:multictr.card) @multictr:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.card.~=<0>
 ~=(#left##0:multictr.card, #right##0:multictr.card, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -446,7 +446,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: multictr.complicated.=<0>
 =(#left##0:multictr.complicated, #right##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -933,7 +933,7 @@ entry:
 
 
 
-autumn > public {inline} (0 calls)
+proc autumn > public {inline} (0 calls)
 0: multictr.complicated.autumn<0>
 autumn(?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -941,14 +941,14 @@ autumn(?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign llvm move(3:multictr.complicated, ?#result##0:multictr.complicated)
 
 
-c01 > public {inline} (0 calls)
+proc c01 > public {inline} (0 calls)
 0: multictr.complicated.c01<0>
 c01(f01##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#result##0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int) @multictr:nn:nn
-c01 > public {inline} (40 calls)
+proc c01 > public {inline} (40 calls)
 1: multictr.complicated.c01<1>
 c01(?f01##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -974,7 +974,7 @@ c01(?f01##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c02 > public {inline} (0 calls)
+proc c02 > public {inline} (0 calls)
 0: multictr.complicated.c02<0>
 c02(f02##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -982,7 +982,7 @@ c02(f02##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##1:multictr.complicated, 1:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c02 > public {inline} (35 calls)
+proc c02 > public {inline} (35 calls)
 1: multictr.complicated.c02<1>
 c02(?f02##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1008,7 +1008,7 @@ c02(?f02##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c03 > public {inline} (0 calls)
+proc c03 > public {inline} (0 calls)
 0: multictr.complicated.c03<0>
 c03(f03##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1016,7 +1016,7 @@ c03(f03##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##1:multictr.complicated, 2:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c03 > public {inline} (33 calls)
+proc c03 > public {inline} (33 calls)
 1: multictr.complicated.c03<1>
 c03(?f03##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1042,7 +1042,7 @@ c03(?f03##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c04 > public {inline} (0 calls)
+proc c04 > public {inline} (0 calls)
 0: multictr.complicated.c04<0>
 c04(f04##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1050,7 +1050,7 @@ c04(f04##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##1:multictr.complicated, 3:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c04 > public {inline} (31 calls)
+proc c04 > public {inline} (31 calls)
 1: multictr.complicated.c04<1>
 c04(?f04##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1076,7 +1076,7 @@ c04(?f04##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c05 > public {inline} (0 calls)
+proc c05 > public {inline} (0 calls)
 0: multictr.complicated.c05<0>
 c05(f05##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1084,7 +1084,7 @@ c05(f05##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##1:multictr.complicated, 4:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c05 > public {inline} (29 calls)
+proc c05 > public {inline} (29 calls)
 1: multictr.complicated.c05<1>
 c05(?f05##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1110,7 +1110,7 @@ c05(?f05##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c06 > public {inline} (0 calls)
+proc c06 > public {inline} (0 calls)
 0: multictr.complicated.c06<0>
 c06(f06##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1118,7 +1118,7 @@ c06(f06##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##1:multictr.complicated, 5:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c06 > public {inline} (27 calls)
+proc c06 > public {inline} (27 calls)
 1: multictr.complicated.c06<1>
 c06(?f06##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1144,7 +1144,7 @@ c06(?f06##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c07 > public {inline} (0 calls)
+proc c07 > public {inline} (0 calls)
 0: multictr.complicated.c07<0>
 c07(f07##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1152,7 +1152,7 @@ c07(f07##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##1:multictr.complicated, 6:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c07 > public {inline} (25 calls)
+proc c07 > public {inline} (25 calls)
 1: multictr.complicated.c07<1>
 c07(?f07##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1178,7 +1178,7 @@ c07(?f07##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c08 > public {inline} (0 calls)
+proc c08 > public {inline} (0 calls)
 0: multictr.complicated.c08<0>
 c08(f08##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1187,7 +1187,7 @@ c08(f08##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c08 > public {inline} (23 calls)
+proc c08 > public {inline} (23 calls)
 1: multictr.complicated.c08<1>
 c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1222,7 +1222,7 @@ c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c09 > public {inline} (0 calls)
+proc c09 > public {inline} (0 calls)
 0: multictr.complicated.c09<0>
 c09(f09##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1231,7 +1231,7 @@ c09(f09##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c09 > public {inline} (21 calls)
+proc c09 > public {inline} (21 calls)
 1: multictr.complicated.c09<1>
 c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1266,7 +1266,7 @@ c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c10 > public {inline} (0 calls)
+proc c10 > public {inline} (0 calls)
 0: multictr.complicated.c10<0>
 c10(f10##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1275,7 +1275,7 @@ c10(f10##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c10 > public {inline} (19 calls)
+proc c10 > public {inline} (19 calls)
 1: multictr.complicated.c10<1>
 c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1310,7 +1310,7 @@ c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c11 > public {inline} (0 calls)
+proc c11 > public {inline} (0 calls)
 0: multictr.complicated.c11<0>
 c11(f11##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1319,7 +1319,7 @@ c11(f11##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c11 > public {inline} (17 calls)
+proc c11 > public {inline} (17 calls)
 1: multictr.complicated.c11<1>
 c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1354,7 +1354,7 @@ c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c12 > public {inline} (0 calls)
+proc c12 > public {inline} (0 calls)
 0: multictr.complicated.c12<0>
 c12(f12##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1363,7 +1363,7 @@ c12(f12##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c12 > public {inline} (15 calls)
+proc c12 > public {inline} (15 calls)
 1: multictr.complicated.c12<1>
 c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1398,7 +1398,7 @@ c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c13 > public {inline} (0 calls)
+proc c13 > public {inline} (0 calls)
 0: multictr.complicated.c13<0>
 c13(f13##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1407,7 +1407,7 @@ c13(f13##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c13 > public {inline} (13 calls)
+proc c13 > public {inline} (13 calls)
 1: multictr.complicated.c13<1>
 c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1442,7 +1442,7 @@ c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c14 > public {inline} (0 calls)
+proc c14 > public {inline} (0 calls)
 0: multictr.complicated.c14<0>
 c14(f14##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1451,7 +1451,7 @@ c14(f14##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 13:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c14 > public {inline} (11 calls)
+proc c14 > public {inline} (11 calls)
 1: multictr.complicated.c14<1>
 c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1486,7 +1486,7 @@ c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c15 > public {inline} (0 calls)
+proc c15 > public {inline} (0 calls)
 0: multictr.complicated.c15<0>
 c15(f15##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1495,7 +1495,7 @@ c15(f15##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 14:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c15 > public {inline} (9 calls)
+proc c15 > public {inline} (9 calls)
 1: multictr.complicated.c15<1>
 c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1530,7 +1530,7 @@ c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c16 > public {inline} (0 calls)
+proc c16 > public {inline} (0 calls)
 0: multictr.complicated.c16<0>
 c16(f16##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1539,7 +1539,7 @@ c16(f16##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 15:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c16 > public {inline} (7 calls)
+proc c16 > public {inline} (7 calls)
 1: multictr.complicated.c16<1>
 c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1574,7 +1574,7 @@ c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-c17 > public {inline} (0 calls)
+proc c17 > public {inline} (0 calls)
 0: multictr.complicated.c17<0>
 c17(f17##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -1583,7 +1583,7 @@ c17(f17##0:wybe.int, ?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 16:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated) @multictr:nn:nn
-c17 > public {inline} (5 calls)
+proc c17 > public {inline} (5 calls)
 1: multictr.complicated.c17<1>
 c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1618,7 +1618,7 @@ c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool)<{
 
 
 
-f01 > public {inline} (0 calls)
+proc f01 > public {inline} (0 calls)
 0: multictr.complicated.f01<0>
 f01(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1642,7 +1642,7 @@ f01(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-f01 > public {inline} (0 calls)
+proc f01 > public {inline} (0 calls)
 1: multictr.complicated.f01<1>
 f01(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1668,7 +1668,7 @@ f01(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f02 > public {inline} (0 calls)
+proc f02 > public {inline} (0 calls)
 0: multictr.complicated.f02<0>
 f02(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1692,7 +1692,7 @@ f02(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-f02 > public {inline} (0 calls)
+proc f02 > public {inline} (0 calls)
 1: multictr.complicated.f02<1>
 f02(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1718,7 +1718,7 @@ f02(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f03 > public {inline} (0 calls)
+proc f03 > public {inline} (0 calls)
 0: multictr.complicated.f03<0>
 f03(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1742,7 +1742,7 @@ f03(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-f03 > public {inline} (0 calls)
+proc f03 > public {inline} (0 calls)
 1: multictr.complicated.f03<1>
 f03(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1768,7 +1768,7 @@ f03(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f04 > public {inline} (0 calls)
+proc f04 > public {inline} (0 calls)
 0: multictr.complicated.f04<0>
 f04(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1792,7 +1792,7 @@ f04(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-f04 > public {inline} (0 calls)
+proc f04 > public {inline} (0 calls)
 1: multictr.complicated.f04<1>
 f04(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1818,7 +1818,7 @@ f04(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f05 > public {inline} (0 calls)
+proc f05 > public {inline} (0 calls)
 0: multictr.complicated.f05<0>
 f05(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1842,7 +1842,7 @@ f05(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-f05 > public {inline} (0 calls)
+proc f05 > public {inline} (0 calls)
 1: multictr.complicated.f05<1>
 f05(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1868,7 +1868,7 @@ f05(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f06 > public {inline} (0 calls)
+proc f06 > public {inline} (0 calls)
 0: multictr.complicated.f06<0>
 f06(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1892,7 +1892,7 @@ f06(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-f06 > public {inline} (0 calls)
+proc f06 > public {inline} (0 calls)
 1: multictr.complicated.f06<1>
 f06(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1918,7 +1918,7 @@ f06(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f07 > public {inline} (0 calls)
+proc f07 > public {inline} (0 calls)
 0: multictr.complicated.f07<0>
 f07(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1942,7 +1942,7 @@ f07(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-f07 > public {inline} (0 calls)
+proc f07 > public {inline} (0 calls)
 1: multictr.complicated.f07<1>
 f07(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1968,7 +1968,7 @@ f07(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f08 > public {inline} (0 calls)
+proc f08 > public {inline} (0 calls)
 0: multictr.complicated.f08<0>
 f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2001,7 +2001,7 @@ f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f08 > public {inline} (0 calls)
+proc f08 > public {inline} (0 calls)
 1: multictr.complicated.f08<1>
 f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2036,7 +2036,7 @@ f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f09 > public {inline} (0 calls)
+proc f09 > public {inline} (0 calls)
 0: multictr.complicated.f09<0>
 f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2069,7 +2069,7 @@ f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f09 > public {inline} (0 calls)
+proc f09 > public {inline} (0 calls)
 1: multictr.complicated.f09<1>
 f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2104,7 +2104,7 @@ f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f10 > public {inline} (0 calls)
+proc f10 > public {inline} (0 calls)
 0: multictr.complicated.f10<0>
 f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2137,7 +2137,7 @@ f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f10 > public {inline} (0 calls)
+proc f10 > public {inline} (0 calls)
 1: multictr.complicated.f10<1>
 f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2172,7 +2172,7 @@ f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f11 > public {inline} (0 calls)
+proc f11 > public {inline} (0 calls)
 0: multictr.complicated.f11<0>
 f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2205,7 +2205,7 @@ f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f11 > public {inline} (0 calls)
+proc f11 > public {inline} (0 calls)
 1: multictr.complicated.f11<1>
 f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2240,7 +2240,7 @@ f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f12 > public {inline} (0 calls)
+proc f12 > public {inline} (0 calls)
 0: multictr.complicated.f12<0>
 f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2273,7 +2273,7 @@ f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f12 > public {inline} (0 calls)
+proc f12 > public {inline} (0 calls)
 1: multictr.complicated.f12<1>
 f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2308,7 +2308,7 @@ f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f13 > public {inline} (0 calls)
+proc f13 > public {inline} (0 calls)
 0: multictr.complicated.f13<0>
 f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2341,7 +2341,7 @@ f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f13 > public {inline} (0 calls)
+proc f13 > public {inline} (0 calls)
 1: multictr.complicated.f13<1>
 f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2376,7 +2376,7 @@ f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f14 > public {inline} (0 calls)
+proc f14 > public {inline} (0 calls)
 0: multictr.complicated.f14<0>
 f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2409,7 +2409,7 @@ f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f14 > public {inline} (0 calls)
+proc f14 > public {inline} (0 calls)
 1: multictr.complicated.f14<1>
 f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2444,7 +2444,7 @@ f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f15 > public {inline} (0 calls)
+proc f15 > public {inline} (0 calls)
 0: multictr.complicated.f15<0>
 f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2477,7 +2477,7 @@ f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f15 > public {inline} (0 calls)
+proc f15 > public {inline} (0 calls)
 1: multictr.complicated.f15<1>
 f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2512,7 +2512,7 @@ f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f16 > public {inline} (0 calls)
+proc f16 > public {inline} (0 calls)
 0: multictr.complicated.f16<0>
 f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2545,7 +2545,7 @@ f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f16 > public {inline} (0 calls)
+proc f16 > public {inline} (0 calls)
 1: multictr.complicated.f16<1>
 f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2580,7 +2580,7 @@ f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-f17 > public {inline} (0 calls)
+proc f17 > public {inline} (0 calls)
 0: multictr.complicated.f17<0>
 f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2613,7 +2613,7 @@ f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
 
 
 
-f17 > public {inline} (0 calls)
+proc f17 > public {inline} (0 calls)
 1: multictr.complicated.f17<1>
 f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -2648,7 +2648,7 @@ f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 
 
-spring > public {inline} (0 calls)
+proc spring > public {inline} (0 calls)
 0: multictr.complicated.spring<0>
 spring(?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -2656,7 +2656,7 @@ spring(?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign llvm move(1:multictr.complicated, ?#result##0:multictr.complicated)
 
 
-summer > public {inline} (0 calls)
+proc summer > public {inline} (0 calls)
 0: multictr.complicated.summer<0>
 summer(?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -2664,7 +2664,7 @@ summer(?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign llvm move(2:multictr.complicated, ?#result##0:multictr.complicated)
 
 
-winter > public {inline} (0 calls)
+proc winter > public {inline} (0 calls)
 0: multictr.complicated.winter<0>
 winter(?#result##0:multictr.complicated)<{}; {}; {}>:
   AliasPairs: []
@@ -2672,7 +2672,7 @@ winter(?#result##0:multictr.complicated)<{}; {}; {}>:
     foreign llvm move(0:multictr.complicated, ?#result##0:multictr.complicated)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.complicated.~=<0>
 ~=(#left##0:multictr.complicated, #right##0:multictr.complicated, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5218,7 +5218,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multictr.length.=<0>
 =(#left##0:multictr.length, #right##0:multictr.length, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5226,13 +5226,13 @@ entry:
     foreign llvm icmp_eq(~#left##0:multictr.length, ~#right##0:multictr.length, ?#success##0:wybe.bool)
 
 
-metres > public {inline} (0 calls)
+proc metres > public {inline} (0 calls)
 0: multictr.length.metres<0>
 metres(value##0:wybe.float, ?#result##2:multictr.length)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~value##0:multictr.length, ?#result##2:multictr.length) @multictr:nn:nn
-metres > public {inline} (0 calls)
+proc metres > public {inline} (0 calls)
 1: multictr.length.metres<1>
 metres(?value##0:wybe.float, #result##0:multictr.length)<{}; {}; {}>:
   AliasPairs: []
@@ -5240,13 +5240,13 @@ metres(?value##0:wybe.float, #result##0:multictr.length)<{}; {}; {}>:
     foreign lpvm cast(~#result##0:multictr.length, ?value##0:wybe.float) @multictr:nn:nn
 
 
-value > public {inline} (0 calls)
+proc value > public {inline} (0 calls)
 0: multictr.length.value<0>
 value(#rec##0:multictr.length, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm cast(~#rec##0:multictr.length, ?#result##0:wybe.float) @multictr:nn:nn
-value > public {inline} (0 calls)
+proc value > public {inline} (0 calls)
 1: multictr.length.value<1>
 value([#rec##0:multictr.length], ?#rec##2:multictr.length, #field##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -5254,7 +5254,7 @@ value([#rec##0:multictr.length], ?#rec##2:multictr.length, #field##0:wybe.float)
     foreign llvm move(~#field##0:multictr.length, ?#rec##2:multictr.length) @multictr:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.length.~=<0>
 ~=(#left##0:multictr.length, #right##0:multictr.length, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5334,7 +5334,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: multictr.maybe_int.=<0>
 =(#left##0:multictr.maybe_int, #right##0:multictr.maybe_int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5358,14 +5358,14 @@ entry:
 
 
 
-just > public {inline} (0 calls)
+proc just > public {inline} (0 calls)
 0: multictr.maybe_int.just<0>
 just(value##0:wybe.int, ?#result##0:multictr.maybe_int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.maybe_int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.maybe_int, ?#result##0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int) @multictr:nn:nn
-just > public {inline} (8 calls)
+proc just > public {inline} (8 calls)
 1: multictr.maybe_int.just<1>
 just(?value##0:wybe.int, #result##0:multictr.maybe_int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5382,7 +5382,7 @@ just(?value##0:wybe.int, #result##0:multictr.maybe_int, ?#success##0:wybe.bool)<
 
 
 
-nothing > public {inline} (0 calls)
+proc nothing > public {inline} (0 calls)
 0: multictr.maybe_int.nothing<0>
 nothing(?#result##0:multictr.maybe_int)<{}; {}; {}>:
   AliasPairs: []
@@ -5390,7 +5390,7 @@ nothing(?#result##0:multictr.maybe_int)<{}; {}; {}>:
     foreign llvm move(0:multictr.maybe_int, ?#result##0:multictr.maybe_int)
 
 
-value > public {inline} (0 calls)
+proc value > public {inline} (0 calls)
 0: multictr.maybe_int.value<0>
 value(#rec##0:multictr.maybe_int, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5405,7 +5405,7 @@ value(#rec##0:multictr.maybe_int, ?#result##0:wybe.int, ?#success##0:wybe.bool)<
         foreign lpvm access(~#rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-value > public {inline} (0 calls)
+proc value > public {inline} (0 calls)
 1: multictr.maybe_int.value<1>
 value(#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5422,7 +5422,7 @@ value(#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, #field##0:wybe.in
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.maybe_int.~=<0>
 ~=(#left##0:multictr.maybe_int, #right##0:multictr.maybe_int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5567,7 +5567,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: multictr.number.=<0>
 =(#left##0:multictr.number, #right##0:multictr.number, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5610,7 +5610,7 @@ entry:
 
 
 
-float > public {inline} (0 calls)
+proc float > public {inline} (0 calls)
 0: multictr.number.float<0>
 float(float_value##0:wybe.float, ?#result##0:multictr.number)<{}; {}; {}>:
   AliasPairs: []
@@ -5618,7 +5618,7 @@ float(float_value##0:wybe.float, ?#result##0:multictr.number)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value##0:wybe.float) @multictr:nn:nn
     foreign llvm or(~#rec##1:multictr.number, 1:wybe.int, ?#result##0:multictr.number) @multictr:nn:nn
-float > public {inline} (5 calls)
+proc float > public {inline} (5 calls)
 1: multictr.number.float<1>
 float(?float_value##0:wybe.float, #result##0:multictr.number, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5636,7 +5636,7 @@ float(?float_value##0:wybe.float, #result##0:multictr.number, ?#success##0:wybe.
 
 
 
-float_value > public {inline} (0 calls)
+proc float_value > public {inline} (0 calls)
 0: multictr.number.float_value<0>
 float_value(#rec##0:multictr.number, ?#result##0:wybe.float, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5652,7 +5652,7 @@ float_value(#rec##0:multictr.number, ?#result##0:wybe.float, ?#success##0:wybe.b
         foreign lpvm access(~#rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.float) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-float_value > public {inline} (0 calls)
+proc float_value > public {inline} (0 calls)
 1: multictr.number.float_value<1>
 float_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.float, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5670,14 +5670,14 @@ float_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.fl
 
 
 
-int > public {inline} (0 calls)
+proc int > public {inline} (0 calls)
 0: multictr.number.int<0>
 int(int_value##0:wybe.int, ?#result##0:multictr.number)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.number, ?#result##0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int) @multictr:nn:nn
-int > public {inline} (10 calls)
+proc int > public {inline} (10 calls)
 1: multictr.number.int<1>
 int(?int_value##0:wybe.int, #result##0:multictr.number, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5695,7 +5695,7 @@ int(?int_value##0:wybe.int, #result##0:multictr.number, ?#success##0:wybe.bool)<
 
 
 
-int_value > public {inline} (0 calls)
+proc int_value > public {inline} (0 calls)
 0: multictr.number.int_value<0>
 int_value(#rec##0:multictr.number, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5711,7 +5711,7 @@ int_value(#rec##0:multictr.number, ?#result##0:wybe.int, ?#success##0:wybe.bool)
         foreign lpvm access(~#rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multictr:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-int_value > public {inline} (0 calls)
+proc int_value > public {inline} (0 calls)
 1: multictr.number.int_value<1>
 int_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5729,7 +5729,7 @@ int_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.int,
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.number.~=<0>
 ~=(#left##0:multictr.number, #right##0:multictr.number, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5964,7 +5964,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multictr.perhaps.=<0>
 =(#left##0:multictr.perhaps, #right##0:multictr.perhaps, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -5972,13 +5972,13 @@ entry:
     foreign llvm icmp_eq(~#left##0:multictr.perhaps, ~#right##0:multictr.perhaps, ?#success##0:wybe.bool)
 
 
-content > public {inline} (0 calls)
+proc content > public {inline} (0 calls)
 0: multictr.perhaps.content<0>
 content(#rec##0:multictr.perhaps, ?#result##0:multictr.maybe_int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm cast(~#rec##0:multictr.perhaps, ?#result##0:multictr.maybe_int) @multictr:nn:nn
-content > public {inline} (0 calls)
+proc content > public {inline} (0 calls)
 1: multictr.perhaps.content<1>
 content([#rec##0:multictr.perhaps], ?#rec##2:multictr.perhaps, #field##0:multictr.maybe_int)<{}; {}; {}>:
   AliasPairs: []
@@ -5986,13 +5986,13 @@ content([#rec##0:multictr.perhaps], ?#rec##2:multictr.perhaps, #field##0:multict
     foreign llvm move(~#field##0:multictr.perhaps, ?#rec##2:multictr.perhaps) @multictr:nn:nn
 
 
-perhaps > public {inline} (0 calls)
+proc perhaps > public {inline} (0 calls)
 0: multictr.perhaps.perhaps<0>
 perhaps(content##0:multictr.maybe_int, ?#result##2:multictr.perhaps)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~content##0:multictr.perhaps, ?#result##2:multictr.perhaps) @multictr:nn:nn
-perhaps > public {inline} (0 calls)
+proc perhaps > public {inline} (0 calls)
 1: multictr.perhaps.perhaps<1>
 perhaps(?content##0:multictr.maybe_int, #result##0:multictr.perhaps)<{}; {}; {}>:
   AliasPairs: []
@@ -6000,7 +6000,7 @@ perhaps(?content##0:multictr.maybe_int, #result##0:multictr.perhaps)<{}; {}; {}>
     foreign lpvm cast(~#result##0:multictr.perhaps, ?content##0:multictr.maybe_int) @multictr:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.perhaps.~=<0>
 ~=(#left##0:multictr.perhaps, #right##0:multictr.perhaps, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6084,7 +6084,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multictr.rank.=<0>
 =(#left##0:multictr.rank, #right##0:multictr.rank, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6092,7 +6092,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:multictr.rank, ~#right##0:multictr.rank, ?#success##0:wybe.bool)
 
 
-ace > public {inline} (0 calls)
+proc ace > public {inline} (0 calls)
 0: multictr.rank.ace<0>
 ace(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6100,7 +6100,7 @@ ace(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(12:multictr.rank, ?#result##0:multictr.rank)
 
 
-jack > public {inline} (0 calls)
+proc jack > public {inline} (0 calls)
 0: multictr.rank.jack<0>
 jack(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6108,7 +6108,7 @@ jack(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(9:multictr.rank, ?#result##0:multictr.rank)
 
 
-king > public {inline} (0 calls)
+proc king > public {inline} (0 calls)
 0: multictr.rank.king<0>
 king(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6116,7 +6116,7 @@ king(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(11:multictr.rank, ?#result##0:multictr.rank)
 
 
-queen > public {inline} (0 calls)
+proc queen > public {inline} (0 calls)
 0: multictr.rank.queen<0>
 queen(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6124,7 +6124,7 @@ queen(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(10:multictr.rank, ?#result##0:multictr.rank)
 
 
-r10 > public {inline} (0 calls)
+proc r10 > public {inline} (0 calls)
 0: multictr.rank.r10<0>
 r10(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6132,7 +6132,7 @@ r10(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(8:multictr.rank, ?#result##0:multictr.rank)
 
 
-r2 > public {inline} (0 calls)
+proc r2 > public {inline} (0 calls)
 0: multictr.rank.r2<0>
 r2(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6140,7 +6140,7 @@ r2(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(0:multictr.rank, ?#result##0:multictr.rank)
 
 
-r3 > public {inline} (0 calls)
+proc r3 > public {inline} (0 calls)
 0: multictr.rank.r3<0>
 r3(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6148,7 +6148,7 @@ r3(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(1:multictr.rank, ?#result##0:multictr.rank)
 
 
-r4 > public {inline} (0 calls)
+proc r4 > public {inline} (0 calls)
 0: multictr.rank.r4<0>
 r4(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6156,7 +6156,7 @@ r4(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(2:multictr.rank, ?#result##0:multictr.rank)
 
 
-r5 > public {inline} (0 calls)
+proc r5 > public {inline} (0 calls)
 0: multictr.rank.r5<0>
 r5(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6164,7 +6164,7 @@ r5(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(3:multictr.rank, ?#result##0:multictr.rank)
 
 
-r6 > public {inline} (0 calls)
+proc r6 > public {inline} (0 calls)
 0: multictr.rank.r6<0>
 r6(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6172,7 +6172,7 @@ r6(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(4:multictr.rank, ?#result##0:multictr.rank)
 
 
-r7 > public {inline} (0 calls)
+proc r7 > public {inline} (0 calls)
 0: multictr.rank.r7<0>
 r7(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6180,7 +6180,7 @@ r7(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(5:multictr.rank, ?#result##0:multictr.rank)
 
 
-r8 > public {inline} (0 calls)
+proc r8 > public {inline} (0 calls)
 0: multictr.rank.r8<0>
 r8(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6188,7 +6188,7 @@ r8(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(6:multictr.rank, ?#result##0:multictr.rank)
 
 
-r9 > public {inline} (0 calls)
+proc r9 > public {inline} (0 calls)
 0: multictr.rank.r9<0>
 r9(?#result##0:multictr.rank)<{}; {}; {}>:
   AliasPairs: []
@@ -6196,7 +6196,7 @@ r9(?#result##0:multictr.rank)<{}; {}; {}>:
     foreign llvm move(7:multictr.rank, ?#result##0:multictr.rank)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.rank.~=<0>
 ~=(#left##0:multictr.rank, #right##0:multictr.rank, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6332,7 +6332,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: multictr.simple.=<0>
 =(#left##0:multictr.simple, #right##0:multictr.simple, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6405,14 +6405,14 @@ entry:
 
 
 
-one > public {inline} (0 calls)
+proc one > public {inline} (0 calls)
 0: multictr.simple.one<0>
 one(one_field##0:wybe.int, ?#result##0:multictr.simple)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.simple) @multictr:nn:nn
     foreign lpvm mutate(~#rec##0:multictr.simple, ?#result##0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int) @multictr:nn:nn
-one > public {inline} (11 calls)
+proc one > public {inline} (11 calls)
 1: multictr.simple.one<1>
 one(?one_field##0:wybe.int, #result##0:multictr.simple, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6438,7 +6438,7 @@ one(?one_field##0:wybe.int, #result##0:multictr.simple, ?#success##0:wybe.bool)<
 
 
 
-one_field > public {inline} (0 calls)
+proc one_field > public {inline} (0 calls)
 0: multictr.simple.one_field<0>
 one_field(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6462,7 +6462,7 @@ one_field(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool)
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-one_field > public {inline} (0 calls)
+proc one_field > public {inline} (0 calls)
 1: multictr.simple.one_field<1>
 one_field(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6488,7 +6488,7 @@ one_field(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int,
 
 
 
-two > public {inline} (0 calls)
+proc two > public {inline} (0 calls)
 0: multictr.simple.two<0>
 two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?#result##0:multictr.simple)<{}; {}; {}>:
   AliasPairs: []
@@ -6497,7 +6497,7 @@ two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?#result##0:multictr.simple)
     foreign lpvm mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field1##0:wybe.int) @multictr:nn:nn
     foreign lpvm mutate(~#rec##1:multictr.simple, ?#rec##2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2##0:wybe.int) @multictr:nn:nn
     foreign llvm or(~#rec##2:multictr.simple, 1:wybe.int, ?#result##0:multictr.simple) @multictr:nn:nn
-two > public {inline} (7 calls)
+proc two > public {inline} (7 calls)
 1: multictr.simple.two<1>
 two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, #result##0:multictr.simple, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6526,7 +6526,7 @@ two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, #result##0:multictr.simple
 
 
 
-two_field1 > public {inline} (0 calls)
+proc two_field1 > public {inline} (0 calls)
 0: multictr.simple.two_field1<0>
 two_field1(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6550,7 +6550,7 @@ two_field1(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-two_field1 > public {inline} (0 calls)
+proc two_field1 > public {inline} (0 calls)
 1: multictr.simple.two_field1<1>
 two_field1(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6576,7 +6576,7 @@ two_field1(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int
 
 
 
-two_field2 > public {inline} (0 calls)
+proc two_field2 > public {inline} (0 calls)
 0: multictr.simple.two_field2<0>
 two_field2(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6600,7 +6600,7 @@ two_field2(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool
             foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-two_field2 > public {inline} (0 calls)
+proc two_field2 > public {inline} (0 calls)
 1: multictr.simple.two_field2<1>
 two_field2(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -6626,7 +6626,7 @@ two_field2(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int
 
 
 
-zero > public {inline} (0 calls)
+proc zero > public {inline} (0 calls)
 0: multictr.simple.zero<0>
 zero(?#result##0:multictr.simple)<{}; {}; {}>:
   AliasPairs: []
@@ -6634,7 +6634,7 @@ zero(?#result##0:multictr.simple)<{}; {}; {}>:
     foreign llvm move(0:multictr.simple, ?#result##0:multictr.simple)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.simple.~=<0>
 ~=(#left##0:multictr.simple, #right##0:multictr.simple, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -7014,7 +7014,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multictr.suit.=<0>
 =(#left##0:multictr.suit, #right##0:multictr.suit, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -7022,7 +7022,7 @@ entry:
     foreign llvm icmp_eq(~#left##0:multictr.suit, ~#right##0:multictr.suit, ?#success##0:wybe.bool)
 
 
-clubs > public {inline} (0 calls)
+proc clubs > public {inline} (0 calls)
 0: multictr.suit.clubs<0>
 clubs(?#result##0:multictr.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -7030,7 +7030,7 @@ clubs(?#result##0:multictr.suit)<{}; {}; {}>:
     foreign llvm move(0:multictr.suit, ?#result##0:multictr.suit)
 
 
-diamonds > public {inline} (0 calls)
+proc diamonds > public {inline} (0 calls)
 0: multictr.suit.diamonds<0>
 diamonds(?#result##0:multictr.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -7038,7 +7038,7 @@ diamonds(?#result##0:multictr.suit)<{}; {}; {}>:
     foreign llvm move(1:multictr.suit, ?#result##0:multictr.suit)
 
 
-hearts > public {inline} (0 calls)
+proc hearts > public {inline} (0 calls)
 0: multictr.suit.hearts<0>
 hearts(?#result##0:multictr.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -7046,7 +7046,7 @@ hearts(?#result##0:multictr.suit)<{}; {}; {}>:
     foreign llvm move(2:multictr.suit, ?#result##0:multictr.suit)
 
 
-spades > public {inline} (0 calls)
+proc spades > public {inline} (0 calls)
 0: multictr.suit.spades<0>
 spades(?#result##0:multictr.suit)<{}; {}; {}>:
   AliasPairs: []
@@ -7054,7 +7054,7 @@ spades(?#result##0:multictr.suit)<{}; {}; {}>:
     foreign llvm move(3:multictr.suit, ?#result##0:multictr.suit)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.suit.~=<0>
 ~=(#left##0:multictr.suit, #right##0:multictr.suit, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -7126,7 +7126,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: multictr.unit.=<0>
 =([#left##0:multictr.unit], [#right##0:multictr.unit], ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -7134,7 +7134,7 @@ entry:
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-unit > public {inline} (0 calls)
+proc unit > public {inline} (0 calls)
 0: multictr.unit.unit<0>
 unit(?#result##0:multictr.unit)<{}; {}; {}>:
   AliasPairs: []
@@ -7142,7 +7142,7 @@ unit(?#result##0:multictr.unit)<{}; {}; {}>:
     foreign llvm move(0:multictr.unit, ?#result##0:multictr.unit)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr.unit.~=<0>
 ~=([#left##0:multictr.unit], [#right##0:multictr.unit], ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -49,7 +49,7 @@ AFTER EVERYTHING:
   submodules      : multictr2.t
   procs           : 
 
-print_t > public (0 calls)
+proc print_t > public (0 calls)
 0: multictr2.print_t<0>
 print_t(x##0:multictr2.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -369,7 +369,7 @@ switch.8.7:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: multictr2.t.=<0>
 =(#left##0:multictr2.t, #right##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -500,14 +500,14 @@ switch.8.7:
 
 
 
-c01 > public {inline} (0 calls)
+proc c01 > public {inline} (0 calls)
 0: multictr2.t.c01<0>
 c01(f01##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:nn:nn
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#result##0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int) @multictr2:nn:nn
-c01 > public {inline} (24 calls)
+proc c01 > public {inline} (24 calls)
 1: multictr2.t.c01<1>
 c01(?f01##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -525,7 +525,7 @@ c01(?f01##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}
 
 
 
-c02 > public {inline} (0 calls)
+proc c02 > public {inline} (0 calls)
 0: multictr2.t.c02<0>
 c02(f02##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
   AliasPairs: []
@@ -533,7 +533,7 @@ c02(f02##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:nn:nn
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int) @multictr2:nn:nn
     foreign llvm or(~#rec##1:multictr2.t, 1:wybe.int, ?#result##0:multictr2.t) @multictr2:nn:nn
-c02 > public {inline} (19 calls)
+proc c02 > public {inline} (19 calls)
 1: multictr2.t.c02<1>
 c02(?f02##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -551,7 +551,7 @@ c02(?f02##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}
 
 
 
-c03 > public {inline} (0 calls)
+proc c03 > public {inline} (0 calls)
 0: multictr2.t.c03<0>
 c03(f03##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
   AliasPairs: []
@@ -559,7 +559,7 @@ c03(f03##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:nn:nn
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int) @multictr2:nn:nn
     foreign llvm or(~#rec##1:multictr2.t, 2:wybe.int, ?#result##0:multictr2.t) @multictr2:nn:nn
-c03 > public {inline} (17 calls)
+proc c03 > public {inline} (17 calls)
 1: multictr2.t.c03<1>
 c03(?f03##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -577,7 +577,7 @@ c03(?f03##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}
 
 
 
-c04 > public {inline} (0 calls)
+proc c04 > public {inline} (0 calls)
 0: multictr2.t.c04<0>
 c04(f04##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
   AliasPairs: []
@@ -585,7 +585,7 @@ c04(f04##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:nn:nn
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int) @multictr2:nn:nn
     foreign llvm or(~#rec##1:multictr2.t, 3:wybe.int, ?#result##0:multictr2.t) @multictr2:nn:nn
-c04 > public {inline} (15 calls)
+proc c04 > public {inline} (15 calls)
 1: multictr2.t.c04<1>
 c04(?f04##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -603,7 +603,7 @@ c04(?f04##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}
 
 
 
-c05 > public {inline} (0 calls)
+proc c05 > public {inline} (0 calls)
 0: multictr2.t.c05<0>
 c05(f05##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
   AliasPairs: []
@@ -611,7 +611,7 @@ c05(f05##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:nn:nn
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int) @multictr2:nn:nn
     foreign llvm or(~#rec##1:multictr2.t, 4:wybe.int, ?#result##0:multictr2.t) @multictr2:nn:nn
-c05 > public {inline} (13 calls)
+proc c05 > public {inline} (13 calls)
 1: multictr2.t.c05<1>
 c05(?f05##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -629,7 +629,7 @@ c05(?f05##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}
 
 
 
-c06 > public {inline} (0 calls)
+proc c06 > public {inline} (0 calls)
 0: multictr2.t.c06<0>
 c06(f06##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
   AliasPairs: []
@@ -637,7 +637,7 @@ c06(f06##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:nn:nn
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int) @multictr2:nn:nn
     foreign llvm or(~#rec##1:multictr2.t, 5:wybe.int, ?#result##0:multictr2.t) @multictr2:nn:nn
-c06 > public {inline} (11 calls)
+proc c06 > public {inline} (11 calls)
 1: multictr2.t.c06<1>
 c06(?f06##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -655,7 +655,7 @@ c06(?f06##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}
 
 
 
-c07 > public {inline} (0 calls)
+proc c07 > public {inline} (0 calls)
 0: multictr2.t.c07<0>
 c07(f07##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
   AliasPairs: []
@@ -663,7 +663,7 @@ c07(f07##0:wybe.int, ?#result##0:multictr2.t)<{}; {}; {}>:
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t) @multictr2:nn:nn
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int) @multictr2:nn:nn
     foreign llvm or(~#rec##1:multictr2.t, 6:wybe.int, ?#result##0:multictr2.t) @multictr2:nn:nn
-c07 > public {inline} (9 calls)
+proc c07 > public {inline} (9 calls)
 1: multictr2.t.c07<1>
 c07(?f07##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -681,7 +681,7 @@ c07(?f07##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}
 
 
 
-c08 > public {inline} (0 calls)
+proc c08 > public {inline} (0 calls)
 0: multictr2.t.c08<0>
 c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?#result##0:multictr2.t)<{}; {}; {}>:
   AliasPairs: []
@@ -691,7 +691,7 @@ c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?#result##0:multi
     foreign lpvm mutate(~#rec##1:multictr2.t, ?#rec##2:multictr2.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_b##0:wybe.int) @multictr2:nn:nn
     foreign lpvm mutate(~#rec##2:multictr2.t, ?#rec##3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c##0:wybe.float) @multictr2:nn:nn
     foreign llvm or(~#rec##3:multictr2.t, 7:wybe.int, ?#result##0:multictr2.t) @multictr2:nn:nn
-c08 > public {inline} (9 calls)
+proc c08 > public {inline} (9 calls)
 1: multictr2.t.c08<1>
 c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, #result##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -713,7 +713,7 @@ c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, #result##0:mul
 
 
 
-f01 > public {inline} (0 calls)
+proc f01 > public {inline} (0 calls)
 0: multictr2.t.f01<0>
 f01(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -729,7 +729,7 @@ f01(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f01 > public {inline} (0 calls)
+proc f01 > public {inline} (0 calls)
 1: multictr2.t.f01<1>
 f01(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -747,7 +747,7 @@ f01(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
 
 
 
-f02 > public {inline} (0 calls)
+proc f02 > public {inline} (0 calls)
 0: multictr2.t.f02<0>
 f02(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -763,7 +763,7 @@ f02(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f02 > public {inline} (0 calls)
+proc f02 > public {inline} (0 calls)
 1: multictr2.t.f02<1>
 f02(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -781,7 +781,7 @@ f02(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
 
 
 
-f03 > public {inline} (0 calls)
+proc f03 > public {inline} (0 calls)
 0: multictr2.t.f03<0>
 f03(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -797,7 +797,7 @@ f03(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f03 > public {inline} (0 calls)
+proc f03 > public {inline} (0 calls)
 1: multictr2.t.f03<1>
 f03(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -815,7 +815,7 @@ f03(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
 
 
 
-f04 > public {inline} (0 calls)
+proc f04 > public {inline} (0 calls)
 0: multictr2.t.f04<0>
 f04(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -831,7 +831,7 @@ f04(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f04 > public {inline} (0 calls)
+proc f04 > public {inline} (0 calls)
 1: multictr2.t.f04<1>
 f04(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -849,7 +849,7 @@ f04(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
 
 
 
-f05 > public {inline} (0 calls)
+proc f05 > public {inline} (0 calls)
 0: multictr2.t.f05<0>
 f05(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -865,7 +865,7 @@ f05(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f05 > public {inline} (0 calls)
+proc f05 > public {inline} (0 calls)
 1: multictr2.t.f05<1>
 f05(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -883,7 +883,7 @@ f05(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
 
 
 
-f06 > public {inline} (0 calls)
+proc f06 > public {inline} (0 calls)
 0: multictr2.t.f06<0>
 f06(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -899,7 +899,7 @@ f06(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f06 > public {inline} (0 calls)
+proc f06 > public {inline} (0 calls)
 1: multictr2.t.f06<1>
 f06(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -917,7 +917,7 @@ f06(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
 
 
 
-f07 > public {inline} (0 calls)
+proc f07 > public {inline} (0 calls)
 0: multictr2.t.f07<0>
 f07(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -933,7 +933,7 @@ f07(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f07 > public {inline} (0 calls)
+proc f07 > public {inline} (0 calls)
 1: multictr2.t.f07<1>
 f07(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -951,7 +951,7 @@ f07(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:
 
 
 
-f08_a > public {inline} (0 calls)
+proc f08_a > public {inline} (0 calls)
 0: multictr2.t.f08_a<0>
 f08_a(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -967,7 +967,7 @@ f08_a(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {};
         foreign lpvm access(~#rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f08_a > public {inline} (0 calls)
+proc f08_a > public {inline} (0 calls)
 1: multictr2.t.f08_a<1>
 f08_a(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -985,7 +985,7 @@ f08_a(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##
 
 
 
-f08_b > public {inline} (0 calls)
+proc f08_b > public {inline} (0 calls)
 0: multictr2.t.f08_b<0>
 f08_b(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1001,7 +1001,7 @@ f08_b(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {};
         foreign lpvm access(~#rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f08_b > public {inline} (0 calls)
+proc f08_b > public {inline} (0 calls)
 1: multictr2.t.f08_b<1>
 f08_b(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1019,7 +1019,7 @@ f08_b(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##
 
 
 
-f08_c > public {inline} (0 calls)
+proc f08_c > public {inline} (0 calls)
 0: multictr2.t.f08_c<0>
 f08_c(#rec##0:multictr2.t, ?#result##0:wybe.float, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1035,7 +1035,7 @@ f08_c(#rec##0:multictr2.t, ?#result##0:wybe.float, ?#success##0:wybe.bool)<{}; {
         foreign lpvm access(~#rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.float) @multictr2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-f08_c > public {inline} (0 calls)
+proc f08_c > public {inline} (0 calls)
 1: multictr2.t.f08_c<1>
 f08_c(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.float, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1053,7 +1053,7 @@ f08_c(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.float, ?#success
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: multictr2.t.~=<0>
 ~=(#left##0:multictr2.t, #right##0:multictr2.t, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -44,7 +44,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: mutual_type.a.=<0>
 =(#left##0:mutual_type.a, #right##0:mutual_type.a, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -77,7 +77,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 
 
-a > public {inline} (0 calls)
+proc a > public {inline} (0 calls)
 0: mutual_type.a.a<0>
 a(ahead##0:wybe.int, atail##0:mutual_type.b, ?#result##0:mutual_type.a)<{}; {}; {}>:
   AliasPairs: []
@@ -85,7 +85,7 @@ a(ahead##0:wybe.int, atail##0:mutual_type.b, ?#result##0:mutual_type.a)<{}; {}; 
     foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.a) @mutual_type:nn:nn
     foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead##0:wybe.int) @mutual_type:nn:nn
     foreign lpvm mutate(~#rec##1:mutual_type.a, ?#result##0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b) @mutual_type:nn:nn
-a > public {inline} (12 calls)
+proc a > public {inline} (12 calls)
 1: mutual_type.a.a<1>
 a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, #result##0:mutual_type.a, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -104,7 +104,7 @@ a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, #result##0:mutual_type.a, ?#succe
 
 
 
-ahead > public {inline} (0 calls)
+proc ahead > public {inline} (0 calls)
 0: mutual_type.a.ahead<0>
 ahead(#rec##0:mutual_type.a, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -119,7 +119,7 @@ ahead(#rec##0:mutual_type.a, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {
         foreign lpvm access(~#rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-ahead > public {inline} (0 calls)
+proc ahead > public {inline} (0 calls)
 1: mutual_type.a.ahead<1>
 ahead(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -136,7 +136,7 @@ ahead(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:wybe.int, ?#succe
 
 
 
-atail > public {inline} (0 calls)
+proc atail > public {inline} (0 calls)
 0: mutual_type.a.atail<0>
 atail(#rec##0:mutual_type.a, ?#result##0:mutual_type.b, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -151,7 +151,7 @@ atail(#rec##0:mutual_type.a, ?#result##0:mutual_type.b, ?#success##0:wybe.bool)<
         foreign lpvm access(~#rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.b) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-atail > public {inline} (0 calls)
+proc atail > public {inline} (0 calls)
 1: mutual_type.a.atail<1>
 atail(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:mutual_type.b, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -168,7 +168,7 @@ atail(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:mutual_type.b, ?#
 
 
 
-no_a > public {inline} (0 calls)
+proc no_a > public {inline} (0 calls)
 0: mutual_type.a.no_a<0>
 no_a(?#result##0:mutual_type.a)<{}; {}; {}>:
   AliasPairs: []
@@ -176,7 +176,7 @@ no_a(?#result##0:mutual_type.a)<{}; {}; {}>:
     foreign llvm move(0:mutual_type.a, ?#result##0:mutual_type.a)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: mutual_type.a.~=<0>
 ~=(#left##0:mutual_type.a, #right##0:mutual_type.a, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -382,7 +382,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (1 calls)
+proc = > public (1 calls)
 0: mutual_type.b.=<0>
 =(#left##0:mutual_type.b, #right##0:mutual_type.b, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -415,7 +415,7 @@ entry:
 
 
 
-b > public {inline} (0 calls)
+proc b > public {inline} (0 calls)
 0: mutual_type.b.b<0>
 b(bhead##0:wybe.int, btail##0:mutual_type.a, ?#result##0:mutual_type.b)<{}; {}; {}>:
   AliasPairs: []
@@ -423,7 +423,7 @@ b(bhead##0:wybe.int, btail##0:mutual_type.a, ?#result##0:mutual_type.b)<{}; {}; 
     foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.b) @mutual_type:nn:nn
     foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead##0:wybe.int) @mutual_type:nn:nn
     foreign lpvm mutate(~#rec##1:mutual_type.b, ?#result##0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a) @mutual_type:nn:nn
-b > public {inline} (12 calls)
+proc b > public {inline} (12 calls)
 1: mutual_type.b.b<1>
 b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, #result##0:mutual_type.b, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -442,7 +442,7 @@ b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, #result##0:mutual_type.b, ?#succe
 
 
 
-bhead > public {inline} (0 calls)
+proc bhead > public {inline} (0 calls)
 0: mutual_type.b.bhead<0>
 bhead(#rec##0:mutual_type.b, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -457,7 +457,7 @@ bhead(#rec##0:mutual_type.b, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {
         foreign lpvm access(~#rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-bhead > public {inline} (0 calls)
+proc bhead > public {inline} (0 calls)
 1: mutual_type.b.bhead<1>
 bhead(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -474,7 +474,7 @@ bhead(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:wybe.int, ?#succe
 
 
 
-btail > public {inline} (0 calls)
+proc btail > public {inline} (0 calls)
 0: mutual_type.b.btail<0>
 btail(#rec##0:mutual_type.b, ?#result##0:mutual_type.a, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -489,7 +489,7 @@ btail(#rec##0:mutual_type.b, ?#result##0:mutual_type.a, ?#success##0:wybe.bool)<
         foreign lpvm access(~#rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.a) @mutual_type:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-btail > public {inline} (0 calls)
+proc btail > public {inline} (0 calls)
 1: mutual_type.b.btail<1>
 btail(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:mutual_type.a, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -506,7 +506,7 @@ btail(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:mutual_type.a, ?#
 
 
 
-no_b > public {inline} (0 calls)
+proc no_b > public {inline} (0 calls)
 0: mutual_type.b.no_b<0>
 no_b(?#result##0:mutual_type.b)<{}; {}; {}>:
   AliasPairs: []
@@ -514,7 +514,7 @@ no_b(?#result##0:mutual_type.b)<{}; {}; {}>:
     foreign llvm move(0:mutual_type.b, ?#result##0:mutual_type.b)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: mutual_type.b.~=<0>
 ~=(#left##0:mutual_type.b, #right##0:mutual_type.b, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -23,7 +23,7 @@ AFTER EVERYTHING:
   submodules      : mytree.tree
   procs           : 
 
-printTree > public {inline} (0 calls)
+proc printTree > public {inline} (0 calls)
 0: mytree.printTree<0>
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -32,7 +32,7 @@ printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
 
 
-printTree1 > public (3 calls)
+proc printTree1 > public (3 calls)
 0: mytree.printTree1<0>
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(prefix##0,prefix##3)]
@@ -143,7 +143,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public (7 calls)
+proc = > public (7 calls)
 0: mytree.tree.=<0>
 =(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -185,7 +185,7 @@ if.else:
 
 
 
-empty > public {inline} (0 calls)
+proc empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
 empty(?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -193,7 +193,7 @@ empty(?#result##0:mytree.tree)<{}; {}; {}>:
     foreign llvm move(0:mytree.tree, ?#result##0:mytree.tree)
 
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 0: mytree.tree.key<0>
 key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -208,7 +208,7 @@ key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 1: mytree.tree.key<1>
 key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -225,7 +225,7 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:
 
 
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 0: mytree.tree.left<0>
 left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -240,7 +240,7 @@ left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {
         foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 1: mytree.tree.left<1>
 left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -257,7 +257,7 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success
 
 
 
-node > public {inline} (0 calls)
+proc node > public {inline} (0 calls)
 0: mytree.tree.node<0>
 node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -266,7 +266,7 @@ node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:myt
     foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree) @mytree:nn:nn
     foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @mytree:nn:nn
     foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree) @mytree:nn:nn
-node > public {inline} (16 calls)
+proc node > public {inline} (16 calls)
 1: mytree.tree.node<1>
 node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -287,7 +287,7 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
 
 
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 0: mytree.tree.right<0>
 right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -302,7 +302,7 @@ right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool)<{}; 
         foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree) @mytree:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 1: mytree.tree.right<1>
 right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -319,7 +319,7 @@ right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#succes
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
 ~=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/need.exp
+++ b/test-cases/final-dump/need.exp
@@ -19,13 +19,13 @@ module top-level code > public {inline,semipure} (0 calls)
     need.#anon#1<0> #0 @need:nn:nn
 
 
-#anon#1 > {inline,impure} (1 calls)
+proc #anon#1 > {inline,impure} (1 calls)
 0: need.#anon#1<0>
 #anon#1()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     need.iota<0>(1000:wybe.int, outByReference l##0:wybe.list(wybe.int)) #0 @need:nn:nn
-#anon#1 > {inline,impure} (1 calls)
+proc #anon#1 > {inline,impure} (1 calls)
 1: need.#anon#1<1>
 #anon#1()<{}; {}; {}>:
   AliasPairs: []
@@ -33,7 +33,7 @@ module top-level code > public {inline,semipure} (0 calls)
     need.iota<0>(1000:wybe.int, outByReference tmp#0##0:wybe.list(wybe.int)) #1 @need:nn:nn
 
 
-iota > public (2 calls)
+proc iota > public (2 calls)
 0: need.iota<0>
 iota(n##0:wybe.int, outByReference #result##0:wybe.list(wybe.int))<{}; {}; {}>:
   AliasPairs: []
@@ -52,7 +52,7 @@ iota(n##0:wybe.int, outByReference #result##0:wybe.list(wybe.int))<{}; {}; {}>:
 
 
 
-need > public {inline,semipure} (1 calls)
+proc need > public {inline,semipure} (1 calls)
 0: need.need<0>
 need(stmt##0:{impure}())<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/nested_if.exp
+++ b/test-cases/final-dump/nested_if.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-nested_if > public (0 calls)
+proc nested_if > public (0 calls)
 0: nested_if.nested_if<0>
 nested_if(i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -25,7 +25,7 @@ module top-level code > public {semipure} (0 calls)
     nested_loop.#cont#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @nested_loop:nn:nn
 
 
-#cont#1 > {inline} (1 calls)
+proc #cont#1 > {inline} (1 calls)
 0: nested_loop.#cont#1<0>
 #cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -41,7 +41,7 @@ module top-level code > public {semipure} (0 calls)
     nested_loop.#cont#2<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @nested_loop:nn:nn
 
 
-#cont#2 > {inline} (2 calls)
+proc #cont#2 > {inline} (2 calls)
 0: nested_loop.#cont#2<0>
 #cont#2()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/numbers.exp
+++ b/test-cases/final-dump/numbers.exp
@@ -22,7 +22,7 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#2##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-factorial > public (1 calls)
+proc factorial > public (1 calls)
 0: numbers.factorial<0>
 factorial(n##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -39,7 +39,7 @@ factorial(n##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
 
 
 
-toCelsius > public {inline} (0 calls)
+proc toCelsius > public {inline} (0 calls)
 0: numbers.toCelsius<0>
 toCelsius(f##0:wybe.float, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/out_global_overwritten.exp
+++ b/test-cases/final-dump/out_global_overwritten.exp
@@ -23,7 +23,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#0##0:wybe.int, <<out_global_overwritten.res>>:wybe.int) @out_global_overwritten:nn:nn
 
 
-out > {noinline} (1 calls)
+proc out > {noinline} (1 calls)
 0: out_global_overwritten.out<0>
 out()<{}; {<<out_global_overwritten.res>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/out_only_global_flow.exp
+++ b/test-cases/final-dump/out_only_global_flow.exp
@@ -24,7 +24,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#0##0:wybe.int, <<out_only_global_flow.res>>:wybe.int) @out_only_global_flow:nn:nn
 
 
-out > {noinline} (1 calls)
+proc out > {noinline} (1 calls)
 0: out_only_global_flow.out<0>
 out()<{}; {<<out_only_global_flow.res>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -72,7 +72,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: person1.person.=<0>
 =(#left##0:person1.person, #right##0:person1.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -93,13 +93,13 @@ entry:
 
 
 
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 0: person1.person.firstname<0>
 firstname(#rec##0:person1.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person1:nn:nn
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 1: person1.person.firstname<1>
 firstname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -107,13 +107,13 @@ firstname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string
     foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person1:nn:nn
 
 
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 0: person1.person.lastname<0>
 lastname(#rec##0:person1.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person1:nn:nn
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 1: person1.person.lastname<1>
 lastname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -121,7 +121,7 @@ lastname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string)
     foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person1:nn:nn
 
 
-person > public {inline} (0 calls)
+proc person > public {inline} (0 calls)
 0: person1.person.person<0>
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person1.person)<{}; {}; {}>:
   AliasPairs: []
@@ -129,7 +129,7 @@ person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person1.pe
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person1.person) @person1:nn:nn
     foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person1:nn:nn
     foreign lpvm mutate(~#rec##1:person1.person, ?#result##0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person1:nn:nn
-person > public {inline} (6 calls)
+proc person > public {inline} (6 calls)
 1: person1.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.person)<{}; {}; {}>:
   AliasPairs: []
@@ -138,7 +138,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.p
     foreign lpvm access(~#result##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person1:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: person1.person.~=<0>
 ~=(#left##0:person1.person, #right##0:person1.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -74,7 +74,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: person2.person.=<0>
 =(#left##0:person2.person, #right##0:person2.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -95,13 +95,13 @@ entry:
 
 
 
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 0: person2.person.firstname<0>
 firstname(#rec##0:person2.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person2:nn:nn
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 1: person2.person.firstname<1>
 firstname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -109,13 +109,13 @@ firstname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string
     foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person2:nn:nn
 
 
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 0: person2.person.lastname<0>
 lastname(#rec##0:person2.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person2:nn:nn
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 1: person2.person.lastname<1>
 lastname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -123,7 +123,7 @@ lastname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string)
     foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person2:nn:nn
 
 
-person > public {inline} (0 calls)
+proc person > public {inline} (0 calls)
 0: person2.person.person<0>
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person2.person)<{}; {}; {}>:
   AliasPairs: []
@@ -131,7 +131,7 @@ person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person2.pe
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person2.person) @person2:nn:nn
     foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person2:nn:nn
     foreign lpvm mutate(~#rec##1:person2.person, ?#result##0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person2:nn:nn
-person > public {inline} (6 calls)
+proc person > public {inline} (6 calls)
 1: person2.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.person)<{}; {}; {}>:
   AliasPairs: []
@@ -140,7 +140,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.p
     foreign lpvm access(~#result##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person2:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: person2.person.~=<0>
 ~=(#left##0:person2.person, #right##0:person2.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -80,7 +80,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: person3.person.=<0>
 =(#left##0:person3.person, #right##0:person3.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -101,13 +101,13 @@ entry:
 
 
 
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 0: person3.person.firstname<0>
 firstname(#rec##0:person3.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person3:nn:nn
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 1: person3.person.firstname<1>
 firstname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -115,13 +115,13 @@ firstname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string
     foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person3:nn:nn
 
 
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 0: person3.person.lastname<0>
 lastname(#rec##0:person3.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person3:nn:nn
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 1: person3.person.lastname<1>
 lastname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -129,7 +129,7 @@ lastname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string)
     foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person3:nn:nn
 
 
-person > public {inline} (0 calls)
+proc person > public {inline} (0 calls)
 0: person3.person.person<0>
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person3.person)<{}; {}; {}>:
   AliasPairs: []
@@ -137,7 +137,7 @@ person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person3.pe
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person3.person) @person3:nn:nn
     foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person3:nn:nn
     foreign lpvm mutate(~#rec##1:person3.person, ?#result##0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person3:nn:nn
-person > public {inline} (6 calls)
+proc person > public {inline} (6 calls)
 1: person3.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.person)<{}; {}; {}>:
   AliasPairs: []
@@ -146,7 +146,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.p
     foreign lpvm access(~#result##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person3:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: person3.person.~=<0>
 ~=(#left##0:person3.person, #right##0:person3.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -80,7 +80,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: person4.person.=<0>
 =(#left##0:person4.person, #right##0:person4.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -101,13 +101,13 @@ entry:
 
 
 
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 0: person4.person.firstname<0>
 firstname(#rec##0:person4.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person4:nn:nn
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 1: person4.person.firstname<1>
 firstname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -115,13 +115,13 @@ firstname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string
     foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person4:nn:nn
 
 
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 0: person4.person.lastname<0>
 lastname(#rec##0:person4.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person4:nn:nn
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 1: person4.person.lastname<1>
 lastname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -129,7 +129,7 @@ lastname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string)
     foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person4:nn:nn
 
 
-person > public {inline} (0 calls)
+proc person > public {inline} (0 calls)
 0: person4.person.person<0>
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person4.person)<{}; {}; {}>:
   AliasPairs: []
@@ -137,7 +137,7 @@ person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person4.pe
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person4.person) @person4:nn:nn
     foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person4:nn:nn
     foreign lpvm mutate(~#rec##1:person4.person, ?#result##0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person4:nn:nn
-person > public {inline} (6 calls)
+proc person > public {inline} (6 calls)
 1: person4.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.person)<{}; {}; {}>:
   AliasPairs: []
@@ -146,7 +146,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.p
     foreign lpvm access(~#result##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person4:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: person4.person.~=<0>
 ~=(#left##0:person4.person, #right##0:person4.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -28,7 +28,7 @@ module top-level code > public {inline,semipure} (0 calls)
     wybe.string.print<0>("Bob":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @person5:nn:nn
 
 
-update_both > {inline} (1 calls)
+proc update_both > {inline} (1 calls)
 0: person5.update_both<0>
 update_both(p1##0:person5.person, ?p1##1:person5.person, p2##0:person5.person, ?p2##1:person5.person)<{}; {}; {}>:
   AliasPairs: []
@@ -115,7 +115,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: person5.person.=<0>
 =(#left##0:person5.person, #right##0:person5.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -136,13 +136,13 @@ entry:
 
 
 
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 0: person5.person.firstname<0>
 firstname(#rec##0:person5.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person5:nn:nn
-firstname > public {inline} (0 calls)
+proc firstname > public {inline} (0 calls)
 1: person5.person.firstname<1>
 firstname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -150,13 +150,13 @@ firstname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string
     foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person5:nn:nn
 
 
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 0: person5.person.lastname<0>
 lastname(#rec##0:person5.person, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @person5:nn:nn
-lastname > public {inline} (0 calls)
+proc lastname > public {inline} (0 calls)
 1: person5.person.lastname<1>
 lastname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -164,7 +164,7 @@ lastname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string)
     foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @person5:nn:nn
 
 
-person > public {inline} (0 calls)
+proc person > public {inline} (0 calls)
 0: person5.person.person<0>
 person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person5.person)<{}; {}; {}>:
   AliasPairs: []
@@ -172,7 +172,7 @@ person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person5.pe
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person5.person) @person5:nn:nn
     foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string) @person5:nn:nn
     foreign lpvm mutate(~#rec##1:person5.person, ?#result##0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string) @person5:nn:nn
-person > public {inline} (6 calls)
+proc person > public {inline} (6 calls)
 1: person5.person.person<1>
 person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.person)<{}; {}; {}>:
   AliasPairs: []
@@ -181,7 +181,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.p
     foreign lpvm access(~#result##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string) @person5:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: person5.person.~=<0>
 ~=(#left##0:person5.person, #right##0:person5.person, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -19,7 +19,7 @@ AFTER EVERYTHING:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -113,7 +113,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -132,7 +132,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -140,7 +140,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -149,13 +149,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -163,13 +163,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -177,7 +177,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -19,7 +19,7 @@ AFTER EVERYTHING:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -113,7 +113,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -132,7 +132,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -140,7 +140,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -149,13 +149,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -163,13 +163,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -177,7 +177,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -19,7 +19,7 @@ AFTER EVERYTHING:
   submodules      : position.position
   procs           : 
 
-printPosition > public (0 calls)
+proc printPosition > public (0 calls)
 0: position.printPosition<0>
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -113,7 +113,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position.position.=<0>
 =(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -132,7 +132,7 @@ entry:
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position.position.position<0>
 position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -140,7 +140,7 @@ position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position)<{}; {}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position) @position:nn:nn
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @position:nn:nn
     foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @position:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position.position.position<1>
 position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {}>:
   AliasPairs: []
@@ -149,13 +149,13 @@ position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position)<{}; {}; {
     foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position.position.x<0>
 x(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -163,13 +163,13 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position.position.y<0>
 y(#rec##0:position.position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -177,7 +177,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int)<{};
     foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @position:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position.position.~=<0>
 ~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -49,7 +49,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: position_float.position.=<0>
 =(#left##0:position_float.position, #right##0:position_float.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -68,7 +68,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
 
 
 
-position > public {inline} (0 calls)
+proc position > public {inline} (0 calls)
 0: position_float.position.position<0>
 position(x##0:wybe.float, y##0:wybe.float, ?#result##0:position_float.position)<{}; {}; {}>:
   AliasPairs: []
@@ -76,7 +76,7 @@ position(x##0:wybe.float, y##0:wybe.float, ?#result##0:position_float.position)<
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position_float.position) @position_float:nn:nn
     foreign lpvm mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.float) @position_float:nn:nn
     foreign lpvm mutate(~#rec##1:position_float.position, ?#result##0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.float) @position_float:nn:nn
-position > public {inline} (6 calls)
+proc position > public {inline} (6 calls)
 1: position_float.position.position<1>
 position(?x##0:wybe.float, ?y##0:wybe.float, #result##0:position_float.position)<{}; {}; {}>:
   AliasPairs: []
@@ -85,13 +85,13 @@ position(?x##0:wybe.float, ?y##0:wybe.float, #result##0:position_float.position)
     foreign lpvm access(~#result##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.float) @position_float:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: position_float.position.x<0>
 x(#rec##0:position_float.position, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.float) @position_float:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: position_float.position.x<1>
 x(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -99,13 +99,13 @@ x(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:w
     foreign lpvm {noalias} mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.float) @position_float:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: position_float.position.y<0>
 y(#rec##0:position_float.position, ?#result##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.float) @position_float:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: position_float.position.y<1>
 y(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:wybe.float)<{}; {}; {}>:
   AliasPairs: []
@@ -113,7 +113,7 @@ y(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:w
     foreign lpvm {noalias} mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.float) @position_float:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: position_float.position.~=<0>
 ~=(#left##0:position_float.position, #right##0:position_float.position, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/proc_allin.exp
+++ b/test-cases/final-dump/proc_allin.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-nada > public {inline} (0 calls)
+proc nada > public {inline} (0 calls)
 0: proc_allin.nada<0>
 nada([x##0:wybe.int], [y##0:wybe.int])<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/proc_beer.exp
+++ b/test-cases/final-dump/proc_beer.exp
@@ -18,7 +18,7 @@ module top-level code > public {inline,semipure} (0 calls)
     proc_beer.beer99#cont#1<0>(99:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @proc_beer:nn:nn
 
 
-beer99 > public {inline} (1 calls)
+proc beer99 > public {inline} (1 calls)
 0: proc_beer.beer99<0>
 beer99()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -26,7 +26,7 @@ beer99()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     proc_beer.beer99#cont#1<0>(99:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @proc_beer:nn:nn
 
 
-beer99#cont#1 > (2 calls)
+proc beer99#cont#1 > (2 calls)
 0: proc_beer.beer99#cont#1<0>
 beer99#cont#1(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -48,7 +48,7 @@ beer99#cont#1(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-beer99#cont#2 > {inline} (1 calls)
+proc beer99#cont#2 > {inline} (1 calls)
 0: proc_beer.beer99#cont#2<0>
 beer99#cont#2(count##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/proc_factorial.exp
+++ b/test-cases/final-dump/proc_factorial.exp
@@ -22,7 +22,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-factorial > public {inline} (1 calls)
+proc factorial > public {inline} (1 calls)
 0: proc_factorial.factorial<0>
 factorial(n##0:wybe.int, ?result##1:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -30,7 +30,7 @@ factorial(n##0:wybe.int, ?result##1:wybe.int)<{}; {}; {}>:
     proc_factorial.factorial#cont#1<0>(~n##0:wybe.int, 1:wybe.int, ?result##1:wybe.int) #0 @proc_factorial:nn:nn
 
 
-factorial#cont#1 > (2 calls)
+proc factorial#cont#1 > (2 calls)
 0: proc_factorial.factorial#cont#1<0>
 factorial#cont#1(n##0:wybe.int, result##0:wybe.int, ?result##1:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -47,7 +47,7 @@ factorial#cont#1(n##0:wybe.int, result##0:wybe.int, ?result##1:wybe.int)<{}; {};
 
 
 
-factorial#cont#2 > {inline} (1 calls)
+proc factorial#cont#2 > {inline} (1 calls)
 0: proc_factorial.factorial#cont#2<0>
 factorial#cont#2(n##0:wybe.int, result##0:wybe.int, ?result##2:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/proc_gcd.exp
+++ b/test-cases/final-dump/proc_gcd.exp
@@ -22,7 +22,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-gcd > public {inline} (1 calls)
+proc gcd > public {inline} (1 calls)
 0: proc_gcd.gcd<0>
 gcd(a##0:wybe.int, b##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -30,7 +30,7 @@ gcd(a##0:wybe.int, b##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.i
     proc_gcd.gcd#cont#1<0>(_:wybe.int, ~a##0:wybe.int, ~b##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @proc_gcd:nn:nn
 
 
-gcd#cont#1 > (2 calls)
+proc gcd#cont#1 > (2 calls)
 0: proc_gcd.gcd#cont#1<0>
 gcd#cont#1([t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -46,7 +46,7 @@ gcd#cont#1([t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wyb
 
 
 
-gcd#cont#2 > {inline} (1 calls)
+proc gcd#cont#2 > {inline} (1 calls)
 0: proc_gcd.gcd#cont#2<0>
 gcd#cont#2([t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -55,7 +55,7 @@ gcd#cont#2([t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wyb
     proc_gcd.gcd#cont#1<0>(_:wybe.int, ~y##0:wybe.int, ~y##1:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @proc_gcd:nn:nn
 
 
-mod > public (1 calls)
+proc mod > public (1 calls)
 0: proc_gcd.mod<0>
 mod(x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/proc_hello.exp
+++ b/test-cases/final-dump/proc_hello.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-print2 > public {inline} (0 calls)
+proc print2 > public {inline} (0 calls)
 0: proc_hello.print2<0>
 print2([x##0:wybe.int], [y##0:wybe.int])<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/proc_print2.exp
+++ b/test-cases/final-dump/proc_print2.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-print2 > public {inline} (0 calls)
+proc print2 > public {inline} (0 calls)
 0: proc_print2.print2<0>
 print2(x##0:wybe.int, y##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -22,7 +22,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-is_yes > {inline} (4 calls)
+proc is_yes > {inline} (4 calls)
 0: proc_yorn.is_yes<0>
 is_yes(ch##0:wybe.char, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -33,7 +33,7 @@ is_yes(ch##0:wybe.char, ?#result##0:wybe.bool)<{}; {}; {}>:
     foreign llvm xor(~tmp#1##0:wybe.bool, 1:wybe.bool, ?#result##0:wybe.bool) @bool:nn:nn
 
 
-is_yes_or_no > (3 calls)
+proc is_yes_or_no > (3 calls)
 0: proc_yorn.is_yes_or_no<0>
 is_yes_or_no(ch##0:wybe.char, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -48,7 +48,7 @@ is_yes_or_no(ch##0:wybe.char, ?#result##0:wybe.bool)<{}; {}; {}>:
     foreign llvm or(~tmp#1##0:wybe.bool, ~tmp#2##0:wybe.bool, ?#result##0:wybe.bool) @bool:nn:nn
 
 
-yorn > public {inline} (1 calls)
+proc yorn > public {inline} (1 calls)
 0: proc_yorn.yorn<0>
 yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -56,7 +56,7 @@ yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.i
     proc_yorn.yorn#cont#1<0>(~prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @proc_yorn:nn:nn
 
 
-yorn#cont#1 > (2 calls)
+proc yorn#cont#1 > (2 calls)
 0: proc_yorn.yorn#cont#1<0>
 yorn#cont#1(prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-yorn > public {inline} (0 calls)
+proc yorn > public {inline} (0 calls)
 0: proc_yorn2.yorn<0>
 yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -17,7 +17,7 @@ yorn(prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.i
     proc_yorn2.yorn#cont#1<0>(~prompt##0:wybe.string, ?result##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @proc_yorn2:nn:nn
 
 
-yorn#cont#1 > (2 calls)
+proc yorn#cont#1 > (2 calls)
 0: proc_yorn2.yorn#cont#1<0>
 yorn#cont#1(prompt##0:wybe.string, ?result##1:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/purity_error.exp
+++ b/test-cases/final-dump/purity_error.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) purity_error
 [91mfinal-dump/purity_error.wybe:3:41: Calling impure proc purity_error.something_impure<0>, expecting at least semipure
-[0m[91mfinal-dump/purity_error.wybe:7:29: Calling impure foreign mul, expecting at least semipure
+[0m[91mfinal-dump/purity_error.wybe:7:29: Calling impure foreign proc mul, expecting at least semipure
 [0m[91mfinal-dump/purity_error.wybe:12:5: Calling impure proc purity_error.another_impure<0> without ! non-purity marker
 [0m

--- a/test-cases/final-dump/representation.exp
+++ b/test-cases/final-dump/representation.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-+ > public {inline} (0 calls)
+proc + > public {inline} (0 calls)
 0: representation.+<0>
 +(x##0:representation, y##0:representation, ?#result##0:representation)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/resource_error2.exp
+++ b/test-cases/final-dump/resource_error2.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) resource_error2
 [91mfinal-dump/resource_error2.wybe:2:7: Resource wybe.io.io not in scope at call to proc println
 [0m[91mfinal-dump/resource_error2.wybe:17:7: Resource res_decl.count not in scope at call to proc use_resource
-[0m[91mfinal-dump/resource_error2.wybe:25:14: 'call_source_file_name' unknown in bad_special_use
+[0m[91mfinal-dump/resource_error2.wybe:25:14: proc call_source_file_name unknown in proc bad_special_use
 [0m

--- a/test-cases/final-dump/resource_rollback.exp
+++ b/test-cases/final-dump/resource_rollback.exp
@@ -35,7 +35,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: resource_rollback.#cont#1<0>
 #cont#1()<{<<resource_rollback.res>>, <<resource_rollback.ser>>, <<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -50,7 +50,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-foo > {noinline} (3 calls)
+proc foo > {noinline} (3 calls)
 0: resource_rollback.foo<0>
 foo(?s##0:wybe.c_string, ?#success##0:wybe.bool, %call_source_location##0:wybe.c_string)<{<<resource_rollback.res>>}; {<<resource_rollback.res>>}; {}>:
   AliasPairs: [(call_source_location##0,s##0)]

--- a/test-cases/final-dump/resource_tmp_vars.exp
+++ b/test-cases/final-dump/resource_tmp_vars.exp
@@ -23,7 +23,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-#cont#1 > {inline} (1 calls)
+proc #cont#1 > {inline} (1 calls)
 0: resource_tmp_vars.#cont#1<0>
 #cont#1([tmp#0##0:wybe.int], tmp#1##0:wybe.int)<{<<wybe.io.io>>}; {<<resource_tmp_vars.counter>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/simple_loop.exp
+++ b/test-cases/final-dump/simple_loop.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     simple_loop.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @simple_loop:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: simple_loop.#cont#1<0>
 #cont#1()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/sister_module.exp
+++ b/test-cases/final-dump/sister_module.exp
@@ -12,7 +12,7 @@ AFTER EVERYTHING:
   submodules      : sister_module.m1, sister_module.m2
   procs           : 
 
-baz > {inline} (0 calls)
+proc baz > {inline} (0 calls)
 0: sister_module.baz<0>
 baz(i##0:wybe.int, ?j##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -20,7 +20,7 @@ baz(i##0:wybe.int, ?j##0:wybe.int)<{}; {}; {}>:
     sister_module.m1.foo<0>(~i##0:wybe.int, ?j##0:wybe.int) #0 @sister_module:nn:nn
 
 
-buzz > {inline} (0 calls)
+proc buzz > {inline} (0 calls)
 0: sister_module.buzz<0>
 buzz(i##0:wybe.int, ?j##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -64,7 +64,7 @@ entry:
   resources       : 
   procs           : 
 
-foo > public {inline} (0 calls)
+proc foo > public {inline} (0 calls)
 0: sister_module.m1.foo<0>
 foo(i##0:wybe.int, ?j##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -101,7 +101,7 @@ entry:
   resources       : 
   procs           : 
 
-bar > public {inline} (0 calls)
+proc bar > public {inline} (0 calls)
 0: sister_module.m2.bar<0>
 bar(i##0:wybe.int, ?j##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/specials.exp
+++ b/test-cases/final-dump/specials.exp
@@ -14,7 +14,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-show_column > public {inline} (0 calls)
+proc show_column > public {inline} (0 calls)
 0: specials.show_column<0>
 show_column(%call_source_column_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -25,7 +25,7 @@ show_column(%call_source_column_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_file > public {inline} (0 calls)
+proc show_file > public {inline} (0 calls)
 0: specials.show_file<0>
 show_file(%call_source_file_name##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ show_file(%call_source_file_name##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_full_file > public {inline} (0 calls)
+proc show_full_file > public {inline} (0 calls)
 0: specials.show_full_file<0>
 show_full_file(%call_source_file_full_name##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -47,7 +47,7 @@ show_full_file(%call_source_file_full_name##0:wybe.c_string)<{<<wybe.io.io>>}; {
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_full_location > public {inline} (0 calls)
+proc show_full_location > public {inline} (0 calls)
 0: specials.show_full_location<0>
 show_full_location(%call_source_full_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -58,7 +58,7 @@ show_full_location(%call_source_full_location##0:wybe.c_string)<{<<wybe.io.io>>}
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_line > public {inline} (0 calls)
+proc show_line > public {inline} (0 calls)
 0: specials.show_line<0>
 show_line(%call_source_line_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -69,7 +69,7 @@ show_line(%call_source_line_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_location > public {inline} (0 calls)
+proc show_location > public {inline} (0 calls)
 0: specials.show_location<0>
 show_location(%call_source_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/specials_one_module.exp
+++ b/test-cases/final-dump/specials_one_module.exp
@@ -30,7 +30,7 @@ module top-level code > public {semipure} (0 calls)
     specials_one_module.indirect_call_location<0>(c"specials_one_module:29:2":wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @specials_one_module:nn:nn
 
 
-indirect_call_location > public (1 calls)
+proc indirect_call_location > public (1 calls)
 0: specials_one_module.indirect_call_location<0>
 indirect_call_location(%call_source_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -44,7 +44,7 @@ indirect_call_location(%call_source_location##0:wybe.c_string)<{<<wybe.io.io>>};
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_column > public {inline} (1 calls)
+proc show_column > public {inline} (1 calls)
 0: specials_one_module.show_column<0>
 show_column(%call_source_column_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -55,7 +55,7 @@ show_column(%call_source_column_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_file > public {inline} (1 calls)
+proc show_file > public {inline} (1 calls)
 0: specials_one_module.show_file<0>
 show_file(%call_source_file_name##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -66,7 +66,7 @@ show_file(%call_source_file_name##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_line > public {inline} (1 calls)
+proc show_line > public {inline} (1 calls)
 0: specials_one_module.show_line<0>
 show_line(%call_source_line_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -77,7 +77,7 @@ show_line(%call_source_line_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_location > public {inline} (1 calls)
+proc show_location > public {inline} (1 calls)
 0: specials_one_module.show_location<0>
 show_location(%call_source_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/specials_use.exp
+++ b/test-cases/final-dump/specials_use.exp
@@ -14,7 +14,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-show_column > public {inline} (0 calls)
+proc show_column > public {inline} (0 calls)
 0: specials.show_column<0>
 show_column(%call_source_column_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -25,7 +25,7 @@ show_column(%call_source_column_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_file > public {inline} (0 calls)
+proc show_file > public {inline} (0 calls)
 0: specials.show_file<0>
 show_file(%call_source_file_name##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ show_file(%call_source_file_name##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_full_file > public {inline} (0 calls)
+proc show_full_file > public {inline} (0 calls)
 0: specials.show_full_file<0>
 show_full_file(%call_source_file_full_name##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -47,7 +47,7 @@ show_full_file(%call_source_file_full_name##0:wybe.c_string)<{<<wybe.io.io>>}; {
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_full_location > public {inline} (0 calls)
+proc show_full_location > public {inline} (0 calls)
 0: specials.show_full_location<0>
 show_full_location(%call_source_full_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -58,7 +58,7 @@ show_full_location(%call_source_full_location##0:wybe.c_string)<{<<wybe.io.io>>}
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_line > public {inline} (0 calls)
+proc show_line > public {inline} (0 calls)
 0: specials.show_line<0>
 show_line(%call_source_line_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -69,7 +69,7 @@ show_line(%call_source_line_number##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-show_location > public {inline} (0 calls)
+proc show_location > public {inline} (0 calls)
 0: specials.show_location<0>
 show_location(%call_source_location##0:wybe.c_string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -114,7 +114,7 @@ module top-level code > public {semipure} (0 calls)
     stmt_for.using_irange_reverse#cont#1<0>(~tmp#42##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #46 @stmt_for:nn:nn
 
 
-irange > public (2 calls)
+proc irange > public (2 calls)
 0: stmt_for.irange<0>
 irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_for.int_sequence)<{}; {}; {}>:
   AliasPairs: []
@@ -137,7 +137,7 @@ irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_
 
 
 
-multiple_generator > public (1 calls)
+proc multiple_generator > public (1 calls)
 0: stmt_for.multiple_generator<0>
 multiple_generator()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -163,7 +163,7 @@ multiple_generator()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.multiple_generator#cont#1<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @stmt_for:nn:nn
 
 
-multiple_generator#cont#1 > (2 calls)
+proc multiple_generator#cont#1 > (2 calls)
 0: stmt_for.multiple_generator#cont#1<0>
 multiple_generator#cont#1(tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -193,7 +193,7 @@ multiple_generator#cont#1(tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.
 
 
 
-semi_det_for_loop > public (0 calls)
+proc semi_det_for_loop > public (0 calls)
 0: stmt_for.semi_det_for_loop<0>
 semi_det_for_loop(?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -202,7 +202,7 @@ semi_det_for_loop(?#success##0:wybe.bool)<{}; {}; {}>:
     stmt_for.semi_det_for_loop#cont#1<0>(~tmp#1##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #1 @stmt_for:nn:nn
 
 
-semi_det_for_loop#cont#1 > (2 calls)
+proc semi_det_for_loop#cont#1 > (2 calls)
 0: stmt_for.semi_det_for_loop#cont#1<0>
 semi_det_for_loop#cont#1(tmp#0##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -224,7 +224,7 @@ semi_det_for_loop#cont#1(tmp#0##0:stmt_for.int_sequence, ?#success##0:wybe.bool)
 
 
 
-shortest_generator_termination > public (1 calls)
+proc shortest_generator_termination > public (1 calls)
 0: stmt_for.shortest_generator_termination<0>
 shortest_generator_termination()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -250,7 +250,7 @@ shortest_generator_termination()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.shortest_generator_termination#cont#1<0>(~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @stmt_for:nn:nn
 
 
-shortest_generator_termination#cont#1 > (2 calls)
+proc shortest_generator_termination#cont#1 > (2 calls)
 0: stmt_for.shortest_generator_termination#cont#1<0>
 shortest_generator_termination#cont#1(tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -280,7 +280,7 @@ shortest_generator_termination#cont#1(tmp#8##0:wybe.list(wybe.int), tmp#9##0:wyb
 
 
 
-single_generator > public (1 calls)
+proc single_generator > public (1 calls)
 0: stmt_for.single_generator<0>
 single_generator()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -297,7 +297,7 @@ single_generator()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.single_generator#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @stmt_for:nn:nn
 
 
-single_generator#cont#1 > (2 calls)
+proc single_generator#cont#1 > (2 calls)
 0: stmt_for.single_generator#cont#1<0>
 single_generator#cont#1(tmp#4##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -317,7 +317,7 @@ single_generator#cont#1(tmp#4##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.
 
 
 
-using_break > public (1 calls)
+proc using_break > public (1 calls)
 0: stmt_for.using_break<0>
 using_break()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -337,7 +337,7 @@ using_break()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_break#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @stmt_for:nn:nn
 
 
-using_break#cont#1 > (2 calls)
+proc using_break#cont#1 > (2 calls)
 0: stmt_for.using_break#cont#1<0>
 using_break#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -363,7 +363,7 @@ using_break#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io
 
 
 
-using_irange > public {inline} (1 calls)
+proc using_irange > public {inline} (1 calls)
 0: stmt_for.using_irange<0>
 using_irange()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -372,7 +372,7 @@ using_irange()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_irange#cont#1<0>(~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @stmt_for:nn:nn
 
 
-using_irange#cont#1 > (2 calls)
+proc using_irange#cont#1 > (2 calls)
 0: stmt_for.using_irange#cont#1<0>
 using_irange#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -390,7 +390,7 @@ using_irange#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io
 
 
 
-using_irange_reverse > public {inline} (1 calls)
+proc using_irange_reverse > public {inline} (1 calls)
 0: stmt_for.using_irange_reverse<0>
 using_irange_reverse()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -399,7 +399,7 @@ using_irange_reverse()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_irange_reverse#cont#1<0>(~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @stmt_for:nn:nn
 
 
-using_irange_reverse#cont#1 > (2 calls)
+proc using_irange_reverse#cont#1 > (2 calls)
 0: stmt_for.using_irange_reverse#cont#1<0>
 using_irange_reverse#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -417,7 +417,7 @@ using_irange_reverse#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<
 
 
 
-using_next > public (1 calls)
+proc using_next > public (1 calls)
 0: stmt_for.using_next<0>
 using_next()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -437,7 +437,7 @@ using_next()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_next#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @stmt_for:nn:nn
 
 
-using_next#cont#1 > (3 calls)
+proc using_next#cont#1 > (3 calls)
 0: stmt_for.using_next#cont#1<0>
 using_next#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -464,7 +464,7 @@ using_next#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>
 
 
 
-using_unless > public (1 calls)
+proc using_unless > public (1 calls)
 0: stmt_for.using_unless<0>
 using_unless()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -484,7 +484,7 @@ using_unless()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_unless#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @stmt_for:nn:nn
 
 
-using_unless#cont#1 > (3 calls)
+proc using_unless#cont#1 > (3 calls)
 0: stmt_for.using_unless#cont#1<0>
 using_unless#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -511,7 +511,7 @@ using_unless#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.i
 
 
 
-using_until > public (1 calls)
+proc using_until > public (1 calls)
 0: stmt_for.using_until<0>
 using_until()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -531,7 +531,7 @@ using_until()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_until#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @stmt_for:nn:nn
 
 
-using_until#cont#1 > (2 calls)
+proc using_until#cont#1 > (2 calls)
 0: stmt_for.using_until#cont#1<0>
 using_until#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -557,7 +557,7 @@ using_until#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io
 
 
 
-using_when > public (1 calls)
+proc using_when > public (1 calls)
 0: stmt_for.using_when<0>
 using_when()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -577,7 +577,7 @@ using_when()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_when#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @stmt_for:nn:nn
 
 
-using_when#cont#1 > (3 calls)
+proc using_when#cont#1 > (3 calls)
 0: stmt_for.using_when#cont#1<0>
 using_when#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -604,7 +604,7 @@ using_when#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>
 
 
 
-using_while > public (1 calls)
+proc using_while > public (1 calls)
 0: stmt_for.using_while<0>
 using_while()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -624,7 +624,7 @@ using_while()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_while#cont#1<0>(~tmp#0##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @stmt_for:nn:nn
 
 
-using_while#cont#1 > (2 calls)
+proc using_while#cont#1 > (2 calls)
 0: stmt_for.using_while#cont#1<0>
 using_while#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -650,7 +650,7 @@ using_while#cont#1(tmp#5##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io
 
 
 
-using_xrange > public {inline} (1 calls)
+proc using_xrange > public {inline} (1 calls)
 0: stmt_for.using_xrange<0>
 using_xrange()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -659,7 +659,7 @@ using_xrange()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_xrange#cont#1<0>(~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @stmt_for:nn:nn
 
 
-using_xrange#cont#1 > (2 calls)
+proc using_xrange#cont#1 > (2 calls)
 0: stmt_for.using_xrange#cont#1<0>
 using_xrange#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -677,7 +677,7 @@ using_xrange#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io
 
 
 
-using_xrange_reverse > public {inline} (1 calls)
+proc using_xrange_reverse > public {inline} (1 calls)
 0: stmt_for.using_xrange_reverse<0>
 using_xrange_reverse()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -686,7 +686,7 @@ using_xrange_reverse()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     stmt_for.using_xrange_reverse#cont#1<0>(~tmp#1##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @stmt_for:nn:nn
 
 
-using_xrange_reverse#cont#1 > (2 calls)
+proc using_xrange_reverse#cont#1 > (2 calls)
 0: stmt_for.using_xrange_reverse#cont#1<0>
 using_xrange_reverse#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -704,7 +704,7 @@ using_xrange_reverse#cont#1(tmp#0##0:stmt_for.int_sequence)<{<<wybe.io.io>>}; {<
 
 
 
-xrange > public (3 calls)
+proc xrange > public (3 calls)
 0: stmt_for.xrange<0>
 xrange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_for.int_sequence)<{}; {}; {}>:
   AliasPairs: []
@@ -1666,7 +1666,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: stmt_for.int_sequence.=<0>
 =(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1694,7 +1694,7 @@ entry:
 
 
 
-[|] > public (0 calls)
+proc [|] > public (0 calls)
 0: stmt_for.int_sequence.[|]<0>
 [|](?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, current##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1730,7 +1730,7 @@ entry:
 
 
 
-[|]#cont#1 > (2 calls)
+proc [|]#cont#1 > (2 calls)
 0: stmt_for.int_sequence.[|]#cont#1<0>
 [|]#cont#1(en##0:wybe.int, s##0:wybe.int, st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -1744,13 +1744,13 @@ entry:
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
-end > public {inline} (0 calls)
+proc end > public {inline} (0 calls)
 0: stmt_for.int_sequence.end<0>
 end(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_for:nn:nn
-end > public {inline} (0 calls)
+proc end > public {inline} (0 calls)
 1: stmt_for.int_sequence.end<1>
 end(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1758,7 +1758,7 @@ end(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wyb
     foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_for:nn:nn
 
 
-int_sequence > public {inline} (1 calls)
+proc int_sequence > public {inline} (1 calls)
 0: stmt_for.int_sequence.int_sequence<0>
 int_sequence(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_for.int_sequence)<{}; {}; {}>:
   AliasPairs: []
@@ -1767,7 +1767,7 @@ int_sequence(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0
     foreign lpvm mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int) @stmt_for:nn:nn
     foreign lpvm mutate(~#rec##1:stmt_for.int_sequence, ?#rec##2:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int) @stmt_for:nn:nn
     foreign lpvm mutate(~#rec##2:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int) @stmt_for:nn:nn
-int_sequence > public {inline} (16 calls)
+proc int_sequence > public {inline} (16 calls)
 1: stmt_for.int_sequence.int_sequence<1>
 int_sequence(?start##0:wybe.int, ?stride##0:wybe.int, ?end##0:wybe.int, #result##0:stmt_for.int_sequence)<{}; {}; {}>:
   AliasPairs: []
@@ -1777,13 +1777,13 @@ int_sequence(?start##0:wybe.int, ?stride##0:wybe.int, ?end##0:wybe.int, #result#
     foreign lpvm access(~#result##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end##0:wybe.int) @stmt_for:nn:nn
 
 
-start > public {inline} (0 calls)
+proc start > public {inline} (0 calls)
 0: stmt_for.int_sequence.start<0>
 start(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_for:nn:nn
-start > public {inline} (0 calls)
+proc start > public {inline} (0 calls)
 1: stmt_for.int_sequence.start<1>
 start(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1791,13 +1791,13 @@ start(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:w
     foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_for:nn:nn
 
 
-stride > public {inline} (0 calls)
+proc stride > public {inline} (0 calls)
 0: stmt_for.int_sequence.stride<0>
 stride(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_for:nn:nn
-stride > public {inline} (0 calls)
+proc stride > public {inline} (0 calls)
 1: stmt_for.int_sequence.stride<1>
 stride(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -1805,7 +1805,7 @@ stride(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:
     foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @stmt_for:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: stmt_for.int_sequence.~=<0>
 ~=(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -22,7 +22,7 @@ AFTER EVERYTHING:
   submodules      : stmt_if.tree
   procs           : 
 
-foobar > (0 calls)
+proc foobar > (0 calls)
 0: stmt_if.foobar<0>
 foobar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -49,7 +49,7 @@ foobar()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-foobar#cont#1 > (2 calls)
+proc foobar#cont#1 > (2 calls)
 0: stmt_if.foobar#cont#1<0>
 foobar#cont#1(tr##0:stmt_if.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -70,7 +70,7 @@ foobar#cont#1(tr##0:stmt_if.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-lookup > public (8 calls)
+proc lookup > public (8 calls)
 0: stmt_if.lookup<0>
 lookup(key##0:wybe.int, tree##0:stmt_if.tree, ?result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -238,7 +238,7 @@ if.else2:
   resources       : 
   procs           : 
 
-= > public (7 calls)
+proc = > public (7 calls)
 0: stmt_if.tree.=<0>
 =(#left##0:stmt_if.tree, #right##0:stmt_if.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -280,7 +280,7 @@ if.else2:
 
 
 
-empty > public {inline} (0 calls)
+proc empty > public {inline} (0 calls)
 0: stmt_if.tree.empty<0>
 empty(?#result##0:stmt_if.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -288,7 +288,7 @@ empty(?#result##0:stmt_if.tree)<{}; {}; {}>:
     foreign llvm move(0:stmt_if.tree, ?#result##0:stmt_if.tree)
 
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 0: stmt_if.tree.key<0>
 key(#rec##0:stmt_if.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -303,7 +303,7 @@ key(#rec##0:stmt_if.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; 
         foreign lpvm access(~#rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 1: stmt_if.tree.key<1>
 key(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -320,7 +320,7 @@ key(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:wybe.int, ?#success##
 
 
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 0: stmt_if.tree.left<0>
 left(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -335,7 +335,7 @@ left(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?#success##0:wybe.bool)<{};
         foreign lpvm access(~#rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 1: stmt_if.tree.left<1>
 left(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -352,7 +352,7 @@ left(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?#succ
 
 
 
-node > public {inline} (0 calls)
+proc node > public {inline} (0 calls)
 0: stmt_if.tree.node<0>
 node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?#result##0:stmt_if.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -361,7 +361,7 @@ node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?#result##0:s
     foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if.tree) @stmt_if:nn:nn
     foreign lpvm mutate(~#rec##1:stmt_if.tree, ?#rec##2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @stmt_if:nn:nn
     foreign lpvm mutate(~#rec##2:stmt_if.tree, ?#result##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree) @stmt_if:nn:nn
-node > public {inline} (16 calls)
+proc node > public {inline} (16 calls)
 1: stmt_if.tree.node<1>
 node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, #result##0:stmt_if.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -382,7 +382,7 @@ node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, #result##0
 
 
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 0: stmt_if.tree.right<0>
 right(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -397,7 +397,7 @@ right(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?#success##0:wybe.bool)<{}
         foreign lpvm access(~#rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree) @stmt_if:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 1: stmt_if.tree.right<1>
 right(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -414,7 +414,7 @@ right(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?#suc
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: stmt_if.tree.~=<0>
 ~=(#left##0:stmt_if.tree, #right##0:stmt_if.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -41,7 +41,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-lookup > public (5 calls)
+proc lookup > public (5 calls)
 0: stmt_if2.lookup<0>
 lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -80,7 +80,7 @@ lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?#result##0:wybe.bool)<{}; {}; {}
 
 
 
-lookup#cont#1 > {inline} (3 calls)
+proc lookup#cont#1 > {inline} (3 calls)
 0: stmt_if2.lookup#cont#1<0>
 lookup#cont#1(tmp#4##0:wybe.bool, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -194,7 +194,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (7 calls)
+proc = > public (7 calls)
 0: stmt_if2.tree.=<0>
 =(#left##0:stmt_if2.tree, #right##0:stmt_if2.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -236,7 +236,7 @@ entry:
 
 
 
-empty > public {inline} (0 calls)
+proc empty > public {inline} (0 calls)
 0: stmt_if2.tree.empty<0>
 empty(?#result##0:stmt_if2.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -244,7 +244,7 @@ empty(?#result##0:stmt_if2.tree)<{}; {}; {}>:
     foreign llvm move(0:stmt_if2.tree, ?#result##0:stmt_if2.tree)
 
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 0: stmt_if2.tree.key<0>
 key(#rec##0:stmt_if2.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -259,7 +259,7 @@ key(#rec##0:stmt_if2.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {};
         foreign lpvm access(~#rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @stmt_if2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 1: stmt_if2.tree.key<1>
 key(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -276,7 +276,7 @@ key(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:wybe.int, ?#success
 
 
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 0: stmt_if2.tree.left<0>
 left(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -291,7 +291,7 @@ left(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?#success##0:wybe.bool)<{
         foreign lpvm access(~#rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree) @stmt_if2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 1: stmt_if2.tree.left<1>
 left(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -308,7 +308,7 @@ left(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?#s
 
 
 
-node > public {inline} (0 calls)
+proc node > public {inline} (0 calls)
 0: stmt_if2.tree.node<0>
 node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?#result##0:stmt_if2.tree)<{}; {}; {}>:
   AliasPairs: []
@@ -317,7 +317,7 @@ node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?#result##0
     foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if2.tree) @stmt_if2:nn:nn
     foreign lpvm mutate(~#rec##1:stmt_if2.tree, ?#rec##2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int) @stmt_if2:nn:nn
     foreign lpvm mutate(~#rec##2:stmt_if2.tree, ?#result##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree) @stmt_if2:nn:nn
-node > public {inline} (16 calls)
+proc node > public {inline} (16 calls)
 1: stmt_if2.tree.node<1>
 node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, #result##0:stmt_if2.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -338,7 +338,7 @@ node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, #result#
 
 
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 0: stmt_if2.tree.right<0>
 right(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -353,7 +353,7 @@ right(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?#success##0:wybe.bool)<
         foreign lpvm access(~#rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree) @stmt_if2:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 1: stmt_if2.tree.right<1>
 right(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -370,7 +370,7 @@ right(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?#
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: stmt_if2.tree.~=<0>
 ~=(#left##0:stmt_if2.tree, #right##0:stmt_if2.tree, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/stmt_unless.exp
+++ b/test-cases/final-dump/stmt_unless.exp
@@ -18,7 +18,7 @@ module top-level code > public {inline,semipure} (0 calls)
     stmt_unless.#cont#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @stmt_unless:nn:nn
 
 
-#cont#1 > (3 calls)
+proc #cont#1 > (3 calls)
 0: stmt_unless.#cont#1<0>
 #cont#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -32,7 +32,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-#cont#2 > (1 calls)
+proc #cont#2 > (1 calls)
 0: stmt_unless.#cont#2<0>
 #cont#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-mod > public {inline} (3 calls)
+proc mod > public {inline} (3 calls)
 0: stmt_unless.mod<0>
 mod(x##0:wybe.int, y##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/stmt_until.exp
+++ b/test-cases/final-dump/stmt_until.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     stmt_until.#cont#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @stmt_until:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: stmt_until.#cont#1<0>
 #cont#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-#cont#2 > {inline} (1 calls)
+proc #cont#2 > {inline} (1 calls)
 0: stmt_until.#cont#2<0>
 #cont#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/stmt_when.exp
+++ b/test-cases/final-dump/stmt_when.exp
@@ -18,7 +18,7 @@ module top-level code > public {inline,semipure} (0 calls)
     stmt_when.#cont#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @stmt_when:nn:nn
 
 
-#cont#1 > (3 calls)
+proc #cont#1 > (3 calls)
 0: stmt_when.#cont#1<0>
 #cont#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -32,7 +32,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-#cont#2 > (1 calls)
+proc #cont#2 > (1 calls)
 0: stmt_when.#cont#2<0>
 #cont#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-mod > public {inline} (3 calls)
+proc mod > public {inline} (3 calls)
 0: stmt_when.mod<0>
 mod(x##0:wybe.int, y##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/stmt_while.exp
+++ b/test-cases/final-dump/stmt_while.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     stmt_while.#cont#1<0>(10:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @stmt_while:nn:nn
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: stmt_while.#cont#1<0>
 #cont#1(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 
 
-#cont#2 > {inline} (1 calls)
+proc #cont#2 > {inline} (1 calls)
 0: stmt_while.#cont#2<0>
 #cont#2(n##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -113,7 +113,7 @@ module top-level code > public {semipure} (0 calls)
     string.test_index<0>(~tmp#25##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #61 @string:nn:nn
 
 
-print_loop > {inline} (2 calls)
+proc print_loop > {inline} (2 calls)
 0: string.print_loop<0>
 print_loop(s##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -121,7 +121,7 @@ print_loop(s##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     string.print_loop#cont#1<0>(~s##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @string:nn:nn
 
 
-print_loop#cont#1 > (2 calls)
+proc print_loop#cont#1 > (2 calls)
 0: string.print_loop#cont#1<0>[410bae77d3]
 print_loop#cont#1(tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -156,7 +156,7 @@ print_loop#cont#1(tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 
 
 
-test_index > (13 calls)
+proc test_index > (13 calls)
 0: string.test_index<0>
 test_index(s##0:wybe.string, i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -45,7 +45,7 @@ module top-level code > public {semipure} (0 calls)
     student.printStudent<0>[410bae77d3](~tmp#11##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @student:nn:nn
 
 
-printStudent > public (1 calls)
+proc printStudent > public (1 calls)
 0: student.printStudent<0>[410bae77d3]
 printStudent(stu##0:student.student)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -230,7 +230,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: student.course.=<0>
 =(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -250,13 +250,13 @@ entry:
 
 
 
-code > public {inline} (0 calls)
+proc code > public {inline} (0 calls)
 0: student.course.code<0>
 code(#rec##0:student.course, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @student:nn:nn
-code > public {inline} (0 calls)
+proc code > public {inline} (0 calls)
 1: student.course.code<1>
 code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -264,7 +264,7 @@ code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int)<{}; {}
     foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @student:nn:nn
 
 
-course > public {inline} (0 calls)
+proc course > public {inline} (0 calls)
 0: student.course.course<0>
 course(code##0:wybe.int, name##0:wybe.string, ?#result##0:student.course)<{}; {}; {}>:
   AliasPairs: []
@@ -272,7 +272,7 @@ course(code##0:wybe.int, name##0:wybe.string, ?#result##0:student.course)<{}; {}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course) @student:nn:nn
     foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int) @student:nn:nn
     foreign lpvm mutate(~#rec##1:student.course, ?#result##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string) @student:nn:nn
-course > public {inline} (6 calls)
+proc course > public {inline} (6 calls)
 1: student.course.course<1>
 course(?code##0:wybe.int, ?name##0:wybe.string, #result##0:student.course)<{}; {}; {}>:
   AliasPairs: []
@@ -281,13 +281,13 @@ course(?code##0:wybe.int, ?name##0:wybe.string, #result##0:student.course)<{}; {
     foreign lpvm access(~#result##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string) @student:nn:nn
 
 
-name > public {inline} (0 calls)
+proc name > public {inline} (0 calls)
 0: student.course.name<0>
 name(#rec##0:student.course, ?#result##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string) @student:nn:nn
-name > public {inline} (0 calls)
+proc name > public {inline} (0 calls)
 1: student.course.name<1>
 name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string)<{}; {}; {}>:
   AliasPairs: []
@@ -295,7 +295,7 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string)<{};
     foreign lpvm {noalias} mutate(~#rec##0:student.course, ?#rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string) @student:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: student.course.~=<0>
 ~=(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -472,7 +472,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: student.student.=<0>
 =(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -503,13 +503,13 @@ if.else:
 
 
 
-id > public {inline} (0 calls)
+proc id > public {inline} (0 calls)
 0: student.student.id<0>
 id(#rec##0:student.student, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @student:nn:nn
-id > public {inline} (0 calls)
+proc id > public {inline} (0 calls)
 1: student.student.id<1>
 id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -517,13 +517,13 @@ id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int)<{}; {}
     foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @student:nn:nn
 
 
-major > public {inline} (0 calls)
+proc major > public {inline} (0 calls)
 0: student.student.major<0>
 major(#rec##0:student.student, ?#result##0:student.course)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:student.course) @student:nn:nn
-major > public {inline} (0 calls)
+proc major > public {inline} (0 calls)
 1: student.student.major<1>
 major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.course)<{}; {}; {}>:
   AliasPairs: []
@@ -531,7 +531,7 @@ major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.cours
     foreign lpvm {noalias} mutate(~#rec##0:student.student, ?#rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:student.course) @student:nn:nn
 
 
-student > public {inline} (0 calls)
+proc student > public {inline} (0 calls)
 0: student.student.student<0>
 student(id##0:wybe.int, major##0:student.course, ?#result##0:student.student)<{}; {}; {}>:
   AliasPairs: []
@@ -539,7 +539,7 @@ student(id##0:wybe.int, major##0:student.course, ?#result##0:student.student)<{}
     foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student) @student:nn:nn
     foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int) @student:nn:nn
     foreign lpvm mutate(~#rec##1:student.student, ?#result##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course) @student:nn:nn
-student > public {inline} (6 calls)
+proc student > public {inline} (6 calls)
 1: student.student.student<1>
 student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student)<{}; {}; {}>:
   AliasPairs: []
@@ -548,7 +548,7 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student)<{
     foreign lpvm access(~#result##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course) @student:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: student.student.~=<0>
 ~=(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/submodule.exp
+++ b/test-cases/final-dump/submodule.exp
@@ -36,7 +36,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   resources       : 
   procs           : 
 
-hidden > {inline} (0 calls)
+proc hidden > {inline} (0 calls)
 0: submodule.privatetest.hidden<0>
 hidden()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -44,7 +44,7 @@ hidden()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     wybe.string.print<0>("private proc in a private module":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @submodule:nn:nn
 
 
-semi_hidden > public {inline} (0 calls)
+proc semi_hidden > public {inline} (0 calls)
 0: submodule.privatetest.semi_hidden<0>
 semi_hidden()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -103,7 +103,7 @@ entry:
   resources       : 
   procs           : 
 
-semi_visible > {inline} (0 calls)
+proc semi_visible > {inline} (0 calls)
 0: submodule.publictest.semi_visible<0>
 semi_visible()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -111,7 +111,7 @@ semi_visible()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     wybe.string.print<0>("private proc in a public module":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @submodule:nn:nn
 
 
-visible > public {inline} (0 calls)
+proc visible > public {inline} (0 calls)
 0: submodule.publictest.visible<0>
 visible()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/terminal_ok.exp
+++ b/test-cases/final-dump/terminal_ok.exp
@@ -17,7 +17,7 @@ module top-level code > public {inline,semipure} (0 calls)
     terminal_ok.exit_bool<0>(0:wybe.bool) #1 @terminal_ok:nn:nn
 
 
-exit_bool > {terminal,semipure} (1 calls)
+proc exit_bool > {terminal,semipure} (1 calls)
 0: terminal_ok.exit_bool<0>
 exit_bool(b##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -31,7 +31,7 @@ module top-level code > public {inline,semipure} (0 calls)
     test_loop.find_test<0>(7:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @test_loop:nn:nn
 
 
-find_modulo > {inline} (3 calls)
+proc find_modulo > {inline} (3 calls)
 0: test_loop.find_modulo<0>
 find_modulo(seq##0:test_loop.int_seq, modulus##0:wybe.int, ?i##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -39,7 +39,7 @@ find_modulo(seq##0:test_loop.int_seq, modulus##0:wybe.int, ?i##0:wybe.int, ?#suc
     test_loop.find_modulo#cont#1<0>(~modulus##0:wybe.int, ~seq##0:test_loop.int_seq, ?i##0:wybe.int, ?#success##0:wybe.bool) #0 @test_loop:nn:nn
 
 
-find_modulo#cont#1 > (2 calls)
+proc find_modulo#cont#1 > (2 calls)
 0: test_loop.find_modulo#cont#1<0>[6dacb8fd25]
 find_modulo#cont#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -84,7 +84,7 @@ find_modulo#cont#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int
 
 
 
-find_test > (2 calls)
+proc find_test > (2 calls)
 0: test_loop.find_test<0>
 find_test(modulus##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -284,7 +284,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: test_loop.int_seq.=<0>
 =(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -312,13 +312,13 @@ if.else:
 
 
 
-high > public {inline} (0 calls)
+proc high > public {inline} (0 calls)
 0: test_loop.int_seq.high<0>
 high(#rec##0:test_loop.int_seq, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @test_loop:nn:nn
-high > public {inline} (0 calls)
+proc high > public {inline} (0 calls)
 1: test_loop.int_seq.high<1>
 high(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -326,7 +326,7 @@ high(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int)<
     foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @test_loop:nn:nn
 
 
-int_seq > public {inline} (0 calls)
+proc int_seq > public {inline} (0 calls)
 0: test_loop.int_seq.int_seq<0>
 int_seq(low##0:wybe.int, step##0:wybe.int, high##0:wybe.int, ?#result##0:test_loop.int_seq)<{}; {}; {}>:
   AliasPairs: []
@@ -335,7 +335,7 @@ int_seq(low##0:wybe.int, step##0:wybe.int, high##0:wybe.int, ?#result##0:test_lo
     foreign lpvm mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~low##0:wybe.int) @test_loop:nn:nn
     foreign lpvm mutate(~#rec##1:test_loop.int_seq, ?#rec##2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step##0:wybe.int) @test_loop:nn:nn
     foreign lpvm mutate(~#rec##2:test_loop.int_seq, ?#result##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high##0:wybe.int) @test_loop:nn:nn
-int_seq > public {inline} (13 calls)
+proc int_seq > public {inline} (13 calls)
 1: test_loop.int_seq.int_seq<1>
 int_seq(?low##0:wybe.int, ?step##0:wybe.int, ?high##0:wybe.int, #result##0:test_loop.int_seq)<{}; {}; {}>:
   AliasPairs: []
@@ -345,13 +345,13 @@ int_seq(?low##0:wybe.int, ?step##0:wybe.int, ?high##0:wybe.int, #result##0:test_
     foreign lpvm access(~#result##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high##0:wybe.int) @test_loop:nn:nn
 
 
-low > public {inline} (0 calls)
+proc low > public {inline} (0 calls)
 0: test_loop.int_seq.low<0>
 low(#rec##0:test_loop.int_seq, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @test_loop:nn:nn
-low > public {inline} (1 calls)
+proc low > public {inline} (1 calls)
 1: test_loop.int_seq.low<1>
 low(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -359,7 +359,7 @@ low(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int)<{
     foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @test_loop:nn:nn
 
 
-seq_next > public (0 calls)
+proc seq_next > public (0 calls)
 0: test_loop.int_seq.seq_next<0>[410bae77d3]
 seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: [(seq##0,seq##1)]
@@ -395,13 +395,13 @@ seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, 
 
 
 
-step > public {inline} (0 calls)
+proc step > public {inline} (0 calls)
 0: test_loop.int_seq.step<0>
 step(#rec##0:test_loop.int_seq, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @test_loop:nn:nn
-step > public {inline} (0 calls)
+proc step > public {inline} (0 calls)
 1: test_loop.int_seq.step<1>
 step(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -409,7 +409,7 @@ step(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int)<
     foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @test_loop:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: test_loop.int_seq.~=<0>
 ~=(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -27,7 +27,7 @@ AFTER EVERYTHING:
   submodules      : tests.map
   procs           : 
 
-lookup > public (6 calls)
+proc lookup > public (6 calls)
 0: tests.lookup<0>
 lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -61,7 +61,7 @@ lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?#success##0:wybe
 
 
 
-lt > public (1 calls)
+proc lt > public (1 calls)
 0: tests.lt<0>
 lt(x##0:wybe.int, y##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -76,7 +76,7 @@ lt(x##0:wybe.int, y##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
 
 
 
-lt2 > public {inline} (1 calls)
+proc lt2 > public {inline} (1 calls)
 0: tests.lt2<0>
 lt2(x##0:wybe.int, y##0:wybe.int, ?res##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -84,7 +84,7 @@ lt2(x##0:wybe.int, y##0:wybe.int, ?res##0:wybe.bool)<{}; {}; {}>:
     tests.lt<0>(~x##0:wybe.int, ~y##0:wybe.int, ?res##0:wybe.bool) #0 @tests:nn:nn
 
 
-lt3 > public {inline} (0 calls)
+proc lt3 > public {inline} (0 calls)
 0: tests.lt3<0>
 lt3(x##0:wybe.int, y##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -197,7 +197,7 @@ entry:
   resources       : 
   procs           : 
 
-= > public (9 calls)
+proc = > public (9 calls)
 0: tests.map.=<0>
 =(#left##0:tests.map, #right##0:tests.map, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -248,7 +248,7 @@ entry:
 
 
 
-empty > public {inline} (0 calls)
+proc empty > public {inline} (0 calls)
 0: tests.map.empty<0>
 empty(?#result##0:tests.map)<{}; {}; {}>:
   AliasPairs: []
@@ -256,7 +256,7 @@ empty(?#result##0:tests.map)<{}; {}; {}>:
     foreign llvm move(0:tests.map, ?#result##0:tests.map)
 
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 0: tests.map.key<0>
 key(#rec##0:tests.map, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -271,7 +271,7 @@ key(#rec##0:tests.map, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>
         foreign lpvm access(~#rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-key > public {inline} (0 calls)
+proc key > public {inline} (0 calls)
 1: tests.map.key<1>
 key(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -288,7 +288,7 @@ key(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?#success##0:wybe
 
 
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 0: tests.map.left<0>
 left(#rec##0:tests.map, ?#result##0:tests.map, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -303,7 +303,7 @@ left(#rec##0:tests.map, ?#result##0:tests.map, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-left > public {inline} (0 calls)
+proc left > public {inline} (0 calls)
 1: tests.map.left<1>
 left(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -320,7 +320,7 @@ left(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?#success##0:wy
 
 
 
-node > public {inline} (0 calls)
+proc node > public {inline} (0 calls)
 0: tests.map.node<0>
 node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, ?#result##0:tests.map)<{}; {}; {}>:
   AliasPairs: []
@@ -330,7 +330,7 @@ node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, 
     foreign lpvm mutate(~#rec##1:tests.map, ?#rec##2:tests.map, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~key##0:wybe.int) @tests:nn:nn
     foreign lpvm mutate(~#rec##2:tests.map, ?#rec##3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value##0:wybe.int) @tests:nn:nn
     foreign lpvm mutate(~#rec##3:tests.map, ?#result##0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map) @tests:nn:nn
-node > public {inline} (20 calls)
+proc node > public {inline} (20 calls)
 1: tests.map.node<1>
 node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, #result##0:tests.map, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -353,7 +353,7 @@ node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.m
 
 
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 0: tests.map.right<0>
 right(#rec##0:tests.map, ?#result##0:tests.map, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -368,7 +368,7 @@ right(#rec##0:tests.map, ?#result##0:tests.map, ?#success##0:wybe.bool)<{}; {}; 
         foreign lpvm access(~#rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-right > public {inline} (0 calls)
+proc right > public {inline} (0 calls)
 1: tests.map.right<1>
 right(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -385,7 +385,7 @@ right(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?#success##0:w
 
 
 
-value > public {inline} (0 calls)
+proc value > public {inline} (0 calls)
 0: tests.map.value<0>
 value(#rec##0:tests.map, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -400,7 +400,7 @@ value(#rec##0:tests.map, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {
         foreign lpvm access(~#rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @tests:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-value > public {inline} (0 calls)
+proc value > public {inline} (0 calls)
 1: tests.map.value<1>
 value(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -417,7 +417,7 @@ value(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?#success##0:wy
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: tests.map.~=<0>
 ~=(#left##0:tests.map, #right##0:tests.map, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -49,7 +49,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: thistype.=<0>
 =(#left##0:thistype, #right##0:thistype, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -82,7 +82,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-concat > public (2 calls)
+proc concat > public (2 calls)
 0: thistype.concat<0>[410bae77d3]
 concat(x##0:thistype, y##0:thistype, outByReference #result##0:thistype)<{}; {}; {}>:
   AliasPairs: [(#result##0,y##0)]
@@ -114,7 +114,7 @@ concat(x##0:thistype, y##0:thistype, outByReference #result##0:thistype)<{}; {};
 
 
 
-cons > public {inline} (6 calls)
+proc cons > public {inline} (6 calls)
 0: thistype.cons<0>
 cons(head##0:wybe.int, tail##0:thistype, ?#result##0:thistype)<{}; {}; {}>:
   AliasPairs: []
@@ -122,7 +122,7 @@ cons(head##0:wybe.int, tail##0:thistype, ?#result##0:thistype)<{}; {}; {}>:
     foreign lpvm alloc(16:wybe.int, ?#rec##0:thistype) @thistype:nn:nn
     foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @thistype:nn:nn
     foreign lpvm mutate(~#rec##1:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype) @thistype:nn:nn
-cons > public {inline} (18 calls)
+proc cons > public {inline} (18 calls)
 1: thistype.cons<1>
 cons(?head##0:wybe.int, ?tail##0:thistype, #result##0:thistype, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -141,7 +141,7 @@ cons(?head##0:wybe.int, ?tail##0:thistype, #result##0:thistype, ?#success##0:wyb
 
 
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 0: thistype.head<0>
 head(#rec##0:thistype, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -156,7 +156,7 @@ head(#rec##0:thistype, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>
         foreign lpvm access(~#rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @thistype:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 1: thistype.head<1>
 head(#rec##0:thistype, ?#rec##1:thistype, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -173,7 +173,7 @@ head(#rec##0:thistype, ?#rec##1:thistype, #field##0:wybe.int, ?#success##0:wybe.
 
 
 
-length > public (2 calls)
+proc length > public (2 calls)
 0: thistype.length<0>
 length(x##0:thistype, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -190,7 +190,7 @@ length(x##0:thistype, ?#result##0:wybe.int)<{}; {}; {}>:
 
 
 
-nil > public {inline} (2 calls)
+proc nil > public {inline} (2 calls)
 0: thistype.nil<0>
 nil(?#result##0:thistype)<{}; {}; {}>:
   AliasPairs: []
@@ -198,7 +198,7 @@ nil(?#result##0:thistype)<{}; {}; {}>:
     foreign llvm move(0:thistype, ?#result##0:thistype)
 
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 0: thistype.tail<0>
 tail(#rec##0:thistype, ?#result##0:thistype, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -213,7 +213,7 @@ tail(#rec##0:thistype, ?#result##0:thistype, ?#success##0:wybe.bool)<{}; {}; {}>
         foreign lpvm access(~#rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:thistype) @thistype:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 1: thistype.tail<1>
 tail(#rec##0:thistype, ?#rec##1:thistype, #field##0:thistype, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -230,7 +230,7 @@ tail(#rec##0:thistype, ?#rec##1:thistype, #field##0:thistype, ?#success##0:wybe.
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: thistype.~=<0>
 ~=(#left##0:thistype, #right##0:thistype, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/type_change.exp
+++ b/test-cases/final-dump/type_change.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) type_change
-[91mfinal-dump/type_change.wybe:4:2: Type error in call to =, argument 1
-[0m[91mfinal-dump/type_change.wybe:4:2: Type error in call to =, argument 2
+[91mfinal-dump/type_change.wybe:4:2: Type error in call to proc =, argument 1
+[0m[91mfinal-dump/type_change.wybe:4:2: Type error in call to proc =, argument 2
 [0m[91mfinal-dump/type_change.wybe:4:2: Type of 1.0 incompatible with ?x
 [0m

--- a/test-cases/final-dump/type_enum.exp
+++ b/test-cases/final-dump/type_enum.exp
@@ -45,7 +45,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   resources       : 
   procs           : 
 
-= > public {inline} (1 calls)
+proc = > public {inline} (1 calls)
 0: type_enum.season.=<0>
 =(#left##0:type_enum.season, #right##0:type_enum.season, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -53,7 +53,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm icmp_eq(~#left##0:type_enum.season, ~#right##0:type_enum.season, ?#success##0:wybe.bool)
 
 
-autumn > public {inline} (0 calls)
+proc autumn > public {inline} (0 calls)
 0: type_enum.season.autumn<0>
 autumn(?#result##0:type_enum.season)<{}; {}; {}>:
   AliasPairs: []
@@ -61,7 +61,7 @@ autumn(?#result##0:type_enum.season)<{}; {}; {}>:
     foreign llvm move(3:type_enum.season, ?#result##0:type_enum.season)
 
 
-spring > public {inline} (0 calls)
+proc spring > public {inline} (0 calls)
 0: type_enum.season.spring<0>
 spring(?#result##0:type_enum.season)<{}; {}; {}>:
   AliasPairs: []
@@ -69,7 +69,7 @@ spring(?#result##0:type_enum.season)<{}; {}; {}>:
     foreign llvm move(1:type_enum.season, ?#result##0:type_enum.season)
 
 
-summer > public {inline} (0 calls)
+proc summer > public {inline} (0 calls)
 0: type_enum.season.summer<0>
 summer(?#result##0:type_enum.season)<{}; {}; {}>:
   AliasPairs: []
@@ -77,7 +77,7 @@ summer(?#result##0:type_enum.season)<{}; {}; {}>:
     foreign llvm move(2:type_enum.season, ?#result##0:type_enum.season)
 
 
-winter > public {inline} (0 calls)
+proc winter > public {inline} (0 calls)
 0: type_enum.season.winter<0>
 winter(?#result##0:type_enum.season)<{}; {}; {}>:
   AliasPairs: []
@@ -85,7 +85,7 @@ winter(?#result##0:type_enum.season)<{}; {}; {}>:
     foreign llvm move(0:type_enum.season, ?#result##0:type_enum.season)
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: type_enum.season.~=<0>
 ~=(#left##0:type_enum.season, #right##0:type_enum.season, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/type_error.exp
+++ b/test-cases/final-dump/type_error.exp
@@ -1,4 +1,4 @@
 Error detected during type checking of module(s) type_error
-[91mfinal-dump/type_error.wybe:1:30: Type error in call to *, argument 1
-[0m[91mfinal-dump/type_error.wybe:1:30: Type error in call to *, argument 2
+[91mfinal-dump/type_error.wybe:1:30: Type error in call to proc *, argument 1
+[0m[91mfinal-dump/type_error.wybe:1:30: Type error in call to proc *, argument 2
 [0m

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -32,7 +32,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#1 > (2 calls)
+proc #cont#1 > (2 calls)
 0: type_generics.#cont#1<0>
 #cont#1([x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -51,7 +51,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#2 > (2 calls)
+proc #cont#2 > (2 calls)
 0: type_generics.#cont#2<0>
 #cont#2([x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -70,7 +70,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#3 > (2 calls)
+proc #cont#3 > (2 calls)
 0: type_generics.#cont#3<0>
 #cont#3([x##0:wybe.float])<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -89,7 +89,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#4 > (2 calls)
+proc #cont#4 > (2 calls)
 0: type_generics.#cont#4<0>
 #cont#4()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -108,7 +108,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-#cont#5 > (2 calls)
+proc #cont#5 > (2 calls)
 0: type_generics.#cont#5<0>
 #cont#5()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -125,7 +125,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-foo > (12 calls)
+proc foo > (12 calls)
 0: type_generics.foo<0>
 foo(x##0:T <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -140,7 +140,7 @@ foo(x##0:T <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
     foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-foo2 > (18 calls)
+proc foo2 > (18 calls)
 0: type_generics.foo2<0>
 foo2(x##0:T0 <{}; {}; {0}>, ?y##0:T0 <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/type_int.exp
+++ b/test-cases/final-dump/type_int.exp
@@ -61,7 +61,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
   resources       : 
   procs           : 
 
-* > public {inline} (0 calls)
+proc * > public {inline} (0 calls)
 0: type_int.myint.*<0>
 *(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:type_int.myint)<{}; {}; {}>:
   AliasPairs: []
@@ -69,19 +69,19 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm mul(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:type_int.myint) @type_int:nn:nn
 
 
-+ > public {inline} (0 calls)
+proc + > public {inline} (0 calls)
 0: type_int.myint.+<0>
 +(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:type_int.myint)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:type_int.myint) @type_int:nn:nn
-+ > public {inline} (0 calls)
+proc + > public {inline} (0 calls)
 1: type_int.myint.+<1>
 +(?x##0:type_int.myint, y##0:type_int.myint, z##0:type_int.myint)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm sub(~z##0:type_int.myint, ~y##0:type_int.myint, ?x##0:type_int.myint) @type_int:nn:nn
-+ > public {inline} (0 calls)
+proc + > public {inline} (0 calls)
 2: type_int.myint.+<2>
 +(x##0:type_int.myint, ?y##0:type_int.myint, z##0:type_int.myint)<{}; {}; {}>:
   AliasPairs: []
@@ -89,19 +89,19 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm sub(~z##0:type_int.myint, ~x##0:type_int.myint, ?y##0:type_int.myint) @type_int:nn:nn
 
 
-- > public {inline} (0 calls)
+proc - > public {inline} (0 calls)
 0: type_int.myint.-<0>
 -(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:type_int.myint)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm sub(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:type_int.myint) @type_int:nn:nn
-- > public {inline} (0 calls)
+proc - > public {inline} (0 calls)
 1: type_int.myint.-<1>
 -(?x##0:type_int.myint, y##0:type_int.myint, z##0:type_int.myint)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~y##0:type_int.myint, ~z##0:type_int.myint, ?x##0:type_int.myint) @type_int:nn:nn
-- > public {inline} (0 calls)
+proc - > public {inline} (0 calls)
 2: type_int.myint.-<2>
 -(x##0:type_int.myint, ?y##0:type_int.myint, z##0:type_int.myint)<{}; {}; {}>:
   AliasPairs: []
@@ -109,7 +109,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm sub(~z##0:type_int.myint, ~x##0:type_int.myint, ?y##0:type_int.myint) @type_int:nn:nn
 
 
-/ > public {inline} (0 calls)
+proc / > public {inline} (0 calls)
 0: type_int.myint./<0>
 /(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:type_int.myint)<{}; {}; {}>:
   AliasPairs: []
@@ -117,7 +117,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm sdiv(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:type_int.myint) @type_int:nn:nn
 
 
-< > public {inline} (0 calls)
+proc < > public {inline} (0 calls)
 0: type_int.myint.<<0>
 <(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -125,7 +125,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm icmp_slt(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
-<= > public {inline} (0 calls)
+proc <= > public {inline} (0 calls)
 0: type_int.myint.<=<0>
 <=(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -133,7 +133,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm icmp_sle(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
-= > public {inline} (0 calls)
+proc = > public {inline} (0 calls)
 0: type_int.myint.=<0>
 =(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -141,7 +141,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm icmp_eq(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
-> > public {inline} (0 calls)
+proc > > public {inline} (0 calls)
 0: type_int.myint.><0>
 >(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -149,7 +149,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm icmp_sgt(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
->= > public {inline} (0 calls)
+proc >= > public {inline} (0 calls)
 0: type_int.myint.>=<0>
 >=(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -157,7 +157,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)
     foreign llvm icmp_sge(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: type_int.myint.~=<0>
 ~=(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -50,7 +50,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#36##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-,, > public (2 calls)
+proc ,, > public (2 calls)
 0: type_list.,,<0>[410bae77d3]
 ,,(x##0:type_list.intlist, y##0:type_list.intlist, outByReference #result##0:type_list.intlist)<{}; {}; {}>:
   AliasPairs: [(#result##0,y##0)]
@@ -82,7 +82,7 @@ module top-level code > public {semipure} (0 calls)
 
 
 
-length > public (2 calls)
+proc length > public (2 calls)
 0: type_list.length<0>
 length(x##0:type_list.intlist, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -244,7 +244,7 @@ if.else:
   resources       : 
   procs           : 
 
-= > public (2 calls)
+proc = > public (2 calls)
 0: type_list.intlist.=<0>
 =(#left##0:type_list.intlist, #right##0:type_list.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -277,7 +277,7 @@ if.else:
 
 
 
-cons > public {inline} (0 calls)
+proc cons > public {inline} (0 calls)
 0: type_list.intlist.cons<0>
 cons(head##0:wybe.int, tail##0:type_list.intlist, ?#result##0:type_list.intlist)<{}; {}; {}>:
   AliasPairs: []
@@ -285,7 +285,7 @@ cons(head##0:wybe.int, tail##0:type_list.intlist, ?#result##0:type_list.intlist)
     foreign lpvm alloc(16:wybe.int, ?#rec##0:type_list.intlist) @type_list:nn:nn
     foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int) @type_list:nn:nn
     foreign lpvm mutate(~#rec##1:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist) @type_list:nn:nn
-cons > public {inline} (12 calls)
+proc cons > public {inline} (12 calls)
 1: type_list.intlist.cons<1>
 cons(?head##0:wybe.int, ?tail##0:type_list.intlist, #result##0:type_list.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -304,7 +304,7 @@ cons(?head##0:wybe.int, ?tail##0:type_list.intlist, #result##0:type_list.intlist
 
 
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 0: type_list.intlist.head<0>
 head(#rec##0:type_list.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -319,7 +319,7 @@ head(#rec##0:type_list.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}
         foreign lpvm access(~#rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @type_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-head > public {inline} (0 calls)
+proc head > public {inline} (0 calls)
 1: type_list.intlist.head<1>
 head(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -336,7 +336,7 @@ head(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:wybe.int, 
 
 
 
-nil > public {inline} (0 calls)
+proc nil > public {inline} (0 calls)
 0: type_list.intlist.nil<0>
 nil(?#result##0:type_list.intlist)<{}; {}; {}>:
   AliasPairs: []
@@ -344,7 +344,7 @@ nil(?#result##0:type_list.intlist)<{}; {}; {}>:
     foreign llvm move(0:type_list.intlist, ?#result##0:type_list.intlist)
 
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 0: type_list.intlist.tail<0>
 tail(#rec##0:type_list.intlist, ?#result##0:type_list.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -359,7 +359,7 @@ tail(#rec##0:type_list.intlist, ?#result##0:type_list.intlist, ?#success##0:wybe
         foreign lpvm access(~#rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:type_list.intlist) @type_list:nn:nn
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
-tail > public {inline} (0 calls)
+proc tail > public {inline} (0 calls)
 1: type_list.intlist.tail<1>
 tail(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:type_list.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []
@@ -376,7 +376,7 @@ tail(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:type_list.
 
 
 
-~= > public {inline} (0 calls)
+proc ~= > public {inline} (0 calls)
 0: type_list.intlist.~=<0>
 ~=(#left##0:type_list.intlist, #right##0:type_list.intlist, ?#success##0:wybe.bool)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/unbound_after_for.exp
+++ b/test-cases/final-dump/unbound_after_for.exp
@@ -1,3 +1,3 @@
 Error detected during type checking of module(s) unbound_after_for
-[91mfinal-dump/unbound_after_for.wybe:2:2: Uninitialised argument in call to println, argument 1
+[91mfinal-dump/unbound_after_for.wybe:2:2: Uninitialised argument in call to proc println, argument 1
 [0m

--- a/test-cases/final-dump/unbranch_bug.exp
+++ b/test-cases/final-dump/unbranch_bug.exp
@@ -17,21 +17,21 @@ module top-level code > public {inline,semipure} (0 calls)
     unbranch_bug.#cont#3<0>(0:wybe.list(5))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @unbranch_bug:nn:nn
 
 
-#cont#1 > {inline} (1 calls)
+proc #cont#1 > {inline} (1 calls)
 0: unbranch_bug.#cont#1<0>
 #cont#1()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-#cont#2 > {inline} (1 calls)
+proc #cont#2 > {inline} (1 calls)
 0: unbranch_bug.#cont#2<0>
 #cont#2()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-#cont#3 > (2 calls)
+proc #cont#3 > (2 calls)
 0: unbranch_bug.#cont#3<0>
 #cont#3(tmp#0##0:wybe.list(5) <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/unbranch_inout.exp
+++ b/test-cases/final-dump/unbranch_inout.exp
@@ -19,7 +19,7 @@ module top-level code > public {inline,semipure} (0 calls)
     foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-bug > {inline} (1 calls)
+proc bug > {inline} (1 calls)
 0: unbranch_inout.bug<0>
 bug(i##0:wybe.int, ?i##1:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -27,7 +27,7 @@ bug(i##0:wybe.int, ?i##1:wybe.int)<{}; {}; {}>:
     foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
 
-bug#cont#1 > {inline} (1 calls)
+proc bug#cont#1 > {inline} (1 calls)
 0: unbranch_inout.bug#cont#1<0>
 bug#cont#1(i##0:wybe.int, [?i##0:wybe.int])<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/uneeded_closure_args.exp
+++ b/test-cases/final-dump/uneeded_closure_args.exp
@@ -20,7 +20,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int:nn:nn
 
 
-#closure#1 > {inline} (1 calls)
+proc #closure#1 > {inline} (1 calls)
 0: uneeded_closure_args.#closure#1<0>
 #closure#1([^a##0:A <{}; {}; {0}>], b##0:B <{}; {}; {1}>, ?#result##0:B <{}; {}; {1}>)<{}; {}; {}>:
   AliasPairs: []
@@ -28,7 +28,7 @@ module top-level code > public {semipure} (0 calls)
     foreign llvm move(~b##0:B, ?#result##0:B) @uneeded_closure_args:nn:nn
 
 
-call > {noinline} (1 calls)
+proc call > {noinline} (1 calls)
 0: uneeded_closure_args.call<0>
 call(f##0:(A, ?A) <{}; {}; {0}>, a##0:A <{}; {}; {1}>, ?#result##0:A <{}; {}; {0, 1}>)<{}; {}; {}>:
   AliasPairs: []
@@ -36,7 +36,7 @@ call(f##0:(A, ?A) <{}; {}; {0}>, a##0:A <{}; {}; {1}>, ?#result##0:A <{}; {}; {0
     ~f##0:(A, ?A)(~a##0:A, ?#result##0:A) #0 @uneeded_closure_args:nn:nn
 
 
-second > {inline} (1 calls)
+proc second > {inline} (1 calls)
 0: uneeded_closure_args.second<0>
 second([a##0:A <{}; {}; {0}>], b##0:B <{}; {}; {1}>, ?#result##0:B <{}; {}; {1}>)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/unexported_type_overload.exp
+++ b/test-cases/final-dump/unexported_type_overload.exp
@@ -1,3 +1,3 @@
 Error detected during checking parameter type declarations in module(s) unexported_type_overload, unexported_type_overload.sub, unexported_type_overload.sub.hidden
-[91mfinal-dump/unexported_type_overload.wybe:8:5: Public proc 'proc2' with undeclared parameter or return type
+[91mfinal-dump/unexported_type_overload.wybe:8:5: Public proc proc2 with undeclared parameter or return type
 [0m

--- a/test-cases/final-dump/unique_conditional.exp
+++ b/test-cases/final-dump/unique_conditional.exp
@@ -11,21 +11,21 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-bar > public {inline} (1 calls)
+proc bar > public {inline} (1 calls)
 0: unique_conditional.bar<0>
 bar([a##0:unique_conditional])<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-baz > public {inline} (1 calls)
+proc baz > public {inline} (1 calls)
 0: unique_conditional.baz<0>
 baz([a##0:unique_conditional])<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
 
-foo > (0 calls)
+proc foo > (0 calls)
 0: unique_conditional.foo<0>
 foo(b##0:wybe.bool, [a##0:unique_conditional])<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/unique_position.exp
+++ b/test-cases/final-dump/unique_position.exp
@@ -30,7 +30,7 @@ module top-level code > public {semipure} (0 calls)
     unique_position.printPosition<0>(~p2##1:unique_position.unique_position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @unique_position:nn:nn
 
 
-printPosition > public (1 calls)
+proc printPosition > public (1 calls)
 0: unique_position.printPosition<0>
 printPosition(pos##0:unique_position.unique_position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
@@ -140,7 +140,7 @@ entry:
   resources       : 
   procs           : 
 
-unique_position > public {inline} (0 calls)
+proc unique_position > public {inline} (0 calls)
 0: unique_position.unique_position.unique_position<0>
 unique_position(x##0:wybe.int, y##0:wybe.int, ?#result##0:unique_position.unique_position)<{}; {}; {}>:
   AliasPairs: []
@@ -148,7 +148,7 @@ unique_position(x##0:wybe.int, y##0:wybe.int, ?#result##0:unique_position.unique
     foreign lpvm alloc(16:wybe.int, ?#rec##0:unique_position.unique_position) @unique_position:nn:nn
     foreign lpvm mutate(~#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int) @unique_position:nn:nn
     foreign lpvm mutate(~#rec##1:unique_position.unique_position, ?#result##0:unique_position.unique_position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int) @unique_position:nn:nn
-unique_position > public {inline} (0 calls)
+proc unique_position > public {inline} (0 calls)
 1: unique_position.unique_position.unique_position<1>
 unique_position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:unique_position.unique_position)<{}; {}; {}>:
   AliasPairs: []
@@ -157,13 +157,13 @@ unique_position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:unique_position.uniqu
     foreign lpvm {unique} access(~#result##0:unique_position.unique_position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @unique_position:nn:nn
 
 
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 0: unique_position.unique_position.x<0>
 x(#rec##0:unique_position.unique_position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:unique_position.unique_position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @unique_position:nn:nn
-x > public {inline} (0 calls)
+proc x > public {inline} (0 calls)
 1: unique_position.unique_position.x<1>
 x(#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
@@ -171,13 +171,13 @@ x(#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_posit
     foreign lpvm {noalias} mutate(~#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int) @unique_position:nn:nn
 
 
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 0: unique_position.unique_position.y<0>
 y(#rec##0:unique_position.unique_position, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~#rec##0:unique_position.unique_position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int) @unique_position:nn:nn
-y > public {inline} (0 calls)
+proc y > public {inline} (0 calls)
 1: unique_position.unique_position.y<1>
 y(#rec##0:unique_position.unique_position, ?#rec##1:unique_position.unique_position, #field##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/unneeded.exp
+++ b/test-cases/final-dump/unneeded.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-unneeded > {inline} (0 calls)
+proc unneeded > {inline} (0 calls)
 0: unneeded.unneeded<0>
 unneeded(x##0:wybe.int, [y##0:wybe.int], ?z##0:wybe.int, q##0:wybe.int, [?q##0:wybe.int])<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/update.exp
+++ b/test-cases/final-dump/update.exp
@@ -10,14 +10,14 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-inc2 > public {inline} (0 calls)
+proc inc2 > public {inline} (0 calls)
 0: update.inc2<0>
 inc2(x##0:wybe.int, ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
     foreign llvm add(~tmp#1##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
-inc2 > public {inline} (0 calls)
+proc inc2 > public {inline} (0 calls)
 1: update.inc2<1>
 inc2(?x##0:wybe.int, y##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []

--- a/test-cases/final-dump/use_before_def.exp
+++ b/test-cases/final-dump/use_before_def.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) use_before_def
 [91mfinal-dump/use_before_def.wybe:1:5: Output parameter result not defined by proc use_before_def
-[0m[91mfinal-dump/use_before_def.wybe:2:9: Uninitialised argument in call to =, argument 2
-[0m[91mfinal-dump/use_before_def.wybe:2:18: Uninitialised argument in call to +, argument 1
+[0m[91mfinal-dump/use_before_def.wybe:2:9: Uninitialised argument in call to proc =, argument 2
+[0m[91mfinal-dump/use_before_def.wybe:2:18: Uninitialised argument in call to proc +, argument 1
 [0m

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -27,7 +27,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @io:nn:nn
 
 
-inc_count > {inline} (4 calls)
+proc inc_count > {inline} (4 calls)
 0: use_resource.inc_count<0>
 inc_count()<{<<use_resource.count>>}; {<<use_resource.count>>}; {}>:
   AliasPairs: []
@@ -37,7 +37,7 @@ inc_count()<{<<use_resource.count>>}; {<<use_resource.count>>}; {}>:
     foreign lpvm store(~tmp#0##0:wybe.int, <<use_resource.count>>:wybe.int) @use_resource:nn:nn
 
 
-use_test > {inline} (1 calls)
+proc use_test > {inline} (1 calls)
 0: use_resource.use_test<0>
 use_test()<{<<use_resource.count>>, <<wybe.io.io>>}; {<<use_resource.count>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []


### PR DESCRIPTION
This PR more consistently shows proc names as "proc foo" instead of "'foo'" or just "foo".  It also refers to higher order terms as "higher-order term foo", foreign procs as "foreign proc foo", and the top-level code in a module as "module top-level code" (because we don't know the module name when we report this).  This mainly shows up for users in error messages, but most of the files in the PR are changed because logging messages now begin a proc listing with "proc foo >" instead of just "foo >".