### PR TITLE
 Fix determinism analysis of case statements and expressions

### DIFF
--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -446,7 +446,7 @@ flattenAssignment var varArg value pos = do
 
 translateCases :: Placed Exp -> OptPos -> [(Placed Exp,[Placed Stmt])]
                -> Maybe [Placed Stmt] -> [Placed Stmt]
-translateCases val pos [] Nothing = [Unplaced Fail]
+translateCases val pos [] Nothing = [Unplaced Nop]
 translateCases val pos [] (Just deflt) = deflt
 translateCases val pos ((key,body):rest) deflt =
     [maybePlace

--- a/test-cases/final-dump/alias_recursion2.exp
+++ b/test-cases/final-dump/alias_recursion2.exp
@@ -1,4 +1,5 @@
 Error detected during type checking of module(s) alias_recursion2, alias_recursion2.mynode
-[91mfinal-dump/alias_recursion2.wybe:18:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
+[91mfinal-dump/alias_recursion2.wybe:12:5: proc reverseList has test determinism, but declared normal (total)
+[0m[91mfinal-dump/alias_recursion2.wybe:18:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion2.wybe:19:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
 [0m

--- a/test-cases/final-dump/card.wybe
+++ b/test-cases/final-dump/card.wybe
@@ -9,6 +9,7 @@ pub type suit { pub constructors
         |   diamonds :: 'D'
         |   hearts   :: 'H'
         |   spades   :: 'S'
+        |   else     :: shouldnt
         }
 
     pub def print(r:_) use !io {
@@ -38,6 +39,7 @@ pub type rank { pub constructors
         |   queen :: 'Q'
         |   king  :: 'K'
         |   ace   :: 'A'
+        |   else  :: shouldnt
         }
 
     pub def print(r:_) use !io {

--- a/test-cases/final-dump/case_detism.exp
+++ b/test-cases/final-dump/case_detism.exp
@@ -1,0 +1,3 @@
+Error detected during type checking of module(s) case_detism
+[91mmodule top-level code has test determinism, but declared normal (total)
+[0m

--- a/test-cases/final-dump/case_detism.wybe
+++ b/test-cases/final-dump/case_detism.wybe
@@ -1,0 +1,15 @@
+
+
+def {noinline} one:int = 1
+def {noinline} two:int = 2
+
+!println(
+    case one <=> two in {
+        lesser ::
+            "less"
+    |   equal ::
+            "equal"
+    |   greater ::
+            "greater"
+    }
+)

--- a/test-cases/final-dump/detism_error.exp
+++ b/test-cases/final-dump/detism_error.exp
@@ -1,4 +1,5 @@
 Error detected during type checking of module(s) detism_error
-[91mfinal-dump/detism_error.wybe:4:6: Calling test proc wybe.int.=<0> in a normal (total) context
-[0m[91mfinal-dump/detism_error.wybe:16:5: not_really_terminal has normal (total) determinism, but declared terminal
+[91mfinal-dump/detism_error.wybe:3:5: proc not_really_det has test determinism, but declared normal (total)
+[0m[91mfinal-dump/detism_error.wybe:4:6: Calling test proc wybe.int.=<0> in a normal (total) context
+[0m[91mfinal-dump/detism_error.wybe:16:5: proc not_really_terminal has normal (total) determinism, but declared terminal
 [0m

--- a/test-cases/final-dump/error_mode.exp
+++ b/test-cases/final-dump/error_mode.exp
@@ -1,4 +1,5 @@
 Error detected during type checking of module(s) error_mode, error_mode.tree
-[91mfinal-dump/error_mode.wybe:8:40: Calling test proc error_mode.tree.left<0> in a normal (total) context
+[91mfinal-dump/error_mode.wybe:5:5: proc lookup has test determinism, but declared normal (total)
+[0m[91mfinal-dump/error_mode.wybe:8:40: Calling test proc error_mode.tree.left<0> in a normal (total) context
 [0m[91mfinal-dump/error_mode.wybe:9:30: Calling test proc error_mode.tree.right<0> in a normal (total) context
 [0m

--- a/test-cases/final-dump/error_mode2.exp
+++ b/test-cases/final-dump/error_mode2.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) error_mode2
-[91mfinal-dump/error_mode2.wybe:3:5: non_terminal has normal (total) determinism, but declared terminal
-[0m[91mfinal-dump/error_mode2.wybe:7:5: non_terminal2 has failing determinism, but declared terminal
-[0m[91mfinal-dump/error_mode2.wybe:15:5: non_failing has normal (total) determinism, but declared failing
+[91mfinal-dump/error_mode2.wybe:3:5: proc non_terminal has normal (total) determinism, but declared terminal
+[0m[91mfinal-dump/error_mode2.wybe:7:5: proc non_terminal2 has failing determinism, but declared terminal
+[0m[91mfinal-dump/error_mode2.wybe:15:5: proc non_failing has normal (total) determinism, but declared failing
 [0m

--- a/wybelibs/wybe/char.wybe
+++ b/wybelibs/wybe/char.wybe
@@ -3,7 +3,7 @@
 
 pragma no_standard_library  # Standard library can't depend on itself!
 
-use wybe.bool, wybe.int, wybe.comparison, wybe.string, wybe.io
+use wybe.bool, wybe.count, wybe.int, wybe.comparison, wybe.string, wybe.io
 
 representation is 8 bit unsigned
 
@@ -29,8 +29,14 @@ pub def (x:_ <=> y:_):comparison =
 # Int ordinal of a char
 pub def ord(c:_):int = foreign lpvm cast(c)
 
-# Char of an integer character code
+# Count (unsigned) ordinal of a char
+pub def ord(c:_):count = foreign lpvm cast(c)
+
+# Char of an int character code
 pub def {test} chr(i:int):_ = foreign lpvm cast(i) where { 0 <= i ; i <= 255 }
+
+# Char of a count (unsigned) character code
+pub def {test} chr(i:count):_ = foreign lpvm cast(i) where { i <= 255:count }
 
 ## Formatting
 pub def fmt(x:_):string = string(x)

--- a/wybelibs/wybe/control.wybe
+++ b/wybelibs/wybe/control.wybe
@@ -27,6 +27,14 @@ pub def {terminal,semipure} error(message:c_string) use call_source_location {
 }
 
 
+pub def {terminal,semipure} shouldnt use call_source_location {
+    !error("shouldn't happen!")
+}
+
+pub def {terminal,pure} shouldnt(?result:T) use call_source_location {
+    !error("shouldn't happen!")
+}
+
 pub def {semipure} assert(condition:bool) use call_source_location {
     if { ~condition :: !error(c"assertion failed") }
 }

--- a/wybelibs/wybe/count.wybe
+++ b/wybelibs/wybe/count.wybe
@@ -90,8 +90,7 @@ pub def {partial} decr(!x:_) { ?x = x - 1:_ }
 ## Formatting
 pub def fmt(x:_):string = s where
     { ?s = (if {x >= 10:_ :: fmt(x/10:_) | else :: ""})
-         ,, chr(ord('0')+int(x%10:_))
-    | !error("can't happen!")
+           ,, ( chr(ord('0')+int(x%10:_)) | shouldnt )
     }
 
 

--- a/wybelibs/wybe/string.wybe
+++ b/wybelibs/wybe/string.wybe
@@ -4,7 +4,7 @@
 pragma no_standard_library
 
 use wybe.c_string, wybe.range, wybe.int, wybe.char, wybe.bool, wybe.comparison
-use wybe.io 
+use wybe.control, wybe.io 
 
 # Private constructors.
 # This ensures that strings can only be manipulated with public procedures,
@@ -158,6 +158,7 @@ pub def print(x:_) use !io {
       | concat(?left, ?right) :: !print(left); !print(right)
       | slice(_, _) :: for ?c in x { !print(c) }
       | singleton(?c) :: !print(c)
+      | else :: !shouldnt
     }
 }
 
@@ -188,6 +189,7 @@ def pack(s:_, !raw:c_string, size:int, !offset:int) {
       | singleton(?c) ::
             foreign lpvm mutate(raw, ?raw, offset, true, size, 0, c)
             incr(!offset)
+      | else :: !shouldnt
     }
 }
 


### PR DESCRIPTION
Introduce `shouldnt` proc and function to report an error that shouldn't happen. Fixes #433.