### PR TITLE
 Allow conditional and case expressions to omit the else branch

### DIFF
--- a/src/Clause.hs
+++ b/src/Clause.hs
@@ -318,6 +318,7 @@ compileArg' typ (Closure ms es) _ = do
     unless (sameLength es as)
            $ shouldnt "compileArg' Closure with in/out args"
     return [ArgClosure ms as typ]
+compileArg' typ FailExpr _ = return [ArgInt 0 typ]
 compileArg' typ var@(Var name flow flowType) pos = do
     inArg <- if flowsIn flow
         then do

--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -515,6 +515,9 @@ flattenExp expr@(Var "_" flow _) ty castFrom pos = do
                               ++ flowPrefix flow ++ " mode prefix"
     dummyName <- tempVar
     return $ typeAndPlace (Var dummyName ParamOut Ordinary) ty castFrom pos
+flattenExp FailExpr ty castFrom pos = do
+    emit pos Fail
+    return $ typeAndPlace FailExpr ty castFrom pos
 flattenExp expr@(Var name dir flowType) ty castFrom pos = do
     logFlatten $ "  Flattening arg " ++ show expr
     defd <- gets (Set.member name . defdVars)

--- a/src/Unique.hs
+++ b/src/Unique.hs
@@ -349,6 +349,7 @@ uniquenessCheckExp CharValue{} _ = return ()
 uniquenessCheckExp StringValue{} _ = return ()
 uniquenessCheckExp var@Var{} _ =
     shouldnt $ "Untyped variable " ++ show var ++ " in uniqueness checking"
+uniquenessCheckExp FailExpr _ = return ()
 uniquenessCheckExp (Where stmts exp) pos = do
     uniquenessCheckStmts stmts
     defaultPlacedApply uniquenessCheckExp pos exp

