### PR TITLE
Fixed `seqToStmt` on an empty list to return `Nop`

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2950,8 +2950,7 @@ instance Show Stmt where
 -- |Produce a single statement comprising the conjunctions of the statements
 --  in the supplied list.
 seqToStmt :: [Placed Stmt] -> Placed Stmt
-seqToStmt [] = Unplaced $ TestBool
-               $ Typed (IntValue 1) AnyType $ Just $ TypeSpec ["wybe"] "bool" []
+seqToStmt [] = Unplaced Nop
 seqToStmt [stmt] = stmt
 seqToStmt stmts = Unplaced $ And stmts
 


### PR DESCRIPTION
Previously we have
https://github.com/pschachte/wybe/blob/6fe5353e751051e4e1292b644f379980ea484735/src/AST.hs#L2950-L2954
but this would fail type-checking with the following message
```
Error detected during type checking of module(s) <module>
Type of 1 incompatible with wybe.bool
```