### PR TITLE
Fix #414

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ The following have contributed code to the Wybe project:
 * Marco Ho
 * James Barnes
 * Leyan (Terry) Lin
+* Chris Chamberlain

--- a/test-cases/final-dump/resource_conflict_a.exp
+++ b/test-cases/final-dump/resource_conflict_a.exp
@@ -1,0 +1,27 @@
+======================================================================
+AFTER EVERYTHING:
+ Module resource_conflict_a
+  representation  : (not a type)
+  public submods  : 
+  public resources: res: resource_conflict_a.res
+  public procs    : 
+  imports         : use wybe
+  resources       : res: fromList [(resource_conflict_a.res,wybe.int = 42 @resource_conflict_a:nn:nn @resource_conflict_a:nn:nn)]
+  procs           : 
+
+
+  LLVM code       :
+
+; ModuleID = 'resource_conflict_a'
+
+
+ 
+
+
+@"resource#resource_conflict_a.res" =    global i64 undef
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    

--- a/test-cases/final-dump/resource_conflict_a.wybe
+++ b/test-cases/final-dump/resource_conflict_a.wybe
@@ -1,0 +1,1 @@
+pub resource res:int  = 42

--- a/test-cases/final-dump/resource_conflict_b.exp
+++ b/test-cases/final-dump/resource_conflict_b.exp
@@ -1,0 +1,27 @@
+======================================================================
+AFTER EVERYTHING:
+ Module resource_conflict_b
+  representation  : (not a type)
+  public submods  : 
+  public resources: res: resource_conflict_b.res
+  public procs    : 
+  imports         : use wybe
+  resources       : res: fromList [(resource_conflict_b.res,wybe.char = 'c' @resource_conflict_b:nn:nn @resource_conflict_b:nn:nn)]
+  procs           : 
+
+
+  LLVM code       :
+
+; ModuleID = 'resource_conflict_b'
+
+
+ 
+
+
+@"resource#resource_conflict_b.res" =    global i8 undef
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    

--- a/test-cases/final-dump/resource_conflict_b.wybe
+++ b/test-cases/final-dump/resource_conflict_b.wybe
@@ -1,0 +1,1 @@
+pub resource res:char = 'c'

--- a/test-cases/final-dump/resource_conflict_c.exp
+++ b/test-cases/final-dump/resource_conflict_c.exp
@@ -1,0 +1,3 @@
+Error detected during type checking of module(s) resource_conflict_c
+[91mOverloaded resources resource_conflict_a.res, resource_conflict_b.res
+[0m

--- a/test-cases/final-dump/resource_conflict_c.wybe
+++ b/test-cases/final-dump/resource_conflict_c.wybe
@@ -1,0 +1,2 @@
+use resource_conflict_a, resource_conflict_b
+?c = 0


### PR DESCRIPTION
When type checking code, look for multiple modules with the same resource names, and report that as an overloading error.  Until we support module qualifying resource names when using or assigning, this is the best we can do.