### PR TITLE
Only report the first ambiguous overloading error

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1493,7 +1493,10 @@ typecheckCalls [] residue False foreigns = do
     case List.filter (List.null . typingErrs) $ snd <$> typings' of
         [typing] -> put typing
         _ -> do
-            typeErrors $ overloadErr <$> residue
+            typeErrors $ overloadErr
+                 <$> case residue of
+                    [] -> []
+                    (e:_) -> [e]
             typecheckCalls [] [] False foreigns
 typecheckCalls (stmtTyping@(StmtTypings pstmt typs):calls)
         residue chg foreigns = do


### PR DESCRIPTION
If there's an unresolved residue after type checking, only report the first one to avoid overwhelming error messages.