--- a/test-cases/final-dump/cond_expr_no_else.exp
+++ b/test-cases/final-dump/cond_expr_no_else.exp
@@ -1,0 +1,362 @@
+======================================================================
+AFTER EVERYTHING:
+ Module cond_expr_no_else
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : cond_expr_no_else.<0>
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+module top-level code > public {semipure} (0 calls)
+0: cond_expr_no_else.<0>
+()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    cond_expr_no_else.to_count<0>(5:wybe.int, ?tmp#3##0:wybe.count, ?tmp#19##0:wybe.bool) #0 @cond_expr_no_else:nn:nn
+    case ~tmp#19##0:wybe.bool of
+    0:
+        cond_expr_no_else.#cont#1<0>(10:wybe.count)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
+
+    1:
+        cond_expr_no_else.#cont#1<0>(~tmp#3##0:wybe.count)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1
+
+
+
+proc #cont#1 > {semipure} (2 calls)
+0: cond_expr_no_else.#cont#1<0>
+#cont#1(tmp#2##0:wybe.count)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+  MultiSpeczDepInfo: [(7,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.count.fmt<2>(~tmp#2##0:wybe.count, 0:wybe.int, ' ':wybe.char, ?tmp#1##0:wybe.string) #6 @cond_expr_no_else:nn:nn
+    wybe.string.,,<0>("5:int -> ":wybe.string, ~tmp#1##0:wybe.string, ?tmp#0##0:wybe.string) #1 @cond_expr_no_else:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @cond_expr_no_else:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @cond_expr_no_else:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @cond_expr_no_else:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @cond_expr_no_else:nn:nn
+    cond_expr_no_else.to_count<0>(-5:wybe.int, ?tmp#7##0:wybe.count, ?tmp#18##0:wybe.bool) #3 @cond_expr_no_else:nn:nn
+    case ~tmp#18##0:wybe.bool of
+    0:
+        cond_expr_no_else.#cont#2<0>(10:wybe.count)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5
+
+    1:
+        cond_expr_no_else.#cont#2<0>(~tmp#7##0:wybe.count)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
+
+
+
+proc #cont#2 > {semipure} (2 calls)
+0: cond_expr_no_else.#cont#2<0>
+#cont#2(tmp#6##0:wybe.count)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+  MultiSpeczDepInfo: [(7,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.count.fmt<2>(~tmp#6##0:wybe.count, 0:wybe.int, ' ':wybe.char, ?tmp#5##0:wybe.string) #6 @cond_expr_no_else:nn:nn
+    wybe.string.,,<0>("-5:int -> ":wybe.string, ~tmp#5##0:wybe.string, ?tmp#4##0:wybe.string) #1 @cond_expr_no_else:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @cond_expr_no_else:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @cond_expr_no_else:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @cond_expr_no_else:nn:nn
+    foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @cond_expr_no_else:nn:nn
+    cond_expr_no_else.vowel_num<0>('e':wybe.char, ?tmp#11##0:wybe.int, ?tmp#17##0:wybe.bool) #3 @cond_expr_no_else:nn:nn
+    case ~tmp#17##0:wybe.bool of
+    0:
+        cond_expr_no_else.#cont#3<0>(0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5
+
+    1:
+        cond_expr_no_else.#cont#3<0>(~tmp#11##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
+
+
+
+proc #cont#3 > {semipure} (2 calls)
+0: cond_expr_no_else.#cont#3<0>
+#cont#3(tmp#10##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+  MultiSpeczDepInfo: [(7,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.int.fmt<2>(~tmp#10##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#9##0:wybe.string) #6 @cond_expr_no_else:nn:nn
+    wybe.string.,,<0>("e is vowel number ":wybe.string, ~tmp#9##0:wybe.string, ?tmp#8##0:wybe.string) #1 @cond_expr_no_else:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#8##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @cond_expr_no_else:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @cond_expr_no_else:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @cond_expr_no_else:nn:nn
+    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @cond_expr_no_else:nn:nn
+    cond_expr_no_else.vowel_num<0>('f':wybe.char, ?tmp#15##0:wybe.int, ?tmp#16##0:wybe.bool) #3 @cond_expr_no_else:nn:nn
+    case ~tmp#16##0:wybe.bool of
+    0:
+        cond_expr_no_else.#cont#4<0>(0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5
+
+    1:
+        cond_expr_no_else.#cont#4<0>(~tmp#15##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
+
+
+
+proc #cont#4 > {semipure} (2 calls)
+0: cond_expr_no_else.#cont#4<0>
+#cont#4(tmp#14##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.int.fmt<2>(~tmp#14##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#13##0:wybe.string) #3 @cond_expr_no_else:nn:nn
+    wybe.string.,,<0>("f is vowel number ":wybe.string, ~tmp#13##0:wybe.string, ?tmp#12##0:wybe.string) #1 @cond_expr_no_else:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#12##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @cond_expr_no_else:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @cond_expr_no_else:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @cond_expr_no_else:nn:nn
+    foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @cond_expr_no_else:nn:nn
+
+
+proc to_count > (6 calls)
+0: cond_expr_no_else.to_count<0>
+to_count(i##0:wybe.int, ?#result##0:wybe.count, ?#success##0:wybe.bool)<{}; {}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_sge(i##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @cond_expr_no_else:nn:nn
+    case ~tmp#1##0:wybe.bool of
+    0:
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
+        foreign llvm move(undef:wybe.count, ?#result##0:wybe.count)
+
+    1:
+        foreign llvm move(~i##0:wybe.count, ?#result##0:wybe.count) @cond_expr_no_else:nn:nn
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+
+
+proc vowel_num > (6 calls)
+0: cond_expr_no_else.vowel_num<0>
+vowel_num(c##0:wybe.char, ?#result##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm icmp_eq(c##0:wybe.char, 'a':wybe.char, ?tmp#5##0:wybe.bool) @cond_expr_no_else:nn:nn
+    case ~tmp#5##0:wybe.bool of
+    0:
+        foreign llvm icmp_eq(c##0:wybe.char, 'e':wybe.char, ?tmp#4##0:wybe.bool) @cond_expr_no_else:nn:nn
+        case ~tmp#4##0:wybe.bool of
+        0:
+            foreign llvm icmp_eq(c##0:wybe.char, 'i':wybe.char, ?tmp#3##0:wybe.bool) @cond_expr_no_else:nn:nn
+            case ~tmp#3##0:wybe.bool of
+            0:
+                foreign llvm icmp_eq(c##0:wybe.char, 'o':wybe.char, ?tmp#2##0:wybe.bool) @cond_expr_no_else:nn:nn
+                case ~tmp#2##0:wybe.bool of
+                0:
+                    foreign llvm icmp_eq(~c##0:wybe.char, 'u':wybe.char, ?tmp#1##0:wybe.bool) @cond_expr_no_else:nn:nn
+                    case ~tmp#1##0:wybe.bool of
+                    0:
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
+                        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
+
+                    1:
+                        foreign llvm move(5:wybe.int, ?#result##0:wybe.int) @cond_expr_no_else:nn:nn
+                        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+
+                1:
+                    foreign llvm move(4:wybe.int, ?#result##0:wybe.int) @cond_expr_no_else:nn:nn
+                    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+
+            1:
+                foreign llvm move(3:wybe.int, ?#result##0:wybe.int) @cond_expr_no_else:nn:nn
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+
+        1:
+            foreign llvm move(2:wybe.int, ?#result##0:wybe.int) @cond_expr_no_else:nn:nn
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+
+    1:
+        foreign llvm move(1:wybe.int, ?#result##0:wybe.int) @cond_expr_no_else:nn:nn
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
+
+
+  LLVM code       :
+
+; ModuleID = 'cond_expr_no_else'
+
+
+ 
+
+
+@cond_expr_no_else.1 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @cond_expr_no_else.0 to i64) }
+
+
+@cond_expr_no_else.3 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @cond_expr_no_else.2 to i64) }
+
+
+@cond_expr_no_else.5 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @cond_expr_no_else.4 to i64) }
+
+
+@cond_expr_no_else.7 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @cond_expr_no_else.6 to i64) }
+
+
+@cond_expr_no_else.2 =    constant [?? x i8] c"-5:int -> \00"
+
+
+@cond_expr_no_else.0 =    constant [?? x i8] c"5:int -> \00"
+
+
+@cond_expr_no_else.4 =    constant [?? x i8] c"e is vowel number \00"
+
+
+@cond_expr_no_else.6 =    constant [?? x i8] c"f is vowel number \00"
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external fastcc  void @"wybe.string.print<0>[410bae77d3]"(i64)    
+
+
+declare external fastcc  i64 @"wybe.string.,,<0>"(i64, i64)    
+
+
+declare external fastcc  i64 @"wybe.int.fmt<2>"(i64, i64, i8)    
+
+
+declare external fastcc  i64 @"wybe.count.fmt<2>"(i64, i64, i8)    
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i1)    
+
+
+define external fastcc  void @"cond_expr_no_else.<0>"()    {
+entry:
+  %0 = tail call fastcc  {i64, i1}  @"cond_expr_no_else.to_count<0>"(i64  5)  
+  %1 = extractvalue {i64, i1} %0, 0 
+  %2 = extractvalue {i64, i1} %0, 1 
+  br i1 %2, label %if.then, label %if.else 
+if.then:
+  tail call fastcc  void  @"cond_expr_no_else.#cont#1<0>"(i64  %1)  
+  ret void 
+if.else:
+  tail call fastcc  void  @"cond_expr_no_else.#cont#1<0>"(i64  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"cond_expr_no_else.#cont#1<0>"(i64  %"tmp#2##0")    {
+entry:
+  %0 = tail call fastcc  i64  @"wybe.count.fmt<2>"(i64  %"tmp#2##0", i64  0, i8  32)  
+  %1 = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @cond_expr_no_else.1, i32 0, i32 0) to i64), i64  %0)  
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  %2 = tail call fastcc  {i64, i1}  @"cond_expr_no_else.to_count<0>"(i64  -5)  
+  %3 = extractvalue {i64, i1} %2, 0 
+  %4 = extractvalue {i64, i1} %2, 1 
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  musttail call fastcc  void  @"cond_expr_no_else.#cont#2<0>"(i64  %3)  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"cond_expr_no_else.#cont#2<0>"(i64  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"cond_expr_no_else.#cont#2<0>"(i64  %"tmp#6##0")    {
+entry:
+  %0 = tail call fastcc  i64  @"wybe.count.fmt<2>"(i64  %"tmp#6##0", i64  0, i8  32)  
+  %1 = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @cond_expr_no_else.3, i32 0, i32 0) to i64), i64  %0)  
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  %2 = tail call fastcc  {i64, i1}  @"cond_expr_no_else.vowel_num<0>"(i8  101)  
+  %3 = extractvalue {i64, i1} %2, 0 
+  %4 = extractvalue {i64, i1} %2, 1 
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  musttail call fastcc  void  @"cond_expr_no_else.#cont#3<0>"(i64  %3)  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"cond_expr_no_else.#cont#3<0>"(i64  0)  
+  ret void 
+}
+
+
+define external fastcc  void @"cond_expr_no_else.#cont#3<0>"(i64  %"tmp#10##0")    {
+entry:
+  %0 = tail call fastcc  i64  @"wybe.int.fmt<2>"(i64  %"tmp#10##0", i64  0, i8  32)  
+  %1 = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @cond_expr_no_else.5, i32 0, i32 0) to i64), i64  %0)  
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  %2 = tail call fastcc  {i64, i1}  @"cond_expr_no_else.vowel_num<0>"(i8  102)  
+  %3 = extractvalue {i64, i1} %2, 0 
+  %4 = extractvalue {i64, i1} %2, 1 
+  br i1 %4, label %if.then, label %if.else 
+if.then:
+  musttail call fastcc  void  @"cond_expr_no_else.#cont#4<0>"(i64  %3)  
+  ret void 
+if.else:
+  musttail call fastcc  void  @"cond_expr_no_else.#cont#4<0>"(i64  0)  
+  ret void 
+}
+
+
+define external fastcc  void @"cond_expr_no_else.#cont#4<0>"(i64  %"tmp#14##0")    {
+entry:
+  %0 = tail call fastcc  i64  @"wybe.int.fmt<2>"(i64  %"tmp#14##0", i64  0, i8  32)  
+  %1 = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @cond_expr_no_else.7, i32 0, i32 0) to i64), i64  %0)  
+  tail call fastcc  void  @"wybe.string.print<0>[410bae77d3]"(i64  %1)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  {i64, i1} @"cond_expr_no_else.to_count<0>"(i64  %"i##0")    {
+entry:
+  %0 = icmp sge i64 %"i##0", 0 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = insertvalue {i64, i1} undef, i64 %"i##0", 0 
+  %2 = insertvalue {i64, i1} %1, i1 1, 1 
+  ret {i64, i1} %2 
+if.else:
+  %3 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %4 = insertvalue {i64, i1} %3, i1 0, 1 
+  ret {i64, i1} %4 
+}
+
+
+define external fastcc  {i64, i1} @"cond_expr_no_else.vowel_num<0>"(i8  %"c##0")    {
+entry:
+  %0 = icmp eq i8 %"c##0", 97 
+  br i1 %0, label %if.then, label %if.else 
+if.then:
+  %1 = insertvalue {i64, i1} undef, i64 1, 0 
+  %2 = insertvalue {i64, i1} %1, i1 1, 1 
+  ret {i64, i1} %2 
+if.else:
+  %3 = icmp eq i8 %"c##0", 101 
+  br i1 %3, label %if.then1, label %if.else1 
+if.then1:
+  %4 = insertvalue {i64, i1} undef, i64 2, 0 
+  %5 = insertvalue {i64, i1} %4, i1 1, 1 
+  ret {i64, i1} %5 
+if.else1:
+  %6 = icmp eq i8 %"c##0", 105 
+  br i1 %6, label %if.then2, label %if.else2 
+if.then2:
+  %7 = insertvalue {i64, i1} undef, i64 3, 0 
+  %8 = insertvalue {i64, i1} %7, i1 1, 1 
+  ret {i64, i1} %8 
+if.else2:
+  %9 = icmp eq i8 %"c##0", 111 
+  br i1 %9, label %if.then3, label %if.else3 
+if.then3:
+  %10 = insertvalue {i64, i1} undef, i64 4, 0 
+  %11 = insertvalue {i64, i1} %10, i1 1, 1 
+  ret {i64, i1} %11 
+if.else3:
+  %12 = icmp eq i8 %"c##0", 117 
+  br i1 %12, label %if.then4, label %if.else4 
+if.then4:
+  %13 = insertvalue {i64, i1} undef, i64 5, 0 
+  %14 = insertvalue {i64, i1} %13, i1 1, 1 
+  ret {i64, i1} %14 
+if.else4:
+  %15 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %16 = insertvalue {i64, i1} %15, i1 0, 1 
+  ret {i64, i1} %16 
+}

--- a/test-cases/final-dump/cond_expr_no_else.wybe
+++ b/test-cases/final-dump/cond_expr_no_else.wybe
@@ -1,0 +1,19 @@
+# Test conditional partial expression with no else
+
+def {partial} to_count(i:int):count =
+    (if {i>=0 :: i:!count})
+
+!println "5:int -> $((to_count(5)|10:count))"
+!println "-5:int -> $((to_count(-5)|10:count))"
+
+def {partial} vowel_num(c:char):int =
+    (case c in {
+        'a' :: 1
+    |   'e' :: 2
+    |   'i' :: 3
+    |   'o' :: 4
+    |   'u' :: 5
+    })
+
+!println "e is vowel number $((vowel_num('e')|0))"
+!println "f is vowel number $((vowel_num('f')|0))"

--- a/test-cases/final-dump/cond_expr_no_else_err1.exp
+++ b/test-cases/final-dump/cond_expr_no_else_err1.exp
@@ -1,0 +1,3 @@
+Error detected during type checking of module(s) cond_expr_no_else_err1
+[91mfinal-dump/cond_expr_no_else_err1.wybe:1:1: proc to_count has test determinism, but declared normal (total)
+[0m

--- a/test-cases/final-dump/cond_expr_no_else_err1.wybe
+++ b/test-cases/final-dump/cond_expr_no_else_err1.wybe
@@ -1,0 +1,2 @@
+def to_count(i:int):count =
+    (if {i>=0 :: i:!count})

--- a/test-cases/final-dump/cond_expr_no_else_err2.exp
+++ b/test-cases/final-dump/cond_expr_no_else_err2.exp
@@ -1,0 +1,3 @@
+Error detected during type checking of module(s) cond_expr_no_else_err2
+[91mfinal-dump/cond_expr_no_else_err2.wybe:1:1: proc vowel_num has test determinism, but declared normal (total)
+[0m

--- a/test-cases/final-dump/cond_expr_no_else_err2.wybe
+++ b/test-cases/final-dump/cond_expr_no_else_err2.wybe
@@ -1,0 +1,8 @@
+def vowel_num(c:char):int =
+    (case c in {
+        'a' :: 1
+    |   'e' :: 2
+    |   'i' :: 3
+    |   'o' :: 4
+    |   'u' :: 5
+    })


### PR DESCRIPTION
This makes the expression semidet, so it can only be done in test/partial contexts.
added test cases.