### PR TITLE
Specially handle short strings in the parser

### DIFF
--- a/WYBE.md
+++ b/WYBE.md
@@ -2245,38 +2245,46 @@ Floating point multiplication
 Floating point division
 - `foreign llvm frem(`arg1:float, arg2:float`)`:float
 Floating point remainder
-- `foreign llvm fcmp_ord(`arg1:float, arg2:float`)`:bool
-Floating point ordered (neither is a NaN)
+
+
+##### Floating point comparisons
+
+Floating point comparisons are either *ordered* or *unordered*, the former
+returning false if either comparand is not a number (NaN), while the latter sort
+return true in that case.
+
+- `foreign llvm fcmp_false(`arg1:float, arg2:float`)`:bool
+Always returns false with no comparison
 - `foreign llvm fcmp_oeq(`arg1:float, arg2:float`)`:bool
 Floating point equality
+- `foreign llvm fcmp_ogt(`arg1:float, arg2:float`)`:bool
+Floating point strictly greater
+- `foreign llvm fcmp_oge(`arg1:float, arg2:float`)`:bool
+Floating point greater or equal
+- `foreign llvm fcmp_olt(`arg1:float, arg2:float`)`:bool
+Floating point strictly less
+- `foreign llvm fcmp_ole(`arg1:float, arg2:float`)`:bool
+Floating point less or equal
 - `foreign llvm fcmp_one(`arg1:float, arg2:float`)`:bool
 Floating point disequality
-- `foreign llvm fcmp_olt(`arg1:float, arg2:float`)`:bool
-Floating point (signed) strictly less
-- `foreign llvm fcmp_ole(`arg1:float, arg2:float`)`:bool
-Floating point (signed) less or equal
-- `foreign llvm fcmp_ogt(`arg1:float, arg2:float`)`:bool
-Floating point (signed) strictly greater
-- `foreign llvm fcmp_oge(`arg1:float, arg2:float`)`:bool
-Floating point (signed) greater or equal
 - `foreign llvm fcmp_ord(`arg1:float, arg2:float`)`:bool
-Floating point unordered (either is a NaN)
+Floating point ordered (neither is a NaN)
 - `foreign llvm fcmp_ueq(`arg1:float, arg2:float`)`:bool
 Floating point unordered or equal
-- `foreign llvm fcmp_une(`arg1:float, arg2:float`)`:bool
-Floating point unordered or not equal
-- `foreign llvm fcmp_ult(`arg1:float, arg2:float`)`:bool
-Floating point unordered or strictly less
-- `foreign llvm fcmp_ule(`arg1:float, arg2:float`)`:bool
-Floating point unordered or less or equal
 - `foreign llvm fcmp_ugt(`arg1:float, arg2:float`)`:bool
 Floating point unordered or strictly greater
 - `foreign llvm fcmp_uge(`arg1:float, arg2:float`)`:bool
 Floating point unordered or greater or equal
+- `foreign llvm fcmp_ult(`arg1:float, arg2:float`)`:bool
+Floating point unordered or strictly less
+- `foreign llvm fcmp_ule(`arg1:float, arg2:float`)`:bool
+Floating point unordered or less or equal
+- `foreign llvm fcmp_une(`arg1:float, arg2:float`)`:bool
+Floating point unordered or not equal
+- `foreign llvm fcmp_uno(`arg1:float, arg2:float`)`:bool
+Floating point unordered (either is a NaN)
 - `foreign llvm fcmp_true(`arg1:float, arg2:float`)`:bool
 Always returns true with no comparison
-- `foreign llvm fcmp_false(`arg1:float, arg2:float`)`:bool
-Always returns false with no comparison
 
 #####  <a name="conversion"></a>Integer/floating point conversion
 
@@ -2309,7 +2317,7 @@ treat this as an ordinary pointer.
 - `opaque`
 the type is a machine address, similar to the `void *` type in C.  Wybe treats such values as opaque.
 - *n* `bit signed`
-a signed primitive number type comprising *n* bits, where *n* is any non-negative
+a signed primitive number type comprising *n* bits, where *n* is any positive
 integer.  Represents integers between -2<sup>*n*-1</sup> and 2<sup>*n*-1</sup>-1 inclusive.
 - *n* `bit unsigned`
 an unsigned primitive number type comprising *n* bits, where *n* is any non-negative

--- a/src/BodyBuilder.hs
+++ b/src/BodyBuilder.hs
@@ -1127,38 +1127,38 @@ simplifyOp "fdiv" _ [ArgFloat n1 ty, ArgFloat n2 _, output] =
 simplifyOp "fdiv" _ [arg, ArgFloat 1 _, output] =
   primMove arg output
 -- Float comparisons
-simplifyOp "fcmp_ord" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
-  primMove (boolConstant True) output
+simplifyOp "fcmp_false" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+  primMove (boolConstant False) output
 simplifyOp "fcmp_oeq" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
   primMove (boolConstant $ n1==n2) output
-simplifyOp "fcmp_one" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
-  primMove (boolConstant $ n1/=n2) output
-simplifyOp "fcmp_olt" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
-  primMove (boolConstant $ n1<n2) output
-simplifyOp "fcmp_ole" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
-  primMove (boolConstant $ n1<=n2) output
 simplifyOp "fcmp_ogt" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
   primMove (boolConstant $ n1>n2) output
 simplifyOp "fcmp_oge" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
   primMove (boolConstant $ n1>=n2) output
+simplifyOp "fcmp_olt" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+  primMove (boolConstant $ n1<n2) output
+simplifyOp "fcmp_ole" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+  primMove (boolConstant $ n1<=n2) output
+simplifyOp "fcmp_one" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+  primMove (boolConstant $ n1/=n2) output
 simplifyOp "fcmp_ord" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
   primMove (boolConstant True) output
-simplifyOp "fcmp_oeq" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+simplifyOp "fcmp_ueq" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
   primMove (boolConstant $ n1==n2) output
-simplifyOp "fcmp_une" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
-  primMove (boolConstant $ n1/=n2) output
-simplifyOp "fcmp_ult" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
-  primMove (boolConstant $ n1<n2) output
-simplifyOp "fcmp_ule" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
-  primMove (boolConstant $ n1<=n2) output
 simplifyOp "fcmp_ugt" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
   primMove (boolConstant $ n1>n2) output
 simplifyOp "fcmp_uge" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
   primMove (boolConstant $ n1>=n2) output
+simplifyOp "fcmp_ult" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+  primMove (boolConstant $ n1<n2) output
+simplifyOp "fcmp_ule" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+  primMove (boolConstant $ n1<=n2) output
+simplifyOp "fcmp_une" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+  primMove (boolConstant $ n1/=n2) output
+simplifyOp "fcmp_uno" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
+  primMove (boolConstant False) output
 simplifyOp "fcmp_true" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
   primMove (boolConstant True) output
-simplifyOp "fcmp_false" _ [ArgFloat n1 _, ArgFloat n2 _, output] =
-  primMove (boolConstant False) output
 simplifyOp name flags args = PrimForeign "llvm" name flags args
 
 

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -171,7 +171,7 @@ typeRep = do
 -- | Type declaration body where visibility, constructors, and items are given
 typeCtors :: Parser (TypeImpln,[Item])
 typeCtors = betweenB Brace $ do
-    vis <- option Private 
+    vis <- option Private
         $ try (visibility <* (ident "constructor" <|> ident "constructors"))
     ctors <- TypeCtors vis <$> ctorDecls
     items <- option [] (separator *> items)
@@ -260,7 +260,7 @@ procOrFuncItem vis = do
                 Nothing -> do
                     body <- embracedTerm >>= parseWith termToBody
                     return $ ProcDecl vis mods proto' body $ Just pos
-        
+
 
 
 -- | Parse an optional series of resource flows
@@ -1171,9 +1171,9 @@ termToExp (Call pos [] "@" flow exps) = do
     exps' <- mapM termToExp exps
     case content <$> exps' of
         [] -> return $ Placed (AnonParamVar Nothing flow) pos
-        [IntValue i] | i > 0 
+        [IntValue i] | i > 0
             -> return $ Placed (AnonParamVar (Just i) flow) pos
-        [exp] 
+        [exp]
             -> return $ Placed (AnonFunc $ head exps') pos
         _ -> syntaxError pos "invalid anonymous parameter/function expression"
 termToExp (Call pos [] "|" ParamIn [exp1,exp2]) = do
@@ -1219,6 +1219,11 @@ termToExp (Foreign pos lang inst flags args) =
 termToExp (IntConst pos num) = Right $ Placed (IntValue num) pos
 termToExp (FloatConst pos num) = Right $ Placed (FloatValue num) pos
 termToExp (CharConst pos char) = Right $ Placed (CharValue char) pos
+termToExp (StringConst pos "" DoubleQuote)
+    = return $ Placed (Fncall ["wybe","string"] "empty" False []) pos
+termToExp (StringConst pos [chr] DoubleQuote)
+    = return $ Placed (Fncall ["wybe","string"] "singleton" False
+                        [Unplaced (CharValue chr)]) pos
 termToExp (StringConst pos str DoubleQuote)
     = return $ Placed (StringValue str WybeString) pos
 termToExp (StringConst pos str (IdentQuote "c" DoubleQuote))

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -1219,11 +1219,6 @@ termToExp (Foreign pos lang inst flags args) =
 termToExp (IntConst pos num) = Right $ Placed (IntValue num) pos
 termToExp (FloatConst pos num) = Right $ Placed (FloatValue num) pos
 termToExp (CharConst pos char) = Right $ Placed (CharValue char) pos
-termToExp (StringConst pos "" DoubleQuote)
-    = return $ Placed (Fncall ["wybe","string"] "empty" False []) pos
-termToExp (StringConst pos [chr] DoubleQuote)
-    = return $ Placed (Fncall ["wybe","string"] "singleton" False
-                        [Unplaced (CharValue chr)]) pos
 termToExp (StringConst pos str DoubleQuote)
     = return $ Placed (StringValue str WybeString) pos
 termToExp (StringConst pos str (IdentQuote "c" DoubleQuote))

--- a/src/Snippets.hs
+++ b/src/Snippets.hs
@@ -7,7 +7,7 @@
 
 module Snippets (castFromTo, castTo, withType, intType, intCast,
                  tagType, tagCast, phantomType, stringType, cStringType,
-                 isTypeVar,
+                 charType, isTypeVar,
                  varSet, varGet, varGetSet,
                  varSetTyped, varGetTyped, varGetSetTyped,
                  boolType, boolCast, boolTrue, boolFalse, boolBool,
@@ -83,6 +83,10 @@ stringType = TypeSpec ["wybe"] "string" []
 -- | The c_string type, a C string
 cStringType :: TypeSpec
 cStringType = TypeSpec ["wybe"] "c_string" []
+
+-- | The char type, a single character constant
+charType :: TypeSpec
+charType = TypeSpec ["wybe"] "char" []
 
 -- | Is the given string a type variable name
 isTypeVar :: String -> Bool

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1219,10 +1219,9 @@ typecheckProcDecl' pdef = do
                         typeError $ ReasonUndef name callee $ place pcall
                     _ -> shouldnt "typecheckProcDecl'"
                 ) badCalls
-            ifOK pdef $ do
-                typecheckCalls calls' [] False
-                    $ List.filter (isForeign . content) calls
-                ifOK pdef $ modeCheckProcDecl pdef
+            typecheckCalls calls' [] False
+                $ List.filter (isForeign . content) calls
+            ifOK pdef $ modeCheckProcDecl pdef
 
 
 -- | If no type errors have been recorded, execute the enclosed code; otherwise

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -149,8 +149,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @drone:nn:nn
     foreign c read_char(?ch##0:wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp#1##0:wybe.char) @drone:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, ~tmp#1##0:wybe.char, ?tmp#2##0:wybe.bool) @drone:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, -1:wybe.char, ?tmp#2##0:wybe.bool) @drone:nn:nn
     case ~tmp#2##0:wybe.bool of
     0:
         drone.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6
@@ -283,7 +282,7 @@ proc loop > (2 calls)
 loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(5,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]]))]
+  MultiSpeczDepInfo: [(5,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @drone:nn:nn
     foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @drone:nn:nn
     foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @drone:nn:nn
@@ -310,7 +309,7 @@ loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>};
 
 
         1:
-            wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @drone:nn:nn
+            wybe.string.print<0>[410bae77d3](1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @drone:nn:nn
             foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int) @drone:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @drone:nn:nn
             foreign c print_int(~tmp#22##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
@@ -345,8 +344,7 @@ loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @drone:nn:nn
     foreign c read_char(?ch##1:wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp#3##0:wybe.char) @drone:nn:nn
-    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp#3##0:wybe.char, ?tmp#4##0:wybe.bool) @drone:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, -1:wybe.char, ?tmp#4##0:wybe.bool) @drone:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
 
@@ -360,27 +358,27 @@ proc print_info > {inline} (1 calls)
 print_info(d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @drone:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @drone:nn:nn
-    foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @drone:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @drone:nn:nn
-    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @drone:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @drone:nn:nn
-    foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
+    wybe.string.print<0>(1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @drone:nn:nn
+    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @drone:nn:nn
+    foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @drone:nn:nn
+    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
+    wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @drone:nn:nn
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#4##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @drone:nn:nn
+    foreign lpvm store(~%tmp#26##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
 
   LLVM code       :
 
@@ -768,8 +766,7 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @drone:nn:nn
     foreign c read_char(?ch##0:wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp#1##0:wybe.char) @drone:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, ~tmp#1##0:wybe.char, ?tmp#2##0:wybe.bool) @drone:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, -1:wybe.char, ?tmp#2##0:wybe.bool) @drone:nn:nn
     case ~tmp#2##0:wybe.bool of
     0:
         drone.#cont#1<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6
@@ -981,7 +978,7 @@ proc loop > (2 calls)
 loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(5,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]]))]
+  MultiSpeczDepInfo: [(5,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.loop#cont#1<0>,fromList [NonAliasedParamCond 1 [0]])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @drone:nn:nn
     foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @drone:nn:nn
     foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @drone:nn:nn
@@ -1008,7 +1005,7 @@ loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>};
 
 
         1:
-            wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @drone:nn:nn
+            wybe.string.print<0>[410bae77d3](1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @drone:nn:nn
             foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int) @drone:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @drone:nn:nn
             foreign c print_int(~tmp#22##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
@@ -1059,7 +1056,7 @@ loop(d##0:drone.drone_info, ch##0:wybe.char)<{<<wybe.io.io>>}; {<<wybe.io.io>>};
 
 
         1:
-            wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @drone:nn:nn
+            wybe.string.print<0>[410bae77d3](1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @drone:nn:nn
             foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int) @drone:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @drone:nn:nn
             foreign c print_int(~tmp#22##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
@@ -1094,8 +1091,7 @@ loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @drone:nn:nn
     foreign c read_char(?ch##1:wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp#3##0:wybe.char) @drone:nn:nn
-    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp#3##0:wybe.char, ?tmp#4##0:wybe.bool) @drone:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, -1:wybe.char, ?tmp#4##0:wybe.bool) @drone:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
 
@@ -1106,8 +1102,7 @@ loop#cont#1([ch##0:wybe.char], d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @drone:nn:nn
     foreign c read_char(?ch##1:wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp#3##0:wybe.char) @drone:nn:nn
-    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp#3##0:wybe.char, ?tmp#4##0:wybe.bool) @drone:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, -1:wybe.char, ?tmp#4##0:wybe.bool) @drone:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
 
@@ -1121,27 +1116,27 @@ proc print_info > {inline} (1 calls)
 print_info(d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @drone:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @drone:nn:nn
-    foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @drone:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @drone:nn:nn
-    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @drone:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @drone:nn:nn
-    foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
+    wybe.string.print<0>(1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @drone:nn:nn
+    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @drone:nn:nn
+    foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @drone:nn:nn
+    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
+    wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @drone:nn:nn
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#4##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @drone:nn:nn
+    foreign lpvm store(~%tmp#26##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
 
   LLVM code       :
 
@@ -1151,18 +1146,17 @@ print_info(d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 source_filename = "/private!TMP!/drone.wybe"
 target triple   = ???
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"(\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c") #\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"** malloc count: \00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c", \00", align 8
-@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"invalid action!\00", align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#6" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#7" = private unnamed_addr constant {i64, i64} { i64 17, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#8" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
-@"string#9" = private unnamed_addr constant {i64, i64} { i64 15, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
+@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c") #\00", align 8
+@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"** malloc count: \00", align 8
+@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c", \00", align 8
+@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"invalid action!\00", align 8
+@"string#4" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
+@"string#5" = private unnamed_addr constant {i64, i64} { i64 17, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
+@"string#6" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#7" = private unnamed_addr constant {i64, i64} { i64 15, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc i64 @malloc_count()
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
@@ -1173,8 +1167,7 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 define external fastcc void @"drone.<0>"() {
   %"tmp#0##0" = tail call fastcc i64 @"drone.drone_init<0>"()
   %"ch##0" = call ccc i8 @read_char()
-  %"tmp#1##0" = trunc i64 -1 to i8
-  %"tmp#2##0" = icmp ne i8 %"ch##0", %"tmp#1##0"
+  %"tmp#2##0" = icmp ne i8 %"ch##0", -1
   br i1 %"tmp#2##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"drone.loop<0>[410bae77d3]"(i64 %"tmp#0##0", i8 %"ch##0")
@@ -1187,7 +1180,7 @@ if.else.0:
 
 define external fastcc void @"drone.#cont#1<0>"() {
   %"mc##0" = call ccc i64 @malloc_count()
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#7" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
   call ccc void @print_int(i64 %"mc##0")
   call ccc void @putchar(i8 10)
   ret void
@@ -1463,21 +1456,21 @@ if.then.0:
   %"tmp#6##0" = icmp eq i8 %"ch##0", 112
   br i1 %"tmp#6##0", label %if.then.1, label %if.else.1
 if.then.1:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1187)
   %"tmp#35##0" = inttoptr i64 %"d##0" to ptr
   %"tmp#22##0" = load i64, ptr %"tmp#35##0"
   call ccc void @print_int(i64 %"tmp#22##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
   %"tmp#36##0" = add i64 %"d##0", 8
   %"tmp#37##0" = inttoptr i64 %"tmp#36##0" to ptr
   %"tmp#25##0" = load i64, ptr %"tmp#37##0"
   call ccc void @print_int(i64 %"tmp#25##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
   %"tmp#38##0" = add i64 %"d##0", 16
   %"tmp#39##0" = inttoptr i64 %"tmp#38##0" to ptr
   %"tmp#28##0" = load i64, ptr %"tmp#39##0"
   call ccc void @print_int(i64 %"tmp#28##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   %"tmp#40##0" = add i64 %"d##0", 24
   %"tmp#41##0" = inttoptr i64 %"tmp#40##0" to ptr
   %"tmp#31##0" = load i64, ptr %"tmp#41##0"
@@ -1492,7 +1485,7 @@ if.else.1:
   %"tmp#5##0" = icmp eq i1 %"success##0", 0
   br i1 %"tmp#5##0", label %if.then.2, label %if.else.2
 if.then.2:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#7" to i64 ))
   call ccc void @putchar(i8 10)
   tail call fastcc void @"drone.loop#cont#1<0>"(i64 %"d##1")
   ret void
@@ -1513,21 +1506,21 @@ if.then.0:
   %"tmp#6##0" = icmp eq i8 %"ch##0", 112
   br i1 %"tmp#6##0", label %if.then.1, label %if.else.1
 if.then.1:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1187)
   %"tmp#35##0" = inttoptr i64 %"d##0" to ptr
   %"tmp#22##0" = load i64, ptr %"tmp#35##0"
   call ccc void @print_int(i64 %"tmp#22##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
   %"tmp#36##0" = add i64 %"d##0", 8
   %"tmp#37##0" = inttoptr i64 %"tmp#36##0" to ptr
   %"tmp#25##0" = load i64, ptr %"tmp#37##0"
   call ccc void @print_int(i64 %"tmp#25##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
   %"tmp#38##0" = add i64 %"d##0", 16
   %"tmp#39##0" = inttoptr i64 %"tmp#38##0" to ptr
   %"tmp#28##0" = load i64, ptr %"tmp#39##0"
   call ccc void @print_int(i64 %"tmp#28##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   %"tmp#40##0" = add i64 %"d##0", 24
   %"tmp#41##0" = inttoptr i64 %"tmp#40##0" to ptr
   %"tmp#31##0" = load i64, ptr %"tmp#41##0"
@@ -1542,7 +1535,7 @@ if.else.1:
   %"tmp#5##0" = icmp eq i1 %"success##0", 0
   br i1 %"tmp#5##0", label %if.then.2, label %if.else.2
 if.then.2:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#7" to i64 ))
   call ccc void @putchar(i8 10)
   tail call fastcc void @"drone.loop#cont#1<0>[6dacb8fd25]"(i64 %"d##1")
   ret void
@@ -1556,8 +1549,7 @@ if.else.0:
 
 define external fastcc void @"drone.loop#cont#1<0>"(i64 %"d##0") {
   %"ch##1" = call ccc i8 @read_char()
-  %"tmp#3##0" = trunc i64 -1 to i8
-  %"tmp#4##0" = icmp ne i8 %"ch##1", %"tmp#3##0"
+  %"tmp#4##0" = icmp ne i8 %"ch##1", -1
   br i1 %"tmp#4##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"drone.loop<0>"(i64 %"d##0", i8 %"ch##1")
@@ -1568,8 +1560,7 @@ if.else.0:
 
 define external fastcc void @"drone.loop#cont#1<0>[6dacb8fd25]"(i64 %"d##0") {
   %"ch##1" = call ccc i8 @read_char()
-  %"tmp#3##0" = trunc i64 -1 to i8
-  %"tmp#4##0" = icmp ne i8 %"ch##1", %"tmp#3##0"
+  %"tmp#4##0" = icmp ne i8 %"ch##1", -1
   br i1 %"tmp#4##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"drone.loop<0>[410bae77d3]"(i64 %"d##0", i8 %"ch##1")
@@ -1579,25 +1570,25 @@ if.else.0:
 }
 
 define external fastcc void @"drone.print_info<0>"(i64 %"d##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#22##0" = inttoptr i64 %"d##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#22##0"
-  call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
-  %"tmp#23##0" = add i64 %"d##0", 8
-  %"tmp#24##0" = inttoptr i64 %"tmp#23##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#24##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 1187)
+  %"tmp#27##0" = inttoptr i64 %"d##0" to ptr
+  %"tmp#1##0" = load i64, ptr %"tmp#27##0"
   call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
-  %"tmp#25##0" = add i64 %"d##0", 16
-  %"tmp#26##0" = inttoptr i64 %"tmp#25##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#26##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
+  %"tmp#28##0" = add i64 %"d##0", 8
+  %"tmp#29##0" = inttoptr i64 %"tmp#28##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#29##0"
   call ccc void @print_int(i64 %"tmp#2##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
-  %"tmp#27##0" = add i64 %"d##0", 24
-  %"tmp#28##0" = inttoptr i64 %"tmp#27##0" to ptr
-  %"tmp#3##0" = load i64, ptr %"tmp#28##0"
+  %"tmp#30##0" = add i64 %"d##0", 16
+  %"tmp#31##0" = inttoptr i64 %"tmp#30##0" to ptr
+  %"tmp#3##0" = load i64, ptr %"tmp#31##0"
   call ccc void @print_int(i64 %"tmp#3##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  %"tmp#32##0" = add i64 %"d##0", 24
+  %"tmp#33##0" = inttoptr i64 %"tmp#32##0" to ptr
+  %"tmp#4##0" = load i64, ptr %"tmp#33##0"
+  call ccc void @print_int(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -358,25 +358,25 @@ proc print_info > {inline} (1 calls)
 print_info(d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.string.print<0>(1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
+    wybe.string.print<0>(1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @drone:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @drone:nn:nn
-    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
+    wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @drone:nn:nn
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#4##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#26##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
 
@@ -1116,25 +1116,25 @@ proc print_info > {inline} (1 calls)
 print_info(d##0:drone.drone_info)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.string.print<0>(1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
+    wybe.string.print<0>(1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @drone:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @drone:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @drone:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
+    wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @drone:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @drone:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
-    wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @drone:nn:nn
-    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int) @drone:nn:nn
+    wybe.string.print<0>(") #":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @drone:nn:nn
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @drone:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @drone:nn:nn
-    foreign c print_int(~tmp#4##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
+    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @drone:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @drone:nn:nn
     foreign lpvm store(~%tmp#26##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @drone:nn:nn
 
@@ -1572,23 +1572,23 @@ if.else.0:
 define external fastcc void @"drone.print_info<0>"(i64 %"d##0") {
   tail call fastcc void @"wybe.string.print<0>"(i64 1187)
   %"tmp#27##0" = inttoptr i64 %"d##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#27##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
+  %"tmp#0##0" = load i64, ptr %"tmp#27##0"
+  call ccc void @print_int(i64 %"tmp#0##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
   %"tmp#28##0" = add i64 %"d##0", 8
   %"tmp#29##0" = inttoptr i64 %"tmp#28##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#29##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#29##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
   %"tmp#30##0" = add i64 %"d##0", 16
   %"tmp#31##0" = inttoptr i64 %"tmp#30##0" to ptr
-  %"tmp#3##0" = load i64, ptr %"tmp#31##0"
-  call ccc void @print_int(i64 %"tmp#3##0")
+  %"tmp#2##0" = load i64, ptr %"tmp#31##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   %"tmp#32##0" = add i64 %"d##0", 24
   %"tmp#33##0" = inttoptr i64 %"tmp#32##0" to ptr
-  %"tmp#4##0" = load i64, ptr %"tmp#33##0"
-  call ccc void @print_int(i64 %"tmp#4##0")
+  %"tmp#3##0" = load i64, ptr %"tmp#33##0"
+  call ccc void @print_int(i64 %"tmp#3##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -870,48 +870,48 @@ proc test_int_list > (2 calls)
 test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2]
-  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(9,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(14,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(15,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(23,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(24,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]])),(25,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(29,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(31,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(33,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #23 @int_list_test:nn:nn
-    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #24 @int_list_test:nn:nn
+  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]])),(22,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(27,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(30,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(33,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list_test:nn:nn
+    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list_test:nn:nn
     int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#26##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#27##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#3##0:int_list.int_list) #9 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#3##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp#3##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp#5##0:int_list.int_list, 20:wybe.int, outByReference tmp#6##0:int_list.int_list) #14 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp#6##0:int_list.int_list, 2:wybe.int, outByReference tmp#7##0:int_list.int_list) #15 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#7##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp#7##0:int_list.int_list, ?l##5:int_list.int_list) #19 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#34##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#35##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, outByReference tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#42##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#42##0:wybe.phantom, ?tmp#43##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#43##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#5##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#45##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#45##0:wybe.phantom, ?tmp#46##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#46##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
     wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @int_list_test:nn:nn
@@ -2641,48 +2641,48 @@ proc test_int_list > (2 calls)
 test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2]
-  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(9,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(14,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(15,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(23,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(24,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]])),(25,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(29,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(31,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(33,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #23 @int_list_test:nn:nn
-    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #24 @int_list_test:nn:nn
+  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]])),(22,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(27,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(30,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(33,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list_test:nn:nn
+    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list_test:nn:nn
     int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#26##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#27##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#3##0:int_list.int_list) #9 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#3##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp#3##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp#5##0:int_list.int_list, 20:wybe.int, outByReference tmp#6##0:int_list.int_list) #14 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp#6##0:int_list.int_list, 2:wybe.int, outByReference tmp#7##0:int_list.int_list) #15 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#7##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp#7##0:int_list.int_list, ?l##5:int_list.int_list) #19 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#34##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#35##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, outByReference tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#42##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#42##0:wybe.phantom, ?tmp#43##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#43##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#5##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#45##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#45##0:wybe.phantom, ?tmp#46##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#46##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
     wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @int_list_test:nn:nn
@@ -2692,47 +2692,47 @@ test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_
     foreign c putchar('\n':wybe.char, ~tmp#56##0:wybe.phantom, ?tmp#57##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#57##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
  [9e35cb823b] [NonAliasedParam 0,NonAliasedParam 1,NonAliasedParam 2] :
-    int_list.reverse_helper<0>[410bae77d3](~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #23 @int_list_test:nn:nn
-    int_list.reverse_helper<0>[410bae77d3](~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #24 @int_list_test:nn:nn
+    int_list.reverse_helper<0>[410bae77d3](~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list_test:nn:nn
+    int_list.reverse_helper<0>[410bae77d3](~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list_test:nn:nn
     int_list.append<0>[410bae77d3](~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#26##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#27##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#3##0:int_list.int_list) #9 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#3##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp#3##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp#5##0:int_list.int_list, 20:wybe.int, outByReference tmp#6##0:int_list.int_list) #14 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp#6##0:int_list.int_list, 2:wybe.int, outByReference tmp#7##0:int_list.int_list) #15 @int_list_test:nn:nn
-    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#7##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp#7##0:int_list.int_list, ?l##5:int_list.int_list) #19 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#34##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#35##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, outByReference tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#42##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#42##0:wybe.phantom, ?tmp#43##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#43##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#5##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#45##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#45##0:wybe.phantom, ?tmp#46##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#46##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
     wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @int_list_test:nn:nn
@@ -2854,28 +2854,28 @@ define external fastcc void @"int_list_test.test_int_list<0>"(i64 %"x##0", i64 %
   call ccc void @putchar(i8 10)
   %"tmp#58##0" = alloca i8, i64 8, align 8
   call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"x##1", i64 %"tmp#0##0", ptr %"tmp#58##0")
-  %"tmp#2##0" = load i64, ptr %"tmp#58##0"
+  %"tmp#1##0" = load i64, ptr %"tmp#58##0"
   %"tmp#59##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"tmp#2##0", i64 %"z##1", ptr %"tmp#59##0")
-  %"tmp#3##0" = load i64, ptr %"tmp#59##0"
+  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"tmp#1##0", i64 %"z##1", ptr %"tmp#59##0")
+  %"tmp#2##0" = load i64, ptr %"tmp#59##0"
   call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
-  call fastcc void @"int_list.print<0>"(i64 %"tmp#3##0")
+  call fastcc void @"int_list.print<0>"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
   %"tmp#60##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.insert<0>[410bae77d3]"(i64 %"tmp#3##0", i64 4, i64 78, ptr %"tmp#60##0")
-  %"tmp#5##0" = load i64, ptr %"tmp#60##0"
+  call fastcc void @"int_list.insert<0>[410bae77d3]"(i64 %"tmp#2##0", i64 4, i64 78, ptr %"tmp#60##0")
+  %"tmp#3##0" = load i64, ptr %"tmp#60##0"
   %"tmp#61##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.pop<0>[410bae77d3]"(i64 %"tmp#5##0", i64 20, ptr %"tmp#61##0")
-  %"tmp#6##0" = load i64, ptr %"tmp#61##0"
+  call fastcc void @"int_list.pop<0>[410bae77d3]"(i64 %"tmp#3##0", i64 20, ptr %"tmp#61##0")
+  %"tmp#4##0" = load i64, ptr %"tmp#61##0"
   %"tmp#62##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.remove<0>[410bae77d3]"(i64 %"tmp#6##0", i64 2, ptr %"tmp#62##0")
-  %"tmp#7##0" = load i64, ptr %"tmp#62##0"
+  call fastcc void @"int_list.remove<0>[410bae77d3]"(i64 %"tmp#4##0", i64 2, ptr %"tmp#62##0")
+  %"tmp#5##0" = load i64, ptr %"tmp#62##0"
   call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
-  call fastcc void @"int_list.print<0>"(i64 %"tmp#7##0")
+  call fastcc void @"int_list.print<0>"(i64 %"tmp#5##0")
   call ccc void @putchar(i8 10)
-  %"l##5" = call fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64 %"tmp#7##0")
+  %"l##5" = call fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64 %"tmp#5##0")
   call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
   call fastcc void @"int_list.print<0>"(i64 %"l##5")
@@ -2897,28 +2897,28 @@ define external fastcc void @"int_list_test.test_int_list<0>[9e35cb823b]"(i64 %"
   call ccc void @putchar(i8 10)
   %"tmp#58##0" = alloca i8, i64 8, align 8
   call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"x##1", i64 %"tmp#0##0", ptr %"tmp#58##0")
-  %"tmp#2##0" = load i64, ptr %"tmp#58##0"
+  %"tmp#1##0" = load i64, ptr %"tmp#58##0"
   %"tmp#59##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"tmp#2##0", i64 %"z##1", ptr %"tmp#59##0")
-  %"tmp#3##0" = load i64, ptr %"tmp#59##0"
+  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"tmp#1##0", i64 %"z##1", ptr %"tmp#59##0")
+  %"tmp#2##0" = load i64, ptr %"tmp#59##0"
   call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
-  call fastcc void @"int_list.print<0>"(i64 %"tmp#3##0")
+  call fastcc void @"int_list.print<0>"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
   %"tmp#60##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.insert<0>[410bae77d3]"(i64 %"tmp#3##0", i64 4, i64 78, ptr %"tmp#60##0")
-  %"tmp#5##0" = load i64, ptr %"tmp#60##0"
+  call fastcc void @"int_list.insert<0>[410bae77d3]"(i64 %"tmp#2##0", i64 4, i64 78, ptr %"tmp#60##0")
+  %"tmp#3##0" = load i64, ptr %"tmp#60##0"
   %"tmp#61##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.pop<0>[410bae77d3]"(i64 %"tmp#5##0", i64 20, ptr %"tmp#61##0")
-  %"tmp#6##0" = load i64, ptr %"tmp#61##0"
+  call fastcc void @"int_list.pop<0>[410bae77d3]"(i64 %"tmp#3##0", i64 20, ptr %"tmp#61##0")
+  %"tmp#4##0" = load i64, ptr %"tmp#61##0"
   %"tmp#62##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.remove<0>[410bae77d3]"(i64 %"tmp#6##0", i64 2, ptr %"tmp#62##0")
-  %"tmp#7##0" = load i64, ptr %"tmp#62##0"
+  call fastcc void @"int_list.remove<0>[410bae77d3]"(i64 %"tmp#4##0", i64 2, ptr %"tmp#62##0")
+  %"tmp#5##0" = load i64, ptr %"tmp#62##0"
   call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
-  call fastcc void @"int_list.print<0>"(i64 %"tmp#7##0")
+  call fastcc void @"int_list.print<0>"(i64 %"tmp#5##0")
   call ccc void @putchar(i8 10)
-  %"l##5" = call fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64 %"tmp#7##0")
+  %"l##5" = call fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64 %"tmp#5##0")
   call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
   call fastcc void @"int_list.print<0>"(i64 %"l##5")

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -870,56 +870,56 @@ proc test_int_list > (2 calls)
 test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2]
-  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]]))]
-    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list_test:nn:nn
-    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list_test:nn:nn
+  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(9,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(14,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(15,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(23,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(24,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]])),(25,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(29,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(31,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(33,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #23 @int_list_test:nn:nn
+    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #24 @int_list_test:nn:nn
     int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#2##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#24##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, outByReference tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#5##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#30##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#30##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#31##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#26##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#27##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#3##0:int_list.int_list) #9 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(~l##5:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
+    int_list.print<0>(tmp#3##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#3##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#5##0:int_list.int_list, 20:wybe.int, outByReference tmp#6##0:int_list.int_list) #14 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#6##0:int_list.int_list, 2:wybe.int, outByReference tmp#7##0:int_list.int_list) #15 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#7##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#7##0:int_list.int_list, ?l##5:int_list.int_list) #19 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#54##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#56##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#56##0:wybe.phantom, ?tmp#57##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#57##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
 
   LLVM code       :
 
@@ -2641,106 +2641,106 @@ proc test_int_list > (2 calls)
 test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2]
-  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]]))]
-    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list_test:nn:nn
-    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list_test:nn:nn
+  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(9,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(14,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(15,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(23,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(24,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]])),(25,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(29,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(31,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(33,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #23 @int_list_test:nn:nn
+    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #24 @int_list_test:nn:nn
     int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#2##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#24##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, outByReference tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#5##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#30##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#30##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#31##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#26##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#27##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#3##0:int_list.int_list) #9 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(~l##5:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
+    int_list.print<0>(tmp#3##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#3##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#5##0:int_list.int_list, 20:wybe.int, outByReference tmp#6##0:int_list.int_list) #14 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#6##0:int_list.int_list, 2:wybe.int, outByReference tmp#7##0:int_list.int_list) #15 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#7##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#7##0:int_list.int_list, ?l##5:int_list.int_list) #19 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#54##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#56##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#56##0:wybe.phantom, ?tmp#57##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#57##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
  [9e35cb823b] [NonAliasedParam 0,NonAliasedParam 1,NonAliasedParam 2] :
-    int_list.reverse_helper<0>[410bae77d3](~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list_test:nn:nn
-    int_list.reverse_helper<0>[410bae77d3](~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list_test:nn:nn
+    int_list.reverse_helper<0>[410bae77d3](~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #23 @int_list_test:nn:nn
+    int_list.reverse_helper<0>[410bae77d3](~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #24 @int_list_test:nn:nn
     int_list.append<0>[410bae77d3](~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#2##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#24##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, outByReference tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(tmp#5##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#30##0:wybe.phantom) @int_list_test:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#30##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @int_list_test:nn:nn
-    foreign lpvm store(~%tmp#31##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
-    wybe.string.print<0>("-":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(x##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #27 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#23##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(z##1:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#26##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#27##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, outByReference tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~z##1:int_list.int_list, outByReference tmp#3##0:int_list.int_list) #9 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
-    int_list.print<0>(~l##5:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
+    int_list.print<0>(tmp#3##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @int_list_test:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @int_list_test:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @int_list_test:nn:nn
     foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#3##0:int_list.int_list, 4:wybe.int, 78:wybe.int, outByReference tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#5##0:int_list.int_list, 20:wybe.int, outByReference tmp#6##0:int_list.int_list) #14 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#6##0:int_list.int_list, 2:wybe.int, outByReference tmp#7##0:int_list.int_list) #15 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(tmp#7##0:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#7##0:int_list.int_list, ?l##5:int_list.int_list) #19 @int_list_test:nn:nn
+    wybe.string.print<0>[410bae77d3](1207:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#54##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @int_list_test:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#56##0:wybe.phantom) @int_list_test:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#56##0:wybe.phantom, ?tmp#57##0:wybe.phantom) @int_list_test:nn:nn
+    foreign lpvm store(~%tmp#57##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @int_list_test:nn:nn
 
   LLVM code       :
 
@@ -2753,21 +2753,19 @@ target triple   = ???
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" ** malloc count of building lists: \00", align 8
 @"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c" ** malloc count of test(aliased): \00", align 8
 @"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c" ** malloc count of test(non-aliased): \00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"-\00", align 8
-@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"--------------------\00", align 8
-@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"original x y z:\00", align 8
-@"cstring#6" = private unnamed_addr constant [ ?? x i8 ] c"tests with alias\00", align 8
-@"cstring#7" = private unnamed_addr constant [ ?? x i8 ] c"tests without alias\00", align 8
-@"cstring#8" = private unnamed_addr constant [ ?? x i8 ] c"x y z:\00", align 8
-@"string#9" = private unnamed_addr constant {i64, i64} { i64 36, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#10" = private unnamed_addr constant {i64, i64} { i64 35, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#11" = private unnamed_addr constant {i64, i64} { i64 39, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#12" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
-@"string#13" = private unnamed_addr constant {i64, i64} { i64 20, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
-@"string#14" = private unnamed_addr constant {i64, i64} { i64 15, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
-@"string#15" = private unnamed_addr constant {i64, i64} { i64 16, i64 ptrtoint( ptr @"cstring#6" to i64 ) }, align 8
-@"string#16" = private unnamed_addr constant {i64, i64} { i64 19, i64 ptrtoint( ptr @"cstring#7" to i64 ) }, align 8
-@"string#17" = private unnamed_addr constant {i64, i64} { i64 6, i64 ptrtoint( ptr @"cstring#8" to i64 ) }, align 8
+@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"--------------------\00", align 8
+@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"original x y z:\00", align 8
+@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"tests with alias\00", align 8
+@"cstring#6" = private unnamed_addr constant [ ?? x i8 ] c"tests without alias\00", align 8
+@"cstring#7" = private unnamed_addr constant [ ?? x i8 ] c"x y z:\00", align 8
+@"string#8" = private unnamed_addr constant {i64, i64} { i64 36, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
+@"string#9" = private unnamed_addr constant {i64, i64} { i64 35, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
+@"string#10" = private unnamed_addr constant {i64, i64} { i64 39, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#11" = private unnamed_addr constant {i64, i64} { i64 20, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
+@"string#12" = private unnamed_addr constant {i64, i64} { i64 15, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
+@"string#13" = private unnamed_addr constant {i64, i64} { i64 16, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
+@"string#14" = private unnamed_addr constant {i64, i64} { i64 19, i64 ptrtoint( ptr @"cstring#6" to i64 ) }, align 8
+@"string#15" = private unnamed_addr constant {i64, i64} { i64 6, i64 ptrtoint( ptr @"cstring#7" to i64 ) }, align 8
 
 declare external fastcc i64 @"int_list.append<0>"(i64, i64)
 declare external fastcc i64 @"int_list.append<0>[410bae77d3]"(i64, i64)
@@ -2781,6 +2779,7 @@ declare external fastcc i64 @"int_list.reverse_helper<0>"(i64, i64)
 declare external fastcc i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64, i64)
 declare external fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64)
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc i64 @malloc_count()
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
@@ -2791,7 +2790,7 @@ define external fastcc void @"int_list_test.<0>"() {
   %"tmp#0##0" = tail call fastcc i64 @"int_list.range#cont#1<0>[410bae77d3]"(i64 0, i64 1, i64 1, i64 10)
   %"tmp#1##0" = tail call fastcc i64 @"int_list.range#cont#1<0>[410bae77d3]"(i64 0, i64 2, i64 2, i64 20)
   %"tmp#2##0" = tail call fastcc i64 @"int_list.range#cont#1<0>[410bae77d3]"(i64 0, i64 3, i64 3, i64 30)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#17" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#15" to i64 ))
   call ccc void @putchar(i8 10)
   tail call fastcc void @"int_list.print<0>"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
@@ -2801,15 +2800,15 @@ define external fastcc void @"int_list_test.<0>"() {
   call ccc void @putchar(i8 10)
   %"mc2##0" = call ccc i64 @malloc_count()
   %"tmp#3##0" = sub i64 %"mc2##0", %"mc1##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#13" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#15" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#13" to i64 ))
   call ccc void @putchar(i8 10)
   %"mc1##1" = call ccc i64 @malloc_count()
   tail call fastcc void @"int_list_test.test_int_list<0>"(i64 %"tmp#0##0", i64 %"tmp#1##0", i64 %"tmp#2##0")
   %"mc2##1" = call ccc i64 @malloc_count()
   %"tmp#4##0" = sub i64 %"mc2##1", %"mc1##1"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
   call ccc void @putchar(i8 10)
   tail call fastcc void @"int_list.print<0>"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
@@ -2817,25 +2816,25 @@ define external fastcc void @"int_list_test.<0>"() {
   call ccc void @putchar(i8 10)
   tail call fastcc void @"int_list.print<0>"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#13" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#13" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#16" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
   call ccc void @putchar(i8 10)
   %"mc1##2" = call ccc i64 @malloc_count()
   tail call fastcc void @"int_list_test.test_int_list<0>[9e35cb823b]"(i64 %"tmp#0##0", i64 %"tmp#1##0", i64 %"tmp#2##0")
   %"mc2##2" = call ccc i64 @malloc_count()
   %"tmp#5##0" = sub i64 %"mc2##2", %"mc1##2"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#13" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
   call ccc void @print_int(i64 %"tmp#3##0")
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#10" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
   call ccc void @print_int(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#10" to i64 ))
   call ccc void @print_int(i64 %"tmp#5##0")
   call ccc void @putchar(i8 10)
   ret void
@@ -2845,7 +2844,7 @@ define external fastcc void @"int_list_test.test_int_list<0>"(i64 %"x##0", i64 %
   %"x##1" = tail call fastcc i64 @"int_list.reverse_helper<0>"(i64 %"x##0", i64 0)
   %"z##1" = tail call fastcc i64 @"int_list.reverse_helper<0>"(i64 %"z##0", i64 0)
   %"tmp#0##0" = tail call fastcc i64 @"int_list.append<0>"(i64 %"y##0", i64 99)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
   tail call fastcc void @"int_list.print<0>"(i64 %"x##1")
   call ccc void @putchar(i8 10)
@@ -2853,31 +2852,31 @@ define external fastcc void @"int_list_test.test_int_list<0>"(i64 %"x##0", i64 %
   call ccc void @putchar(i8 10)
   tail call fastcc void @"int_list.print<0>"(i64 %"z##1")
   call ccc void @putchar(i8 10)
-  %"tmp#38##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"x##1", i64 %"tmp#0##0", ptr %"tmp#38##0")
-  %"tmp#1##0" = load i64, ptr %"tmp#38##0"
-  %"tmp#39##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"tmp#1##0", i64 %"z##1", ptr %"tmp#39##0")
-  %"tmp#2##0" = load i64, ptr %"tmp#39##0"
-  call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  %"tmp#58##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"x##1", i64 %"tmp#0##0", ptr %"tmp#58##0")
+  %"tmp#2##0" = load i64, ptr %"tmp#58##0"
+  %"tmp#59##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"tmp#2##0", i64 %"z##1", ptr %"tmp#59##0")
+  %"tmp#3##0" = load i64, ptr %"tmp#59##0"
+  call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
-  call fastcc void @"int_list.print<0>"(i64 %"tmp#2##0")
+  call fastcc void @"int_list.print<0>"(i64 %"tmp#3##0")
   call ccc void @putchar(i8 10)
-  %"tmp#40##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.insert<0>[410bae77d3]"(i64 %"tmp#2##0", i64 4, i64 78, ptr %"tmp#40##0")
-  %"tmp#3##0" = load i64, ptr %"tmp#40##0"
-  %"tmp#41##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.pop<0>[410bae77d3]"(i64 %"tmp#3##0", i64 20, ptr %"tmp#41##0")
-  %"tmp#4##0" = load i64, ptr %"tmp#41##0"
-  %"tmp#42##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.remove<0>[410bae77d3]"(i64 %"tmp#4##0", i64 2, ptr %"tmp#42##0")
-  %"tmp#5##0" = load i64, ptr %"tmp#42##0"
-  call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  %"tmp#60##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.insert<0>[410bae77d3]"(i64 %"tmp#3##0", i64 4, i64 78, ptr %"tmp#60##0")
+  %"tmp#5##0" = load i64, ptr %"tmp#60##0"
+  %"tmp#61##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.pop<0>[410bae77d3]"(i64 %"tmp#5##0", i64 20, ptr %"tmp#61##0")
+  %"tmp#6##0" = load i64, ptr %"tmp#61##0"
+  %"tmp#62##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.remove<0>[410bae77d3]"(i64 %"tmp#6##0", i64 2, ptr %"tmp#62##0")
+  %"tmp#7##0" = load i64, ptr %"tmp#62##0"
+  call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
-  call fastcc void @"int_list.print<0>"(i64 %"tmp#5##0")
+  call fastcc void @"int_list.print<0>"(i64 %"tmp#7##0")
   call ccc void @putchar(i8 10)
-  %"l##5" = call fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64 %"tmp#5##0")
-  call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  %"l##5" = call fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64 %"tmp#7##0")
+  call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
   call fastcc void @"int_list.print<0>"(i64 %"l##5")
   call ccc void @putchar(i8 10)
@@ -2888,7 +2887,7 @@ define external fastcc void @"int_list_test.test_int_list<0>[9e35cb823b]"(i64 %"
   %"x##1" = tail call fastcc i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64 %"x##0", i64 0)
   %"z##1" = tail call fastcc i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64 %"z##0", i64 0)
   %"tmp#0##0" = tail call fastcc i64 @"int_list.append<0>[410bae77d3]"(i64 %"y##0", i64 99)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
   tail call fastcc void @"int_list.print<0>"(i64 %"x##1")
   call ccc void @putchar(i8 10)
@@ -2896,31 +2895,31 @@ define external fastcc void @"int_list_test.test_int_list<0>[9e35cb823b]"(i64 %"
   call ccc void @putchar(i8 10)
   tail call fastcc void @"int_list.print<0>"(i64 %"z##1")
   call ccc void @putchar(i8 10)
-  %"tmp#38##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"x##1", i64 %"tmp#0##0", ptr %"tmp#38##0")
-  %"tmp#1##0" = load i64, ptr %"tmp#38##0"
-  %"tmp#39##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"tmp#1##0", i64 %"z##1", ptr %"tmp#39##0")
-  %"tmp#2##0" = load i64, ptr %"tmp#39##0"
-  call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  %"tmp#58##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"x##1", i64 %"tmp#0##0", ptr %"tmp#58##0")
+  %"tmp#2##0" = load i64, ptr %"tmp#58##0"
+  %"tmp#59##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.extend<0>[410bae77d3]"(i64 %"tmp#2##0", i64 %"z##1", ptr %"tmp#59##0")
+  %"tmp#3##0" = load i64, ptr %"tmp#59##0"
+  call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
-  call fastcc void @"int_list.print<0>"(i64 %"tmp#2##0")
+  call fastcc void @"int_list.print<0>"(i64 %"tmp#3##0")
   call ccc void @putchar(i8 10)
-  %"tmp#40##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.insert<0>[410bae77d3]"(i64 %"tmp#2##0", i64 4, i64 78, ptr %"tmp#40##0")
-  %"tmp#3##0" = load i64, ptr %"tmp#40##0"
-  %"tmp#41##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.pop<0>[410bae77d3]"(i64 %"tmp#3##0", i64 20, ptr %"tmp#41##0")
-  %"tmp#4##0" = load i64, ptr %"tmp#41##0"
-  %"tmp#42##0" = alloca i8, i64 8, align 8
-  call fastcc void @"int_list.remove<0>[410bae77d3]"(i64 %"tmp#4##0", i64 2, ptr %"tmp#42##0")
-  %"tmp#5##0" = load i64, ptr %"tmp#42##0"
-  call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  %"tmp#60##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.insert<0>[410bae77d3]"(i64 %"tmp#3##0", i64 4, i64 78, ptr %"tmp#60##0")
+  %"tmp#5##0" = load i64, ptr %"tmp#60##0"
+  %"tmp#61##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.pop<0>[410bae77d3]"(i64 %"tmp#5##0", i64 20, ptr %"tmp#61##0")
+  %"tmp#6##0" = load i64, ptr %"tmp#61##0"
+  %"tmp#62##0" = alloca i8, i64 8, align 8
+  call fastcc void @"int_list.remove<0>[410bae77d3]"(i64 %"tmp#6##0", i64 2, ptr %"tmp#62##0")
+  %"tmp#7##0" = load i64, ptr %"tmp#62##0"
+  call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
-  call fastcc void @"int_list.print<0>"(i64 %"tmp#5##0")
+  call fastcc void @"int_list.print<0>"(i64 %"tmp#7##0")
   call ccc void @putchar(i8 10)
-  %"l##5" = call fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64 %"tmp#5##0")
-  call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  %"l##5" = call fastcc i64 @"int_list.sort<0>[410bae77d3]"(i64 %"tmp#7##0")
+  call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1207)
   call ccc void @putchar(i8 10)
   call fastcc void @"int_list.print<0>"(i64 %"l##5")
   call ccc void @putchar(i8 10)

--- a/test-cases/final-dump-test.sh
+++ b/test-cases/final-dump-test.sh
@@ -19,7 +19,7 @@ do
 	out=`echo -e "$f" | sed 's/.wybe$/.out/'`
 	exp=`echo -e "$f" | sed 's/.wybe$/.exp/'`
 	targ=`echo -e "$f" | sed 's/.wybe$/.o/'`
-	$TIMEOUT ../wybemk --log=FinalDump --force-all -L $LIBDIR $targ 2>&1 \
+	$TIMEOUT ../wybemk --log=FinalDump --force-all -n -L $LIBDIR $targ 2>&1 \
 	    | sed -e 's/@\([A-Za-z0-9_]*\):[0-9:]*/@\1:nn:nn/g' \
             -e "s|`pwd`|!ROOT!|g" \
             -e 's/\[ [0-9][0-9]* x i8 \]/[ ?? x i8 ]/g' \

--- a/test-cases/final-dump/T.exp
+++ b/test-cases/final-dump/T.exp
@@ -1,3 +1,2 @@
 Error detected during loading module: T
-[91mInvalid module T (looks like a type variable)
-[0m
+Invalid module T (looks like a type variable)

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -351,20 +351,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -375,28 +376,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -351,17 +351,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -392,8 +392,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -183,17 +183,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -224,8 +224,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -183,20 +183,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -207,28 +208,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -173,20 +173,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -197,28 +198,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -173,17 +173,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -214,8 +214,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -178,20 +178,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -202,28 +203,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -178,17 +178,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -219,8 +219,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -236,20 +236,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -260,28 +261,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -236,17 +236,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -277,8 +277,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -147,20 +147,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -171,28 +172,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -147,17 +147,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -188,8 +188,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -81,20 +81,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -105,28 +106,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -81,17 +81,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -122,8 +122,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -19,6 +19,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(9,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(10,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree) @alias_fork1:nn:nn
     foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork1:nn:nn
     foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 222:wybe.int) @alias_fork1:nn:nn
@@ -28,8 +29,8 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#18##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 111:wybe.int) @alias_fork1:nn:nn
     foreign lpvm mutate(~tmp#18##0:mytree.tree, ?tmp#3##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork1:nn:nn
     alias_fork1.simpleMerge<0>(~tmp#0##0:mytree.tree, ~tmp#3##0:mytree.tree, ?tmp#6##0:mytree.tree) #6 @alias_fork1:nn:nn
-    mytree.printTree1<0>(~tmp#6##0:mytree.tree, "{":wybe.string, ?tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @alias_fork1:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork1:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](~tmp#6##0:mytree.tree, 1519:wybe.string, ?tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @alias_fork1:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork1:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @alias_fork1:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @alias_fork1:nn:nn
     foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork1:nn:nn
@@ -95,13 +96,9 @@ simpleMerge#cont#1(tmp#2##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
 source_filename = "!ROOT!/final-dump/alias_fork1.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"{\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"}\00", align 8
-@"string#2" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
 
-declare external fastcc i64 @"mytree.printTree1<0>"(i64, i64)
-declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64, i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
@@ -128,8 +125,8 @@ define external fastcc void @"alias_fork1.<0>"() {
   %"tmp#34##0" = inttoptr i64 %"tmp#33##0" to ptr
   store i64 0, ptr %"tmp#34##0"
   %"tmp#6##0" = tail call fastcc i64 @"alias_fork1.simpleMerge<0>"(i64 %"tmp#10##0", i64 %"tmp#16##0")
-  %"tmp#20##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"tmp#6##0", i64 ptrtoint( ptr @"string#2" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
+  %"tmp#20##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"tmp#6##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
   call ccc void @putchar(i8 10)
   ret void
 }
@@ -238,12 +235,12 @@ proc printTree > public {inline} (0 calls)
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @mytree:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @mytree:nn:nn
 
 
 proc printTree1 > public (3 calls)
-0: mytree.printTree1<0>
+0: mytree.printTree1<0>[6dacb8fd25]
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(prefix##0,prefix##3)]
   InterestingCallProperties: [InterestingUnaliased 1]
@@ -264,6 +261,23 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
         foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mytree:nn:nn
         mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @mytree:nn:nn
 
+ [6dacb8fd25] [NonAliasedParam 1] :
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @mytree:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+        foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
+
+    1:
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree) @mytree:nn:nn
+        mytree.printTree1<0>[6dacb8fd25](~l##0:mytree.tree, ~prefix##0:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+        wybe.string.print<0>[410bae77d3](~prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @mytree:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @mytree:nn:nn
+        foreign c print_int(~k##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @mytree:nn:nn
+        foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mytree:nn:nn
+        mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @mytree:nn:nn
+
 
   LLVM code       :
 
@@ -274,19 +288,16 @@ source_filename = "!ROOT!/final-dump/mytree.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c", \00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"{\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"}\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"mytree.printTree<0>"(i64 %"t##0") {
-  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 ptrtoint( ptr @"string#4" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>"(i64 1527)
   ret void
 }
 
@@ -305,7 +316,28 @@ if.then.0:
   %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"l##0", i64 %"prefix##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 %"prefix##1")
   call ccc void @print_int(i64 %"k##0")
-  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#3" to i64 ))
+  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#1" to i64 ))
+  ret i64 %"tmp#11##0"
+if.else.0:
+  ret i64 %"prefix##0"
+}
+
+define external fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t##0", i64 %"prefix##0") {
+  %"tmp#2##0" = icmp ne i64 %"t##0", 0
+  br i1 %"tmp#2##0", label %if.then.0, label %if.else.0
+if.then.0:
+  %"tmp#6##0" = inttoptr i64 %"t##0" to ptr
+  %"l##0" = load i64, ptr %"tmp#6##0"
+  %"tmp#7##0" = add i64 %"t##0", 8
+  %"tmp#8##0" = inttoptr i64 %"tmp#7##0" to ptr
+  %"k##0" = load i64, ptr %"tmp#8##0"
+  %"tmp#9##0" = add i64 %"t##0", 16
+  %"tmp#10##0" = inttoptr i64 %"tmp#9##0" to ptr
+  %"r##0" = load i64, ptr %"tmp#10##0"
+  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"l##0", i64 %"prefix##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"prefix##1")
+  call ccc void @print_int(i64 %"k##0")
+  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#1" to i64 ))
   ret i64 %"tmp#11##0"
 if.else.0:
   ret i64 %"prefix##0"

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -235,8 +235,8 @@ proc printTree > public {inline} (0 calls)
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
-    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @mytree:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @mytree:nn:nn
+    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
 
 
 proc printTree1 > public (3 calls)

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -19,34 +19,34 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(13,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(15,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(24:wybe.int, ?tmp#12##0:mytree.tree) @alias_fork2:nn:nn
-    foreign lpvm mutate(~tmp#12##0:mytree.tree, ?tmp#13##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
-    foreign lpvm mutate(~tmp#13##0:mytree.tree, ?tmp#14##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @alias_fork2:nn:nn
-    foreign lpvm mutate(~tmp#14##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
+  MultiSpeczDepInfo: [(12,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(13,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(15,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree) @alias_fork2:nn:nn
+    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @alias_fork2:nn:nn
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
     alias_fork2.simpleMerge<0>(tmp#0##0:mytree.tree, ?tmp#3##0:mytree.tree) #3 @alias_fork2:nn:nn
-    wybe.string.print<0>("expect t -  1 200:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    mytree.printTree1<0>[6dacb8fd25](tmp#3##0:mytree.tree, 1519:wybe.string, ?tmp#19##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork2:nn:nn
-    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @alias_fork2:nn:nn
+    wybe.string.print<0>("expect t -  1 200:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](tmp#3##0:mytree.tree, 1519:wybe.string, ?tmp#16##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork2:nn:nn
     wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #15 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#24##0:wybe.bool) @alias_fork2:nn:nn
-    case ~tmp#24##0:wybe.bool of
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.bool) @alias_fork2:nn:nn
+    case ~tmp#22##0:wybe.bool of
     0:
-        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, 0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11
+        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, 0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10
 
     1:
         foreign lpvm access(~tmp#0##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @alias_fork2:nn:nn
-        foreign lpvm alloc(24:wybe.int, ?tmp#28##0:mytree.tree) @alias_fork2:nn:nn
-        foreign lpvm mutate(~tmp#28##0:mytree.tree, ?tmp#29##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree) @alias_fork2:nn:nn
-        foreign lpvm mutate(~tmp#29##0:mytree.tree, ?tmp#30##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @alias_fork2:nn:nn
-        foreign lpvm mutate(~tmp#30##0:mytree.tree, ?tmp#5##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
-        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, ~tmp#5##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10
+        foreign lpvm alloc(24:wybe.int, ?tmp#26##0:mytree.tree) @alias_fork2:nn:nn
+        foreign lpvm mutate(~tmp#26##0:mytree.tree, ?tmp#27##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree) @alias_fork2:nn:nn
+        foreign lpvm mutate(~tmp#27##0:mytree.tree, ?tmp#28##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @alias_fork2:nn:nn
+        foreign lpvm mutate(~tmp#28##0:mytree.tree, ?tmp#4##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
+        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, ~tmp#4##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9
 
 
 
@@ -55,27 +55,27 @@ proc #cont#1 > {semipure} (2 calls)
 #cont#1(t##0:mytree.tree, t1##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(9,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(10,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(11,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(13,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(15,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    wybe.string.print<0>("expect t1 - 1000:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    mytree.printTree1<0>[6dacb8fd25](~t1##0:mytree.tree, 1519:wybe.string, ?tmp#12##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @alias_fork2:nn:nn
-    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork2:nn:nn
-    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    wybe.string.print<0>("expect t1 - 1 200:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    mytree.printTree1<0>[6dacb8fd25](~t##0:mytree.tree, 1519:wybe.string, ?tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork2:nn:nn
-    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @alias_fork2:nn:nn
+  MultiSpeczDepInfo: [(7,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(10,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(12,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(13,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(15,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.string.print<0>("expect t1 - 1000:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](~t1##0:mytree.tree, 1519:wybe.string, ?tmp#9##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    wybe.string.print<0>("expect t1 - 1 200:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](~t##0:mytree.tree, 1519:wybe.string, ?tmp#18##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork2:nn:nn
     wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #15 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
 
 
 proc simpleMerge > public (3 calls)
@@ -111,39 +111,39 @@ declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"alias_fork2.<0>"() {
-  %"tmp#31##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#12##0" = ptrtoint ptr %"tmp#31##0" to i64
-  %"tmp#32##0" = inttoptr i64 %"tmp#12##0" to ptr
-  store i64 0, ptr %"tmp#32##0"
-  %"tmp#33##0" = add i64 %"tmp#12##0", 8
+  %"tmp#29##0" = call ccc ptr @wybe_malloc(i32 24)
+  %"tmp#9##0" = ptrtoint ptr %"tmp#29##0" to i64
+  %"tmp#30##0" = inttoptr i64 %"tmp#9##0" to ptr
+  store i64 0, ptr %"tmp#30##0"
+  %"tmp#31##0" = add i64 %"tmp#9##0", 8
+  %"tmp#32##0" = inttoptr i64 %"tmp#31##0" to ptr
+  store i64 1, ptr %"tmp#32##0"
+  %"tmp#33##0" = add i64 %"tmp#9##0", 16
   %"tmp#34##0" = inttoptr i64 %"tmp#33##0" to ptr
-  store i64 1, ptr %"tmp#34##0"
-  %"tmp#35##0" = add i64 %"tmp#12##0", 16
-  %"tmp#36##0" = inttoptr i64 %"tmp#35##0" to ptr
-  store i64 0, ptr %"tmp#36##0"
-  %"tmp#3##0" = tail call fastcc i64 @"alias_fork2.simpleMerge<0>"(i64 %"tmp#12##0")
+  store i64 0, ptr %"tmp#34##0"
+  %"tmp#3##0" = tail call fastcc i64 @"alias_fork2.simpleMerge<0>"(i64 %"tmp#9##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#19##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"tmp#3##0", i64 1519)
+  %"tmp#16##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"tmp#3##0", i64 1519)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
-  %"tmp#24##0" = icmp ne i64 %"tmp#12##0", 0
-  br i1 %"tmp#24##0", label %if.then.0, label %if.else.0
+  %"tmp#22##0" = icmp ne i64 %"tmp#9##0", 0
+  br i1 %"tmp#22##0", label %if.then.0, label %if.else.0
 if.then.0:
-  %"tmp#37##0" = inttoptr i64 %"tmp#12##0" to ptr
-  %"l##0" = load i64, ptr %"tmp#37##0"
-  %"tmp#38##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#28##0" = ptrtoint ptr %"tmp#38##0" to i64
-  %"tmp#39##0" = inttoptr i64 %"tmp#28##0" to ptr
-  store i64 %"l##0", ptr %"tmp#39##0"
-  %"tmp#40##0" = add i64 %"tmp#28##0", 8
+  %"tmp#35##0" = inttoptr i64 %"tmp#9##0" to ptr
+  %"l##0" = load i64, ptr %"tmp#35##0"
+  %"tmp#36##0" = call ccc ptr @wybe_malloc(i32 24)
+  %"tmp#26##0" = ptrtoint ptr %"tmp#36##0" to i64
+  %"tmp#37##0" = inttoptr i64 %"tmp#26##0" to ptr
+  store i64 %"l##0", ptr %"tmp#37##0"
+  %"tmp#38##0" = add i64 %"tmp#26##0", 8
+  %"tmp#39##0" = inttoptr i64 %"tmp#38##0" to ptr
+  store i64 1000, ptr %"tmp#39##0"
+  %"tmp#40##0" = add i64 %"tmp#26##0", 16
   %"tmp#41##0" = inttoptr i64 %"tmp#40##0" to ptr
-  store i64 1000, ptr %"tmp#41##0"
-  %"tmp#42##0" = add i64 %"tmp#28##0", 16
-  %"tmp#43##0" = inttoptr i64 %"tmp#42##0" to ptr
-  store i64 0, ptr %"tmp#43##0"
-  tail call fastcc void @"alias_fork2.#cont#1<0>"(i64 %"tmp#3##0", i64 %"tmp#28##0")
+  store i64 0, ptr %"tmp#41##0"
+  tail call fastcc void @"alias_fork2.#cont#1<0>"(i64 %"tmp#3##0", i64 %"tmp#26##0")
   ret void
 if.else.0:
   tail call fastcc void @"alias_fork2.#cont#1<0>"(i64 %"tmp#3##0", i64 0)
@@ -153,13 +153,13 @@ if.else.0:
 define external fastcc void @"alias_fork2.#cont#1<0>"(i64 %"t##0", i64 %"t1##0") {
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#12##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t1##0", i64 1519)
+  %"tmp#9##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t1##0", i64 1519)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#20##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t##0", i64 1519)
+  %"tmp#18##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t##0", i64 1519)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
@@ -209,8 +209,8 @@ proc printTree > public {inline} (0 calls)
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
-    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @mytree:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @mytree:nn:nn
+    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
 
 
 proc printTree1 > public (3 calls)

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -19,33 +19,34 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree) @alias_fork2:nn:nn
-    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
-    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @alias_fork2:nn:nn
-    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
+  MultiSpeczDepInfo: [(13,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(15,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign lpvm alloc(24:wybe.int, ?tmp#12##0:mytree.tree) @alias_fork2:nn:nn
+    foreign lpvm mutate(~tmp#12##0:mytree.tree, ?tmp#13##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
+    foreign lpvm mutate(~tmp#13##0:mytree.tree, ?tmp#14##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @alias_fork2:nn:nn
+    foreign lpvm mutate(~tmp#14##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
     alias_fork2.simpleMerge<0>(tmp#0##0:mytree.tree, ?tmp#3##0:mytree.tree) #3 @alias_fork2:nn:nn
-    wybe.string.print<0>("expect t -  1 200:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    mytree.printTree1<0>(tmp#3##0:mytree.tree, "{":wybe.string, ?tmp#16##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork2:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork2:nn:nn
-    wybe.string.print<0>("":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#21##0:wybe.bool) @alias_fork2:nn:nn
-    case ~tmp#21##0:wybe.bool of
+    wybe.string.print<0>("expect t -  1 200:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](tmp#3##0:mytree.tree, 1519:wybe.string, ?tmp#19##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #15 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#24##0:wybe.bool) @alias_fork2:nn:nn
+    case ~tmp#24##0:wybe.bool of
     0:
-        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, 0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10
+        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, 0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11
 
     1:
         foreign lpvm access(~tmp#0##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @alias_fork2:nn:nn
-        foreign lpvm alloc(24:wybe.int, ?tmp#25##0:mytree.tree) @alias_fork2:nn:nn
-        foreign lpvm mutate(~tmp#25##0:mytree.tree, ?tmp#26##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree) @alias_fork2:nn:nn
-        foreign lpvm mutate(~tmp#26##0:mytree.tree, ?tmp#27##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @alias_fork2:nn:nn
-        foreign lpvm mutate(~tmp#27##0:mytree.tree, ?tmp#4##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
-        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, ~tmp#4##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9
+        foreign lpvm alloc(24:wybe.int, ?tmp#28##0:mytree.tree) @alias_fork2:nn:nn
+        foreign lpvm mutate(~tmp#28##0:mytree.tree, ?tmp#29##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree) @alias_fork2:nn:nn
+        foreign lpvm mutate(~tmp#29##0:mytree.tree, ?tmp#30##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int) @alias_fork2:nn:nn
+        foreign lpvm mutate(~tmp#30##0:mytree.tree, ?tmp#5##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork2:nn:nn
+        alias_fork2.#cont#1<0>(~tmp#3##0:mytree.tree, ~tmp#5##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10
 
 
 
@@ -54,26 +55,27 @@ proc #cont#1 > {semipure} (2 calls)
 #cont#1(t##0:mytree.tree, t1##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.string.print<0>("expect t1 - 1000:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    mytree.printTree1<0>(~t1##0:mytree.tree, "{":wybe.string, ?tmp#9##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @alias_fork2:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @alias_fork2:nn:nn
-    wybe.string.print<0>("":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    wybe.string.print<0>("expect t1 - 1 200:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork2:nn:nn
+  MultiSpeczDepInfo: [(9,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(10,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(11,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(13,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(15,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.string.print<0>("expect t1 - 1000:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](~t1##0:mytree.tree, 1519:wybe.string, ?tmp#12##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork2:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @alias_fork2:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @alias_fork2:nn:nn
     foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
-    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?tmp#17##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork2:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork2:nn:nn
-    wybe.string.print<0>("":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork2:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @alias_fork2:nn:nn
-    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    wybe.string.print<0>("expect t1 - 1 200:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](~t##0:mytree.tree, 1519:wybe.string, ?tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @alias_fork2:nn:nn
+    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #15 @alias_fork2:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @alias_fork2:nn:nn
+    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork2:nn:nn
 
 
 proc simpleMerge > public (3 calls)
@@ -94,59 +96,54 @@ simpleMerge(tl##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
 source_filename = "!ROOT!/final-dump/alias_fork2.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"expect t -  1 200:\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"expect t1 - 1 200:\00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"expect t1 - 1000:\00", align 8
-@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"{\00", align 8
-@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"}\00", align 8
-@"string#6" = private unnamed_addr constant {i64, i64} { i64 0, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#7" = private unnamed_addr constant {i64, i64} { i64 18, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#8" = private unnamed_addr constant {i64, i64} { i64 18, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#9" = private unnamed_addr constant {i64, i64} { i64 17, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
-@"string#10" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
-@"string#11" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
+@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"expect t -  1 200:\00", align 8
+@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"expect t1 - 1 200:\00", align 8
+@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"expect t1 - 1000:\00", align 8
+@"string#3" = private unnamed_addr constant {i64, i64} { i64 18, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
+@"string#4" = private unnamed_addr constant {i64, i64} { i64 18, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
+@"string#5" = private unnamed_addr constant {i64, i64} { i64 17, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
 
-declare external fastcc i64 @"mytree.printTree1<0>"(i64, i64)
+declare external fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64, i64)
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"alias_fork2.<0>"() {
-  %"tmp#28##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#9##0" = ptrtoint ptr %"tmp#28##0" to i64
-  %"tmp#29##0" = inttoptr i64 %"tmp#9##0" to ptr
-  store i64 0, ptr %"tmp#29##0"
-  %"tmp#30##0" = add i64 %"tmp#9##0", 8
-  %"tmp#31##0" = inttoptr i64 %"tmp#30##0" to ptr
-  store i64 1, ptr %"tmp#31##0"
-  %"tmp#32##0" = add i64 %"tmp#9##0", 16
-  %"tmp#33##0" = inttoptr i64 %"tmp#32##0" to ptr
-  store i64 0, ptr %"tmp#33##0"
-  %"tmp#3##0" = tail call fastcc i64 @"alias_fork2.simpleMerge<0>"(i64 %"tmp#9##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#7" to i64 ))
+  %"tmp#31##0" = call ccc ptr @wybe_malloc(i32 24)
+  %"tmp#12##0" = ptrtoint ptr %"tmp#31##0" to i64
+  %"tmp#32##0" = inttoptr i64 %"tmp#12##0" to ptr
+  store i64 0, ptr %"tmp#32##0"
+  %"tmp#33##0" = add i64 %"tmp#12##0", 8
+  %"tmp#34##0" = inttoptr i64 %"tmp#33##0" to ptr
+  store i64 1, ptr %"tmp#34##0"
+  %"tmp#35##0" = add i64 %"tmp#12##0", 16
+  %"tmp#36##0" = inttoptr i64 %"tmp#35##0" to ptr
+  store i64 0, ptr %"tmp#36##0"
+  %"tmp#3##0" = tail call fastcc i64 @"alias_fork2.simpleMerge<0>"(i64 %"tmp#12##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#16##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"tmp#3##0", i64 ptrtoint( ptr @"string#10" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
+  %"tmp#19##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"tmp#3##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
-  %"tmp#21##0" = icmp ne i64 %"tmp#9##0", 0
-  br i1 %"tmp#21##0", label %if.then.0, label %if.else.0
+  %"tmp#24##0" = icmp ne i64 %"tmp#12##0", 0
+  br i1 %"tmp#24##0", label %if.then.0, label %if.else.0
 if.then.0:
-  %"tmp#34##0" = inttoptr i64 %"tmp#9##0" to ptr
-  %"l##0" = load i64, ptr %"tmp#34##0"
-  %"tmp#35##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#25##0" = ptrtoint ptr %"tmp#35##0" to i64
-  %"tmp#36##0" = inttoptr i64 %"tmp#25##0" to ptr
-  store i64 %"l##0", ptr %"tmp#36##0"
-  %"tmp#37##0" = add i64 %"tmp#25##0", 8
-  %"tmp#38##0" = inttoptr i64 %"tmp#37##0" to ptr
-  store i64 1000, ptr %"tmp#38##0"
-  %"tmp#39##0" = add i64 %"tmp#25##0", 16
-  %"tmp#40##0" = inttoptr i64 %"tmp#39##0" to ptr
-  store i64 0, ptr %"tmp#40##0"
-  tail call fastcc void @"alias_fork2.#cont#1<0>"(i64 %"tmp#3##0", i64 %"tmp#25##0")
+  %"tmp#37##0" = inttoptr i64 %"tmp#12##0" to ptr
+  %"l##0" = load i64, ptr %"tmp#37##0"
+  %"tmp#38##0" = call ccc ptr @wybe_malloc(i32 24)
+  %"tmp#28##0" = ptrtoint ptr %"tmp#38##0" to i64
+  %"tmp#39##0" = inttoptr i64 %"tmp#28##0" to ptr
+  store i64 %"l##0", ptr %"tmp#39##0"
+  %"tmp#40##0" = add i64 %"tmp#28##0", 8
+  %"tmp#41##0" = inttoptr i64 %"tmp#40##0" to ptr
+  store i64 1000, ptr %"tmp#41##0"
+  %"tmp#42##0" = add i64 %"tmp#28##0", 16
+  %"tmp#43##0" = inttoptr i64 %"tmp#42##0" to ptr
+  store i64 0, ptr %"tmp#43##0"
+  tail call fastcc void @"alias_fork2.#cont#1<0>"(i64 %"tmp#3##0", i64 %"tmp#28##0")
   ret void
 if.else.0:
   tail call fastcc void @"alias_fork2.#cont#1<0>"(i64 %"tmp#3##0", i64 0)
@@ -154,17 +151,17 @@ if.else.0:
 }
 
 define external fastcc void @"alias_fork2.#cont#1<0>"(i64 %"t##0", i64 %"t1##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#9##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t1##0", i64 ptrtoint( ptr @"string#10" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
+  %"tmp#12##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t1##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#17##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 ptrtoint( ptr @"string#10" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
+  %"tmp#20##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
   ret void
 }
@@ -212,12 +209,12 @@ proc printTree > public {inline} (0 calls)
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @mytree:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @mytree:nn:nn
 
 
 proc printTree1 > public (3 calls)
-0: mytree.printTree1<0>
+0: mytree.printTree1<0>[6dacb8fd25]
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(prefix##0,prefix##3)]
   InterestingCallProperties: [InterestingUnaliased 1]
@@ -238,6 +235,23 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
         foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mytree:nn:nn
         mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @mytree:nn:nn
 
+ [6dacb8fd25] [NonAliasedParam 1] :
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @mytree:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+        foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
+
+    1:
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree) @mytree:nn:nn
+        mytree.printTree1<0>[6dacb8fd25](~l##0:mytree.tree, ~prefix##0:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+        wybe.string.print<0>[410bae77d3](~prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @mytree:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @mytree:nn:nn
+        foreign c print_int(~k##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @mytree:nn:nn
+        foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mytree:nn:nn
+        mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @mytree:nn:nn
+
 
   LLVM code       :
 
@@ -248,19 +262,16 @@ source_filename = "!ROOT!/final-dump/mytree.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c", \00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"{\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"}\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"mytree.printTree<0>"(i64 %"t##0") {
-  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 ptrtoint( ptr @"string#4" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>"(i64 1527)
   ret void
 }
 
@@ -279,7 +290,28 @@ if.then.0:
   %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"l##0", i64 %"prefix##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 %"prefix##1")
   call ccc void @print_int(i64 %"k##0")
-  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#3" to i64 ))
+  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#1" to i64 ))
+  ret i64 %"tmp#11##0"
+if.else.0:
+  ret i64 %"prefix##0"
+}
+
+define external fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t##0", i64 %"prefix##0") {
+  %"tmp#2##0" = icmp ne i64 %"t##0", 0
+  br i1 %"tmp#2##0", label %if.then.0, label %if.else.0
+if.then.0:
+  %"tmp#6##0" = inttoptr i64 %"t##0" to ptr
+  %"l##0" = load i64, ptr %"tmp#6##0"
+  %"tmp#7##0" = add i64 %"t##0", 8
+  %"tmp#8##0" = inttoptr i64 %"tmp#7##0" to ptr
+  %"k##0" = load i64, ptr %"tmp#8##0"
+  %"tmp#9##0" = add i64 %"t##0", 16
+  %"tmp#10##0" = inttoptr i64 %"tmp#9##0" to ptr
+  %"r##0" = load i64, ptr %"tmp#10##0"
+  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"l##0", i64 %"prefix##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"prefix##1")
+  call ccc void @print_int(i64 %"k##0")
+  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#1" to i64 ))
   ret i64 %"tmp#11##0"
 if.else.0:
   ret i64 %"prefix##0"

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -19,25 +19,26 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp#15##0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#15##0:mytree.tree, ?tmp#16##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
+  MultiSpeczDepInfo: [(11,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(12,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(13,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#12##0:mytree.tree, ?tmp#1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#16##0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#18##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#18##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
     alias_fork3.simpleSlice<0>(~tmp#0##0:mytree.tree, ?tmp#5##0:mytree.tree) #5 @alias_fork3:nn:nn
-    wybe.string.print<0>("expect t - 100:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @alias_fork3:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @alias_fork3:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @alias_fork3:nn:nn
-    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork3:nn:nn
-    mytree.printTree1<0>(~tmp#5##0:mytree.tree, "{":wybe.string, ?tmp#22##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork3:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork3:nn:nn
-    wybe.string.print<0>("":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork3:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#24##0:wybe.phantom) @alias_fork3:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @alias_fork3:nn:nn
-    foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork3:nn:nn
+    wybe.string.print<0>("expect t - 100:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork3:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @alias_fork3:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @alias_fork3:nn:nn
+    foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork3:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](~tmp#5##0:mytree.tree, 1519:wybe.string, ?tmp#23##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork3:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork3:nn:nn
+    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork3:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#25##0:wybe.phantom) @alias_fork3:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @alias_fork3:nn:nn
+    foreign lpvm store(~%tmp#26##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork3:nn:nn
 
 
 proc simpleSlice > public (1 calls)
@@ -65,48 +66,43 @@ simpleSlice(tr##0:mytree.tree, ?#result##0:mytree.tree)<{}; {}; {}>:
 source_filename = "!ROOT!/final-dump/alias_fork3.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"expect t - 100:\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"{\00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"}\00", align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 0, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 15, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#6" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#7" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
+@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"expect t - 100:\00", align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 15, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
-declare external fastcc i64 @"mytree.printTree1<0>"(i64, i64)
+declare external fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64, i64)
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"alias_fork3.<0>"() {
-  %"tmp#26##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#9##0" = ptrtoint ptr %"tmp#26##0" to i64
-  %"tmp#27##0" = inttoptr i64 %"tmp#9##0" to ptr
-  store i64 0, ptr %"tmp#27##0"
-  %"tmp#28##0" = add i64 %"tmp#9##0", 8
-  %"tmp#29##0" = inttoptr i64 %"tmp#28##0" to ptr
-  store i64 100, ptr %"tmp#29##0"
-  %"tmp#30##0" = add i64 %"tmp#9##0", 16
-  %"tmp#31##0" = inttoptr i64 %"tmp#30##0" to ptr
-  store i64 0, ptr %"tmp#31##0"
-  %"tmp#32##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#15##0" = ptrtoint ptr %"tmp#32##0" to i64
-  %"tmp#33##0" = inttoptr i64 %"tmp#15##0" to ptr
-  store i64 %"tmp#9##0", ptr %"tmp#33##0"
-  %"tmp#34##0" = add i64 %"tmp#15##0", 8
-  %"tmp#35##0" = inttoptr i64 %"tmp#34##0" to ptr
-  store i64 200, ptr %"tmp#35##0"
-  %"tmp#36##0" = add i64 %"tmp#15##0", 16
-  %"tmp#37##0" = inttoptr i64 %"tmp#36##0" to ptr
-  store i64 0, ptr %"tmp#37##0"
-  %"tmp#5##0" = tail call fastcc i64 @"alias_fork3.simpleSlice<0>"(i64 %"tmp#15##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  %"tmp#27##0" = call ccc ptr @wybe_malloc(i32 24)
+  %"tmp#10##0" = ptrtoint ptr %"tmp#27##0" to i64
+  %"tmp#28##0" = inttoptr i64 %"tmp#10##0" to ptr
+  store i64 0, ptr %"tmp#28##0"
+  %"tmp#29##0" = add i64 %"tmp#10##0", 8
+  %"tmp#30##0" = inttoptr i64 %"tmp#29##0" to ptr
+  store i64 100, ptr %"tmp#30##0"
+  %"tmp#31##0" = add i64 %"tmp#10##0", 16
+  %"tmp#32##0" = inttoptr i64 %"tmp#31##0" to ptr
+  store i64 0, ptr %"tmp#32##0"
+  %"tmp#33##0" = call ccc ptr @wybe_malloc(i32 24)
+  %"tmp#16##0" = ptrtoint ptr %"tmp#33##0" to i64
+  %"tmp#34##0" = inttoptr i64 %"tmp#16##0" to ptr
+  store i64 %"tmp#10##0", ptr %"tmp#34##0"
+  %"tmp#35##0" = add i64 %"tmp#16##0", 8
+  %"tmp#36##0" = inttoptr i64 %"tmp#35##0" to ptr
+  store i64 200, ptr %"tmp#36##0"
+  %"tmp#37##0" = add i64 %"tmp#16##0", 16
+  %"tmp#38##0" = inttoptr i64 %"tmp#37##0" to ptr
+  store i64 0, ptr %"tmp#38##0"
+  %"tmp#5##0" = tail call fastcc i64 @"alias_fork3.simpleSlice<0>"(i64 %"tmp#16##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#22##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"tmp#5##0", i64 ptrtoint( ptr @"string#6" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#7" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  %"tmp#23##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"tmp#5##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
   ret void
 }
@@ -161,12 +157,12 @@ proc printTree > public {inline} (0 calls)
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @mytree:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @mytree:nn:nn
 
 
 proc printTree1 > public (3 calls)
-0: mytree.printTree1<0>
+0: mytree.printTree1<0>[6dacb8fd25]
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: [(prefix##0,prefix##3)]
   InterestingCallProperties: [InterestingUnaliased 1]
@@ -187,6 +183,23 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string)<{<<w
         foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mytree:nn:nn
         mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @mytree:nn:nn
 
+ [6dacb8fd25] [NonAliasedParam 1] :
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @mytree:nn:nn
+    case ~tmp#2##0:wybe.bool of
+    0:
+        foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
+
+    1:
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree) @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int) @mytree:nn:nn
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree) @mytree:nn:nn
+        mytree.printTree1<0>[6dacb8fd25](~l##0:mytree.tree, ~prefix##0:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+        wybe.string.print<0>[410bae77d3](~prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @mytree:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @mytree:nn:nn
+        foreign c print_int(~k##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @mytree:nn:nn
+        foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mytree:nn:nn
+        mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?prefix##3:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @mytree:nn:nn
+
 
   LLVM code       :
 
@@ -197,19 +210,16 @@ source_filename = "!ROOT!/final-dump/mytree.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c", \00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"{\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"}\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"mytree.printTree<0>"(i64 %"t##0") {
-  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 ptrtoint( ptr @"string#4" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>"(i64 1527)
   ret void
 }
 
@@ -228,7 +238,28 @@ if.then.0:
   %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"l##0", i64 %"prefix##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 %"prefix##1")
   call ccc void @print_int(i64 %"k##0")
-  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#3" to i64 ))
+  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#1" to i64 ))
+  ret i64 %"tmp#11##0"
+if.else.0:
+  ret i64 %"prefix##0"
+}
+
+define external fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"t##0", i64 %"prefix##0") {
+  %"tmp#2##0" = icmp ne i64 %"t##0", 0
+  br i1 %"tmp#2##0", label %if.then.0, label %if.else.0
+if.then.0:
+  %"tmp#6##0" = inttoptr i64 %"t##0" to ptr
+  %"l##0" = load i64, ptr %"tmp#6##0"
+  %"tmp#7##0" = add i64 %"t##0", 8
+  %"tmp#8##0" = inttoptr i64 %"tmp#7##0" to ptr
+  %"k##0" = load i64, ptr %"tmp#8##0"
+  %"tmp#9##0" = add i64 %"t##0", 16
+  %"tmp#10##0" = inttoptr i64 %"tmp#9##0" to ptr
+  %"r##0" = load i64, ptr %"tmp#10##0"
+  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"l##0", i64 %"prefix##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"prefix##1")
+  call ccc void @print_int(i64 %"k##0")
+  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#1" to i64 ))
   ret i64 %"tmp#11##0"
 if.else.0:
   ret i64 %"prefix##0"

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -19,22 +19,22 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(11,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(12,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(13,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#12##0:mytree.tree, ?tmp#1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp#16##0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:mytree.tree) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#18##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int) @alias_fork3:nn:nn
-    foreign lpvm mutate(~tmp#18##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
+  MultiSpeczDepInfo: [(10,(mytree.printTree1<0>,fromList [NonAliasedParamCond 1 []])),(11,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(13,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#15##0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#15##0:mytree.tree, ?tmp#16##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:mytree.tree) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int) @alias_fork3:nn:nn
+    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree) @alias_fork3:nn:nn
     alias_fork3.simpleSlice<0>(~tmp#0##0:mytree.tree, ?tmp#5##0:mytree.tree) #5 @alias_fork3:nn:nn
-    wybe.string.print<0>("expect t - 100:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork3:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @alias_fork3:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @alias_fork3:nn:nn
-    foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork3:nn:nn
-    mytree.printTree1<0>[6dacb8fd25](~tmp#5##0:mytree.tree, 1519:wybe.string, ?tmp#23##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork3:nn:nn
-    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @alias_fork3:nn:nn
+    wybe.string.print<0>("expect t - 100:":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @alias_fork3:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @alias_fork3:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @alias_fork3:nn:nn
+    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @alias_fork3:nn:nn
+    mytree.printTree1<0>[6dacb8fd25](~tmp#5##0:mytree.tree, 1519:wybe.string, ?tmp#22##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @alias_fork3:nn:nn
+    wybe.string.print<0>[410bae77d3](1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @alias_fork3:nn:nn
     wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @alias_fork3:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#25##0:wybe.phantom) @alias_fork3:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @alias_fork3:nn:nn
@@ -78,29 +78,29 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"alias_fork3.<0>"() {
   %"tmp#27##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#10##0" = ptrtoint ptr %"tmp#27##0" to i64
-  %"tmp#28##0" = inttoptr i64 %"tmp#10##0" to ptr
+  %"tmp#9##0" = ptrtoint ptr %"tmp#27##0" to i64
+  %"tmp#28##0" = inttoptr i64 %"tmp#9##0" to ptr
   store i64 0, ptr %"tmp#28##0"
-  %"tmp#29##0" = add i64 %"tmp#10##0", 8
+  %"tmp#29##0" = add i64 %"tmp#9##0", 8
   %"tmp#30##0" = inttoptr i64 %"tmp#29##0" to ptr
   store i64 100, ptr %"tmp#30##0"
-  %"tmp#31##0" = add i64 %"tmp#10##0", 16
+  %"tmp#31##0" = add i64 %"tmp#9##0", 16
   %"tmp#32##0" = inttoptr i64 %"tmp#31##0" to ptr
   store i64 0, ptr %"tmp#32##0"
   %"tmp#33##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#16##0" = ptrtoint ptr %"tmp#33##0" to i64
-  %"tmp#34##0" = inttoptr i64 %"tmp#16##0" to ptr
-  store i64 %"tmp#10##0", ptr %"tmp#34##0"
-  %"tmp#35##0" = add i64 %"tmp#16##0", 8
+  %"tmp#15##0" = ptrtoint ptr %"tmp#33##0" to i64
+  %"tmp#34##0" = inttoptr i64 %"tmp#15##0" to ptr
+  store i64 %"tmp#9##0", ptr %"tmp#34##0"
+  %"tmp#35##0" = add i64 %"tmp#15##0", 8
   %"tmp#36##0" = inttoptr i64 %"tmp#35##0" to ptr
   store i64 200, ptr %"tmp#36##0"
-  %"tmp#37##0" = add i64 %"tmp#16##0", 16
+  %"tmp#37##0" = add i64 %"tmp#15##0", 16
   %"tmp#38##0" = inttoptr i64 %"tmp#37##0" to ptr
   store i64 0, ptr %"tmp#38##0"
-  %"tmp#5##0" = tail call fastcc i64 @"alias_fork3.simpleSlice<0>"(i64 %"tmp#16##0")
+  %"tmp#5##0" = tail call fastcc i64 @"alias_fork3.simpleSlice<0>"(i64 %"tmp#15##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#23##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"tmp#5##0", i64 1519)
+  %"tmp#22##0" = tail call fastcc i64 @"mytree.printTree1<0>[6dacb8fd25]"(i64 %"tmp#5##0", i64 1519)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1527)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
@@ -157,8 +157,8 @@ proc printTree > public {inline} (0 calls)
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
-    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @mytree:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @mytree:nn:nn
+    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
 
 
 proc printTree1 > public (3 calls)

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -344,17 +344,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -385,8 +385,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -344,20 +344,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -368,28 +369,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -275,17 +275,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -316,8 +316,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -275,20 +275,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -299,28 +300,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -275,17 +275,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -316,8 +316,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -275,20 +275,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -299,28 +300,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -105,17 +105,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -146,8 +146,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -105,20 +105,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -129,28 +130,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -223,17 +223,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -264,8 +264,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -223,20 +223,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -247,28 +248,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -207,20 +207,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -231,28 +232,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -207,17 +207,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -248,8 +248,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -194,17 +194,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -235,8 +235,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -194,20 +194,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -218,28 +219,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -160,20 +160,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -184,28 +185,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -160,17 +160,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -201,8 +201,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -258,20 +258,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -282,28 +283,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -258,17 +258,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -299,8 +299,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -191,20 +191,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -215,28 +216,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -191,17 +191,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -232,8 +232,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_recursion2.exp
+++ b/test-cases/final-dump/alias_recursion2.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) alias_recursion2, alias_recursion2.mynode
-[91mfinal-dump/alias_recursion2.wybe:12:5: proc reverseList has test determinism, but declared normal (total)
-[0m[91mfinal-dump/alias_recursion2.wybe:18:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
-[0m[91mfinal-dump/alias_recursion2.wybe:19:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
-[0m
+final-dump/alias_recursion2.wybe:12:5: proc reverseList has test determinism, but declared normal (total)
+final-dump/alias_recursion2.wybe:18:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context
+final-dump/alias_recursion2.wybe:19:20: Calling test proc alias_recursion2.mynode.next<1> in a normal (total) context

--- a/test-cases/final-dump/alias_recursion3.exp
+++ b/test-cases/final-dump/alias_recursion3.exp
@@ -1,6 +1,5 @@
 Error detected during type checking of module(s) alias_recursion3, alias_recursion3.mynode
-[91mfinal-dump/alias_recursion3.wybe:12:5: Output parameter resutl1 not defined by proc foo
-[0m[91mfinal-dump/alias_recursion3.wybe:15:17: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context
-[0m[91mfinal-dump/alias_recursion3.wybe:16:13: Calling test proc alias_recursion3.mynode.next<1> in a normal (total) context
-[0m[91mfinal-dump/alias_recursion3.wybe:16:28: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context
-[0m
+final-dump/alias_recursion3.wybe:12:5: Output parameter resutl1 not defined by proc foo
+final-dump/alias_recursion3.wybe:15:17: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context
+final-dump/alias_recursion3.wybe:16:13: Calling test proc alias_recursion3.mynode.next<1> in a normal (total) context
+final-dump/alias_recursion3.wybe:16:28: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -303,17 +303,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -344,8 +344,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -303,20 +303,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -327,28 +328,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/backquote_control_char.exp
+++ b/test-cases/final-dump/backquote_control_char.exp
@@ -1,4 +1,3 @@
 Error detected during loading module: backquote_control_char
-[91mfinal-dump/backquote_control_char.wybe:1:5: Syntax error: unexpected control character in a backquoted symbol
+final-dump/backquote_control_char.wybe:1:5: Syntax error: unexpected control character in a backquoted symbol
 expecting simple expression
-[0m

--- a/test-cases/final-dump/backquote_empty.exp
+++ b/test-cases/final-dump/backquote_empty.exp
@@ -1,4 +1,3 @@
 Error detected during loading module: backquote_empty
-[91mfinal-dump/backquote_empty.wybe:1:5: Syntax error: unexpected empty backquoted symbol
+final-dump/backquote_empty.wybe:1:5: Syntax error: unexpected empty backquoted symbol
 expecting simple expression
-[0m

--- a/test-cases/final-dump/backquote_hash.exp
+++ b/test-cases/final-dump/backquote_hash.exp
@@ -1,4 +1,3 @@
 Error detected during loading module: backquote_hash
-[91mfinal-dump/backquote_hash.wybe:1:5: Syntax error: unexpected hash character (#) in backquoted symbol
+final-dump/backquote_hash.wybe:1:5: Syntax error: unexpected hash character (#) in backquoted symbol
 expecting simple expression
-[0m

--- a/test-cases/final-dump/backquote_multiline.exp
+++ b/test-cases/final-dump/backquote_multiline.exp
@@ -1,4 +1,3 @@
 Error detected during loading module: backquote_multiline
-[91mfinal-dump/backquote_multiline.wybe:1:5: Syntax error: unexpected multiline backquoted symbol
+final-dump/backquote_multiline.wybe:1:5: Syntax error: unexpected multiline backquoted symbol
 expecting simple expression
-[0m

--- a/test-cases/final-dump/backquote_unclosed.exp
+++ b/test-cases/final-dump/backquote_unclosed.exp
@@ -1,4 +1,3 @@
 Error detected during loading module: backquote_unclosed
-[91mfinal-dump/backquote_unclosed.wybe:1:5: Syntax error: unexpected multiline backquoted symbol
+final-dump/backquote_unclosed.wybe:1:5: Syntax error: unexpected multiline backquoted symbol
 expecting simple expression
-[0m

--- a/test-cases/final-dump/bad_assign.exp
+++ b/test-cases/final-dump/bad_assign.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) bad_assign
-[91mfinal-dump/bad_assign.wybe:5:1: proc l unknown in module top-level code
-[0m
+final-dump/bad_assign.wybe:5:1: proc l unknown in module top-level code

--- a/test-cases/final-dump/bad_module_name.exp
+++ b/test-cases/final-dump/bad_module_name.exp
@@ -1,3 +1,2 @@
 Error detected during loading module: bad_module_name
-[91mfinal-dump/bad_module_name.wybe:3:8: Syntax error: unexpected identifier T0
-[0m
+final-dump/bad_module_name.wybe:3:8: Syntax error: unexpected identifier T0

--- a/test-cases/final-dump/bad_reification.exp
+++ b/test-cases/final-dump/bad_reification.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) bad_reification
-[91mfinal-dump/bad_reification.wybe:3:1: Can't reify call to test proc foo with outputs
-[0m
+final-dump/bad_reification.wybe:3:1: Can't reify call to test proc foo with outputs

--- a/test-cases/final-dump/badmodname.exp
+++ b/test-cases/final-dump/badmodname.exp
@@ -1,3 +1,2 @@
 Error detected during preliminary processing of module badmodname
-[91mfinal-dump/badmodname.wybe:6:1: invalid character in module name `a.b`
-[0m
+final-dump/badmodname.wybe:6:1: invalid character in module name `a.b`

--- a/test-cases/final-dump/bang_expression_error.exp
+++ b/test-cases/final-dump/bang_expression_error.exp
@@ -1,6 +1,5 @@
 Error detected during final normalisation of module(s) bang_expression_error
-[91mfinal-dump/bang_expression_error.wybe:4:28: function call cannot have preceding !
-[0m[91mfinal-dump/bang_expression_error.wybe:4:36: function call cannot have preceding !
-[0m[91mfinal-dump/bang_expression_error.wybe:10:33: function call cannot have preceding !
-[0m[91mfinal-dump/bang_expression_error.wybe:10:63: function call cannot have preceding !
-[0m
+final-dump/bang_expression_error.wybe:4:28: function call cannot have preceding !
+final-dump/bang_expression_error.wybe:4:36: function call cannot have preceding !
+final-dump/bang_expression_error.wybe:10:33: function call cannot have preceding !
+final-dump/bang_expression_error.wybe:10:63: function call cannot have preceding !

--- a/test-cases/final-dump/break_outside_loop.exp
+++ b/test-cases/final-dump/break_outside_loop.exp
@@ -1,3 +1,2 @@
 Error detected during handling loops and conditionals in module(s) break_outside_loop
-[91mfinal-dump/break_outside_loop.wybe:1:1: Break outside of a loop
-[0m
+final-dump/break_outside_loop.wybe:1:1: Break outside of a loop

--- a/test-cases/final-dump/bug214.exp
+++ b/test-cases/final-dump/bug214.exp
@@ -1003,17 +1003,18 @@ proc print > public (0 calls)
 print(pos##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.string.print<0>("(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @bug214:nn:nn
-    foreign lpvm access(pos##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @bug214:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @bug214:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @bug214:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @bug214:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @bug214:nn:nn
-    foreign lpvm access(~pos##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @bug214:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @bug214:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @bug214:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @bug214:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @bug214:nn:nn
+  MultiSpeczDepInfo: [(1,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.string.print<0>[410bae77d3](1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @bug214:nn:nn
+    foreign lpvm access(pos##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @bug214:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @bug214:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @bug214:nn:nn
+    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @bug214:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @bug214:nn:nn
+    foreign lpvm access(~pos##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @bug214:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @bug214:nn:nn
+    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @bug214:nn:nn
+    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @bug214:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @bug214:nn:nn
 
 
 proc x > public {inline} (1 calls)
@@ -1072,14 +1073,8 @@ proc ~= > public {inline} (0 calls)
 source_filename = "!ROOT!/final-dump/bug214.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"(\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
 
-declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
@@ -1138,16 +1133,16 @@ define external fastcc {i64, i64} @"bug214.position.position<1>"(i64 %"#result##
 }
 
 define external fastcc void @"bug214.position.print<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#10##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#10##0"
-  call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#11##0" = add i64 %"pos##0", 8
-  %"tmp#12##0" = inttoptr i64 %"tmp#11##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#12##0"
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1187)
+  %"tmp#25##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
   call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#26##0" = add i64 %"pos##0", 8
+  %"tmp#27##0" = inttoptr i64 %"tmp#26##0" to ptr
+  %"tmp#3##0" = load i64, ptr %"tmp#27##0"
+  call ccc void @print_int(i64 %"tmp#3##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   ret void
 }
 

--- a/test-cases/final-dump/bug214.exp
+++ b/test-cases/final-dump/bug214.exp
@@ -1003,18 +1003,18 @@ proc print > public (0 calls)
 print(pos##0:bug214.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(1,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    wybe.string.print<0>[410bae77d3](1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @bug214:nn:nn
-    foreign lpvm access(pos##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @bug214:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @bug214:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @bug214:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @bug214:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @bug214:nn:nn
-    foreign lpvm access(~pos##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int) @bug214:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @bug214:nn:nn
-    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @bug214:nn:nn
-    foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @bug214:nn:nn
-    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @bug214:nn:nn
+  MultiSpeczDepInfo: [(0,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(6,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.string.print<0>[410bae77d3](1187:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @bug214:nn:nn
+    foreign lpvm access(pos##0:bug214.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @bug214:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @bug214:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @bug214:nn:nn
+    foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @bug214:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @bug214:nn:nn
+    foreign lpvm access(~pos##0:bug214.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @bug214:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @bug214:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @bug214:nn:nn
+    foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @bug214:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @bug214:nn:nn
 
 
 proc x > public {inline} (1 calls)
@@ -1135,13 +1135,13 @@ define external fastcc {i64, i64} @"bug214.position.position<1>"(i64 %"#result##
 define external fastcc void @"bug214.position.print<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1187)
   %"tmp#25##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
+  %"tmp#0##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#0##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#26##0" = add i64 %"pos##0", 8
   %"tmp#27##0" = inttoptr i64 %"tmp#26##0" to ptr
-  %"tmp#3##0" = load i64, ptr %"tmp#27##0"
-  call ccc void @print_int(i64 %"tmp#3##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#27##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   ret void
 }

--- a/test-cases/final-dump/bug228-out-of-scope.exp
+++ b/test-cases/final-dump/bug228-out-of-scope.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) bug228-out-of-scope
-[91mfinal-dump/bug228-out-of-scope.wybe:3:6: Resource wybe.io.io not in scope at call to proc read
-[0m
+final-dump/bug228-out-of-scope.wybe:3:6: Resource wybe.io.io not in scope at call to proc read

--- a/test-cases/final-dump/bug228-type.exp
+++ b/test-cases/final-dump/bug228-type.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) bug228-type
-[91mfinal-dump/bug228-type.wybe:5:2: Type error in call to proc =, argument 1
-[0m[91mfinal-dump/bug228-type.wybe:5:2: Type error in call to proc =, argument 2
-[0m[91mfinal-dump/bug228-type.wybe:5:2: Type of "1.0" incompatible with ?bar
-[0m
+final-dump/bug228-type.wybe:5:2: Type error in call to proc =, argument 1
+final-dump/bug228-type.wybe:5:2: Type error in call to proc =, argument 2
+final-dump/bug228-type.wybe:5:2: Type of "1.0" incompatible with ?bar

--- a/test-cases/final-dump/bug228-undefined.exp
+++ b/test-cases/final-dump/bug228-undefined.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) bug228-undefined
-[91mfinal-dump/bug228-undefined.wybe:10:10: proc res unknown in module top-level code
-[0m
+final-dump/bug228-undefined.wybe:10:10: proc res unknown in module top-level code

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -65,18 +65,18 @@ proc foo > public (1 calls)
 foo(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(1,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(7,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(11,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(13,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(0,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(1,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(2,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(6,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @call_site_id:nn:nn
     wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @call_site_id:nn:nn
     wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @call_site_id:nn:nn
     wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @call_site_id:nn:nn
-    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @call_site_id:nn:nn
-    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @call_site_id:nn:nn
-    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @call_site_id:nn:nn
-    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @call_site_id:nn:nn
-    foreign llvm mul(~x##0:wybe.int, 5:wybe.int, ?tmp#8##0:wybe.int) @call_site_id:nn:nn
-    foreign llvm add(~tmp#8##0:wybe.int, 10:wybe.int, ?tmp#7##0:wybe.int) @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @call_site_id:nn:nn
+    foreign llvm mul(~x##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.int) @call_site_id:nn:nn
+    foreign llvm add(~tmp#1##0:wybe.int, 10:wybe.int, ?tmp#0##0:wybe.int) @call_site_id:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#42##0:wybe.phantom) @call_site_id:nn:nn
-    foreign c print_int(~tmp#7##0:wybe.int, ~tmp#42##0:wybe.phantom, ?tmp#43##0:wybe.phantom) @call_site_id:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#42##0:wybe.phantom, ?tmp#43##0:wybe.phantom) @call_site_id:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @call_site_id:nn:nn
     foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @call_site_id:nn:nn
 
@@ -138,9 +138,9 @@ define external fastcc void @"call_site_id.foo<0>"(i64 %"x##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
-  %"tmp#8##0" = mul i64 %"x##0", 5
-  %"tmp#7##0" = add i64 %"tmp#8##0", 10
-  call ccc void @print_int(i64 %"tmp#7##0")
+  %"tmp#1##0" = mul i64 %"x##0", 5
+  %"tmp#0##0" = add i64 %"tmp#1##0", 10
+  call ccc void @print_int(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -65,19 +65,20 @@ proc foo > public (1 calls)
 foo(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @call_site_id:nn:nn
-    wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @call_site_id:nn:nn
-    wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @call_site_id:nn:nn
-    wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @call_site_id:nn:nn
-    wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @call_site_id:nn:nn
-    wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @call_site_id:nn:nn
-    wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @call_site_id:nn:nn
-    foreign llvm mul(~x##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.int) @call_site_id:nn:nn
-    foreign llvm add(~tmp#1##0:wybe.int, 10:wybe.int, ?tmp#0##0:wybe.int) @call_site_id:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#7##0:wybe.phantom) @call_site_id:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @call_site_id:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @call_site_id:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @call_site_id:nn:nn
+  MultiSpeczDepInfo: [(1,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(7,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(11,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(13,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @call_site_id:nn:nn
+    wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @call_site_id:nn:nn
+    foreign llvm mul(~x##0:wybe.int, 5:wybe.int, ?tmp#8##0:wybe.int) @call_site_id:nn:nn
+    foreign llvm add(~tmp#8##0:wybe.int, 10:wybe.int, ?tmp#7##0:wybe.int) @call_site_id:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#42##0:wybe.phantom) @call_site_id:nn:nn
+    foreign c print_int(~tmp#7##0:wybe.int, ~tmp#42##0:wybe.phantom, ?tmp#43##0:wybe.phantom) @call_site_id:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @call_site_id:nn:nn
+    foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @call_site_id:nn:nn
 
   LLVM code       :
 
@@ -87,10 +88,8 @@ foo(x##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 source_filename = "!ROOT!/final-dump/call_site_id.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" \00", align 8
-@"string#1" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
-declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc i64 @read_int()
@@ -132,16 +131,16 @@ define external fastcc void @"call_site_id.bar<0>"(i64 %"x##0") {
 }
 
 define external fastcc void @"call_site_id.foo<0>"(i64 %"x##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
-  %"tmp#1##0" = mul i64 %"x##0", 5
-  %"tmp#0##0" = add i64 %"tmp#1##0", 10
-  call ccc void @print_int(i64 %"tmp#0##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
+  %"tmp#8##0" = mul i64 %"x##0", 5
+  %"tmp#7##0" = add i64 %"tmp#8##0", 10
+  call ccc void @print_int(i64 %"tmp#7##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/call_unknown.exp
+++ b/test-cases/final-dump/call_unknown.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) call_unknown
-[91mfinal-dump/call_unknown.wybe:1:26: proc nonexistent_proc unknown in proc foo
-[0m
+final-dump/call_unknown.wybe:1:26: proc nonexistent_proc unknown in proc foo

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -609,17 +609,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -650,8 +650,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -609,20 +609,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -633,28 +634,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/case_detism.exp
+++ b/test-cases/final-dump/case_detism.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) case_detism
-[91mmodule top-level code has test determinism, but declared normal (total)
-[0m
+module top-level code has test determinism, but declared normal (total)

--- a/test-cases/final-dump/common_fields.exp
+++ b/test-cases/final-dump/common_fields.exp
@@ -39,52 +39,52 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(6,(common_fields.id<1>,fromList [NonAliasedParamCond 0 []])),(16,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(32:wybe.int, ?tmp#15##0:common_fields) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#15##0:common_fields, ?tmp#16##0:common_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, "a":wybe.string) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#16##0:common_fields, ?tmp#17##0:common_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, "b":wybe.string) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#17##0:common_fields, ?tmp#18##0:common_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, "c":wybe.string) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#18##0:common_fields, ?tmp#0##0:common_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @common_fields:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp#22##0:common_fields) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#22##0:common_fields, ?tmp#23##0:common_fields, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, "b":wybe.string) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#23##0:common_fields, ?tmp#24##0:common_fields, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#24##0:common_fields, ?tmp#25##0:common_fields, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @common_fields:nn:nn
-    foreign llvm or(~tmp#25##0:common_fields, 1:wybe.int, ?tmp#1##0:common_fields) @common_fields:nn:nn
-    common_fields.title<0>(tmp#0##0:common_fields, ?tmp#2##0:wybe.string) #2 @common_fields:nn:nn
-    wybe.string.print<0>(~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @common_fields:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @common_fields:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @common_fields:nn:nn
-    common_fields.id<0>(tmp#1##0:common_fields, ?tmp#3##0:wybe.int) #4 @common_fields:nn:nn
-    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#28##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @common_fields:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @common_fields:nn:nn
-    common_fields.id<1>[410bae77d3](~tmp#1##0:common_fields, ?c##1:common_fields, 10:wybe.int) #6 @common_fields:nn:nn
-    common_fields.id<0>(~c##1:common_fields, ?tmp#4##0:wybe.int) #7 @common_fields:nn:nn
-    foreign c print_int(~tmp#4##0:wybe.int, ~tmp#32##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @common_fields:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @common_fields:nn:nn
-    foreign lpvm store(~%tmp#36##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
-    common_fields.genre<0>(tmp#0##0:common_fields, ?tmp#5##0:wybe.string, ?tmp#9##0:wybe.bool) #9 @common_fields:nn:nn
-    case ~tmp#9##0:wybe.bool of
+  MultiSpeczDepInfo: [(10,(common_fields.id<1>,fromList [NonAliasedParamCond 0 []])),(21,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign lpvm alloc(32:wybe.int, ?tmp#32##0:common_fields) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#32##0:common_fields, ?tmp#33##0:common_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1415:wybe.string) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#33##0:common_fields, ?tmp#34##0:common_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1419:wybe.string) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#34##0:common_fields, ?tmp#35##0:common_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1423:wybe.string) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#35##0:common_fields, ?tmp#0##0:common_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @common_fields:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#43##0:common_fields) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#43##0:common_fields, ?tmp#44##0:common_fields, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1419:wybe.string) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#44##0:common_fields, ?tmp#45##0:common_fields, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#45##0:common_fields, ?tmp#46##0:common_fields, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @common_fields:nn:nn
+    foreign llvm or(~tmp#46##0:common_fields, 1:wybe.int, ?tmp#4##0:common_fields) @common_fields:nn:nn
+    common_fields.title<0>(tmp#0##0:common_fields, ?tmp#6##0:wybe.string) #6 @common_fields:nn:nn
+    wybe.string.print<0>(~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @common_fields:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#48##0:wybe.phantom) @common_fields:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#48##0:wybe.phantom, ?tmp#49##0:wybe.phantom) @common_fields:nn:nn
+    common_fields.id<0>(tmp#4##0:common_fields, ?tmp#7##0:wybe.int) #8 @common_fields:nn:nn
+    foreign c print_int(~tmp#7##0:wybe.int, ~tmp#49##0:wybe.phantom, ?tmp#52##0:wybe.phantom) @common_fields:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#52##0:wybe.phantom, ?tmp#53##0:wybe.phantom) @common_fields:nn:nn
+    common_fields.id<1>[410bae77d3](~tmp#4##0:common_fields, ?c##1:common_fields, 10:wybe.int) #10 @common_fields:nn:nn
+    common_fields.id<0>(~c##1:common_fields, ?tmp#8##0:wybe.int) #11 @common_fields:nn:nn
+    foreign c print_int(~tmp#8##0:wybe.int, ~tmp#53##0:wybe.phantom, ?tmp#56##0:wybe.phantom) @common_fields:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#56##0:wybe.phantom, ?tmp#57##0:wybe.phantom) @common_fields:nn:nn
+    foreign lpvm store(~%tmp#57##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
+    common_fields.genre<0>(tmp#0##0:common_fields, ?tmp#9##0:wybe.string, ?tmp#14##0:wybe.bool) #13 @common_fields:nn:nn
+    case ~tmp#14##0:wybe.bool of
     0:
 
     1:
-        common_fields.genre<1>(~tmp#0##0:common_fields, ?b##1:common_fields, "g":wybe.string, ?tmp#10##0:wybe.bool) #10 @common_fields:nn:nn
-        case ~tmp#10##0:wybe.bool of
+        common_fields.genre<1>(~tmp#0##0:common_fields, ?b##1:common_fields, 1439:wybe.string, ?tmp#15##0:wybe.bool) #15 @common_fields:nn:nn
+        case ~tmp#15##0:wybe.bool of
         0:
 
         1:
-            wybe.string.print<0>(~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #15 @common_fields:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @common_fields:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @common_fields:nn:nn
-            foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
-            common_fields.genre<0>(~b##1:common_fields, ?tmp#6##0:wybe.string, ?tmp#8##0:wybe.bool) #12 @common_fields:nn:nn
-            case ~tmp#8##0:wybe.bool of
+            wybe.string.print<0>(~tmp#9##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @common_fields:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#63##0:wybe.phantom) @common_fields:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#63##0:wybe.phantom, ?tmp#64##0:wybe.phantom) @common_fields:nn:nn
+            foreign lpvm store(~%tmp#64##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
+            common_fields.genre<0>(~b##1:common_fields, ?tmp#11##0:wybe.string, ?tmp#13##0:wybe.bool) #17 @common_fields:nn:nn
+            case ~tmp#13##0:wybe.bool of
             0:
 
             1:
-                wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @common_fields:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#41##0:wybe.phantom) @common_fields:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp#41##0:wybe.phantom, ?tmp#42##0:wybe.phantom) @common_fields:nn:nn
-                foreign lpvm store(~%tmp#42##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
+                wybe.string.print<0>[410bae77d3](~tmp#11##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @common_fields:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#66##0:wybe.phantom) @common_fields:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#66##0:wybe.phantom, ?tmp#67##0:wybe.phantom) @common_fields:nn:nn
+                foreign lpvm store(~%tmp#67##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
 
 
 
@@ -618,14 +618,6 @@ proc ~= > public {inline} (0 calls)
 source_filename = "!ROOT!/final-dump/common_fields.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"a\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"b\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"c\00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"g\00", align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#6" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#7" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
 
 declare external fastcc i2 @"wybe.string.<=>#cont#2<0>"(i2, i64, i64, i64, i64)
 declare external fastcc void @"wybe.string.print<0>"(i64)
@@ -636,58 +628,58 @@ declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"common_fields.<0>"() {
-  %"tmp#43##0" = call ccc ptr @wybe_malloc(i32 32)
-  %"tmp#15##0" = ptrtoint ptr %"tmp#43##0" to i64
-  %"tmp#44##0" = inttoptr i64 %"tmp#15##0" to ptr
-  store i64 ptrtoint( ptr @"string#4" to i64 ), ptr %"tmp#44##0"
-  %"tmp#45##0" = add i64 %"tmp#15##0", 8
-  %"tmp#46##0" = inttoptr i64 %"tmp#45##0" to ptr
-  store i64 ptrtoint( ptr @"string#5" to i64 ), ptr %"tmp#46##0"
-  %"tmp#47##0" = add i64 %"tmp#15##0", 16
-  %"tmp#48##0" = inttoptr i64 %"tmp#47##0" to ptr
-  store i64 ptrtoint( ptr @"string#6" to i64 ), ptr %"tmp#48##0"
-  %"tmp#49##0" = add i64 %"tmp#15##0", 24
-  %"tmp#50##0" = inttoptr i64 %"tmp#49##0" to ptr
-  store i64 0, ptr %"tmp#50##0"
-  %"tmp#51##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#22##0" = ptrtoint ptr %"tmp#51##0" to i64
-  %"tmp#52##0" = inttoptr i64 %"tmp#22##0" to ptr
-  store i64 ptrtoint( ptr @"string#5" to i64 ), ptr %"tmp#52##0"
-  %"tmp#53##0" = add i64 %"tmp#22##0", 8
-  %"tmp#54##0" = inttoptr i64 %"tmp#53##0" to ptr
-  store i64 0, ptr %"tmp#54##0"
-  %"tmp#55##0" = add i64 %"tmp#22##0", 16
-  %"tmp#56##0" = inttoptr i64 %"tmp#55##0" to ptr
-  store i64 1, ptr %"tmp#56##0"
-  %"tmp#1##0" = or i64 %"tmp#22##0", 1
-  %"tmp#2##0" = tail call fastcc i64 @"common_fields.title<0>"(i64 %"tmp#15##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#2##0")
+  %"tmp#68##0" = call ccc ptr @wybe_malloc(i32 32)
+  %"tmp#32##0" = ptrtoint ptr %"tmp#68##0" to i64
+  %"tmp#69##0" = inttoptr i64 %"tmp#32##0" to ptr
+  store i64 1415, ptr %"tmp#69##0"
+  %"tmp#70##0" = add i64 %"tmp#32##0", 8
+  %"tmp#71##0" = inttoptr i64 %"tmp#70##0" to ptr
+  store i64 1419, ptr %"tmp#71##0"
+  %"tmp#72##0" = add i64 %"tmp#32##0", 16
+  %"tmp#73##0" = inttoptr i64 %"tmp#72##0" to ptr
+  store i64 1423, ptr %"tmp#73##0"
+  %"tmp#74##0" = add i64 %"tmp#32##0", 24
+  %"tmp#75##0" = inttoptr i64 %"tmp#74##0" to ptr
+  store i64 0, ptr %"tmp#75##0"
+  %"tmp#76##0" = call ccc ptr @wybe_malloc(i32 24)
+  %"tmp#43##0" = ptrtoint ptr %"tmp#76##0" to i64
+  %"tmp#77##0" = inttoptr i64 %"tmp#43##0" to ptr
+  store i64 1419, ptr %"tmp#77##0"
+  %"tmp#78##0" = add i64 %"tmp#43##0", 8
+  %"tmp#79##0" = inttoptr i64 %"tmp#78##0" to ptr
+  store i64 0, ptr %"tmp#79##0"
+  %"tmp#80##0" = add i64 %"tmp#43##0", 16
+  %"tmp#81##0" = inttoptr i64 %"tmp#80##0" to ptr
+  store i64 1, ptr %"tmp#81##0"
+  %"tmp#4##0" = or i64 %"tmp#43##0", 1
+  %"tmp#6##0" = tail call fastcc i64 @"common_fields.title<0>"(i64 %"tmp#32##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#6##0")
   call ccc void @putchar(i8 10)
-  %"tmp#3##0" = tail call fastcc i64 @"common_fields.id<0>"(i64 %"tmp#1##0")
-  call ccc void @print_int(i64 %"tmp#3##0")
+  %"tmp#7##0" = tail call fastcc i64 @"common_fields.id<0>"(i64 %"tmp#4##0")
+  call ccc void @print_int(i64 %"tmp#7##0")
   call ccc void @putchar(i8 10)
-  %"c##1" = tail call fastcc i64 @"common_fields.id<1>[410bae77d3]"(i64 %"tmp#1##0", i64 10)
-  %"tmp#4##0" = tail call fastcc i64 @"common_fields.id<0>"(i64 %"c##1")
-  call ccc void @print_int(i64 %"tmp#4##0")
+  %"c##1" = tail call fastcc i64 @"common_fields.id<1>[410bae77d3]"(i64 %"tmp#4##0", i64 10)
+  %"tmp#8##0" = tail call fastcc i64 @"common_fields.id<0>"(i64 %"c##1")
+  call ccc void @print_int(i64 %"tmp#8##0")
   call ccc void @putchar(i8 10)
-  %"tmp#57##0" = tail call fastcc {i64, i1} @"common_fields.genre<0>"(i64 %"tmp#15##0")
-  %"tmp#5##0" = extractvalue {i64, i1}%"tmp#57##0", 0
-  %"tmp#9##0" = extractvalue {i64, i1}%"tmp#57##0", 1
-  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
+  %"tmp#82##0" = tail call fastcc {i64, i1} @"common_fields.genre<0>"(i64 %"tmp#32##0")
+  %"tmp#9##0" = extractvalue {i64, i1}%"tmp#82##0", 0
+  %"tmp#14##0" = extractvalue {i64, i1}%"tmp#82##0", 1
+  br i1 %"tmp#14##0", label %if.then.0, label %if.else.0
 if.then.0:
-  %"tmp#58##0" = tail call fastcc {i64, i1} @"common_fields.genre<1>"(i64 %"tmp#15##0", i64 ptrtoint( ptr @"string#7" to i64 ))
-  %"b##1" = extractvalue {i64, i1}%"tmp#58##0", 0
-  %"tmp#10##0" = extractvalue {i64, i1}%"tmp#58##0", 1
-  br i1 %"tmp#10##0", label %if.then.1, label %if.else.1
+  %"tmp#83##0" = tail call fastcc {i64, i1} @"common_fields.genre<1>"(i64 %"tmp#32##0", i64 1439)
+  %"b##1" = extractvalue {i64, i1}%"tmp#83##0", 0
+  %"tmp#15##0" = extractvalue {i64, i1}%"tmp#83##0", 1
+  br i1 %"tmp#15##0", label %if.then.1, label %if.else.1
 if.then.1:
-  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#5##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#9##0")
   call ccc void @putchar(i8 10)
-  %"tmp#59##0" = tail call fastcc {i64, i1} @"common_fields.genre<0>"(i64 %"b##1")
-  %"tmp#6##0" = extractvalue {i64, i1}%"tmp#59##0", 0
-  %"tmp#8##0" = extractvalue {i64, i1}%"tmp#59##0", 1
-  br i1 %"tmp#8##0", label %if.then.2, label %if.else.2
+  %"tmp#84##0" = tail call fastcc {i64, i1} @"common_fields.genre<0>"(i64 %"b##1")
+  %"tmp#11##0" = extractvalue {i64, i1}%"tmp#84##0", 0
+  %"tmp#13##0" = extractvalue {i64, i1}%"tmp#84##0", 1
+  br i1 %"tmp#13##0", label %if.then.2, label %if.else.2
 if.then.2:
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#6##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#11##0")
   call ccc void @putchar(i8 10)
   ret void
 if.else.2:

--- a/test-cases/final-dump/common_fields.exp
+++ b/test-cases/final-dump/common_fields.exp
@@ -39,49 +39,49 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(10,(common_fields.id<1>,fromList [NonAliasedParamCond 0 []])),(21,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(32:wybe.int, ?tmp#32##0:common_fields) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#32##0:common_fields, ?tmp#33##0:common_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1415:wybe.string) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#33##0:common_fields, ?tmp#34##0:common_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1419:wybe.string) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#34##0:common_fields, ?tmp#35##0:common_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1423:wybe.string) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#35##0:common_fields, ?tmp#0##0:common_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @common_fields:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp#43##0:common_fields) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#43##0:common_fields, ?tmp#44##0:common_fields, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1419:wybe.string) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#44##0:common_fields, ?tmp#45##0:common_fields, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int) @common_fields:nn:nn
-    foreign lpvm mutate(~tmp#45##0:common_fields, ?tmp#46##0:common_fields, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @common_fields:nn:nn
-    foreign llvm or(~tmp#46##0:common_fields, 1:wybe.int, ?tmp#4##0:common_fields) @common_fields:nn:nn
-    common_fields.title<0>(tmp#0##0:common_fields, ?tmp#6##0:wybe.string) #6 @common_fields:nn:nn
-    wybe.string.print<0>(~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @common_fields:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#48##0:wybe.phantom) @common_fields:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#48##0:wybe.phantom, ?tmp#49##0:wybe.phantom) @common_fields:nn:nn
-    common_fields.id<0>(tmp#4##0:common_fields, ?tmp#7##0:wybe.int) #8 @common_fields:nn:nn
-    foreign c print_int(~tmp#7##0:wybe.int, ~tmp#49##0:wybe.phantom, ?tmp#52##0:wybe.phantom) @common_fields:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#52##0:wybe.phantom, ?tmp#53##0:wybe.phantom) @common_fields:nn:nn
-    common_fields.id<1>[410bae77d3](~tmp#4##0:common_fields, ?c##1:common_fields, 10:wybe.int) #10 @common_fields:nn:nn
-    common_fields.id<0>(~c##1:common_fields, ?tmp#8##0:wybe.int) #11 @common_fields:nn:nn
-    foreign c print_int(~tmp#8##0:wybe.int, ~tmp#53##0:wybe.phantom, ?tmp#56##0:wybe.phantom) @common_fields:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#56##0:wybe.phantom, ?tmp#57##0:wybe.phantom) @common_fields:nn:nn
-    foreign lpvm store(~%tmp#57##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
-    common_fields.genre<0>(tmp#0##0:common_fields, ?tmp#9##0:wybe.string, ?tmp#14##0:wybe.bool) #13 @common_fields:nn:nn
-    case ~tmp#14##0:wybe.bool of
+  MultiSpeczDepInfo: [(6,(common_fields.id<1>,fromList [NonAliasedParamCond 0 []])),(21,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign lpvm alloc(32:wybe.int, ?tmp#30##0:common_fields) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#30##0:common_fields, ?tmp#31##0:common_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1415:wybe.string) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#31##0:common_fields, ?tmp#32##0:common_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1419:wybe.string) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#32##0:common_fields, ?tmp#33##0:common_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1423:wybe.string) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#33##0:common_fields, ?tmp#0##0:common_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int) @common_fields:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#42##0:common_fields) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#42##0:common_fields, ?tmp#43##0:common_fields, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1419:wybe.string) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#43##0:common_fields, ?tmp#44##0:common_fields, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int) @common_fields:nn:nn
+    foreign lpvm mutate(~tmp#44##0:common_fields, ?tmp#45##0:common_fields, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int) @common_fields:nn:nn
+    foreign llvm or(~tmp#45##0:common_fields, 1:wybe.int, ?tmp#1##0:common_fields) @common_fields:nn:nn
+    common_fields.title<0>(tmp#0##0:common_fields, ?tmp#2##0:wybe.string) #2 @common_fields:nn:nn
+    wybe.string.print<0>(~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #18 @common_fields:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#47##0:wybe.phantom) @common_fields:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#47##0:wybe.phantom, ?tmp#48##0:wybe.phantom) @common_fields:nn:nn
+    common_fields.id<0>(tmp#1##0:common_fields, ?tmp#3##0:wybe.int) #4 @common_fields:nn:nn
+    foreign c print_int(~tmp#3##0:wybe.int, ~tmp#48##0:wybe.phantom, ?tmp#51##0:wybe.phantom) @common_fields:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#51##0:wybe.phantom, ?tmp#52##0:wybe.phantom) @common_fields:nn:nn
+    common_fields.id<1>[410bae77d3](~tmp#1##0:common_fields, ?c##1:common_fields, 10:wybe.int) #6 @common_fields:nn:nn
+    common_fields.id<0>(~c##1:common_fields, ?tmp#4##0:wybe.int) #7 @common_fields:nn:nn
+    foreign c print_int(~tmp#4##0:wybe.int, ~tmp#52##0:wybe.phantom, ?tmp#55##0:wybe.phantom) @common_fields:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#55##0:wybe.phantom, ?tmp#56##0:wybe.phantom) @common_fields:nn:nn
+    foreign lpvm store(~%tmp#56##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
+    common_fields.genre<0>(tmp#0##0:common_fields, ?tmp#5##0:wybe.string, ?tmp#9##0:wybe.bool) #9 @common_fields:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
 
     1:
-        common_fields.genre<1>(~tmp#0##0:common_fields, ?b##1:common_fields, 1439:wybe.string, ?tmp#15##0:wybe.bool) #15 @common_fields:nn:nn
-        case ~tmp#15##0:wybe.bool of
+        common_fields.genre<1>(~tmp#0##0:common_fields, ?b##1:common_fields, 1439:wybe.string, ?tmp#10##0:wybe.bool) #10 @common_fields:nn:nn
+        case ~tmp#10##0:wybe.bool of
         0:
 
         1:
-            wybe.string.print<0>(~tmp#9##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @common_fields:nn:nn
+            wybe.string.print<0>(~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @common_fields:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#63##0:wybe.phantom) @common_fields:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#63##0:wybe.phantom, ?tmp#64##0:wybe.phantom) @common_fields:nn:nn
             foreign lpvm store(~%tmp#64##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
-            common_fields.genre<0>(~b##1:common_fields, ?tmp#11##0:wybe.string, ?tmp#13##0:wybe.bool) #17 @common_fields:nn:nn
-            case ~tmp#13##0:wybe.bool of
+            common_fields.genre<0>(~b##1:common_fields, ?tmp#6##0:wybe.string, ?tmp#8##0:wybe.bool) #12 @common_fields:nn:nn
+            case ~tmp#8##0:wybe.bool of
             0:
 
             1:
-                wybe.string.print<0>[410bae77d3](~tmp#11##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @common_fields:nn:nn
+                wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @common_fields:nn:nn
                 foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#66##0:wybe.phantom) @common_fields:nn:nn
                 foreign c putchar('\n':wybe.char, ~tmp#66##0:wybe.phantom, ?tmp#67##0:wybe.phantom) @common_fields:nn:nn
                 foreign lpvm store(~%tmp#67##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
@@ -629,57 +629,57 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"common_fields.<0>"() {
   %"tmp#68##0" = call ccc ptr @wybe_malloc(i32 32)
-  %"tmp#32##0" = ptrtoint ptr %"tmp#68##0" to i64
-  %"tmp#69##0" = inttoptr i64 %"tmp#32##0" to ptr
+  %"tmp#30##0" = ptrtoint ptr %"tmp#68##0" to i64
+  %"tmp#69##0" = inttoptr i64 %"tmp#30##0" to ptr
   store i64 1415, ptr %"tmp#69##0"
-  %"tmp#70##0" = add i64 %"tmp#32##0", 8
+  %"tmp#70##0" = add i64 %"tmp#30##0", 8
   %"tmp#71##0" = inttoptr i64 %"tmp#70##0" to ptr
   store i64 1419, ptr %"tmp#71##0"
-  %"tmp#72##0" = add i64 %"tmp#32##0", 16
+  %"tmp#72##0" = add i64 %"tmp#30##0", 16
   %"tmp#73##0" = inttoptr i64 %"tmp#72##0" to ptr
   store i64 1423, ptr %"tmp#73##0"
-  %"tmp#74##0" = add i64 %"tmp#32##0", 24
+  %"tmp#74##0" = add i64 %"tmp#30##0", 24
   %"tmp#75##0" = inttoptr i64 %"tmp#74##0" to ptr
   store i64 0, ptr %"tmp#75##0"
   %"tmp#76##0" = call ccc ptr @wybe_malloc(i32 24)
-  %"tmp#43##0" = ptrtoint ptr %"tmp#76##0" to i64
-  %"tmp#77##0" = inttoptr i64 %"tmp#43##0" to ptr
+  %"tmp#42##0" = ptrtoint ptr %"tmp#76##0" to i64
+  %"tmp#77##0" = inttoptr i64 %"tmp#42##0" to ptr
   store i64 1419, ptr %"tmp#77##0"
-  %"tmp#78##0" = add i64 %"tmp#43##0", 8
+  %"tmp#78##0" = add i64 %"tmp#42##0", 8
   %"tmp#79##0" = inttoptr i64 %"tmp#78##0" to ptr
   store i64 0, ptr %"tmp#79##0"
-  %"tmp#80##0" = add i64 %"tmp#43##0", 16
+  %"tmp#80##0" = add i64 %"tmp#42##0", 16
   %"tmp#81##0" = inttoptr i64 %"tmp#80##0" to ptr
   store i64 1, ptr %"tmp#81##0"
-  %"tmp#4##0" = or i64 %"tmp#43##0", 1
-  %"tmp#6##0" = tail call fastcc i64 @"common_fields.title<0>"(i64 %"tmp#32##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#6##0")
+  %"tmp#1##0" = or i64 %"tmp#42##0", 1
+  %"tmp#2##0" = tail call fastcc i64 @"common_fields.title<0>"(i64 %"tmp#30##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
-  %"tmp#7##0" = tail call fastcc i64 @"common_fields.id<0>"(i64 %"tmp#4##0")
-  call ccc void @print_int(i64 %"tmp#7##0")
+  %"tmp#3##0" = tail call fastcc i64 @"common_fields.id<0>"(i64 %"tmp#1##0")
+  call ccc void @print_int(i64 %"tmp#3##0")
   call ccc void @putchar(i8 10)
-  %"c##1" = tail call fastcc i64 @"common_fields.id<1>[410bae77d3]"(i64 %"tmp#4##0", i64 10)
-  %"tmp#8##0" = tail call fastcc i64 @"common_fields.id<0>"(i64 %"c##1")
-  call ccc void @print_int(i64 %"tmp#8##0")
+  %"c##1" = tail call fastcc i64 @"common_fields.id<1>[410bae77d3]"(i64 %"tmp#1##0", i64 10)
+  %"tmp#4##0" = tail call fastcc i64 @"common_fields.id<0>"(i64 %"c##1")
+  call ccc void @print_int(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
-  %"tmp#82##0" = tail call fastcc {i64, i1} @"common_fields.genre<0>"(i64 %"tmp#32##0")
-  %"tmp#9##0" = extractvalue {i64, i1}%"tmp#82##0", 0
-  %"tmp#14##0" = extractvalue {i64, i1}%"tmp#82##0", 1
-  br i1 %"tmp#14##0", label %if.then.0, label %if.else.0
+  %"tmp#82##0" = tail call fastcc {i64, i1} @"common_fields.genre<0>"(i64 %"tmp#30##0")
+  %"tmp#5##0" = extractvalue {i64, i1}%"tmp#82##0", 0
+  %"tmp#9##0" = extractvalue {i64, i1}%"tmp#82##0", 1
+  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
 if.then.0:
-  %"tmp#83##0" = tail call fastcc {i64, i1} @"common_fields.genre<1>"(i64 %"tmp#32##0", i64 1439)
+  %"tmp#83##0" = tail call fastcc {i64, i1} @"common_fields.genre<1>"(i64 %"tmp#30##0", i64 1439)
   %"b##1" = extractvalue {i64, i1}%"tmp#83##0", 0
-  %"tmp#15##0" = extractvalue {i64, i1}%"tmp#83##0", 1
-  br i1 %"tmp#15##0", label %if.then.1, label %if.else.1
+  %"tmp#10##0" = extractvalue {i64, i1}%"tmp#83##0", 1
+  br i1 %"tmp#10##0", label %if.then.1, label %if.else.1
 if.then.1:
-  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#9##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#5##0")
   call ccc void @putchar(i8 10)
   %"tmp#84##0" = tail call fastcc {i64, i1} @"common_fields.genre<0>"(i64 %"b##1")
-  %"tmp#11##0" = extractvalue {i64, i1}%"tmp#84##0", 0
-  %"tmp#13##0" = extractvalue {i64, i1}%"tmp#84##0", 1
-  br i1 %"tmp#13##0", label %if.then.2, label %if.else.2
+  %"tmp#6##0" = extractvalue {i64, i1}%"tmp#84##0", 0
+  %"tmp#8##0" = extractvalue {i64, i1}%"tmp#84##0", 1
+  br i1 %"tmp#8##0", label %if.then.2, label %if.else.2
 if.then.2:
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#11##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#6##0")
   call ccc void @putchar(i8 10)
   ret void
 if.else.2:

--- a/test-cases/final-dump/cond_expr_no_else_err1.exp
+++ b/test-cases/final-dump/cond_expr_no_else_err1.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) cond_expr_no_else_err1
-[91mfinal-dump/cond_expr_no_else_err1.wybe:1:1: proc to_count has test determinism, but declared normal (total)
-[0m
+final-dump/cond_expr_no_else_err1.wybe:1:1: proc to_count has test determinism, but declared normal (total)

--- a/test-cases/final-dump/cond_expr_no_else_err2.exp
+++ b/test-cases/final-dump/cond_expr_no_else_err2.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) cond_expr_no_else_err2
-[91mfinal-dump/cond_expr_no_else_err2.wybe:1:1: proc vowel_num has test determinism, but declared normal (total)
-[0m
+final-dump/cond_expr_no_else_err2.wybe:1:1: proc vowel_num has test determinism, but declared normal (total)

--- a/test-cases/final-dump/constant_type_constraint_error.exp
+++ b/test-cases/final-dump/constant_type_constraint_error.exp
@@ -1,5 +1,6 @@
 Error detected during type checking of module(s) constant_type_constraint_error, constant_type_constraint_error.my_float, constant_type_constraint_error.my_int
-final-dump/constant_type_constraint_error.wybe:4:6: Type error in call to proc singleton, argument 2
+final-dump/constant_type_constraint_error.wybe:4:6: Type constraint (:int) in call from module top-level code to =, argument 2, is incompatible with expression "s"
 final-dump/constant_type_constraint_error.wybe:5:6: Type constraint (:string) in call from module top-level code to =, argument 2, is incompatible with expression 1
 final-dump/constant_type_constraint_error.wybe:6:6: Type constraint (:float) in call from module top-level code to =, argument 2, is incompatible with expression "1.0"
+final-dump/constant_type_constraint_error.wybe:12:2: Type error in call to proc =, argument 2
 final-dump/constant_type_constraint_error.wybe:13:6: Type constraint (:my_int) in call from module top-level code to =, argument 2, is incompatible with expression 1.0

--- a/test-cases/final-dump/constant_type_constraint_error.exp
+++ b/test-cases/final-dump/constant_type_constraint_error.exp
@@ -1,6 +1,5 @@
 Error detected during type checking of module(s) constant_type_constraint_error, constant_type_constraint_error.my_float, constant_type_constraint_error.my_int
-[91mfinal-dump/constant_type_constraint_error.wybe:4:6: Type constraint (:int) in call from module top-level code to =, argument 2, is incompatible with expression "s"
-[0m[91mfinal-dump/constant_type_constraint_error.wybe:5:6: Type constraint (:string) in call from module top-level code to =, argument 2, is incompatible with expression 1
-[0m[91mfinal-dump/constant_type_constraint_error.wybe:6:6: Type constraint (:float) in call from module top-level code to =, argument 2, is incompatible with expression "1.0"
-[0m[91mfinal-dump/constant_type_constraint_error.wybe:13:6: Type constraint (:my_int) in call from module top-level code to =, argument 2, is incompatible with expression 1.0
-[0m
+final-dump/constant_type_constraint_error.wybe:4:6: Type error in call to proc singleton, argument 2
+final-dump/constant_type_constraint_error.wybe:5:6: Type constraint (:string) in call from module top-level code to =, argument 2, is incompatible with expression 1
+final-dump/constant_type_constraint_error.wybe:6:6: Type constraint (:float) in call from module top-level code to =, argument 2, is incompatible with expression "1.0"
+final-dump/constant_type_constraint_error.wybe:13:6: Type constraint (:my_int) in call from module top-level code to =, argument 2, is incompatible with expression 1.0

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -19,10 +19,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm cast('a':wybe.char, ?tmp#3##0:ctor_char) @ctor_char:nn:nn
-    foreign llvm shl(~tmp#3##0:ctor_char, 1:ctor_char, ?tmp#4##0:ctor_char) @ctor_char:nn:nn
-    foreign llvm or(~tmp#4##0:ctor_char, 512:ctor_char, ?tmp#1##0:ctor_char) @ctor_char:nn:nn
-    ctor_char.foo<0>(~tmp#1##0:ctor_char, ?tmp#0##0:wybe.char) #1 @ctor_char:nn:nn
+    ctor_char.foo<0>(706:ctor_char, ?tmp#0##0:wybe.char) #1 @ctor_char:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @ctor_char:nn:nn
     foreign c putchar(~tmp#0##0:wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @ctor_char:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @ctor_char:nn:nn
@@ -277,10 +274,7 @@ declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"ctor_char.<0>"() {
-  %"tmp#3##0" = zext i8 97 to i64
-  %"tmp#4##0" = shl i64 %"tmp#3##0", 1
-  %"tmp#1##0" = or i64 %"tmp#4##0", 512
-  %"tmp#0##0" = tail call fastcc i8 @"ctor_char.foo<0>"(i64 %"tmp#1##0")
+  %"tmp#0##0" = tail call fastcc i8 @"ctor_char.foo<0>"(i64 706)
   call ccc void @putchar(i8 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -19,10 +19,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm cast('a':wybe.char, ?tmp#3##0:ctor_char2) @ctor_char2:nn:nn
-    foreign llvm shl(~tmp#3##0:ctor_char2, 2:ctor_char2, ?tmp#4##0:ctor_char2) @ctor_char2:nn:nn
-    foreign llvm or(~tmp#4##0:ctor_char2, 1024:ctor_char2, ?tmp#1##0:ctor_char2) @ctor_char2:nn:nn
-    ctor_char2.foo<0>(~tmp#1##0:ctor_char2, ?tmp#0##0:wybe.char) #1 @ctor_char2:nn:nn
+    ctor_char2.foo<0>(1412:ctor_char2, ?tmp#0##0:wybe.char) #1 @ctor_char2:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @ctor_char2:nn:nn
     foreign c putchar(~tmp#0##0:wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @ctor_char2:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @ctor_char2:nn:nn
@@ -323,10 +320,7 @@ declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"ctor_char2.<0>"() {
-  %"tmp#3##0" = zext i8 97 to i64
-  %"tmp#4##0" = shl i64 %"tmp#3##0", 2
-  %"tmp#1##0" = or i64 %"tmp#4##0", 1024
-  %"tmp#0##0" = tail call fastcc i8 @"ctor_char2.foo<0>"(i64 %"tmp#1##0")
+  %"tmp#0##0" = tail call fastcc i8 @"ctor_char2.foo<0>"(i64 1412)
   call ccc void @putchar(i8 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/ctor_field_errors.exp
+++ b/test-cases/final-dump/ctor_field_errors.exp
@@ -1,4 +1,3 @@
 Error detected during final normalisation of module(s) ctor_field_errors, ctor_field_errors.mixed_type, ctor_field_errors.mixed_vis
-[91mfinal-dump/ctor_field_errors.wybe:1:39: field 'a' declared with multiple types
-[0m[91mfinal-dump/ctor_field_errors.wybe:3:26: field 'a' declared with multiple visibilities
-[0m
+final-dump/ctor_field_errors.wybe:1:39: field 'a' declared with multiple types
+final-dump/ctor_field_errors.wybe:3:26: field 'a' declared with multiple visibilities

--- a/test-cases/final-dump/current_module_alias_fail.exp
+++ b/test-cases/final-dump/current_module_alias_fail.exp
@@ -94,8 +94,7 @@ define external fastcc double @"math.temperature.toCelsius<0>"(double %"f##0") {
   %"tmp#6##0" = fdiv double %"tmp#1##0", 1.8
   ret double %"tmp#6##0"
 }
-[93mfinal-dump/current_module_alias_fail.wybe:5:10: Multiple procedures match this call's types and flows:
+final-dump/current_module_alias_fail.wybe:5:10: Multiple procedures match this call's types and flows:
     current_module_alias_fail.toCelsius<0>
     math.temperature.toCelsius<0>
 Defaulting to: current_module_alias_fail.toCelsius<0>
-[0m

--- a/test-cases/final-dump/current_module_alias_warning.exp
+++ b/test-cases/final-dump/current_module_alias_warning.exp
@@ -108,9 +108,8 @@ define external fastcc double @"math.temperature.toCelsius<0>"(double %"f##0") {
   %"tmp#6##0" = fdiv double %"tmp#1##0", 1.8
   ret double %"tmp#6##0"
 }
-[93mfinal-dump/current_module_alias_warning.wybe:6:10: Multiple procedures match this call's types and flows:
+final-dump/current_module_alias_warning.wybe:6:10: Multiple procedures match this call's types and flows:
     current_module_alias_warning.toCelsius<0>
     current_module_alias_warning.toCelsius<1>
     math.temperature.toCelsius<0>
 Defaulting to: current_module_alias_warning.toCelsius<0>
-[0m

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -189,69 +189,70 @@ proc print_t > public (2 calls)
 print_t(x##0:dead_cell_size.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    dead_cell_size.t.=<0>(0:dead_cell_size.t, x##0:dead_cell_size.t, ?tmp#4##0:wybe.bool) #1 @dead_cell_size:nn:nn
-    case ~tmp#4##0:wybe.bool of
+  MultiSpeczDepInfo: [(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(17,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(20,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(26,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    dead_cell_size.t.=<0>(0:dead_cell_size.t, x##0:dead_cell_size.t, ?tmp#9##0:wybe.bool) #1 @dead_cell_size:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool) @dead_cell_size:nn:nn
-        case ~tmp#6##0:wybe.bool of
+        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.bool) @dead_cell_size:nn:nn
+        case ~tmp#11##0:wybe.bool of
         0:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
         1:
-            foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#7##0:wybe.int) @dead_cell_size:nn:nn
-            case ~tmp#7##0:wybe.int of
+            foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#12##0:wybe.int) @dead_cell_size:nn:nn
+            case ~tmp#12##0:wybe.int of
             0:
                 foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
                 wybe.string.print<0>("tb(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#36##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~a##0:wybe.int, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#57##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~a##0:wybe.int, ~tmp#57##0:wybe.phantom, ?tmp#58##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#58##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#63##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#63##0:wybe.phantom, ?tmp#64##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#64##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
             1:
                 foreign lpvm access(x##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?a##1:wybe.int) @dead_cell_size:nn:nn
                 foreign lpvm access(x##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?b##0:wybe.int) @dead_cell_size:nn:nn
                 foreign lpvm access(~x##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?c##0:wybe.int) @dead_cell_size:nn:nn
-                wybe.string.print<0>("tc(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#25##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~a##1:wybe.int, ~tmp#25##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#26##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#28##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~b##0:wybe.int, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~c##0:wybe.int, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>("tc(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#34##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~a##1:wybe.int, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#35##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#41##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~b##0:wybe.int, ~tmp#41##0:wybe.phantom, ?tmp#42##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#42##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #17 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#48##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~c##0:wybe.int, ~tmp#48##0:wybe.phantom, ?tmp#49##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#49##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#54##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#54##0:wybe.phantom, ?tmp#55##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#55##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
             2:
                 foreign lpvm access(~x##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int) @dead_cell_size:nn:nn
-                wybe.string.print<0>("td(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~a##2:wybe.int, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>("td(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#25##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~a##2:wybe.int, ~tmp#25##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#26##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
 
 
     1:
         wybe.string.print<0>("ta":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @dead_cell_size:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#40##0:wybe.phantom) @dead_cell_size:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#40##0:wybe.phantom, ?tmp#41##0:wybe.phantom) @dead_cell_size:nn:nn
-        foreign lpvm store(~%tmp#41##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#65##0:wybe.phantom) @dead_cell_size:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#65##0:wybe.phantom, ?tmp#66##0:wybe.phantom) @dead_cell_size:nn:nn
+        foreign lpvm store(~%tmp#66##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
 
 
@@ -260,33 +261,34 @@ proc print_t2 > public (1 calls)
 print_t2(x##0:dead_cell_size.t2)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x##0:dead_cell_size.t2, ?tmp#2##0:wybe.bool) #1 @dead_cell_size:nn:nn
-    case ~tmp#2##0:wybe.bool of
+  MultiSpeczDepInfo: [(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x##0:dead_cell_size.t2, ?tmp#3##0:wybe.bool) #1 @dead_cell_size:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @dead_cell_size:nn:nn
-        case ~tmp#4##0:wybe.bool of
+        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @dead_cell_size:nn:nn
+        case ~tmp#5##0:wybe.bool of
         0:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
         1:
             foreign lpvm access(~x##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
             wybe.string.print<0>("t2b(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @dead_cell_size:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign c print_int(~a##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-            wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @dead_cell_size:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign c print_int(~a##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+            wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @dead_cell_size:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
 
     1:
         wybe.string.print<0>("t2a":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @dead_cell_size:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @dead_cell_size:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @dead_cell_size:nn:nn
-        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @dead_cell_size:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @dead_cell_size:nn:nn
+        foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
 
   LLVM code       :
@@ -297,24 +299,21 @@ print_t2(x##0:dead_cell_size.t2)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 source_filename = "!ROOT!/final-dump/dead_cell_size.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"t2a\00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"t2b(\00", align 8
-@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"ta\00", align 8
-@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"tb(\00", align 8
-@"cstring#6" = private unnamed_addr constant [ ?? x i8 ] c"tc(\00", align 8
-@"cstring#7" = private unnamed_addr constant [ ?? x i8 ] c"td(\00", align 8
-@"string#8" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#9" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#10" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#11" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
-@"string#12" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
-@"string#13" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
-@"string#14" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#6" to i64 ) }, align 8
-@"string#15" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#7" to i64 ) }, align 8
+@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"t2a\00", align 8
+@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"t2b(\00", align 8
+@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"ta\00", align 8
+@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"tb(\00", align 8
+@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"tc(\00", align 8
+@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"td(\00", align 8
+@"string#6" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
+@"string#7" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
+@"string#8" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#9" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
+@"string#10" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
+@"string#11" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
@@ -461,55 +460,55 @@ if.else.0:
 }
 
 define external fastcc void @"dead_cell_size.print_t<0>"(i64 %"x##0") {
-  %"tmp#4##0" = tail call fastcc i1 @"dead_cell_size.t.=<0>"(i64 0, i64 %"x##0")
-  br i1 %"tmp#4##0", label %if.then.0, label %if.else.0
+  %"tmp#9##0" = tail call fastcc i1 @"dead_cell_size.t.=<0>"(i64 0, i64 %"x##0")
+  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
   call ccc void @putchar(i8 10)
   ret void
 if.else.0:
-  %"tmp#6##0" = icmp ne i64 %"x##0", 0
-  br i1 %"tmp#6##0", label %if.then.1, label %if.else.1
+  %"tmp#11##0" = icmp ne i64 %"x##0", 0
+  br i1 %"tmp#11##0", label %if.then.1, label %if.else.1
 if.then.1:
-  %"tmp#7##0" = and i64 %"x##0", 3
-  switch i64 %"tmp#7##0", label %case.2.switch.2 [
+  %"tmp#12##0" = and i64 %"x##0", 3
+  switch i64 %"tmp#12##0", label %case.2.switch.2 [
     i64 0, label %case.0.switch.2
     i64 1, label %case.1.switch.2
     i64 2, label %case.2.switch.2 ]
 case.0.switch.2:
-  %"tmp#42##0" = inttoptr i64 %"x##0" to ptr
-  %"a##0" = load i64, ptr %"tmp#42##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#13" to i64 ))
+  %"tmp#67##0" = inttoptr i64 %"x##0" to ptr
+  %"a##0" = load i64, ptr %"tmp#67##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
   call ccc void @print_int(i64 %"a##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.1.switch.2:
-  %"tmp#43##0" = add i64 %"x##0", -1
-  %"tmp#44##0" = inttoptr i64 %"tmp#43##0" to ptr
-  %"a##1" = load i64, ptr %"tmp#44##0"
-  %"tmp#45##0" = add i64 %"x##0", 7
-  %"tmp#46##0" = inttoptr i64 %"tmp#45##0" to ptr
-  %"b##0" = load i64, ptr %"tmp#46##0"
-  %"tmp#47##0" = add i64 %"x##0", 15
-  %"tmp#48##0" = inttoptr i64 %"tmp#47##0" to ptr
-  %"c##0" = load i64, ptr %"tmp#48##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
+  %"tmp#68##0" = add i64 %"x##0", -1
+  %"tmp#69##0" = inttoptr i64 %"tmp#68##0" to ptr
+  %"a##1" = load i64, ptr %"tmp#69##0"
+  %"tmp#70##0" = add i64 %"x##0", 7
+  %"tmp#71##0" = inttoptr i64 %"tmp#70##0" to ptr
+  %"b##0" = load i64, ptr %"tmp#71##0"
+  %"tmp#72##0" = add i64 %"x##0", 15
+  %"tmp#73##0" = inttoptr i64 %"tmp#72##0" to ptr
+  %"c##0" = load i64, ptr %"tmp#73##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#10" to i64 ))
   call ccc void @print_int(i64 %"a##1")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   call ccc void @print_int(i64 %"b##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   call ccc void @print_int(i64 %"c##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.2.switch.2:
-  %"tmp#49##0" = add i64 %"x##0", -2
-  %"tmp#50##0" = inttoptr i64 %"tmp#49##0" to ptr
-  %"a##2" = load i64, ptr %"tmp#50##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#15" to i64 ))
+  %"tmp#74##0" = add i64 %"x##0", -2
+  %"tmp#75##0" = inttoptr i64 %"tmp#74##0" to ptr
+  %"a##2" = load i64, ptr %"tmp#75##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
   call ccc void @print_int(i64 %"a##2")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 if.else.1:
@@ -518,21 +517,21 @@ if.else.1:
 }
 
 define external fastcc void @"dead_cell_size.print_t2<0>"(i64 %"x##0") {
-  %"tmp#2##0" = tail call fastcc i1 @"dead_cell_size.t2.=<0>"(i64 0, i64 %"x##0")
-  br i1 %"tmp#2##0", label %if.then.0, label %if.else.0
+  %"tmp#3##0" = tail call fastcc i1 @"dead_cell_size.t2.=<0>"(i64 0, i64 %"x##0")
+  br i1 %"tmp#3##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#10" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
   call ccc void @putchar(i8 10)
   ret void
 if.else.0:
-  %"tmp#4##0" = icmp ne i64 %"x##0", 0
-  br i1 %"tmp#4##0", label %if.then.1, label %if.else.1
+  %"tmp#5##0" = icmp ne i64 %"x##0", 0
+  br i1 %"tmp#5##0", label %if.then.1, label %if.else.1
 if.then.1:
-  %"tmp#14##0" = inttoptr i64 %"x##0" to ptr
-  %"a##0" = load i64, ptr %"tmp#14##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
+  %"tmp#19##0" = inttoptr i64 %"x##0" to ptr
+  %"a##0" = load i64, ptr %"tmp#19##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#7" to i64 ))
   call ccc void @print_int(i64 %"a##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 if.else.1:

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -189,27 +189,27 @@ proc print_t > public (2 calls)
 print_t(x##0:dead_cell_size.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(17,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(20,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(26,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    dead_cell_size.t.=<0>(0:dead_cell_size.t, x##0:dead_cell_size.t, ?tmp#9##0:wybe.bool) #1 @dead_cell_size:nn:nn
-    case ~tmp#9##0:wybe.bool of
+  MultiSpeczDepInfo: [(7,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(12,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(14,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(16,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(21,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    dead_cell_size.t.=<0>(0:dead_cell_size.t, x##0:dead_cell_size.t, ?tmp#4##0:wybe.bool) #1 @dead_cell_size:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.bool) @dead_cell_size:nn:nn
-        case ~tmp#11##0:wybe.bool of
+        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool) @dead_cell_size:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
         1:
-            foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#12##0:wybe.int) @dead_cell_size:nn:nn
-            case ~tmp#12##0:wybe.int of
+            foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#7##0:wybe.int) @dead_cell_size:nn:nn
+            case ~tmp#7##0:wybe.int of
             0:
                 foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
                 wybe.string.print<0>("tb(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#57##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~a##0:wybe.int, ~tmp#57##0:wybe.phantom, ?tmp#58##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#58##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#56##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~a##0:wybe.int, ~tmp#56##0:wybe.phantom, ?tmp#57##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#57##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @dead_cell_size:nn:nn
                 foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#63##0:wybe.phantom) @dead_cell_size:nn:nn
                 foreign c putchar('\n':wybe.char, ~tmp#63##0:wybe.phantom, ?tmp#64##0:wybe.phantom) @dead_cell_size:nn:nn
                 foreign lpvm store(~%tmp#64##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
@@ -218,33 +218,33 @@ print_t(x##0:dead_cell_size.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
                 foreign lpvm access(x##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?a##1:wybe.int) @dead_cell_size:nn:nn
                 foreign lpvm access(x##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?b##0:wybe.int) @dead_cell_size:nn:nn
                 foreign lpvm access(~x##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?c##0:wybe.int) @dead_cell_size:nn:nn
-                wybe.string.print<0>("tc(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#34##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~a##1:wybe.int, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#35##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>("tc(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#30##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~a##1:wybe.int, ~tmp#30##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#31##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~b##0:wybe.int, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
                 wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#41##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~b##0:wybe.int, ~tmp#41##0:wybe.phantom, ?tmp#42##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#42##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #17 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#48##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~c##0:wybe.int, ~tmp#48##0:wybe.phantom, ?tmp#49##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#49##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#54##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp#54##0:wybe.phantom, ?tmp#55##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#55##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~c##0:wybe.int, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#54##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
             2:
                 foreign lpvm access(~x##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int) @dead_cell_size:nn:nn
-                wybe.string.print<0>("td(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#25##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c print_int(~a##2:wybe.int, ~tmp#25##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#26##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @dead_cell_size:nn:nn
-                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @dead_cell_size:nn:nn
-                foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>("td(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#20##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c print_int(~a##2:wybe.int, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#21##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+                wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @dead_cell_size:nn:nn
+                foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @dead_cell_size:nn:nn
+                foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
 
 
@@ -261,24 +261,24 @@ proc print_t2 > public (1 calls)
 print_t2(x##0:dead_cell_size.t2)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x##0:dead_cell_size.t2, ?tmp#3##0:wybe.bool) #1 @dead_cell_size:nn:nn
-    case ~tmp#3##0:wybe.bool of
+  MultiSpeczDepInfo: [(7,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x##0:dead_cell_size.t2, ?tmp#2##0:wybe.bool) #1 @dead_cell_size:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @dead_cell_size:nn:nn
-        case ~tmp#5##0:wybe.bool of
+        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @dead_cell_size:nn:nn
+        case ~tmp#4##0:wybe.bool of
         0:
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
 
         1:
             foreign lpvm access(~x##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @dead_cell_size:nn:nn
             wybe.string.print<0>("t2b(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @dead_cell_size:nn:nn
-            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign c print_int(~a##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @dead_cell_size:nn:nn
-            foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
-            wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @dead_cell_size:nn:nn
+            foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign c print_int(~a##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @dead_cell_size:nn:nn
+            foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
+            wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @dead_cell_size:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @dead_cell_size:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @dead_cell_size:nn:nn
             foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @dead_cell_size:nn:nn
@@ -460,18 +460,18 @@ if.else.0:
 }
 
 define external fastcc void @"dead_cell_size.print_t<0>"(i64 %"x##0") {
-  %"tmp#9##0" = tail call fastcc i1 @"dead_cell_size.t.=<0>"(i64 0, i64 %"x##0")
-  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
+  %"tmp#4##0" = tail call fastcc i1 @"dead_cell_size.t.=<0>"(i64 0, i64 %"x##0")
+  br i1 %"tmp#4##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
   call ccc void @putchar(i8 10)
   ret void
 if.else.0:
-  %"tmp#11##0" = icmp ne i64 %"x##0", 0
-  br i1 %"tmp#11##0", label %if.then.1, label %if.else.1
+  %"tmp#6##0" = icmp ne i64 %"x##0", 0
+  br i1 %"tmp#6##0", label %if.then.1, label %if.else.1
 if.then.1:
-  %"tmp#12##0" = and i64 %"x##0", 3
-  switch i64 %"tmp#12##0", label %case.2.switch.2 [
+  %"tmp#7##0" = and i64 %"x##0", 3
+  switch i64 %"tmp#7##0", label %case.2.switch.2 [
     i64 0, label %case.0.switch.2
     i64 1, label %case.1.switch.2
     i64 2, label %case.2.switch.2 ]
@@ -517,15 +517,15 @@ if.else.1:
 }
 
 define external fastcc void @"dead_cell_size.print_t2<0>"(i64 %"x##0") {
-  %"tmp#3##0" = tail call fastcc i1 @"dead_cell_size.t2.=<0>"(i64 0, i64 %"x##0")
-  br i1 %"tmp#3##0", label %if.then.0, label %if.else.0
+  %"tmp#2##0" = tail call fastcc i1 @"dead_cell_size.t2.=<0>"(i64 0, i64 %"x##0")
+  br i1 %"tmp#2##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
   call ccc void @putchar(i8 10)
   ret void
 if.else.0:
-  %"tmp#5##0" = icmp ne i64 %"x##0", 0
-  br i1 %"tmp#5##0", label %if.then.1, label %if.else.1
+  %"tmp#4##0" = icmp ne i64 %"x##0", 0
+  br i1 %"tmp#4##0", label %if.then.1, label %if.else.1
 if.then.1:
   %"tmp#19##0" = inttoptr i64 %"x##0" to ptr
   %"a##0" = load i64, ptr %"tmp#19##0"

--- a/test-cases/final-dump/detism_error.exp
+++ b/test-cases/final-dump/detism_error.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) detism_error
-[91mfinal-dump/detism_error.wybe:3:5: proc not_really_det has test determinism, but declared normal (total)
-[0m[91mfinal-dump/detism_error.wybe:4:6: Calling test proc wybe.int.=<0> in a normal (total) context
-[0m[91mfinal-dump/detism_error.wybe:16:5: proc not_really_terminal has normal (total) determinism, but declared terminal
-[0m
+final-dump/detism_error.wybe:3:5: proc not_really_det has test determinism, but declared normal (total)
+final-dump/detism_error.wybe:4:6: Calling test proc wybe.int.=<0> in a normal (total) context
+final-dump/detism_error.wybe:16:5: proc not_really_terminal has normal (total) determinism, but declared terminal

--- a/test-cases/final-dump/duplicate_resource.exp
+++ b/test-cases/final-dump/duplicate_resource.exp
@@ -1,4 +1,3 @@
 Error detected during preliminary processing of module duplicate_resource
-[91mfinal-dump/duplicate_resource.wybe:2:1: Duplicate declaration of resource 'foo'
-[0m[91mfinal-dump/duplicate_resource.wybe:3:1: Duplicate declaration of resource 'foo'
-[0m
+final-dump/duplicate_resource.wybe:2:1: Duplicate declaration of resource 'foo'
+final-dump/duplicate_resource.wybe:3:1: Duplicate declaration of resource 'foo'

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -65,5 +65,4 @@ define external fastcc void @"early_error.my_error<0>"(i64 %"msg##0") {
   call ccc void @exit(i64 1)
   ret void
 }
-[93mfinal-dump/early_error.wybe:3:2: In module top-level code, this statement is unreachable
-[0m
+final-dump/early_error.wybe:3:2: In module top-level code, this statement is unreachable

--- a/test-cases/final-dump/early_exit.exp
+++ b/test-cases/final-dump/early_exit.exp
@@ -45,5 +45,4 @@ define external fastcc void @"early_exit.<0>"() {
   call ccc void @exit(i64 1)
   ret void
 }
-[93mfinal-dump/early_exit.wybe:3:2: In module top-level code, this statement is unreachable
-[0m
+final-dump/early_exit.wybe:3:2: In module top-level code, this statement is unreachable

--- a/test-cases/final-dump/early_exit2.exp
+++ b/test-cases/final-dump/early_exit2.exp
@@ -58,5 +58,4 @@ define external fastcc void @"early_exit2.my_exit<0>"(i64 %"code##0") {
   call ccc void @exit(i64 %"code##0")
   ret void
 }
-[93mfinal-dump/early_exit2.wybe:3:2: In module top-level code, this statement is unreachable
-[0m
+final-dump/early_exit2.wybe:3:2: In module top-level code, this statement is unreachable

--- a/test-cases/final-dump/error_mode.exp
+++ b/test-cases/final-dump/error_mode.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) error_mode, error_mode.tree
-[91mfinal-dump/error_mode.wybe:5:5: proc lookup has test determinism, but declared normal (total)
-[0m[91mfinal-dump/error_mode.wybe:8:40: Calling test proc error_mode.tree.left<0> in a normal (total) context
-[0m[91mfinal-dump/error_mode.wybe:9:30: Calling test proc error_mode.tree.right<0> in a normal (total) context
-[0m
+final-dump/error_mode.wybe:5:5: proc lookup has test determinism, but declared normal (total)
+final-dump/error_mode.wybe:8:40: Calling test proc error_mode.tree.left<0> in a normal (total) context
+final-dump/error_mode.wybe:9:30: Calling test proc error_mode.tree.right<0> in a normal (total) context

--- a/test-cases/final-dump/error_mode2.exp
+++ b/test-cases/final-dump/error_mode2.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) error_mode2
-[91mfinal-dump/error_mode2.wybe:3:5: proc non_terminal has normal (total) determinism, but declared terminal
-[0m[91mfinal-dump/error_mode2.wybe:7:5: proc non_terminal2 has failing determinism, but declared terminal
-[0m[91mfinal-dump/error_mode2.wybe:15:5: proc non_failing has normal (total) determinism, but declared failing
-[0m
+final-dump/error_mode2.wybe:3:5: proc non_terminal has normal (total) determinism, but declared terminal
+final-dump/error_mode2.wybe:7:5: proc non_terminal2 has failing determinism, but declared terminal
+final-dump/error_mode2.wybe:15:5: proc non_failing has normal (total) determinism, but declared failing

--- a/test-cases/final-dump/explicit_type_warning.exp
+++ b/test-cases/final-dump/explicit_type_warning.exp
@@ -337,8 +337,7 @@ define external fastcc i1 @"explicit_type_warning.~=<0>"(i64 %"#left##0", i64 %"
   %"tmp#1##0" = xor i1 %"tmp#0##0", 1
   ret i1 %"tmp#1##0"
 }
-[93mfinal-dump/explicit_type_warning.wybe:3:31: Explicit specification of current type explicit_type_warning,
+final-dump/explicit_type_warning.wybe:3:31: Explicit specification of current type explicit_type_warning,
   it is recommended to specify type as _
-[0m[93mfinal-dump/explicit_type_warning.wybe:5:11: Explicit specification of current type explicit_type_warning,
+final-dump/explicit_type_warning.wybe:5:11: Explicit specification of current type explicit_type_warning,
   it is recommended to specify type as _
-[0m

--- a/test-cases/final-dump/fn_update.exp
+++ b/test-cases/final-dump/fn_update.exp
@@ -90,17 +90,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -131,8 +131,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/fn_update.exp
+++ b/test-cases/final-dump/fn_update.exp
@@ -90,20 +90,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -114,28 +115,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/foreign_def_errors.exp
+++ b/test-cases/final-dump/foreign_def_errors.exp
@@ -1,4 +1,3 @@
 Error detected during preliminary processing of module foreign_def_errors
-[91mfinal-dump/foreign_def_errors.wybe:1:23: Foreign procedure declaration parameters must be typed, but p is untyped.
-[0m[91mfinal-dump/foreign_def_errors.wybe:2:1: Foreign procedure declaration of bad_mods has illegal procedure modifiers. Only purity, determinism, and inlining can be specified.
-[0m
+final-dump/foreign_def_errors.wybe:1:23: Foreign procedure declaration parameters must be typed, but p is untyped.
+final-dump/foreign_def_errors.wybe:2:1: Foreign procedure declaration of bad_mods has illegal procedure modifiers. Only purity, determinism, and inlining can be specified.

--- a/test-cases/final-dump/foreign_error.exp
+++ b/test-cases/final-dump/foreign_error.exp
@@ -1,8 +1,7 @@
 Error detected during type checking of module(s) foreign_error
-[91mfinal-dump/foreign_error.wybe:4:5: Unknown llvm instruction 'no_such'
-[0m[91mfinal-dump/foreign_error.wybe:7:5: Unknown llvm instruction 'no_such2'
-[0m[91mfinal-dump/foreign_error.wybe:11:5: Foreign call 'blah' with unknown language 'no_such_language'
-[0m[91mfinal-dump/foreign_error.wybe:14:5: Foreign call 'blah' with unknown language 'no_such_language2'
-[0m[91mfinal-dump/foreign_error.wybe:18:5: Foreign call 'add' with arity 2; should be 3
-[0m[91mfinal-dump/foreign_error.wybe:21:5: Foreign call 'add' with arity 4; should be 3
-[0m
+final-dump/foreign_error.wybe:4:5: Unknown llvm instruction 'no_such'
+final-dump/foreign_error.wybe:7:5: Unknown llvm instruction 'no_such2'
+final-dump/foreign_error.wybe:11:5: Foreign call 'blah' with unknown language 'no_such_language'
+final-dump/foreign_error.wybe:14:5: Foreign call 'blah' with unknown language 'no_such_language2'
+final-dump/foreign_error.wybe:18:5: Foreign call 'add' with arity 2; should be 3
+final-dump/foreign_error.wybe:21:5: Foreign call 'add' with arity 4; should be 3

--- a/test-cases/final-dump/func_no_types.exp
+++ b/test-cases/final-dump/func_no_types.exp
@@ -1,3 +1,2 @@
 Error detected during checking parameter type declarations in module(s) func_no_types
-[91mfinal-dump/func_no_types.wybe:1:5: Public proc double with undeclared parameter or return type
-[0m
+final-dump/func_no_types.wybe:1:5: Public proc double with undeclared parameter or return type

--- a/test-cases/final-dump/generic_missing_param.exp
+++ b/test-cases/final-dump/generic_missing_param.exp
@@ -1,3 +1,2 @@
 Error detected during preliminary processing of module generic_missing_param
-[91mfinal-dump/generic_missing_param.wybe:1:27: Constructors for type generic_missing_param use unbound type variable(s) ?U
-[0m
+final-dump/generic_missing_param.wybe:1:27: Constructors for type generic_missing_param use unbound type variable(s) ?U

--- a/test-cases/final-dump/generic_resource.exp
+++ b/test-cases/final-dump/generic_resource.exp
@@ -1,3 +1,2 @@
 Error detected during preliminary processing of module generic_resource
-[91mfinal-dump/generic_resource.wybe:1:1: Resource type cannot contain type variables: list(F00)
-[0m
+final-dump/generic_resource.wybe:1:1: Resource type cannot contain type variables: list(F00)

--- a/test-cases/final-dump/higher_order_anon_errs.exp
+++ b/test-cases/final-dump/higher_order_anon_errs.exp
@@ -1,5 +1,4 @@
 Error detected during final normalisation of module(s) higher_order_anon_errs
-[91mfinal-dump/higher_order_anon_errs.wybe:1:17: Mixed use of numbered and un-numbered anonymous parameters
-[0m[91mfinal-dump/higher_order_anon_errs.wybe:3:14: Anonymous function cannot contain output variables: @, bar
-[0m[91mfinal-dump/higher_order_anon_errs.wybe:4:14: Anonymous function cannot contain output variables: @
-[0m
+final-dump/higher_order_anon_errs.wybe:1:17: Mixed use of numbered and un-numbered anonymous parameters
+final-dump/higher_order_anon_errs.wybe:3:14: Anonymous function cannot contain output variables: @, bar
+final-dump/higher_order_anon_errs.wybe:4:14: Anonymous function cannot contain output variables: @

--- a/test-cases/final-dump/higher_order_arity_error.exp
+++ b/test-cases/final-dump/higher_order_arity_error.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) higher_order_arity_error
-[91mfinal-dump/higher_order_arity_error.wybe:2:5: Call from proc a to proc f with 1 argument(s), expected 2
-[0m
+final-dump/higher_order_arity_error.wybe:2:5: Call from proc a to proc f with 1 argument(s), expected 2

--- a/test-cases/final-dump/higher_order_flow_error.exp
+++ b/test-cases/final-dump/higher_order_flow_error.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) higher_order_flow_error
-[91mfinal-dump/higher_order_flow_error.wybe:2:5: Higher order call to proc f in proc foo has output (?) flow for argument 2, but expects input flow.
-[0m
+final-dump/higher_order_flow_error.wybe:2:5: Higher order call to proc f in proc foo has output (?) flow for argument 2, but expects input flow.

--- a/test-cases/final-dump/higher_order_impure_fail.exp
+++ b/test-cases/final-dump/higher_order_impure_fail.exp
@@ -1,4 +1,3 @@
 Error detected during type checking of module(s) higher_order_impure_fail
-[91mfinal-dump/higher_order_impure_fail.wybe:2:5: Calling impure higher-order term func, expecting at least semipure
-[0m[91mfinal-dump/higher_order_impure_fail.wybe:2:5: Calling impure higher-order term func without ! non-purity marker
-[0m
+final-dump/higher_order_impure_fail.wybe:2:5: Calling impure higher-order term func, expecting at least semipure
+final-dump/higher_order_impure_fail.wybe:2:5: Calling impure higher-order term func without ! non-purity marker

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -17,16 +17,16 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_tests.#anon#1<0>(_:wybe.int, ?tmp#8##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#8##0:wybe.bool of
+    higher_order_tests.#anon#1<0>(_:wybe.int, ?tmp#12##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#12##0:wybe.bool of
     0:
         higher_order_tests.#cont#1<0>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>("*1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
         higher_order_tests.#cont#1<0>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
@@ -64,17 +64,18 @@ proc #cont#1 > {semipure} (2 calls)
 #cont#1(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(1:I, ?tmp#7##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#7##0:wybe.bool of
+  MultiSpeczDepInfo: [(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    t##0:(I, ?wybe.bool)(1:I, ?tmp#11##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
+        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
 
     1:
-        wybe.string.print<0>("1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
+        wybe.string.print<0>[410bae77d3](1223:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
 
 
@@ -83,16 +84,16 @@ proc #cont#2 > {semipure} (2 calls)
 #cont#2(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(2:I, ?tmp#6##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#6##0:wybe.bool of
+    t##0:(I, ?wybe.bool)(2:I, ?tmp#10##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#10##0:wybe.bool of
     0:
         higher_order_tests.#cont#3<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>("*2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
         higher_order_tests.#cont#3<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
@@ -102,17 +103,18 @@ proc #cont#3 > {semipure} (2 calls)
 #cont#3(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#5##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#5##0:wybe.bool of
+  MultiSpeczDepInfo: [(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#9##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
-        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
+        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
 
     1:
-        wybe.string.print<0>("2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
+        wybe.string.print<0>[410bae77d3](1227:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
 
 
@@ -122,19 +124,19 @@ proc #cont#4 > {semipure} (2 calls)
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>("------":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @higher_order_tests:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @higher_order_tests:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @higher_order_tests:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-    higher_order_tests.#anon#2<0>(1:wybe.int, ?tmp#4##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#4##0:wybe.bool of
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @higher_order_tests:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
+    foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+    higher_order_tests.#anon#2<0>(1:wybe.int, ?tmp#8##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         higher_order_tests.#cont#5<0>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
 
     1:
         wybe.string.print<0>("*1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
         higher_order_tests.#cont#5<0>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
 
@@ -144,17 +146,18 @@ proc #cont#5 > {semipure} (2 calls)
 #cont#5(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(1:I, ?tmp#3##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#3##0:wybe.bool of
+  MultiSpeczDepInfo: [(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    t##0:(I, ?wybe.bool)(1:I, ?tmp#7##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
+        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
 
     1:
-        wybe.string.print<0>("1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#7##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
+        wybe.string.print<0>[410bae77d3](1223:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
 
 
@@ -163,16 +166,16 @@ proc #cont#6 > {semipure} (2 calls)
 #cont#6(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(2:I, ?tmp#2##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#2##0:wybe.bool of
+    t##0:(I, ?wybe.bool)(2:I, ?tmp#6##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#6##0:wybe.bool of
     0:
         higher_order_tests.#cont#7<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>("*2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
         higher_order_tests.#cont#7<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
@@ -182,15 +185,16 @@ proc #cont#7 > {semipure} (2 calls)
 #cont#7(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#1##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#1##0:wybe.bool of
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#5##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
 
     1:
-        wybe.string.print<0>("2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        wybe.string.print<0>[410bae77d3](1227:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
 
 
 
@@ -220,30 +224,27 @@ target triple    ????
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"*1\00", align 8
 @"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"*2\00", align 8
 @"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"------\00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"1\00", align 8
-@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"2\00", align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#6" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#7" = private unnamed_addr constant {i64, i64} { i64 6, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#8" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
-@"string#9" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
-@"closure#10" = private unnamed_addr constant {ptr} { ptr @"higher_order_tests.#anon#1<1>" }, align 8
-@"closure#11" = private unnamed_addr constant {ptr} { ptr @"higher_order_tests.#anon#2<1>" }, align 8
+@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
+@"string#4" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
+@"string#5" = private unnamed_addr constant {i64, i64} { i64 6, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"closure#6" = private unnamed_addr constant {ptr} { ptr @"higher_order_tests.#anon#1<1>" }, align 8
+@"closure#7" = private unnamed_addr constant {ptr} { ptr @"higher_order_tests.#anon#2<1>" }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"higher_order_tests.<0>"() {
-  %"tmp#8##0" = tail call fastcc i1 @"higher_order_tests.#anon#1<0>"()
-  br i1 %"tmp#8##0", label %if.then.0, label %if.else.0
+  %"tmp#12##0" = tail call fastcc i1 @"higher_order_tests.#anon#1<0>"()
+  br i1 %"tmp#12##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"higher_order_tests.#cont#1<0>"(i64 ptrtoint( ptr @"closure#10" to i64 ))
+  tail call fastcc void @"higher_order_tests.#cont#1<0>"(i64 ptrtoint( ptr @"closure#6" to i64 ))
   ret void
 if.else.0:
-  tail call fastcc void @"higher_order_tests.#cont#1<0>"(i64 ptrtoint( ptr @"closure#10" to i64 ))
+  tail call fastcc void @"higher_order_tests.#cont#1<0>"(i64 ptrtoint( ptr @"closure#6" to i64 ))
   ret void
 }
 
@@ -257,8 +258,8 @@ define external fastcc i64 @"higher_order_tests.#anon#1<1>"(i64 %"#env##0", i64 
 }
 
 define external fastcc i1 @"higher_order_tests.#anon#2<0>"(i64 %"anon#2#1##0") {
-  %"tmp#4##0" = icmp eq i64 %"anon#2#1##0", 1
-  ret i1 %"tmp#4##0"
+  %"tmp#8##0" = icmp eq i64 %"anon#2#1##0", 1
+  ret i1 %"tmp#8##0"
 }
 
 define external fastcc i64 @"higher_order_tests.#anon#2<1>"(i64 %"#env##0", i64 %"generic#anon#2#1##0") {
@@ -268,12 +269,12 @@ define external fastcc i64 @"higher_order_tests.#anon#2<1>"(i64 %"#env##0", i64 
 }
 
 define external fastcc void @"higher_order_tests.#cont#1<0>"(i64 %"t##0") {
-  %"tmp#14##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#13##0" = load ptr, ptr %"tmp#14##0"
-  %"tmp#7##0" = tail call fastcc i1 %"tmp#13##0"(i64 %"t##0", i64 1)
-  br i1 %"tmp#7##0", label %if.then.0, label %if.else.0
+  %"tmp#22##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#21##0" = load ptr, ptr %"tmp#22##0"
+  %"tmp#11##0" = tail call fastcc i1 %"tmp#21##0"(i64 %"t##0", i64 1)
+  br i1 %"tmp#11##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1223)
   call ccc void @putchar(i8 10)
   tail call fastcc void @"higher_order_tests.#cont#2<0>"(i64 %"t##0")
   ret void
@@ -283,12 +284,12 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#2<0>"(i64 %"t##0") {
-  %"tmp#13##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#12##0" = load ptr, ptr %"tmp#13##0"
-  %"tmp#6##0" = tail call fastcc i1 %"tmp#12##0"(i64 %"t##0", i64 2)
-  br i1 %"tmp#6##0", label %if.then.0, label %if.else.0
+  %"tmp#17##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#16##0" = load ptr, ptr %"tmp#17##0"
+  %"tmp#10##0" = tail call fastcc i1 %"tmp#16##0"(i64 %"t##0", i64 2)
+  br i1 %"tmp#10##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   call ccc void @putchar(i8 10)
   tail call fastcc void @"higher_order_tests.#cont#3<0>"(i64 %"t##0")
   ret void
@@ -298,12 +299,12 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#3<0>"(i64 %"t##0") {
-  %"tmp#12##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#11##0" = load ptr, ptr %"tmp#12##0"
-  %"tmp#5##0" = tail call fastcc i1 %"tmp#11##0"(i64 %"t##0", i64 2)
-  br i1 %"tmp#5##0", label %if.then.0, label %if.else.0
+  %"tmp#20##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#19##0" = load ptr, ptr %"tmp#20##0"
+  %"tmp#9##0" = tail call fastcc i1 %"tmp#19##0"(i64 %"t##0", i64 2)
+  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1227)
   call ccc void @putchar(i8 10)
   tail call fastcc void @"higher_order_tests.#cont#4<0>"()
   ret void
@@ -313,27 +314,27 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#4<0>"() {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#7" to i64 ))
-  call ccc void @putchar(i8 10)
-  %"tmp#4##0" = tail call fastcc i1 @"higher_order_tests.#anon#2<0>"(i64 1)
-  br i1 %"tmp#4##0", label %if.then.0, label %if.else.0
-if.then.0:
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"higher_order_tests.#cont#5<0>"(i64 ptrtoint( ptr @"closure#11" to i64 ))
+  %"tmp#8##0" = tail call fastcc i1 @"higher_order_tests.#anon#2<0>"(i64 1)
+  br i1 %"tmp#8##0", label %if.then.0, label %if.else.0
+if.then.0:
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
+  call ccc void @putchar(i8 10)
+  tail call fastcc void @"higher_order_tests.#cont#5<0>"(i64 ptrtoint( ptr @"closure#7" to i64 ))
   ret void
 if.else.0:
-  tail call fastcc void @"higher_order_tests.#cont#5<0>"(i64 ptrtoint( ptr @"closure#11" to i64 ))
+  tail call fastcc void @"higher_order_tests.#cont#5<0>"(i64 ptrtoint( ptr @"closure#7" to i64 ))
   ret void
 }
 
 define external fastcc void @"higher_order_tests.#cont#5<0>"(i64 %"t##0") {
-  %"tmp#10##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#9##0" = load ptr, ptr %"tmp#10##0"
-  %"tmp#3##0" = tail call fastcc i1 %"tmp#9##0"(i64 %"t##0", i64 1)
-  br i1 %"tmp#3##0", label %if.then.0, label %if.else.0
+  %"tmp#18##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#17##0" = load ptr, ptr %"tmp#18##0"
+  %"tmp#7##0" = tail call fastcc i1 %"tmp#17##0"(i64 %"t##0", i64 1)
+  br i1 %"tmp#7##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1223)
   call ccc void @putchar(i8 10)
   tail call fastcc void @"higher_order_tests.#cont#6<0>"(i64 %"t##0")
   ret void
@@ -343,12 +344,12 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#6<0>"(i64 %"t##0") {
-  %"tmp#9##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#8##0" = load ptr, ptr %"tmp#9##0"
-  %"tmp#2##0" = tail call fastcc i1 %"tmp#8##0"(i64 %"t##0", i64 2)
-  br i1 %"tmp#2##0", label %if.then.0, label %if.else.0
+  %"tmp#13##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#12##0" = load ptr, ptr %"tmp#13##0"
+  %"tmp#6##0" = tail call fastcc i1 %"tmp#12##0"(i64 %"t##0", i64 2)
+  br i1 %"tmp#6##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#6" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   call ccc void @putchar(i8 10)
   tail call fastcc void @"higher_order_tests.#cont#7<0>"(i64 %"t##0")
   ret void
@@ -358,12 +359,12 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#7<0>"(i64 %"t##0") {
-  %"tmp#8##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#7##0" = load ptr, ptr %"tmp#8##0"
-  %"tmp#1##0" = tail call fastcc i1 %"tmp#7##0"(i64 %"t##0", i64 2)
-  br i1 %"tmp#1##0", label %if.then.0, label %if.else.0
+  %"tmp#16##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#15##0" = load ptr, ptr %"tmp#16##0"
+  %"tmp#5##0" = tail call fastcc i1 %"tmp#15##0"(i64 %"t##0", i64 2)
+  br i1 %"tmp#5##0", label %if.then.0, label %if.else.0
 if.then.0:
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1227)
   call ccc void @putchar(i8 10)
   ret void
 if.else.0:

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -17,16 +17,16 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_tests.#anon#1<0>(_:wybe.int, ?tmp#12##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#12##0:wybe.bool of
+    higher_order_tests.#anon#1<0>(_:wybe.int, ?tmp#8##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         higher_order_tests.#cont#1<0>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>("*1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
         higher_order_tests.#cont#1<0>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
@@ -65,17 +65,17 @@ proc #cont#1 > {semipure} (2 calls)
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    t##0:(I, ?wybe.bool)(1:I, ?tmp#11##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#11##0:wybe.bool of
+    t##0:(I, ?wybe.bool)(1:I, ?tmp#7##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
+        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>[410bae77d3](1223:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        higher_order_tests.#cont#2<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
 
@@ -84,16 +84,16 @@ proc #cont#2 > {semipure} (2 calls)
 #cont#2(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(2:I, ?tmp#10##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#10##0:wybe.bool of
+    t##0:(I, ?wybe.bool)(2:I, ?tmp#6##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#6##0:wybe.bool of
     0:
         higher_order_tests.#cont#3<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>("*2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
         higher_order_tests.#cont#3<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
@@ -104,17 +104,17 @@ proc #cont#3 > {semipure} (2 calls)
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#9##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#9##0:wybe.bool of
+    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#5##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
+        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>[410bae77d3](1227:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        higher_order_tests.#cont#4<0>(_:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
 
@@ -124,19 +124,19 @@ proc #cont#4 > {semipure} (2 calls)
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>("------":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @higher_order_tests:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @higher_order_tests:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
-    foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-    higher_order_tests.#anon#2<0>(1:wybe.int, ?tmp#8##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#8##0:wybe.bool of
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @higher_order_tests:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @higher_order_tests:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+    higher_order_tests.#anon#2<0>(1:wybe.int, ?tmp#4##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
         higher_order_tests.#cont#5<0>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
 
     1:
         wybe.string.print<0>("*1":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
         higher_order_tests.#cont#5<0>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
 
@@ -147,17 +147,17 @@ proc #cont#5 > {semipure} (2 calls)
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    t##0:(I, ?wybe.bool)(1:I, ?tmp#7##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#7##0:wybe.bool of
+    t##0:(I, ?wybe.bool)(1:I, ?tmp#3##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
+        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>[410bae77d3](1223:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        higher_order_tests.#cont#6<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
 
@@ -166,16 +166,16 @@ proc #cont#6 > {semipure} (2 calls)
 #cont#6(t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    t##0:(I, ?wybe.bool)(2:I, ?tmp#6##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#6##0:wybe.bool of
+    t##0:(I, ?wybe.bool)(2:I, ?tmp#2##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
         higher_order_tests.#cont#7<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3
 
     1:
         wybe.string.print<0>("*2":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
         higher_order_tests.#cont#7<0>(~t##0:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2
 
 
@@ -186,15 +186,15 @@ proc #cont#7 > {semipure} (2 calls)
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#5##0:wybe.bool) #0 @higher_order_tests:nn:nn
-    case ~tmp#5##0:wybe.bool of
+    ~t##0:(I, ?wybe.bool)(2:I, ?tmp#1##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
 
     1:
         wybe.string.print<0>[410bae77d3](1227:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @higher_order_tests:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @higher_order_tests:nn:nn
-        foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @higher_order_tests:nn:nn
+        foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
 
 
 
@@ -236,8 +236,8 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"higher_order_tests.<0>"() {
-  %"tmp#12##0" = tail call fastcc i1 @"higher_order_tests.#anon#1<0>"()
-  br i1 %"tmp#12##0", label %if.then.0, label %if.else.0
+  %"tmp#8##0" = tail call fastcc i1 @"higher_order_tests.#anon#1<0>"()
+  br i1 %"tmp#8##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
   call ccc void @putchar(i8 10)
@@ -258,8 +258,8 @@ define external fastcc i64 @"higher_order_tests.#anon#1<1>"(i64 %"#env##0", i64 
 }
 
 define external fastcc i1 @"higher_order_tests.#anon#2<0>"(i64 %"anon#2#1##0") {
-  %"tmp#8##0" = icmp eq i64 %"anon#2#1##0", 1
-  ret i1 %"tmp#8##0"
+  %"tmp#4##0" = icmp eq i64 %"anon#2#1##0", 1
+  ret i1 %"tmp#4##0"
 }
 
 define external fastcc i64 @"higher_order_tests.#anon#2<1>"(i64 %"#env##0", i64 %"generic#anon#2#1##0") {
@@ -269,10 +269,10 @@ define external fastcc i64 @"higher_order_tests.#anon#2<1>"(i64 %"#env##0", i64 
 }
 
 define external fastcc void @"higher_order_tests.#cont#1<0>"(i64 %"t##0") {
-  %"tmp#22##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#21##0" = load ptr, ptr %"tmp#22##0"
-  %"tmp#11##0" = tail call fastcc i1 %"tmp#21##0"(i64 %"t##0", i64 1)
-  br i1 %"tmp#11##0", label %if.then.0, label %if.else.0
+  %"tmp#19##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#18##0" = load ptr, ptr %"tmp#19##0"
+  %"tmp#7##0" = tail call fastcc i1 %"tmp#18##0"(i64 %"t##0", i64 1)
+  br i1 %"tmp#7##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1223)
   call ccc void @putchar(i8 10)
@@ -284,10 +284,10 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#2<0>"(i64 %"t##0") {
-  %"tmp#17##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#16##0" = load ptr, ptr %"tmp#17##0"
-  %"tmp#10##0" = tail call fastcc i1 %"tmp#16##0"(i64 %"t##0", i64 2)
-  br i1 %"tmp#10##0", label %if.then.0, label %if.else.0
+  %"tmp#13##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#12##0" = load ptr, ptr %"tmp#13##0"
+  %"tmp#6##0" = tail call fastcc i1 %"tmp#12##0"(i64 %"t##0", i64 2)
+  br i1 %"tmp#6##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   call ccc void @putchar(i8 10)
@@ -299,10 +299,10 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#3<0>"(i64 %"t##0") {
-  %"tmp#20##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#19##0" = load ptr, ptr %"tmp#20##0"
-  %"tmp#9##0" = tail call fastcc i1 %"tmp#19##0"(i64 %"t##0", i64 2)
-  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
+  %"tmp#17##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#16##0" = load ptr, ptr %"tmp#17##0"
+  %"tmp#5##0" = tail call fastcc i1 %"tmp#16##0"(i64 %"t##0", i64 2)
+  br i1 %"tmp#5##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1227)
   call ccc void @putchar(i8 10)
@@ -316,8 +316,8 @@ if.else.0:
 define external fastcc void @"higher_order_tests.#cont#4<0>"() {
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#8##0" = tail call fastcc i1 @"higher_order_tests.#anon#2<0>"(i64 1)
-  br i1 %"tmp#8##0", label %if.then.0, label %if.else.0
+  %"tmp#4##0" = tail call fastcc i1 @"higher_order_tests.#anon#2<0>"(i64 1)
+  br i1 %"tmp#4##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
   call ccc void @putchar(i8 10)
@@ -329,10 +329,10 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#5<0>"(i64 %"t##0") {
-  %"tmp#18##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#17##0" = load ptr, ptr %"tmp#18##0"
-  %"tmp#7##0" = tail call fastcc i1 %"tmp#17##0"(i64 %"t##0", i64 1)
-  br i1 %"tmp#7##0", label %if.then.0, label %if.else.0
+  %"tmp#15##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#14##0" = load ptr, ptr %"tmp#15##0"
+  %"tmp#3##0" = tail call fastcc i1 %"tmp#14##0"(i64 %"t##0", i64 1)
+  br i1 %"tmp#3##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1223)
   call ccc void @putchar(i8 10)
@@ -344,10 +344,10 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#6<0>"(i64 %"t##0") {
-  %"tmp#13##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#12##0" = load ptr, ptr %"tmp#13##0"
-  %"tmp#6##0" = tail call fastcc i1 %"tmp#12##0"(i64 %"t##0", i64 2)
-  br i1 %"tmp#6##0", label %if.then.0, label %if.else.0
+  %"tmp#9##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#8##0" = load ptr, ptr %"tmp#9##0"
+  %"tmp#2##0" = tail call fastcc i1 %"tmp#8##0"(i64 %"t##0", i64 2)
+  br i1 %"tmp#2##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
   call ccc void @putchar(i8 10)
@@ -359,10 +359,10 @@ if.else.0:
 }
 
 define external fastcc void @"higher_order_tests.#cont#7<0>"(i64 %"t##0") {
-  %"tmp#16##0" = inttoptr i64 %"t##0" to ptr
-  %"tmp#15##0" = load ptr, ptr %"tmp#16##0"
-  %"tmp#5##0" = tail call fastcc i1 %"tmp#15##0"(i64 %"t##0", i64 2)
-  br i1 %"tmp#5##0", label %if.then.0, label %if.else.0
+  %"tmp#13##0" = inttoptr i64 %"t##0" to ptr
+  %"tmp#12##0" = load ptr, ptr %"tmp#13##0"
+  %"tmp#1##0" = tail call fastcc i1 %"tmp#12##0"(i64 %"t##0", i64 2)
+  br i1 %"tmp#1##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1227)
   call ccc void @putchar(i8 10)

--- a/test-cases/final-dump/ho_resources_no_bang.exp
+++ b/test-cases/final-dump/ho_resources_no_bang.exp
@@ -1,3 +1,2 @@
 Error detected during resource checking of module(s) ho_resources_no_bang
-[91mfinal-dump/ho_resources_no_bang.wybe:6:1: Call to resourceful higher-order proc without ! resource marker: f:{resource}() @ho_resources_no_bang:nn:nn
-[0m
+final-dump/ho_resources_no_bang.wybe:6:1: Call to resourceful higher-order proc without ! resource marker: f:{resource}() @ho_resources_no_bang:nn:nn

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -130,20 +130,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -154,28 +155,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -130,17 +130,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -171,8 +171,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/in_before_out.exp
+++ b/test-cases/final-dump/in_before_out.exp
@@ -1,4 +1,3 @@
 Error detected during type checking of module(s) in_before_out
-[91mfinal-dump/in_before_out.wybe:1:5: Output parameter result not defined by proc in_before_out
-[0m[91mfinal-dump/in_before_out.wybe:2:8: Uninitialised argument in call to proc incr, argument 1
-[0m
+final-dump/in_before_out.wybe:1:5: Output parameter result not defined by proc in_before_out
+final-dump/in_before_out.wybe:2:8: Uninitialised argument in call to proc incr, argument 1

--- a/test-cases/final-dump/incompatible_generics.exp
+++ b/test-cases/final-dump/incompatible_generics.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) incompatible_generics
-[91mfinal-dump/incompatible_generics.wybe:1:23: Type error in call to proc =, argument 1
-[0m[91mfinal-dump/incompatible_generics.wybe:1:23: Type error in call to proc =, argument 2
-[0m[91mfinal-dump/incompatible_generics.wybe:1:23: Type of i incompatible with ?j
-[0m
+final-dump/incompatible_generics.wybe:1:23: Type error in call to proc =, argument 1
+final-dump/incompatible_generics.wybe:1:23: Type error in call to proc =, argument 2
+final-dump/incompatible_generics.wybe:1:23: Type of i incompatible with ?j

--- a/test-cases/final-dump/incompatible_generics_2.exp
+++ b/test-cases/final-dump/incompatible_generics_2.exp
@@ -1,4 +1,3 @@
 Error detected during type checking of module(s) incompatible_generics_2
-[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to proc +, argument 1
-[0m[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to proc +, argument 2
-[0m
+final-dump/incompatible_generics_2.wybe:1:27: Type error in call to proc +, argument 1
+final-dump/incompatible_generics_2.wybe:1:27: Type error in call to proc +, argument 2

--- a/test-cases/final-dump/io_flow_error.exp
+++ b/test-cases/final-dump/io_flow_error.exp
@@ -1,6 +1,5 @@
 Error detected during uniqueness checking of module(s) io_flow_error
-[91mUnique resource wybe.io.io live at end of module top-level code
-[0m[91mfinal-dump/io_flow_error.wybe:8:6: Reuse of unique resource wybe.io.io
-[0m[91mfinal-dump/io_flow_error.wybe:11:7: Reuse of unique resource wybe.io.io
-[0m[91mfinal-dump/io_flow_error.wybe:11:7: Unique resource wybe.io.io assigned in a test context
-[0m
+Unique resource wybe.io.io live at end of module top-level code
+final-dump/io_flow_error.wybe:8:6: Reuse of unique resource wybe.io.io
+final-dump/io_flow_error.wybe:11:7: Reuse of unique resource wybe.io.io
+final-dump/io_flow_error.wybe:11:7: Unique resource wybe.io.io assigned in a test context

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -28,16 +28,16 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#11##0:list_loop.intlist, ?tmp#12##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#12##0:list_loop.intlist, ?tmp#13##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#16##0:list_loop.intlist, ?tmp#17##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#17##0:list_loop.intlist, ?tmp#18##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#13##0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#21##0:list_loop.intlist, ?tmp#22##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#22##0:list_loop.intlist, ?tmp#23##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#18##0:list_loop.intlist) @list_loop:nn:nn
-    list_loop.#cont#1<0>(~tmp#23##0:list_loop.intlist, ~tmp#23##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#10##0:list_loop.intlist, ?tmp#11##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#11##0:list_loop.intlist, ?tmp#12##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#15##0:list_loop.intlist, ?tmp#16##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#16##0:list_loop.intlist, ?tmp#17##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#12##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#20##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#20##0:list_loop.intlist, ?tmp#21##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#21##0:list_loop.intlist, ?tmp#22##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#17##0:list_loop.intlist) @list_loop:nn:nn
+    list_loop.#cont#1<0>(~tmp#22##0:list_loop.intlist, ~tmp#22##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
 
 
 proc #cont#1 > {semipure} (2 calls)
@@ -45,17 +45,17 @@ proc #cont#1 > {semipure} (2 calls)
 #cont#1(l##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign llvm icmp_ne(l##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool) @list_loop:nn:nn
-    case ~tmp#10##0:wybe.bool of
+    foreign llvm icmp_ne(l##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @list_loop:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
 
     1:
         foreign lpvm access(l##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @list_loop:nn:nn
         foreign lpvm access(~l##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l##1:list_loop.intlist) @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @list_loop:nn:nn
-        foreign c print_int(h##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @list_loop:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @list_loop:nn:nn
-        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @list_loop:nn:nn
+        foreign c print_int(h##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @list_loop:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
         list_loop.#cont#3<0>(~h##0:wybe.int, ~l##1:list_loop.intlist, ~x##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @list_loop:nn:nn
 
 
@@ -65,10 +65,10 @@ proc #cont#2 > {inline,semipure} (1 calls)
 #cont#2(h##0:wybe.int, l##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @list_loop:nn:nn
-    foreign c print_int(h##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @list_loop:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @list_loop:nn:nn
-    foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @list_loop:nn:nn
+    foreign c print_int(h##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @list_loop:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @list_loop:nn:nn
+    foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
     list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~x##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @list_loop:nn:nn
 
 
@@ -78,8 +78,8 @@ proc #cont#3 > {semipure} (2 calls)
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign llvm icmp_ne(l2##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @list_loop:nn:nn
-    case ~tmp#9##0:wybe.bool of
+    foreign llvm icmp_ne(l2##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @list_loop:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         list_loop.#cont#1<0>(~l##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @list_loop:nn:nn
 
@@ -87,14 +87,14 @@ proc #cont#3 > {semipure} (2 calls)
         foreign lpvm access(l2##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h2##0:wybe.int) @list_loop:nn:nn
         foreign lpvm access(~l2##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l2##1:list_loop.intlist) @list_loop:nn:nn
         wybe.string.print<0>("    ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @list_loop:nn:nn
-        foreign c print_int(h##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @list_loop:nn:nn
-        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @list_loop:nn:nn
+        foreign c print_int(h##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
         wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @list_loop:nn:nn
-        foreign c print_int(~h2##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @list_loop:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @list_loop:nn:nn
-        foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @list_loop:nn:nn
+        foreign c print_int(~h2##0:wybe.int, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @list_loop:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
         list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##1:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @list_loop:nn:nn
 
 
@@ -105,15 +105,15 @@ proc #cont#4 > {inline,semipure} (1 calls)
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>("    ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @list_loop:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @list_loop:nn:nn
-    foreign c print_int(h##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @list_loop:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
-    wybe.string.print<0>(1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @list_loop:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#7##0:wybe.phantom) @list_loop:nn:nn
+    foreign c print_int(h##0:wybe.int, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @list_loop:nn:nn
+    foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+    wybe.string.print<0>(1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @list_loop:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @list_loop:nn:nn
     foreign c print_int(~h2##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @list_loop:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @list_loop:nn:nn
     foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
-    list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @list_loop:nn:nn
+    list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
 
   LLVM code       :
 
@@ -134,40 +134,40 @@ declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"list_loop.<0>"() {
-  %"tmp#24##0" = call ccc ptr @wybe_malloc(i32 16)
-  %"tmp#11##0" = ptrtoint ptr %"tmp#24##0" to i64
-  %"tmp#25##0" = inttoptr i64 %"tmp#11##0" to ptr
-  store i64 3, ptr %"tmp#25##0"
-  %"tmp#26##0" = add i64 %"tmp#11##0", 8
-  %"tmp#27##0" = inttoptr i64 %"tmp#26##0" to ptr
-  store i64 0, ptr %"tmp#27##0"
-  %"tmp#28##0" = call ccc ptr @wybe_malloc(i32 16)
-  %"tmp#16##0" = ptrtoint ptr %"tmp#28##0" to i64
-  %"tmp#29##0" = inttoptr i64 %"tmp#16##0" to ptr
-  store i64 2, ptr %"tmp#29##0"
-  %"tmp#30##0" = add i64 %"tmp#16##0", 8
-  %"tmp#31##0" = inttoptr i64 %"tmp#30##0" to ptr
-  store i64 %"tmp#11##0", ptr %"tmp#31##0"
-  %"tmp#32##0" = call ccc ptr @wybe_malloc(i32 16)
-  %"tmp#21##0" = ptrtoint ptr %"tmp#32##0" to i64
-  %"tmp#33##0" = inttoptr i64 %"tmp#21##0" to ptr
-  store i64 1, ptr %"tmp#33##0"
-  %"tmp#34##0" = add i64 %"tmp#21##0", 8
-  %"tmp#35##0" = inttoptr i64 %"tmp#34##0" to ptr
-  store i64 %"tmp#16##0", ptr %"tmp#35##0"
-  tail call fastcc void @"list_loop.#cont#1<0>"(i64 %"tmp#21##0", i64 %"tmp#21##0")
+  %"tmp#23##0" = call ccc ptr @wybe_malloc(i32 16)
+  %"tmp#10##0" = ptrtoint ptr %"tmp#23##0" to i64
+  %"tmp#24##0" = inttoptr i64 %"tmp#10##0" to ptr
+  store i64 3, ptr %"tmp#24##0"
+  %"tmp#25##0" = add i64 %"tmp#10##0", 8
+  %"tmp#26##0" = inttoptr i64 %"tmp#25##0" to ptr
+  store i64 0, ptr %"tmp#26##0"
+  %"tmp#27##0" = call ccc ptr @wybe_malloc(i32 16)
+  %"tmp#15##0" = ptrtoint ptr %"tmp#27##0" to i64
+  %"tmp#28##0" = inttoptr i64 %"tmp#15##0" to ptr
+  store i64 2, ptr %"tmp#28##0"
+  %"tmp#29##0" = add i64 %"tmp#15##0", 8
+  %"tmp#30##0" = inttoptr i64 %"tmp#29##0" to ptr
+  store i64 %"tmp#10##0", ptr %"tmp#30##0"
+  %"tmp#31##0" = call ccc ptr @wybe_malloc(i32 16)
+  %"tmp#20##0" = ptrtoint ptr %"tmp#31##0" to i64
+  %"tmp#32##0" = inttoptr i64 %"tmp#20##0" to ptr
+  store i64 1, ptr %"tmp#32##0"
+  %"tmp#33##0" = add i64 %"tmp#20##0", 8
+  %"tmp#34##0" = inttoptr i64 %"tmp#33##0" to ptr
+  store i64 %"tmp#15##0", ptr %"tmp#34##0"
+  tail call fastcc void @"list_loop.#cont#1<0>"(i64 %"tmp#20##0", i64 %"tmp#20##0")
   ret void
 }
 
 define external fastcc void @"list_loop.#cont#1<0>"(i64 %"l##0", i64 %"x##0") {
-  %"tmp#10##0" = icmp ne i64 %"l##0", 0
-  br i1 %"tmp#10##0", label %if.then.0, label %if.else.0
+  %"tmp#9##0" = icmp ne i64 %"l##0", 0
+  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
 if.then.0:
-  %"tmp#17##0" = inttoptr i64 %"l##0" to ptr
-  %"h##0" = load i64, ptr %"tmp#17##0"
-  %"tmp#18##0" = add i64 %"l##0", 8
-  %"tmp#19##0" = inttoptr i64 %"tmp#18##0" to ptr
-  %"l##1" = load i64, ptr %"tmp#19##0"
+  %"tmp#16##0" = inttoptr i64 %"l##0" to ptr
+  %"h##0" = load i64, ptr %"tmp#16##0"
+  %"tmp#17##0" = add i64 %"l##0", 8
+  %"tmp#18##0" = inttoptr i64 %"tmp#17##0" to ptr
+  %"l##1" = load i64, ptr %"tmp#18##0"
   call ccc void @print_int(i64 %"h##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"list_loop.#cont#3<0>"(i64 %"h##0", i64 %"l##1", i64 %"x##0", i64 %"x##0")
@@ -184,14 +184,14 @@ define external fastcc void @"list_loop.#cont#2<0>"(i64 %"h##0", i64 %"l##0", i6
 }
 
 define external fastcc void @"list_loop.#cont#3<0>"(i64 %"h##0", i64 %"l##0", i64 %"l2##0", i64 %"x##0") {
-  %"tmp#9##0" = icmp ne i64 %"l2##0", 0
-  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
+  %"tmp#8##0" = icmp ne i64 %"l2##0", 0
+  br i1 %"tmp#8##0", label %if.then.0, label %if.else.0
 if.then.0:
-  %"tmp#20##0" = inttoptr i64 %"l2##0" to ptr
-  %"h2##0" = load i64, ptr %"tmp#20##0"
-  %"tmp#21##0" = add i64 %"l2##0", 8
-  %"tmp#22##0" = inttoptr i64 %"tmp#21##0" to ptr
-  %"l2##1" = load i64, ptr %"tmp#22##0"
+  %"tmp#19##0" = inttoptr i64 %"l2##0" to ptr
+  %"h2##0" = load i64, ptr %"tmp#19##0"
+  %"tmp#20##0" = add i64 %"l2##0", 8
+  %"tmp#21##0" = inttoptr i64 %"tmp#20##0" to ptr
+  %"l2##1" = load i64, ptr %"tmp#21##0"
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
   call ccc void @print_int(i64 %"h##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -28,16 +28,16 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#10##0:list_loop.intlist, ?tmp#11##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#11##0:list_loop.intlist, ?tmp#12##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#15##0:list_loop.intlist, ?tmp#16##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#16##0:list_loop.intlist, ?tmp#17##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#12##0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp#20##0:list_loop.intlist) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#20##0:list_loop.intlist, ?tmp#21##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @list_loop:nn:nn
-    foreign lpvm mutate(~tmp#21##0:list_loop.intlist, ?tmp#22##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#17##0:list_loop.intlist) @list_loop:nn:nn
-    list_loop.#cont#1<0>(~tmp#22##0:list_loop.intlist, ~tmp#22##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#11##0:list_loop.intlist, ?tmp#12##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#12##0:list_loop.intlist, ?tmp#13##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#16##0:list_loop.intlist, ?tmp#17##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#17##0:list_loop.intlist, ?tmp#18##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#13##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:list_loop.intlist) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#21##0:list_loop.intlist, ?tmp#22##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int) @list_loop:nn:nn
+    foreign lpvm mutate(~tmp#22##0:list_loop.intlist, ?tmp#23##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#18##0:list_loop.intlist) @list_loop:nn:nn
+    list_loop.#cont#1<0>(~tmp#23##0:list_loop.intlist, ~tmp#23##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
 
 
 proc #cont#1 > {semipure} (2 calls)
@@ -45,17 +45,17 @@ proc #cont#1 > {semipure} (2 calls)
 #cont#1(l##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign llvm icmp_ne(l##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @list_loop:nn:nn
-    case ~tmp#9##0:wybe.bool of
+    foreign llvm icmp_ne(l##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool) @list_loop:nn:nn
+    case ~tmp#10##0:wybe.bool of
     0:
 
     1:
         foreign lpvm access(l##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int) @list_loop:nn:nn
         foreign lpvm access(~l##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l##1:list_loop.intlist) @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @list_loop:nn:nn
-        foreign c print_int(h##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @list_loop:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @list_loop:nn:nn
-        foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @list_loop:nn:nn
+        foreign c print_int(h##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @list_loop:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
         list_loop.#cont#3<0>(~h##0:wybe.int, ~l##1:list_loop.intlist, ~x##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @list_loop:nn:nn
 
 
@@ -65,10 +65,10 @@ proc #cont#2 > {inline,semipure} (1 calls)
 #cont#2(h##0:wybe.int, l##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @list_loop:nn:nn
-    foreign c print_int(h##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @list_loop:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @list_loop:nn:nn
-    foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @list_loop:nn:nn
+    foreign c print_int(h##0:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @list_loop:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @list_loop:nn:nn
+    foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
     list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~x##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @list_loop:nn:nn
 
 
@@ -77,8 +77,9 @@ proc #cont#3 > {semipure} (2 calls)
 #cont#3(h##0:wybe.int, l##0:list_loop.intlist, l2##0:list_loop.intlist, x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign llvm icmp_ne(l2##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @list_loop:nn:nn
-    case ~tmp#8##0:wybe.bool of
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign llvm icmp_ne(l2##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @list_loop:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
         list_loop.#cont#1<0>(~l##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @list_loop:nn:nn
 
@@ -86,14 +87,14 @@ proc #cont#3 > {semipure} (2 calls)
         foreign lpvm access(l2##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h2##0:wybe.int) @list_loop:nn:nn
         foreign lpvm access(~l2##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l2##1:list_loop.intlist) @list_loop:nn:nn
         wybe.string.print<0>("    ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @list_loop:nn:nn
-        foreign c print_int(h##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @list_loop:nn:nn
-        foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
-        wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @list_loop:nn:nn
-        foreign c print_int(~h2##0:wybe.int, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @list_loop:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @list_loop:nn:nn
-        foreign lpvm store(~%tmp#18##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @list_loop:nn:nn
+        foreign c print_int(h##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+        wybe.string.print<0>[410bae77d3](1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#17##0:wybe.phantom) @list_loop:nn:nn
+        foreign c print_int(~h2##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @list_loop:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @list_loop:nn:nn
+        foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
         list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##1:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @list_loop:nn:nn
 
 
@@ -104,15 +105,15 @@ proc #cont#4 > {inline,semipure} (1 calls)
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.print<0>("    ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @list_loop:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#7##0:wybe.phantom) @list_loop:nn:nn
-    foreign c print_int(h##0:wybe.int, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @list_loop:nn:nn
-    foreign lpvm store(~%tmp#8##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
-    wybe.string.print<0>(" ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #2 @list_loop:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @list_loop:nn:nn
-    foreign c print_int(~h2##0:wybe.int, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @list_loop:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @list_loop:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
-    list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @list_loop:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @list_loop:nn:nn
+    foreign c print_int(h##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @list_loop:nn:nn
+    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+    wybe.string.print<0>(1155:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @list_loop:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @list_loop:nn:nn
+    foreign c print_int(~h2##0:wybe.int, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @list_loop:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @list_loop:nn:nn
+    foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @list_loop:nn:nn
+    list_loop.#cont#3<0>(~h##0:wybe.int, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~x##0:list_loop.intlist)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @list_loop:nn:nn
 
   LLVM code       :
 
@@ -122,52 +123,51 @@ proc #cont#4 > {inline,semipure} (1 calls)
 source_filename = "!ROOT!/final-dump/list_loop.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" \00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"    \00", align 8
-@"string#2" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
+@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"    \00", align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"list_loop.<0>"() {
-  %"tmp#23##0" = call ccc ptr @wybe_malloc(i32 16)
-  %"tmp#10##0" = ptrtoint ptr %"tmp#23##0" to i64
-  %"tmp#24##0" = inttoptr i64 %"tmp#10##0" to ptr
-  store i64 3, ptr %"tmp#24##0"
-  %"tmp#25##0" = add i64 %"tmp#10##0", 8
-  %"tmp#26##0" = inttoptr i64 %"tmp#25##0" to ptr
-  store i64 0, ptr %"tmp#26##0"
-  %"tmp#27##0" = call ccc ptr @wybe_malloc(i32 16)
-  %"tmp#15##0" = ptrtoint ptr %"tmp#27##0" to i64
-  %"tmp#28##0" = inttoptr i64 %"tmp#15##0" to ptr
-  store i64 2, ptr %"tmp#28##0"
-  %"tmp#29##0" = add i64 %"tmp#15##0", 8
-  %"tmp#30##0" = inttoptr i64 %"tmp#29##0" to ptr
-  store i64 %"tmp#10##0", ptr %"tmp#30##0"
-  %"tmp#31##0" = call ccc ptr @wybe_malloc(i32 16)
-  %"tmp#20##0" = ptrtoint ptr %"tmp#31##0" to i64
-  %"tmp#32##0" = inttoptr i64 %"tmp#20##0" to ptr
-  store i64 1, ptr %"tmp#32##0"
-  %"tmp#33##0" = add i64 %"tmp#20##0", 8
-  %"tmp#34##0" = inttoptr i64 %"tmp#33##0" to ptr
-  store i64 %"tmp#15##0", ptr %"tmp#34##0"
-  tail call fastcc void @"list_loop.#cont#1<0>"(i64 %"tmp#20##0", i64 %"tmp#20##0")
+  %"tmp#24##0" = call ccc ptr @wybe_malloc(i32 16)
+  %"tmp#11##0" = ptrtoint ptr %"tmp#24##0" to i64
+  %"tmp#25##0" = inttoptr i64 %"tmp#11##0" to ptr
+  store i64 3, ptr %"tmp#25##0"
+  %"tmp#26##0" = add i64 %"tmp#11##0", 8
+  %"tmp#27##0" = inttoptr i64 %"tmp#26##0" to ptr
+  store i64 0, ptr %"tmp#27##0"
+  %"tmp#28##0" = call ccc ptr @wybe_malloc(i32 16)
+  %"tmp#16##0" = ptrtoint ptr %"tmp#28##0" to i64
+  %"tmp#29##0" = inttoptr i64 %"tmp#16##0" to ptr
+  store i64 2, ptr %"tmp#29##0"
+  %"tmp#30##0" = add i64 %"tmp#16##0", 8
+  %"tmp#31##0" = inttoptr i64 %"tmp#30##0" to ptr
+  store i64 %"tmp#11##0", ptr %"tmp#31##0"
+  %"tmp#32##0" = call ccc ptr @wybe_malloc(i32 16)
+  %"tmp#21##0" = ptrtoint ptr %"tmp#32##0" to i64
+  %"tmp#33##0" = inttoptr i64 %"tmp#21##0" to ptr
+  store i64 1, ptr %"tmp#33##0"
+  %"tmp#34##0" = add i64 %"tmp#21##0", 8
+  %"tmp#35##0" = inttoptr i64 %"tmp#34##0" to ptr
+  store i64 %"tmp#16##0", ptr %"tmp#35##0"
+  tail call fastcc void @"list_loop.#cont#1<0>"(i64 %"tmp#21##0", i64 %"tmp#21##0")
   ret void
 }
 
 define external fastcc void @"list_loop.#cont#1<0>"(i64 %"l##0", i64 %"x##0") {
-  %"tmp#9##0" = icmp ne i64 %"l##0", 0
-  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
+  %"tmp#10##0" = icmp ne i64 %"l##0", 0
+  br i1 %"tmp#10##0", label %if.then.0, label %if.else.0
 if.then.0:
-  %"tmp#16##0" = inttoptr i64 %"l##0" to ptr
-  %"h##0" = load i64, ptr %"tmp#16##0"
-  %"tmp#17##0" = add i64 %"l##0", 8
-  %"tmp#18##0" = inttoptr i64 %"tmp#17##0" to ptr
-  %"l##1" = load i64, ptr %"tmp#18##0"
+  %"tmp#17##0" = inttoptr i64 %"l##0" to ptr
+  %"h##0" = load i64, ptr %"tmp#17##0"
+  %"tmp#18##0" = add i64 %"l##0", 8
+  %"tmp#19##0" = inttoptr i64 %"tmp#18##0" to ptr
+  %"l##1" = load i64, ptr %"tmp#19##0"
   call ccc void @print_int(i64 %"h##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"list_loop.#cont#3<0>"(i64 %"h##0", i64 %"l##1", i64 %"x##0", i64 %"x##0")
@@ -184,17 +184,17 @@ define external fastcc void @"list_loop.#cont#2<0>"(i64 %"h##0", i64 %"l##0", i6
 }
 
 define external fastcc void @"list_loop.#cont#3<0>"(i64 %"h##0", i64 %"l##0", i64 %"l2##0", i64 %"x##0") {
-  %"tmp#8##0" = icmp ne i64 %"l2##0", 0
-  br i1 %"tmp#8##0", label %if.then.0, label %if.else.0
+  %"tmp#9##0" = icmp ne i64 %"l2##0", 0
+  br i1 %"tmp#9##0", label %if.then.0, label %if.else.0
 if.then.0:
-  %"tmp#19##0" = inttoptr i64 %"l2##0" to ptr
-  %"h2##0" = load i64, ptr %"tmp#19##0"
-  %"tmp#20##0" = add i64 %"l2##0", 8
-  %"tmp#21##0" = inttoptr i64 %"tmp#20##0" to ptr
-  %"l2##1" = load i64, ptr %"tmp#21##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
+  %"tmp#20##0" = inttoptr i64 %"l2##0" to ptr
+  %"h2##0" = load i64, ptr %"tmp#20##0"
+  %"tmp#21##0" = add i64 %"l2##0", 8
+  %"tmp#22##0" = inttoptr i64 %"tmp#21##0" to ptr
+  %"l2##1" = load i64, ptr %"tmp#22##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
   call ccc void @print_int(i64 %"h##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#2" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1155)
   call ccc void @print_int(i64 %"h2##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"list_loop.#cont#3<0>"(i64 %"h##0", i64 %"l##0", i64 %"l2##1", i64 %"x##0")
@@ -205,9 +205,9 @@ if.else.0:
 }
 
 define external fastcc void @"list_loop.#cont#4<0>"(i64 %"h##0", i64 %"h2##0", i64 %"l##0", i64 %"l2##0", i64 %"x##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
   call ccc void @print_int(i64 %"h##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#2" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 1155)
   call ccc void @print_int(i64 %"h2##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"list_loop.#cont#3<0>"(i64 %"h##0", i64 %"l##0", i64 %"l2##0", i64 %"x##0")

--- a/test-cases/final-dump/loop_exit.exp
+++ b/test-cases/final-dump/loop_exit.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) loop_exit
-[91mfinal-dump/loop_exit.wybe:5:2: Uninitialised argument in call to proc println, argument 1
-[0m
+final-dump/loop_exit.wybe:5:2: Uninitialised argument in call to proc println, argument 1

--- a/test-cases/final-dump/missing_dep.exp
+++ b/test-cases/final-dump/missing_dep.exp
@@ -1,6 +1,5 @@
 Error detected during loading module: does_not_exist
-[91mCould not find source for module does_not_exist
+Could not find source for module does_not_exist
 in directories:
     !ROOT!/final-dump
     !ROOT!/../wybelibs
-[0m

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -293,17 +293,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -334,8 +334,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -293,20 +293,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -317,28 +318,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -209,20 +209,21 @@ proc printPosition > public (1 calls)
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
 
   LLVM code       :
 
@@ -233,16 +234,13 @@ source_filename = "!ROOT!/final-dump/multi_specz_cyclic_lib.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)
 declare external fastcc void @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64, i64, i64, i64, i64)
 declare external fastcc void @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64, i64, i64, i64, i64)
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
@@ -312,16 +310,16 @@ define external fastcc void @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d
 }
 
 define external fastcc void @"multi_specz_cyclic_lib.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -209,17 +209,17 @@ proc printPosition > public (1 calls)
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
@@ -317,8 +317,8 @@ define external fastcc void @"multi_specz_cyclic_lib.printPosition<0>"(i64 %"pos
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -59,20 +59,21 @@ proc printPosition > public (1 calls)
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
 
   LLVM code       :
 
@@ -83,14 +84,11 @@ source_filename = "!ROOT!/final-dump/multi_specz_cyclic_lib.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
@@ -123,16 +121,16 @@ define external fastcc void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64 %"po
 }
 
 define external fastcc void @"multi_specz_cyclic_lib.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -59,17 +59,17 @@ proc printPosition > public (1 calls)
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
@@ -128,8 +128,8 @@ define external fastcc void @"multi_specz_cyclic_lib.printPosition<0>"(i64 %"pos
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -59,20 +59,21 @@ proc printPosition > public (1 calls)
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
 
   LLVM code       :
 
@@ -83,14 +84,11 @@ source_filename = "!ROOT!/final-dump/multi_specz_cyclic_lib.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"multi_specz_cyclic_lib2.foo2<0>"(i64, i64, i64, i64, i64)
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
@@ -123,16 +121,16 @@ define external fastcc void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64 %"po
 }
 
 define external fastcc void @"multi_specz_cyclic_lib.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -59,17 +59,17 @@ proc printPosition > public (1 calls)
 printPosition(pos##0:multi_specz_cyclic_lib.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @multi_specz_cyclic_lib:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @multi_specz_cyclic_lib:nn:nn
@@ -128,8 +128,8 @@ define external fastcc void @"multi_specz_cyclic_lib.printPosition<0>"(i64 %"pos
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -57,106 +57,106 @@ proc print_t > public (0 calls)
 print_t(x##0:multictr2.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(10,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(16,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(22,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(28,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(34,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(40,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(50,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign llvm and(x##0:wybe.int, 7:wybe.int, ?tmp#17##0:wybe.int) @multictr2:nn:nn
-    case ~tmp#17##0:wybe.int of
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(13,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(18,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(23,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(28,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(33,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(42,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign llvm and(x##0:wybe.int, 7:wybe.int, ?tmp#9##0:wybe.int) @multictr2:nn:nn
+    case ~tmp#9##0:wybe.int of
     0:
         foreign lpvm access(~x##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @multictr2:nn:nn
         wybe.string.print<0>("c01(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#112##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##0:wybe.int, ~tmp#112##0:wybe.phantom, ?tmp#113##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#113##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#111##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##0:wybe.int, ~tmp#111##0:wybe.phantom, ?tmp#112##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#112##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multictr2:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#118##0:wybe.phantom) @multictr2:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#118##0:wybe.phantom, ?tmp#119##0:wybe.phantom) @multictr2:nn:nn
         foreign lpvm store(~%tmp#119##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     1:
         foreign lpvm access(~x##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?a##1:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c03(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#103##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##1:wybe.int, ~tmp#103##0:wybe.phantom, ?tmp#104##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#104##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#109##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#109##0:wybe.phantom, ?tmp#110##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#110##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>("c03(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#101##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##1:wybe.int, ~tmp#101##0:wybe.phantom, ?tmp#102##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#102##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#108##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#108##0:wybe.phantom, ?tmp#109##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#109##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     2:
         foreign lpvm access(~x##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c03(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#94##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##2:wybe.int, ~tmp#94##0:wybe.phantom, ?tmp#95##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#95##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#100##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#100##0:wybe.phantom, ?tmp#101##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#101##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>("c03(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#91##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##2:wybe.int, ~tmp#91##0:wybe.phantom, ?tmp#92##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#92##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#98##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#98##0:wybe.phantom, ?tmp#99##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#99##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     3:
         foreign lpvm access(~x##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?a##3:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c04(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#85##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##3:wybe.int, ~tmp#85##0:wybe.phantom, ?tmp#86##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#86##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#91##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#91##0:wybe.phantom, ?tmp#92##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#92##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>("c04(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#81##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##3:wybe.int, ~tmp#81##0:wybe.phantom, ?tmp#82##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#82##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #18 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#88##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#88##0:wybe.phantom, ?tmp#89##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#89##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     4:
         foreign lpvm access(~x##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?a##4:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c05(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#76##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##4:wybe.int, ~tmp#76##0:wybe.phantom, ?tmp#77##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#77##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#82##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#82##0:wybe.phantom, ?tmp#83##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#83##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>("c05(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#71##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##4:wybe.int, ~tmp#71##0:wybe.phantom, ?tmp#72##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#72##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#78##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#78##0:wybe.phantom, ?tmp#79##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#79##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     5:
         foreign lpvm access(~x##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?a##5:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c06(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#67##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##5:wybe.int, ~tmp#67##0:wybe.phantom, ?tmp#68##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#68##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#73##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#73##0:wybe.phantom, ?tmp#74##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#74##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>("c06(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#61##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##5:wybe.int, ~tmp#61##0:wybe.phantom, ?tmp#62##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#62##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#68##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#68##0:wybe.phantom, ?tmp#69##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#69##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     6:
         foreign lpvm access(~x##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?a##6:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c07(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #37 @multictr2:nn:nn
+        wybe.string.print<0>("c07(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#51##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##6:wybe.int, ~tmp#51##0:wybe.phantom, ?tmp#52##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#52##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @multictr2:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#58##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##6:wybe.int, ~tmp#58##0:wybe.phantom, ?tmp#59##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#58##0:wybe.phantom, ?tmp#59##0:wybe.phantom) @multictr2:nn:nn
         foreign lpvm store(~%tmp#59##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #40 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#64##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#64##0:wybe.phantom, ?tmp#65##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#65##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     7:
         foreign lpvm access(x##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?a##7:wybe.int) @multictr2:nn:nn
         foreign lpvm access(x##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?b##0:wybe.int) @multictr2:nn:nn
         foreign lpvm access(~x##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?c##0:wybe.float) @multictr2:nn:nn
-        wybe.string.print<0>("c08(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #43 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##7:wybe.int, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #45 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~b##0:wybe.int, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #47 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#49##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_float(~c##0:wybe.float, ~tmp#49##0:wybe.phantom, ?tmp#50##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#50##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #50 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#55##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#55##0:wybe.phantom, ?tmp#56##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#56##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>("c08(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #36 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#35##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##7:wybe.int, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#36##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #38 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~b##0:wybe.int, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #40 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#41##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_float(~c##0:wybe.float, ~tmp#41##0:wybe.phantom, ?tmp#42##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#42##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #42 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#48##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#48##0:wybe.phantom, ?tmp#49##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#49##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
 
   LLVM code       :
@@ -192,8 +192,8 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"multictr2.print_t<0>"(i64 %"x##0") {
-  %"tmp#17##0" = and i64 %"x##0", 7
-  switch i64 %"tmp#17##0", label %case.7.switch.0 [
+  %"tmp#9##0" = and i64 %"x##0", 7
+  switch i64 %"tmp#9##0", label %case.7.switch.0 [
     i64 0, label %case.0.switch.0
     i64 1, label %case.1.switch.0
     i64 2, label %case.2.switch.0

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -57,105 +57,106 @@ proc print_t > public (0 calls)
 print_t(x##0:multictr2.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign llvm and(x##0:wybe.int, 7:wybe.int, ?tmp#9##0:wybe.int) @multictr2:nn:nn
-    case ~tmp#9##0:wybe.int of
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(10,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(16,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(22,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(28,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(34,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(40,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(50,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign llvm and(x##0:wybe.int, 7:wybe.int, ?tmp#17##0:wybe.int) @multictr2:nn:nn
+    case ~tmp#17##0:wybe.int of
     0:
         foreign lpvm access(~x##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int) @multictr2:nn:nn
         wybe.string.print<0>("c01(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#76##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##0:wybe.int, ~tmp#76##0:wybe.phantom, ?tmp#77##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#77##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#78##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#78##0:wybe.phantom, ?tmp#79##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#79##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#112##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##0:wybe.int, ~tmp#112##0:wybe.phantom, ?tmp#113##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#113##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#118##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#118##0:wybe.phantom, ?tmp#119##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#119##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     1:
         foreign lpvm access(~x##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?a##1:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c03(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#71##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##1:wybe.int, ~tmp#71##0:wybe.phantom, ?tmp#72##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#72##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @multictr2:nn:nn
+        wybe.string.print<0>("c03(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#103##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##1:wybe.int, ~tmp#103##0:wybe.phantom, ?tmp#104##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#104##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#109##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#109##0:wybe.phantom, ?tmp#110##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#110##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+
+    2:
+        foreign lpvm access(~x##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int) @multictr2:nn:nn
+        wybe.string.print<0>("c03(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#94##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##2:wybe.int, ~tmp#94##0:wybe.phantom, ?tmp#95##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#95##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#100##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#100##0:wybe.phantom, ?tmp#101##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#101##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+
+    3:
+        foreign lpvm access(~x##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?a##3:wybe.int) @multictr2:nn:nn
+        wybe.string.print<0>("c04(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#85##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##3:wybe.int, ~tmp#85##0:wybe.phantom, ?tmp#86##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#86##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#91##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#91##0:wybe.phantom, ?tmp#92##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#92##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+
+    4:
+        foreign lpvm access(~x##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?a##4:wybe.int) @multictr2:nn:nn
+        wybe.string.print<0>("c05(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#76##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##4:wybe.int, ~tmp#76##0:wybe.phantom, ?tmp#77##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#77##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#82##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#82##0:wybe.phantom, ?tmp#83##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#83##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+
+    5:
+        foreign lpvm access(~x##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?a##5:wybe.int) @multictr2:nn:nn
+        wybe.string.print<0>("c06(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#67##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##5:wybe.int, ~tmp#67##0:wybe.phantom, ?tmp#68##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#68##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @multictr2:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#73##0:wybe.phantom) @multictr2:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#73##0:wybe.phantom, ?tmp#74##0:wybe.phantom) @multictr2:nn:nn
         foreign lpvm store(~%tmp#74##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
-    2:
-        foreign lpvm access(~x##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c03(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#66##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##2:wybe.int, ~tmp#66##0:wybe.phantom, ?tmp#67##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#67##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #13 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#68##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#68##0:wybe.phantom, ?tmp#69##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#69##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-
-    3:
-        foreign lpvm access(~x##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?a##3:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c04(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#61##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##3:wybe.int, ~tmp#61##0:wybe.phantom, ?tmp#62##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#62##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #18 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#63##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#63##0:wybe.phantom, ?tmp#64##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#64##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-
-    4:
-        foreign lpvm access(~x##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?a##4:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c05(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#56##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##4:wybe.int, ~tmp#56##0:wybe.phantom, ?tmp#57##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#57##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#58##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#58##0:wybe.phantom, ?tmp#59##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#59##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-
-    5:
-        foreign lpvm access(~x##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?a##5:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c06(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#51##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##5:wybe.int, ~tmp#51##0:wybe.phantom, ?tmp#52##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#52##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#54##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-
     6:
         foreign lpvm access(~x##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?a##6:wybe.int) @multictr2:nn:nn
-        wybe.string.print<0>("c07(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##6:wybe.int, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#48##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#48##0:wybe.phantom, ?tmp#49##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#49##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>("c07(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #37 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#58##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##6:wybe.int, ~tmp#58##0:wybe.phantom, ?tmp#59##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#59##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #40 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#64##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#64##0:wybe.phantom, ?tmp#65##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#65##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
     7:
         foreign lpvm access(x##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?a##7:wybe.int) @multictr2:nn:nn
         foreign lpvm access(x##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?b##0:wybe.int) @multictr2:nn:nn
         foreign lpvm access(~x##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?c##0:wybe.float) @multictr2:nn:nn
-        wybe.string.print<0>("c08(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #36 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#35##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~a##7:wybe.int, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#36##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #38 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_int(~b##0:wybe.int, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #40 @multictr2:nn:nn
-        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#41##0:wybe.phantom) @multictr2:nn:nn
-        foreign c print_float(~c##0:wybe.float, ~tmp#41##0:wybe.phantom, ?tmp#42##0:wybe.phantom) @multictr2:nn:nn
-        foreign lpvm store(~%tmp#42##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
-        wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #42 @multictr2:nn:nn
+        wybe.string.print<0>("c08(":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #43 @multictr2:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @multictr2:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~a##7:wybe.int, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @multictr2:nn:nn
         foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #45 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_int(~b##0:wybe.int, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>(", ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #47 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#49##0:wybe.phantom) @multictr2:nn:nn
+        foreign c print_float(~c##0:wybe.float, ~tmp#49##0:wybe.phantom, ?tmp#50##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#50##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
+        wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #50 @multictr2:nn:nn
+        foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#55##0:wybe.phantom) @multictr2:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#55##0:wybe.phantom, ?tmp#56##0:wybe.phantom) @multictr2:nn:nn
+        foreign lpvm store(~%tmp#56##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @multictr2:nn:nn
 
 
   LLVM code       :
@@ -166,34 +167,33 @@ print_t(x##0:multictr2.t)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 source_filename = "!ROOT!/final-dump/multictr2.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c", \00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"c01(\00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"c03(\00", align 8
-@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"c04(\00", align 8
-@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"c05(\00", align 8
-@"cstring#6" = private unnamed_addr constant [ ?? x i8 ] c"c06(\00", align 8
-@"cstring#7" = private unnamed_addr constant [ ?? x i8 ] c"c07(\00", align 8
-@"cstring#8" = private unnamed_addr constant [ ?? x i8 ] c"c08(\00", align 8
-@"string#9" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#10" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#11" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#12" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
-@"string#13" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
-@"string#14" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
-@"string#15" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#6" to i64 ) }, align 8
-@"string#16" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#7" to i64 ) }, align 8
-@"string#17" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#8" to i64 ) }, align 8
+@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c", \00", align 8
+@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"c01(\00", align 8
+@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"c03(\00", align 8
+@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"c04(\00", align 8
+@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"c05(\00", align 8
+@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"c06(\00", align 8
+@"cstring#6" = private unnamed_addr constant [ ?? x i8 ] c"c07(\00", align 8
+@"cstring#7" = private unnamed_addr constant [ ?? x i8 ] c"c08(\00", align 8
+@"string#8" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
+@"string#9" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
+@"string#10" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#11" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
+@"string#12" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
+@"string#13" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
+@"string#14" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#6" to i64 ) }, align 8
+@"string#15" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#7" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_float(double)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"multictr2.print_t<0>"(i64 %"x##0") {
-  %"tmp#9##0" = and i64 %"x##0", 7
-  switch i64 %"tmp#9##0", label %case.7.switch.0 [
+  %"tmp#17##0" = and i64 %"x##0", 7
+  switch i64 %"tmp#17##0", label %case.7.switch.0 [
     i64 0, label %case.0.switch.0
     i64 1, label %case.1.switch.0
     i64 2, label %case.2.switch.0
@@ -203,84 +203,84 @@ define external fastcc void @"multictr2.print_t<0>"(i64 %"x##0") {
     i64 6, label %case.6.switch.0
     i64 7, label %case.7.switch.0 ]
 case.0.switch.0:
-  %"tmp#80##0" = inttoptr i64 %"x##0" to ptr
-  %"a##0" = load i64, ptr %"tmp#80##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
-  call ccc void @print_int(i64 %"a##0")
+  %"tmp#120##0" = inttoptr i64 %"x##0" to ptr
+  %"a##0" = load i64, ptr %"tmp#120##0"
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  call ccc void @print_int(i64 %"a##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.1.switch.0:
-  %"tmp#81##0" = add i64 %"x##0", -1
-  %"tmp#82##0" = inttoptr i64 %"tmp#81##0" to ptr
-  %"a##1" = load i64, ptr %"tmp#82##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  %"tmp#121##0" = add i64 %"x##0", -1
+  %"tmp#122##0" = inttoptr i64 %"tmp#121##0" to ptr
+  %"a##1" = load i64, ptr %"tmp#122##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#10" to i64 ))
   call ccc void @print_int(i64 %"a##1")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.2.switch.0:
-  %"tmp#83##0" = add i64 %"x##0", -2
-  %"tmp#84##0" = inttoptr i64 %"tmp#83##0" to ptr
-  %"a##2" = load i64, ptr %"tmp#84##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
+  %"tmp#123##0" = add i64 %"x##0", -2
+  %"tmp#124##0" = inttoptr i64 %"tmp#123##0" to ptr
+  %"a##2" = load i64, ptr %"tmp#124##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#10" to i64 ))
   call ccc void @print_int(i64 %"a##2")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.3.switch.0:
-  %"tmp#85##0" = add i64 %"x##0", -3
-  %"tmp#86##0" = inttoptr i64 %"tmp#85##0" to ptr
-  %"a##3" = load i64, ptr %"tmp#86##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#13" to i64 ))
+  %"tmp#125##0" = add i64 %"x##0", -3
+  %"tmp#126##0" = inttoptr i64 %"tmp#125##0" to ptr
+  %"a##3" = load i64, ptr %"tmp#126##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#11" to i64 ))
   call ccc void @print_int(i64 %"a##3")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.4.switch.0:
-  %"tmp#87##0" = add i64 %"x##0", -4
-  %"tmp#88##0" = inttoptr i64 %"tmp#87##0" to ptr
-  %"a##4" = load i64, ptr %"tmp#88##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
+  %"tmp#127##0" = add i64 %"x##0", -4
+  %"tmp#128##0" = inttoptr i64 %"tmp#127##0" to ptr
+  %"a##4" = load i64, ptr %"tmp#128##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#12" to i64 ))
   call ccc void @print_int(i64 %"a##4")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.5.switch.0:
-  %"tmp#89##0" = add i64 %"x##0", -5
-  %"tmp#90##0" = inttoptr i64 %"tmp#89##0" to ptr
-  %"a##5" = load i64, ptr %"tmp#90##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#15" to i64 ))
+  %"tmp#129##0" = add i64 %"x##0", -5
+  %"tmp#130##0" = inttoptr i64 %"tmp#129##0" to ptr
+  %"a##5" = load i64, ptr %"tmp#130##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#13" to i64 ))
   call ccc void @print_int(i64 %"a##5")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.6.switch.0:
-  %"tmp#91##0" = add i64 %"x##0", -6
-  %"tmp#92##0" = inttoptr i64 %"tmp#91##0" to ptr
-  %"a##6" = load i64, ptr %"tmp#92##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#16" to i64 ))
+  %"tmp#131##0" = add i64 %"x##0", -6
+  %"tmp#132##0" = inttoptr i64 %"tmp#131##0" to ptr
+  %"a##6" = load i64, ptr %"tmp#132##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
   call ccc void @print_int(i64 %"a##6")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 case.7.switch.0:
-  %"tmp#93##0" = add i64 %"x##0", -7
-  %"tmp#94##0" = inttoptr i64 %"tmp#93##0" to ptr
-  %"a##7" = load i64, ptr %"tmp#94##0"
-  %"tmp#95##0" = add i64 %"x##0", 1
-  %"tmp#96##0" = inttoptr i64 %"tmp#95##0" to ptr
-  %"b##0" = load i64, ptr %"tmp#96##0"
-  %"tmp#97##0" = add i64 %"x##0", 9
-  %"tmp#98##0" = inttoptr i64 %"tmp#97##0" to ptr
-  %"c##0" = load double, ptr %"tmp#98##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#17" to i64 ))
+  %"tmp#133##0" = add i64 %"x##0", -7
+  %"tmp#134##0" = inttoptr i64 %"tmp#133##0" to ptr
+  %"a##7" = load i64, ptr %"tmp#134##0"
+  %"tmp#135##0" = add i64 %"x##0", 1
+  %"tmp#136##0" = inttoptr i64 %"tmp#135##0" to ptr
+  %"b##0" = load i64, ptr %"tmp#136##0"
+  %"tmp#137##0" = add i64 %"x##0", 9
+  %"tmp#138##0" = inttoptr i64 %"tmp#137##0" to ptr
+  %"c##0" = load double, ptr %"tmp#138##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#15" to i64 ))
   call ccc void @print_int(i64 %"a##7")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#10" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
   call ccc void @print_int(i64 %"b##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#10" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#8" to i64 ))
   call ccc void @print_float(double %"c##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#9" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -31,8 +31,8 @@ proc printTree > public {inline} (0 calls)
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
-    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @mytree:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @mytree:nn:nn
+    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
 
 
 proc printTree1 > public (3 calls)

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -31,8 +31,8 @@ proc printTree > public {inline} (0 calls)
 printTree(t##0:mytree.tree)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @mytree:nn:nn
-    wybe.string.print<0>("}":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, 1519:wybe.string, ?prefix##1:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @mytree:nn:nn
+    wybe.string.print<0>(1527:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @mytree:nn:nn
 
 
 proc printTree1 > public (3 calls)
@@ -67,19 +67,15 @@ source_filename = "!ROOT!/final-dump/mytree.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c", \00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"{\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"}\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"mytree.printTree<0>"(i64 %"t##0") {
-  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 ptrtoint( ptr @"string#4" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"t##0", i64 1519)
+  tail call fastcc void @"wybe.string.print<0>"(i64 1527)
   ret void
 }
 
@@ -98,7 +94,7 @@ if.then.0:
   %"prefix##1" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"l##0", i64 %"prefix##0")
   tail call fastcc void @"wybe.string.print<0>"(i64 %"prefix##1")
   call ccc void @print_int(i64 %"k##0")
-  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#3" to i64 ))
+  %"tmp#11##0" = tail call fastcc i64 @"mytree.printTree1<0>"(i64 %"r##0", i64 ptrtoint( ptr @"string#1" to i64 ))
   ret i64 %"tmp#11##0"
 if.else.0:
   ret i64 %"prefix##0"

--- a/test-cases/final-dump/parametric_repn.exp
+++ b/test-cases/final-dump/parametric_repn.exp
@@ -1,3 +1,2 @@
 Error detected during preliminary processing of module parametric_repn
-[91mfinal-dump/parametric_repn.wybe:1:5: types defined by representation cannot have type parameters
-[0m
+final-dump/parametric_repn.wybe:1:5: types defined by representation cannot have type parameters

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -27,20 +27,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -51,28 +52,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -27,17 +27,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -68,8 +68,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -27,20 +27,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -51,28 +52,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -27,17 +27,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -68,8 +68,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -27,20 +27,21 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
 
   LLVM code       :
 
@@ -51,28 +52,25 @@ source_filename = "!ROOT!/final-dump/position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
-  %"tmp#13##0" = inttoptr i64 %"pos##0" to ptr
-  %"tmp#0##0" = load i64, ptr %"tmp#13##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
+  %"tmp#23##0" = inttoptr i64 %"pos##0" to ptr
+  %"tmp#0##0" = load i64, ptr %"tmp#23##0"
   call ccc void @print_int(i64 %"tmp#0##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
-  %"tmp#14##0" = add i64 %"pos##0", 8
-  %"tmp#15##0" = inttoptr i64 %"tmp#14##0" to ptr
-  %"tmp#1##0" = load i64, ptr %"tmp#15##0"
-  call ccc void @print_int(i64 %"tmp#1##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
+  %"tmp#24##0" = add i64 %"pos##0", 8
+  %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
+  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -27,17 +27,17 @@ proc printPosition > public (0 calls)
 printPosition(pos##0:position.position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(9,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @position:nn:nn
     foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#6##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @position:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int) @position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @position:nn:nn
-    foreign c print_int(~tmp#2##0:wybe.int, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @position:nn:nn
-    foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @position:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int) @position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#13##0:wybe.phantom) @position:nn:nn
+    foreign c print_int(~tmp#1##0:wybe.int, ~tmp#13##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @position:nn:nn
+    foreign lpvm store(~%tmp#14##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #9 @position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @position:nn:nn
@@ -68,8 +68,8 @@ define external fastcc void @"position.printPosition<0>"(i64 %"pos##0") {
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   %"tmp#24##0" = add i64 %"pos##0", 8
   %"tmp#25##0" = inttoptr i64 %"tmp#24##0" to ptr
-  %"tmp#2##0" = load i64, ptr %"tmp#25##0"
-  call ccc void @print_int(i64 %"tmp#2##0")
+  %"tmp#1##0" = load i64, ptr %"tmp#25##0"
+  call ccc void @print_int(i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/purity_error.exp
+++ b/test-cases/final-dump/purity_error.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) purity_error
-[91mfinal-dump/purity_error.wybe:3:41: Calling impure proc purity_error.something_impure<0>, expecting at least semipure
-[0m[91mfinal-dump/purity_error.wybe:7:29: Calling impure foreign proc mul, expecting at least semipure
-[0m[91mfinal-dump/purity_error.wybe:12:5: Calling impure proc purity_error.another_impure<0> without ! non-purity marker
-[0m
+final-dump/purity_error.wybe:3:41: Calling impure proc purity_error.something_impure<0>, expecting at least semipure
+final-dump/purity_error.wybe:7:29: Calling impure foreign proc mul, expecting at least semipure
+final-dump/purity_error.wybe:12:5: Calling impure proc purity_error.another_impure<0> without ! non-purity marker

--- a/test-cases/final-dump/purity_warning.exp
+++ b/test-cases/final-dump/purity_warning.exp
@@ -32,5 +32,4 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 define external fastcc void @"purity_warning.<0>"() {
   ret void
 }
-[93mfinal-dump/purity_warning.wybe:1:2: Calling proc wybe.list.length<0> with unneeded ! marker
-[0m
+final-dump/purity_warning.wybe:1:2: Calling proc wybe.list.length<0> with unneeded ! marker

--- a/test-cases/final-dump/repeated_type.exp
+++ b/test-cases/final-dump/repeated_type.exp
@@ -1,3 +1,2 @@
 Error detected during loading module: repeated_type
-[91mfinal-dump/repeated_type.wybe:2:23: Syntax error: unexpected newline
-[0m
+final-dump/repeated_type.wybe:2:23: Syntax error: unexpected newline

--- a/test-cases/final-dump/resource_conflict_c.exp
+++ b/test-cases/final-dump/resource_conflict_c.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) resource_conflict_c
-[91mOverloaded resources resource_conflict_a.res, resource_conflict_b.res
-[0m
+Overloaded resources resource_conflict_a.res, resource_conflict_b.res

--- a/test-cases/final-dump/resource_error.exp
+++ b/test-cases/final-dump/resource_error.exp
@@ -1,3 +1,2 @@
 Error detected during resource checking of module(s) resource_error
-[91mfinal-dump/resource_error.wybe:2:5: Call to resourceful proc without ! resource marker: wybe.string.<0>println("shouldn't work: no ! before println call":wybe.string @resource_error:nn:nn)
-[0m
+final-dump/resource_error.wybe:2:5: Call to resourceful proc without ! resource marker: wybe.string.<0>println("shouldn't work: no ! before println call":wybe.string @resource_error:nn:nn)

--- a/test-cases/final-dump/resource_error2.exp
+++ b/test-cases/final-dump/resource_error2.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) resource_error2
-[91mfinal-dump/resource_error2.wybe:2:7: Resource wybe.io.io not in scope at call to proc println
-[0m[91mfinal-dump/resource_error2.wybe:17:7: Resource res_decl.count not in scope at call to proc use_resource
-[0m[91mfinal-dump/resource_error2.wybe:25:14: proc call_source_file_name unknown in proc bad_special_use
-[0m
+final-dump/resource_error2.wybe:2:7: Resource wybe.io.io not in scope at call to proc println
+final-dump/resource_error2.wybe:17:7: Resource res_decl.count not in scope at call to proc use_resource
+final-dump/resource_error2.wybe:25:14: proc call_source_file_name unknown in proc bad_special_use

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -17,107 +17,91 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(65,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(68,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(70,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(72,(string.print_loop#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @string:nn:nn
-    foreign c print_string(c"TESTING CONSTRUCTION":wybe.c_string, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#35##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.string.print<0>("":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #62 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#37##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#37##0:wybe.phantom, ?tmp#38##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#38##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.string.print<0>("a":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #63 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#40##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#40##0:wybe.phantom, ?tmp#41##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#41##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.string.print<0>("abc":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #64 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#43##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#43##0:wybe.phantom, ?tmp#44##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#44##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.string.,,<0>("abc":wybe.string, "abc":wybe.string, ?tmp#0##0:wybe.string) #4 @string:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #65 @string:nn:nn
+  MultiSpeczDepInfo: [(64,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(65,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(67,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(68,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(70,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(72,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(74,(string.print_loop#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#35##0:wybe.phantom) @string:nn:nn
+    foreign c print_string(c"TESTING CONSTRUCTION":wybe.c_string, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #64 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#39##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#39##0:wybe.phantom, ?tmp#40##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#40##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+    wybe.string.print<0>[410bae77d3](1415:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #65 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#47##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    foreign lpvm cast('a':wybe.char, ?tmp#111##0:wybe.string) @string:nn:nn
-    foreign llvm shl(~tmp#111##0:wybe.string, 2:wybe.string, ?tmp#112##0:wybe.string) @string:nn:nn
-    foreign llvm or(~tmp#112##0:wybe.string, 1024:wybe.string, ?tmp#113##0:wybe.string) @string:nn:nn
-    foreign llvm or(~tmp#113##0:wybe.string, 3:wybe.string, ?tmp#1##0:wybe.string) @string:nn:nn
-    wybe.string.print<0>(tmp#1##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #66 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#53##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#53##0:wybe.phantom, ?tmp#54##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#54##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.range.construct<0>(1:wybe.int, 3:wybe.int, 100:wybe.int, ?tmp#3##0:wybe.range) #67 @string:nn:nn
-    wybe.string.[]<1>("abcdefghi":wybe.string, tmp#3##0:wybe.range, ?tmp#2##0:wybe.string) #9 @string:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #68 @string:nn:nn
+    wybe.string.print<0>("abc":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #66 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#49##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#49##0:wybe.phantom, ?tmp#50##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#50##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+    wybe.string.,,<0>("abc":wybe.string, "abc":wybe.string, ?tmp#2##0:wybe.string) #6 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #67 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#52##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#52##0:wybe.phantom, ?tmp#53##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#53##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+    wybe.string.print<0>[410bae77d3](1415:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #68 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#59##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#59##0:wybe.phantom, ?tmp#60##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#60##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.string.[]<1>("abcdefghi":wybe.string, ~tmp#3##0:wybe.range, ?tmp#5##0:wybe.string) #12 @string:nn:nn
-    wybe.range...<0>(1:wybe.int, 3:wybe.int, ?tmp#7##0:wybe.range) #13 @string:nn:nn
-    wybe.string.[]<1>(~tmp#5##0:wybe.string, ~tmp#7##0:wybe.range, ?tmp#4##0:wybe.string) #14 @string:nn:nn
+    wybe.range.construct<0>(1:wybe.int, 3:wybe.int, 100:wybe.int, ?tmp#5##0:wybe.range) #69 @string:nn:nn
+    wybe.string.[]<1>("abcdefghi":wybe.string, tmp#5##0:wybe.range, ?tmp#4##0:wybe.string) #11 @string:nn:nn
     wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #70 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#65##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#65##0:wybe.phantom, ?tmp#66##0:wybe.phantom) @string:nn:nn
-    foreign c print_string(c"\nTESTING CONVERSION TO c_string":wybe.c_string, ~tmp#66##0:wybe.phantom, ?tmp#69##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#69##0:wybe.phantom, ?tmp#70##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#70##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    foreign lpvm cast('d':wybe.char, ?tmp#72##0:wybe.string) @string:nn:nn
-    foreign llvm shl(~tmp#72##0:wybe.string, 2:wybe.string, ?tmp#73##0:wybe.string) @string:nn:nn
-    foreign llvm or(~tmp#73##0:wybe.string, 1024:wybe.string, ?tmp#74##0:wybe.string) @string:nn:nn
-    foreign llvm or(~tmp#74##0:wybe.string, 3:wybe.string, ?tmp#10##0:wybe.string) @string:nn:nn
-    wybe.range...<0>(1:wybe.int, 2:wybe.int, ?tmp#12##0:wybe.range) #18 @string:nn:nn
-    wybe.string.[]<1>("efg":wybe.string, ~tmp#12##0:wybe.range, ?tmp#11##0:wybe.string) #19 @string:nn:nn
-    wybe.string.,,<0>(~tmp#10##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#9##0:wybe.string) #20 @string:nn:nn
-    wybe.string.,,<0>("abc":wybe.string, ~tmp#9##0:wybe.string, ?tmp#8##0:wybe.string) #21 @string:nn:nn
-    wybe.string.c_string<0>(tmp#8##0:wybe.string, ?r##0:wybe.c_string) #22 @string:nn:nn
-    wybe.string.print<0>(~tmp#8##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#76##0:wybe.phantom) @string:nn:nn
-    foreign c putchar(' ':wybe.char, ~tmp#76##0:wybe.phantom, ?tmp#77##0:wybe.phantom) @string:nn:nn
-    foreign c print_string(~r##0:wybe.c_string, ~tmp#77##0:wybe.phantom, ?tmp#80##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#80##0:wybe.phantom, ?tmp#81##0:wybe.phantom) @string:nn:nn
-    foreign c print_string(c"\nTESTING LOOPS":wybe.c_string, ~tmp#81##0:wybe.phantom, ?tmp#84##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#84##0:wybe.phantom, ?tmp#85##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#85##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    string.print_loop#cont#1<0>("abc":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #71 @string:nn:nn
-    wybe.range.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.range) #28 @string:nn:nn
-    wybe.string.[]<1>("abcdefghijkl":wybe.string, ~tmp#14##0:wybe.range, ?tmp#13##0:wybe.string) #29 @string:nn:nn
-    string.print_loop#cont#1<0>[410bae77d3](~tmp#13##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #72 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#89##0:wybe.phantom) @string:nn:nn
-    foreign c print_string(c"\nTESTING INDEXING":wybe.c_string, ~tmp#89##0:wybe.phantom, ?tmp#90##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#66##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+    wybe.string.[]<1>("abcdefghi":wybe.string, ~tmp#5##0:wybe.range, ?tmp#7##0:wybe.string) #14 @string:nn:nn
+    wybe.range...<0>(1:wybe.int, 3:wybe.int, ?tmp#9##0:wybe.range) #15 @string:nn:nn
+    wybe.string.[]<1>(~tmp#7##0:wybe.string, ~tmp#9##0:wybe.range, ?tmp#6##0:wybe.string) #16 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #72 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#71##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#71##0:wybe.phantom, ?tmp#72##0:wybe.phantom) @string:nn:nn
+    foreign c print_string(c"\nTESTING CONVERSION TO c_string":wybe.c_string, ~tmp#72##0:wybe.phantom, ?tmp#75##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#75##0:wybe.phantom, ?tmp#76##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#76##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+    wybe.range...<0>(1:wybe.int, 2:wybe.int, ?tmp#14##0:wybe.range) #20 @string:nn:nn
+    wybe.string.[]<1>("efg":wybe.string, ~tmp#14##0:wybe.range, ?tmp#13##0:wybe.string) #21 @string:nn:nn
+    wybe.string.,,<0>(1427:wybe.string, ~tmp#13##0:wybe.string, ?tmp#11##0:wybe.string) #22 @string:nn:nn
+    wybe.string.,,<0>("abc":wybe.string, ~tmp#11##0:wybe.string, ?tmp#10##0:wybe.string) #23 @string:nn:nn
+    wybe.string.c_string<0>(tmp#10##0:wybe.string, ?r##0:wybe.c_string) #24 @string:nn:nn
+    wybe.string.print<0>(~tmp#10##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#82##0:wybe.phantom) @string:nn:nn
+    foreign c putchar(' ':wybe.char, ~tmp#82##0:wybe.phantom, ?tmp#83##0:wybe.phantom) @string:nn:nn
+    foreign c print_string(~r##0:wybe.c_string, ~tmp#83##0:wybe.phantom, ?tmp#86##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#86##0:wybe.phantom, ?tmp#87##0:wybe.phantom) @string:nn:nn
+    foreign c print_string(c"\nTESTING LOOPS":wybe.c_string, ~tmp#87##0:wybe.phantom, ?tmp#90##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#90##0:wybe.phantom, ?tmp#91##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#91##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    string.test_index<0>("abc":wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @string:nn:nn
-    string.test_index<0>("abc":wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @string:nn:nn
-    string.test_index<0>("abcdefghijklmnopqrstuvwxyz":wybe.string, 25:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @string:nn:nn
-    wybe.string.,,<0>("ab":wybe.string, "cd":wybe.string, ?tmp#15##0:wybe.string) #35 @string:nn:nn
-    string.test_index<0>(~tmp#15##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #36 @string:nn:nn
-    wybe.string.,,<0>("ab":wybe.string, "cd":wybe.string, ?tmp#16##0:wybe.string) #37 @string:nn:nn
-    string.test_index<0>(~tmp#16##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #38 @string:nn:nn
-    string.test_index<0>(tmp#1##0:wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #40 @string:nn:nn
-    wybe.range.construct<0>(0:wybe.int, 2:wybe.int, 10:wybe.int, ?tmp#19##0:wybe.range) #73 @string:nn:nn
-    wybe.string.[]<1>("abcdefgh":wybe.string, tmp#19##0:wybe.range, ?tmp#18##0:wybe.string) #42 @string:nn:nn
-    string.test_index<0>(~tmp#18##0:wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #43 @string:nn:nn
-    string.test_index<0>("abc":wybe.string, 3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #44 @string:nn:nn
-    string.test_index<0>(tmp#1##0:wybe.string, 3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #46 @string:nn:nn
-    string.test_index<0>("abc":wybe.string, -3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #47 @string:nn:nn
-    wybe.string.[]<1>("abc":wybe.string, ~tmp#19##0:wybe.range, ?tmp#21##0:wybe.string) #49 @string:nn:nn
-    string.test_index<0>(~tmp#21##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #50 @string:nn:nn
-    wybe.string.,,<0>("abc":wybe.string, tmp#1##0:wybe.string, ?tmp#23##0:wybe.string) #52 @string:nn:nn
-    string.test_index<0>(~tmp#23##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #53 @string:nn:nn
-    foreign lpvm cast('b':wybe.char, ?tmp#115##0:wybe.string) @string:nn:nn
-    foreign llvm shl(~tmp#115##0:wybe.string, 2:wybe.string, ?tmp#116##0:wybe.string) @string:nn:nn
-    foreign llvm or(~tmp#116##0:wybe.string, 1024:wybe.string, ?tmp#117##0:wybe.string) @string:nn:nn
-    foreign llvm or(~tmp#117##0:wybe.string, 3:wybe.string, ?tmp#29##0:wybe.string) @string:nn:nn
-    foreign lpvm cast('c':wybe.char, ?tmp#119##0:wybe.string) @string:nn:nn
-    foreign llvm shl(~tmp#119##0:wybe.string, 2:wybe.string, ?tmp#120##0:wybe.string) @string:nn:nn
-    foreign llvm or(~tmp#120##0:wybe.string, 1024:wybe.string, ?tmp#121##0:wybe.string) @string:nn:nn
-    foreign llvm or(~tmp#121##0:wybe.string, 3:wybe.string, ?tmp#30##0:wybe.string) @string:nn:nn
-    wybe.string.,,<0>(~tmp#29##0:wybe.string, ~tmp#30##0:wybe.string, ?tmp#28##0:wybe.string) #57 @string:nn:nn
-    wybe.string.,,<0>(~tmp#1##0:wybe.string, ~tmp#28##0:wybe.string, ?tmp#26##0:wybe.string) #58 @string:nn:nn
-    wybe.range...<0>(0:wybe.int, 2:wybe.int, ?tmp#31##0:wybe.range) #59 @string:nn:nn
-    wybe.string.[]<1>(~tmp#26##0:wybe.string, ~tmp#31##0:wybe.range, ?tmp#25##0:wybe.string) #60 @string:nn:nn
-    string.test_index<0>(~tmp#25##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #61 @string:nn:nn
+    string.print_loop#cont#1<0>("abc":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #73 @string:nn:nn
+    wybe.range.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#16##0:wybe.range) #30 @string:nn:nn
+    wybe.string.[]<1>("abcdefghijkl":wybe.string, ~tmp#16##0:wybe.range, ?tmp#15##0:wybe.string) #31 @string:nn:nn
+    string.print_loop#cont#1<0>[410bae77d3](~tmp#15##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #74 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#95##0:wybe.phantom) @string:nn:nn
+    foreign c print_string(c"\nTESTING INDEXING":wybe.c_string, ~tmp#95##0:wybe.phantom, ?tmp#96##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#96##0:wybe.phantom, ?tmp#97##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#97##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+    string.test_index<0>("abc":wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @string:nn:nn
+    string.test_index<0>("abc":wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #35 @string:nn:nn
+    string.test_index<0>("abcdefghijklmnopqrstuvwxyz":wybe.string, 25:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #36 @string:nn:nn
+    wybe.string.,,<0>("ab":wybe.string, "cd":wybe.string, ?tmp#17##0:wybe.string) #37 @string:nn:nn
+    string.test_index<0>(~tmp#17##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #38 @string:nn:nn
+    wybe.string.,,<0>("ab":wybe.string, "cd":wybe.string, ?tmp#18##0:wybe.string) #39 @string:nn:nn
+    string.test_index<0>(~tmp#18##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #40 @string:nn:nn
+    string.test_index<0>(1415:wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #42 @string:nn:nn
+    wybe.range.construct<0>(0:wybe.int, 2:wybe.int, 10:wybe.int, ?tmp#21##0:wybe.range) #75 @string:nn:nn
+    wybe.string.[]<1>("abcdefgh":wybe.string, tmp#21##0:wybe.range, ?tmp#20##0:wybe.string) #44 @string:nn:nn
+    string.test_index<0>(~tmp#20##0:wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #45 @string:nn:nn
+    string.test_index<0>("abc":wybe.string, 3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #46 @string:nn:nn
+    string.test_index<0>(1415:wybe.string, 3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #48 @string:nn:nn
+    string.test_index<0>("abc":wybe.string, -3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #49 @string:nn:nn
+    wybe.string.[]<1>("abc":wybe.string, ~tmp#21##0:wybe.range, ?tmp#23##0:wybe.string) #51 @string:nn:nn
+    string.test_index<0>(~tmp#23##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #52 @string:nn:nn
+    wybe.string.,,<0>("abc":wybe.string, 1415:wybe.string, ?tmp#25##0:wybe.string) #54 @string:nn:nn
+    string.test_index<0>(~tmp#25##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #55 @string:nn:nn
+    wybe.string.,,<0>(1419:wybe.string, 1423:wybe.string, ?tmp#30##0:wybe.string) #59 @string:nn:nn
+    wybe.string.,,<0>(1415:wybe.string, ~tmp#30##0:wybe.string, ?tmp#28##0:wybe.string) #60 @string:nn:nn
+    wybe.range...<0>(0:wybe.int, 2:wybe.int, ?tmp#33##0:wybe.range) #61 @string:nn:nn
+    wybe.string.[]<1>(~tmp#28##0:wybe.string, ~tmp#33##0:wybe.range, ?tmp#27##0:wybe.string) #62 @string:nn:nn
+    string.test_index<0>(~tmp#27##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #63 @string:nn:nn
 
 
 proc print_loop > {inline} (2 calls)
@@ -191,31 +175,27 @@ test_index(s##0:wybe.string, i##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; 
 source_filename = "!ROOT!/final-dump/string.wybe"
 target triple    ????
 
-@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"\0ATESTING CONVERSION TO c_string\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"\0ATESTING INDEXING\00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"\0ATESTING LOOPS\00", align 8
-@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"OUT OF RANGE\00", align 8
-@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"TESTING CONSTRUCTION\00", align 8
-@"cstring#6" = private unnamed_addr constant [ ?? x i8 ] c"a\00", align 8
-@"cstring#7" = private unnamed_addr constant [ ?? x i8 ] c"ab\00", align 8
-@"cstring#8" = private unnamed_addr constant [ ?? x i8 ] c"abc\00", align 8
-@"cstring#9" = private unnamed_addr constant [ ?? x i8 ] c"abcdefgh\00", align 8
-@"cstring#10" = private unnamed_addr constant [ ?? x i8 ] c"abcdefghi\00", align 8
-@"cstring#11" = private unnamed_addr constant [ ?? x i8 ] c"abcdefghijkl\00", align 8
-@"cstring#12" = private unnamed_addr constant [ ?? x i8 ] c"abcdefghijklmnopqrstuvwxyz\00", align 8
-@"cstring#13" = private unnamed_addr constant [ ?? x i8 ] c"cd\00", align 8
-@"cstring#14" = private unnamed_addr constant [ ?? x i8 ] c"efg\00", align 8
-@"string#15" = private unnamed_addr constant {i64, i64} { i64 0, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#16" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#6" to i64 ) }, align 8
-@"string#17" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#7" to i64 ) }, align 8
-@"string#18" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#8" to i64 ) }, align 8
-@"string#19" = private unnamed_addr constant {i64, i64} { i64 8, i64 ptrtoint( ptr @"cstring#9" to i64 ) }, align 8
-@"string#20" = private unnamed_addr constant {i64, i64} { i64 9, i64 ptrtoint( ptr @"cstring#10" to i64 ) }, align 8
-@"string#21" = private unnamed_addr constant {i64, i64} { i64 12, i64 ptrtoint( ptr @"cstring#11" to i64 ) }, align 8
-@"string#22" = private unnamed_addr constant {i64, i64} { i64 26, i64 ptrtoint( ptr @"cstring#12" to i64 ) }, align 8
-@"string#23" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#13" to i64 ) }, align 8
-@"string#24" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#14" to i64 ) }, align 8
+@"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c"\0ATESTING CONVERSION TO c_string\00", align 8
+@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c"\0ATESTING INDEXING\00", align 8
+@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"\0ATESTING LOOPS\00", align 8
+@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"OUT OF RANGE\00", align 8
+@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"TESTING CONSTRUCTION\00", align 8
+@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"ab\00", align 8
+@"cstring#6" = private unnamed_addr constant [ ?? x i8 ] c"abc\00", align 8
+@"cstring#7" = private unnamed_addr constant [ ?? x i8 ] c"abcdefgh\00", align 8
+@"cstring#8" = private unnamed_addr constant [ ?? x i8 ] c"abcdefghi\00", align 8
+@"cstring#9" = private unnamed_addr constant [ ?? x i8 ] c"abcdefghijkl\00", align 8
+@"cstring#10" = private unnamed_addr constant [ ?? x i8 ] c"abcdefghijklmnopqrstuvwxyz\00", align 8
+@"cstring#11" = private unnamed_addr constant [ ?? x i8 ] c"cd\00", align 8
+@"cstring#12" = private unnamed_addr constant [ ?? x i8 ] c"efg\00", align 8
+@"string#13" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
+@"string#14" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#6" to i64 ) }, align 8
+@"string#15" = private unnamed_addr constant {i64, i64} { i64 8, i64 ptrtoint( ptr @"cstring#7" to i64 ) }, align 8
+@"string#16" = private unnamed_addr constant {i64, i64} { i64 9, i64 ptrtoint( ptr @"cstring#8" to i64 ) }, align 8
+@"string#17" = private unnamed_addr constant {i64, i64} { i64 12, i64 ptrtoint( ptr @"cstring#9" to i64 ) }, align 8
+@"string#18" = private unnamed_addr constant {i64, i64} { i64 26, i64 ptrtoint( ptr @"cstring#10" to i64 ) }, align 8
+@"string#19" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#11" to i64 ) }, align 8
+@"string#20" = private unnamed_addr constant {i64, i64} { i64 3, i64 ptrtoint( ptr @"cstring#12" to i64 ) }, align 8
 
 declare external fastcc i64 @"wybe.range...<0>"(i64, i64)
 declare external fastcc i64 @"wybe.range.construct<0>"(i64, i64, i64)
@@ -233,86 +213,70 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"string.<0>"() {
-  call ccc void @print_string(i64 ptrtoint( ptr @"cstring#5" to i64 ))
+  call ccc void @print_string(i64 ptrtoint( ptr @"cstring#4" to i64 ))
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#15" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 0)
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#16" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1415)
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#18" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#0##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 ptrtoint( ptr @"string#18" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#0##0")
-  call ccc void @putchar(i8 10)
-  %"tmp#111##0" = zext i8 97 to i64
-  %"tmp#112##0" = shl i64 %"tmp#111##0", 2
-  %"tmp#113##0" = or i64 %"tmp#112##0", 1024
-  %"tmp#1##0" = or i64 %"tmp#113##0", 3
-  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#1##0")
-  call ccc void @putchar(i8 10)
-  %"tmp#3##0" = tail call fastcc i64 @"wybe.range.construct<0>"(i64 1, i64 3, i64 100)
-  %"tmp#2##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#20" to i64 ), i64 %"tmp#3##0")
+  %"tmp#2##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 ptrtoint( ptr @"string#14" to i64 ))
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
-  %"tmp#5##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#20" to i64 ), i64 %"tmp#3##0")
-  %"tmp#7##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 1, i64 3)
-  %"tmp#4##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 %"tmp#5##0", i64 %"tmp#7##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1415)
+  call ccc void @putchar(i8 10)
+  %"tmp#5##0" = tail call fastcc i64 @"wybe.range.construct<0>"(i64 1, i64 3, i64 100)
+  %"tmp#4##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#16" to i64 ), i64 %"tmp#5##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
-  call ccc void @print_string(i64 ptrtoint( ptr @"cstring#1" to i64 ))
+  %"tmp#7##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#16" to i64 ), i64 %"tmp#5##0")
+  %"tmp#9##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 1, i64 3)
+  %"tmp#6##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 %"tmp#7##0", i64 %"tmp#9##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#6##0")
   call ccc void @putchar(i8 10)
-  %"tmp#72##0" = zext i8 100 to i64
-  %"tmp#73##0" = shl i64 %"tmp#72##0", 2
-  %"tmp#74##0" = or i64 %"tmp#73##0", 1024
-  %"tmp#10##0" = or i64 %"tmp#74##0", 3
-  %"tmp#12##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 1, i64 2)
-  %"tmp#11##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#24" to i64 ), i64 %"tmp#12##0")
-  %"tmp#9##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#10##0", i64 %"tmp#11##0")
-  %"tmp#8##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 %"tmp#9##0")
-  %"r##0" = tail call fastcc i64 @"wybe.string.c_string<0>"(i64 %"tmp#8##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#8##0")
+  call ccc void @print_string(i64 ptrtoint( ptr @"cstring#0" to i64 ))
+  call ccc void @putchar(i8 10)
+  %"tmp#14##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 1, i64 2)
+  %"tmp#13##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#20" to i64 ), i64 %"tmp#14##0")
+  %"tmp#11##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1427, i64 %"tmp#13##0")
+  %"tmp#10##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 %"tmp#11##0")
+  %"r##0" = tail call fastcc i64 @"wybe.string.c_string<0>"(i64 %"tmp#10##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#10##0")
   call ccc void @putchar(i8 32)
   call ccc void @print_string(i64 %"r##0")
   call ccc void @putchar(i8 10)
-  call ccc void @print_string(i64 ptrtoint( ptr @"cstring#3" to i64 ))
-  call ccc void @putchar(i8 10)
-  tail call fastcc void @"string.print_loop#cont#1<0>"(i64 ptrtoint( ptr @"string#18" to i64 ))
-  %"tmp#14##0" = tail call fastcc i64 @"wybe.range.irange<0>"(i64 10, i64 -1, i64 1)
-  %"tmp#13##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#21" to i64 ), i64 %"tmp#14##0")
-  tail call fastcc void @"string.print_loop#cont#1<0>[410bae77d3]"(i64 %"tmp#13##0")
   call ccc void @print_string(i64 ptrtoint( ptr @"cstring#2" to i64 ))
   call ccc void @putchar(i8 10)
-  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 0)
-  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 1)
-  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#22" to i64 ), i64 25)
-  %"tmp#15##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#17" to i64 ), i64 ptrtoint( ptr @"string#23" to i64 ))
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#15##0", i64 1)
-  %"tmp#16##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#17" to i64 ), i64 ptrtoint( ptr @"string#23" to i64 ))
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#16##0", i64 2)
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#1##0", i64 0)
-  %"tmp#19##0" = tail call fastcc i64 @"wybe.range.construct<0>"(i64 0, i64 2, i64 10)
-  %"tmp#18##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#19" to i64 ), i64 %"tmp#19##0")
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#18##0", i64 0)
-  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 3)
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#1##0", i64 3)
-  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 -3)
-  %"tmp#21##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 %"tmp#19##0")
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#21##0", i64 2)
-  %"tmp#23##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 %"tmp#1##0")
+  tail call fastcc void @"string.print_loop#cont#1<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
+  %"tmp#16##0" = tail call fastcc i64 @"wybe.range.irange<0>"(i64 10, i64 -1, i64 1)
+  %"tmp#15##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#17" to i64 ), i64 %"tmp#16##0")
+  tail call fastcc void @"string.print_loop#cont#1<0>[410bae77d3]"(i64 %"tmp#15##0")
+  call ccc void @print_string(i64 ptrtoint( ptr @"cstring#1" to i64 ))
+  call ccc void @putchar(i8 10)
+  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 0)
+  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 1)
+  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 25)
+  %"tmp#17##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#13" to i64 ), i64 ptrtoint( ptr @"string#19" to i64 ))
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#17##0", i64 1)
+  %"tmp#18##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#13" to i64 ), i64 ptrtoint( ptr @"string#19" to i64 ))
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#18##0", i64 2)
+  tail call fastcc void @"string.test_index<0>"(i64 1415, i64 0)
+  %"tmp#21##0" = tail call fastcc i64 @"wybe.range.construct<0>"(i64 0, i64 2, i64 10)
+  %"tmp#20##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#15" to i64 ), i64 %"tmp#21##0")
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#20##0", i64 0)
+  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 3)
+  tail call fastcc void @"string.test_index<0>"(i64 1415, i64 3)
+  tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 -3)
+  %"tmp#23##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 %"tmp#21##0")
   tail call fastcc void @"string.test_index<0>"(i64 %"tmp#23##0", i64 2)
-  %"tmp#115##0" = zext i8 98 to i64
-  %"tmp#116##0" = shl i64 %"tmp#115##0", 2
-  %"tmp#117##0" = or i64 %"tmp#116##0", 1024
-  %"tmp#29##0" = or i64 %"tmp#117##0", 3
-  %"tmp#119##0" = zext i8 99 to i64
-  %"tmp#120##0" = shl i64 %"tmp#119##0", 2
-  %"tmp#121##0" = or i64 %"tmp#120##0", 1024
-  %"tmp#30##0" = or i64 %"tmp#121##0", 3
-  %"tmp#28##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#29##0", i64 %"tmp#30##0")
-  %"tmp#26##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#1##0", i64 %"tmp#28##0")
-  %"tmp#31##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 0, i64 2)
-  %"tmp#25##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 %"tmp#26##0", i64 %"tmp#31##0")
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#25##0", i64 1)
+  %"tmp#25##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 1415)
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#25##0", i64 2)
+  %"tmp#30##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1419, i64 1423)
+  %"tmp#28##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1415, i64 %"tmp#30##0")
+  %"tmp#33##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 0, i64 2)
+  %"tmp#27##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 %"tmp#28##0", i64 %"tmp#33##0")
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#27##0", i64 1)
   ret void
 }
 
@@ -361,7 +325,7 @@ if.then.0:
   call ccc void @putchar(i8 10)
   ret void
 if.else.0:
-  call ccc void @print_string(i64 ptrtoint( ptr @"cstring#4" to i64 ))
+  call ccc void @print_string(i64 ptrtoint( ptr @"cstring#3" to i64 ))
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -17,15 +17,15 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(64,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(65,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(67,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(68,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(70,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(72,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(74,(string.print_loop#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#35##0:wybe.phantom) @string:nn:nn
-    foreign c print_string(c"TESTING CONSTRUCTION":wybe.c_string, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#36##0:wybe.phantom, ?tmp#37##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#37##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #64 @string:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#39##0:wybe.phantom) @string:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#39##0:wybe.phantom, ?tmp#40##0:wybe.phantom) @string:nn:nn
-    foreign lpvm store(~%tmp#40##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+  MultiSpeczDepInfo: [(63,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(65,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(67,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(68,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(70,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(72,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(74,(string.print_loop#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @string:nn:nn
+    foreign c print_string(c"TESTING CONSTRUCTION":wybe.c_string, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#35##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
+    wybe.string.print<0>[410bae77d3](0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #63 @string:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @string:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @string:nn:nn
+    foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
     wybe.string.print<0>[410bae77d3](1415:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #65 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#46##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#46##0:wybe.phantom, ?tmp#47##0:wybe.phantom) @string:nn:nn
@@ -34,8 +34,8 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#49##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#49##0:wybe.phantom, ?tmp#50##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#50##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.string.,,<0>("abc":wybe.string, "abc":wybe.string, ?tmp#2##0:wybe.string) #6 @string:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #67 @string:nn:nn
+    wybe.string.,,<0>("abc":wybe.string, "abc":wybe.string, ?tmp#0##0:wybe.string) #4 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #67 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#52##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#52##0:wybe.phantom, ?tmp#53##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#53##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
@@ -43,27 +43,27 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#59##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#59##0:wybe.phantom, ?tmp#60##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#60##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.range.construct<0>(1:wybe.int, 3:wybe.int, 100:wybe.int, ?tmp#5##0:wybe.range) #69 @string:nn:nn
-    wybe.string.[]<1>("abcdefghi":wybe.string, tmp#5##0:wybe.range, ?tmp#4##0:wybe.string) #11 @string:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #70 @string:nn:nn
+    wybe.range.construct<0>(1:wybe.int, 3:wybe.int, 100:wybe.int, ?tmp#3##0:wybe.range) #69 @string:nn:nn
+    wybe.string.[]<1>("abcdefghi":wybe.string, tmp#3##0:wybe.range, ?tmp#2##0:wybe.string) #9 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #70 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#65##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#65##0:wybe.phantom, ?tmp#66##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#66##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.string.[]<1>("abcdefghi":wybe.string, ~tmp#5##0:wybe.range, ?tmp#7##0:wybe.string) #14 @string:nn:nn
-    wybe.range...<0>(1:wybe.int, 3:wybe.int, ?tmp#9##0:wybe.range) #15 @string:nn:nn
-    wybe.string.[]<1>(~tmp#7##0:wybe.string, ~tmp#9##0:wybe.range, ?tmp#6##0:wybe.string) #16 @string:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #72 @string:nn:nn
+    wybe.string.[]<1>("abcdefghi":wybe.string, ~tmp#3##0:wybe.range, ?tmp#5##0:wybe.string) #12 @string:nn:nn
+    wybe.range...<0>(1:wybe.int, 3:wybe.int, ?tmp#7##0:wybe.range) #13 @string:nn:nn
+    wybe.string.[]<1>(~tmp#5##0:wybe.string, ~tmp#7##0:wybe.range, ?tmp#4##0:wybe.string) #14 @string:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #72 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#71##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#71##0:wybe.phantom, ?tmp#72##0:wybe.phantom) @string:nn:nn
     foreign c print_string(c"\nTESTING CONVERSION TO c_string":wybe.c_string, ~tmp#72##0:wybe.phantom, ?tmp#75##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#75##0:wybe.phantom, ?tmp#76##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#76##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    wybe.range...<0>(1:wybe.int, 2:wybe.int, ?tmp#14##0:wybe.range) #20 @string:nn:nn
-    wybe.string.[]<1>("efg":wybe.string, ~tmp#14##0:wybe.range, ?tmp#13##0:wybe.string) #21 @string:nn:nn
-    wybe.string.,,<0>(1427:wybe.string, ~tmp#13##0:wybe.string, ?tmp#11##0:wybe.string) #22 @string:nn:nn
-    wybe.string.,,<0>("abc":wybe.string, ~tmp#11##0:wybe.string, ?tmp#10##0:wybe.string) #23 @string:nn:nn
-    wybe.string.c_string<0>(tmp#10##0:wybe.string, ?r##0:wybe.c_string) #24 @string:nn:nn
-    wybe.string.print<0>(~tmp#10##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #25 @string:nn:nn
+    wybe.range...<0>(1:wybe.int, 2:wybe.int, ?tmp#12##0:wybe.range) #18 @string:nn:nn
+    wybe.string.[]<1>("efg":wybe.string, ~tmp#12##0:wybe.range, ?tmp#11##0:wybe.string) #19 @string:nn:nn
+    wybe.string.,,<0>(1427:wybe.string, ~tmp#11##0:wybe.string, ?tmp#9##0:wybe.string) #20 @string:nn:nn
+    wybe.string.,,<0>("abc":wybe.string, ~tmp#9##0:wybe.string, ?tmp#8##0:wybe.string) #21 @string:nn:nn
+    wybe.string.c_string<0>(tmp#8##0:wybe.string, ?r##0:wybe.c_string) #22 @string:nn:nn
+    wybe.string.print<0>(~tmp#8##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#82##0:wybe.phantom) @string:nn:nn
     foreign c putchar(' ':wybe.char, ~tmp#82##0:wybe.phantom, ?tmp#83##0:wybe.phantom) @string:nn:nn
     foreign c print_string(~r##0:wybe.c_string, ~tmp#83##0:wybe.phantom, ?tmp#86##0:wybe.phantom) @string:nn:nn
@@ -72,36 +72,36 @@ module top-level code > public {semipure} (0 calls)
     foreign c putchar('\n':wybe.char, ~tmp#90##0:wybe.phantom, ?tmp#91##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#91##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
     string.print_loop#cont#1<0>("abc":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #73 @string:nn:nn
-    wybe.range.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#16##0:wybe.range) #30 @string:nn:nn
-    wybe.string.[]<1>("abcdefghijkl":wybe.string, ~tmp#16##0:wybe.range, ?tmp#15##0:wybe.string) #31 @string:nn:nn
-    string.print_loop#cont#1<0>[410bae77d3](~tmp#15##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #74 @string:nn:nn
+    wybe.range.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.range) #28 @string:nn:nn
+    wybe.string.[]<1>("abcdefghijkl":wybe.string, ~tmp#14##0:wybe.range, ?tmp#13##0:wybe.string) #29 @string:nn:nn
+    string.print_loop#cont#1<0>[410bae77d3](~tmp#13##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #74 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#95##0:wybe.phantom) @string:nn:nn
     foreign c print_string(c"\nTESTING INDEXING":wybe.c_string, ~tmp#95##0:wybe.phantom, ?tmp#96##0:wybe.phantom) @string:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#96##0:wybe.phantom, ?tmp#97##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#97##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
-    string.test_index<0>("abc":wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @string:nn:nn
-    string.test_index<0>("abc":wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #35 @string:nn:nn
-    string.test_index<0>("abcdefghijklmnopqrstuvwxyz":wybe.string, 25:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #36 @string:nn:nn
-    wybe.string.,,<0>("ab":wybe.string, "cd":wybe.string, ?tmp#17##0:wybe.string) #37 @string:nn:nn
-    string.test_index<0>(~tmp#17##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #38 @string:nn:nn
-    wybe.string.,,<0>("ab":wybe.string, "cd":wybe.string, ?tmp#18##0:wybe.string) #39 @string:nn:nn
-    string.test_index<0>(~tmp#18##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #40 @string:nn:nn
-    string.test_index<0>(1415:wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #42 @string:nn:nn
-    wybe.range.construct<0>(0:wybe.int, 2:wybe.int, 10:wybe.int, ?tmp#21##0:wybe.range) #75 @string:nn:nn
-    wybe.string.[]<1>("abcdefgh":wybe.string, tmp#21##0:wybe.range, ?tmp#20##0:wybe.string) #44 @string:nn:nn
-    string.test_index<0>(~tmp#20##0:wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #45 @string:nn:nn
-    string.test_index<0>("abc":wybe.string, 3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #46 @string:nn:nn
-    string.test_index<0>(1415:wybe.string, 3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #48 @string:nn:nn
-    string.test_index<0>("abc":wybe.string, -3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #49 @string:nn:nn
-    wybe.string.[]<1>("abc":wybe.string, ~tmp#21##0:wybe.range, ?tmp#23##0:wybe.string) #51 @string:nn:nn
-    string.test_index<0>(~tmp#23##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #52 @string:nn:nn
-    wybe.string.,,<0>("abc":wybe.string, 1415:wybe.string, ?tmp#25##0:wybe.string) #54 @string:nn:nn
-    string.test_index<0>(~tmp#25##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #55 @string:nn:nn
-    wybe.string.,,<0>(1419:wybe.string, 1423:wybe.string, ?tmp#30##0:wybe.string) #59 @string:nn:nn
-    wybe.string.,,<0>(1415:wybe.string, ~tmp#30##0:wybe.string, ?tmp#28##0:wybe.string) #60 @string:nn:nn
-    wybe.range...<0>(0:wybe.int, 2:wybe.int, ?tmp#33##0:wybe.range) #61 @string:nn:nn
-    wybe.string.[]<1>(~tmp#28##0:wybe.string, ~tmp#33##0:wybe.range, ?tmp#27##0:wybe.string) #62 @string:nn:nn
-    string.test_index<0>(~tmp#27##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #63 @string:nn:nn
+    string.test_index<0>("abc":wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @string:nn:nn
+    string.test_index<0>("abc":wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @string:nn:nn
+    string.test_index<0>("abcdefghijklmnopqrstuvwxyz":wybe.string, 25:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #34 @string:nn:nn
+    wybe.string.,,<0>("ab":wybe.string, "cd":wybe.string, ?tmp#15##0:wybe.string) #35 @string:nn:nn
+    string.test_index<0>(~tmp#15##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #36 @string:nn:nn
+    wybe.string.,,<0>("ab":wybe.string, "cd":wybe.string, ?tmp#16##0:wybe.string) #37 @string:nn:nn
+    string.test_index<0>(~tmp#16##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #38 @string:nn:nn
+    string.test_index<0>(1415:wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #40 @string:nn:nn
+    wybe.range.construct<0>(0:wybe.int, 2:wybe.int, 10:wybe.int, ?tmp#19##0:wybe.range) #75 @string:nn:nn
+    wybe.string.[]<1>("abcdefgh":wybe.string, tmp#19##0:wybe.range, ?tmp#18##0:wybe.string) #42 @string:nn:nn
+    string.test_index<0>(~tmp#18##0:wybe.string, 0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #43 @string:nn:nn
+    string.test_index<0>("abc":wybe.string, 3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #44 @string:nn:nn
+    string.test_index<0>(1415:wybe.string, 3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #46 @string:nn:nn
+    string.test_index<0>("abc":wybe.string, -3:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #47 @string:nn:nn
+    wybe.string.[]<1>("abc":wybe.string, ~tmp#19##0:wybe.range, ?tmp#21##0:wybe.string) #49 @string:nn:nn
+    string.test_index<0>(~tmp#21##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #50 @string:nn:nn
+    wybe.string.,,<0>("abc":wybe.string, 1415:wybe.string, ?tmp#23##0:wybe.string) #52 @string:nn:nn
+    string.test_index<0>(~tmp#23##0:wybe.string, 2:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #53 @string:nn:nn
+    wybe.string.,,<0>(1419:wybe.string, 1423:wybe.string, ?tmp#28##0:wybe.string) #57 @string:nn:nn
+    wybe.string.,,<0>(1415:wybe.string, ~tmp#28##0:wybe.string, ?tmp#26##0:wybe.string) #58 @string:nn:nn
+    wybe.range...<0>(0:wybe.int, 2:wybe.int, ?tmp#31##0:wybe.range) #59 @string:nn:nn
+    wybe.string.[]<1>(~tmp#26##0:wybe.string, ~tmp#31##0:wybe.range, ?tmp#25##0:wybe.string) #60 @string:nn:nn
+    string.test_index<0>(~tmp#25##0:wybe.string, 1:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #61 @string:nn:nn
 
 
 proc print_loop > {inline} (2 calls)
@@ -221,62 +221,62 @@ define external fastcc void @"string.<0>"() {
   call ccc void @putchar(i8 10)
   tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#2##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 ptrtoint( ptr @"string#14" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#2##0")
+  %"tmp#0##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 ptrtoint( ptr @"string#14" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1415)
   call ccc void @putchar(i8 10)
-  %"tmp#5##0" = tail call fastcc i64 @"wybe.range.construct<0>"(i64 1, i64 3, i64 100)
-  %"tmp#4##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#16" to i64 ), i64 %"tmp#5##0")
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#4##0")
+  %"tmp#3##0" = tail call fastcc i64 @"wybe.range.construct<0>"(i64 1, i64 3, i64 100)
+  %"tmp#2##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#16" to i64 ), i64 %"tmp#3##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
-  %"tmp#7##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#16" to i64 ), i64 %"tmp#5##0")
-  %"tmp#9##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 1, i64 3)
-  %"tmp#6##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 %"tmp#7##0", i64 %"tmp#9##0")
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#6##0")
+  %"tmp#5##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#16" to i64 ), i64 %"tmp#3##0")
+  %"tmp#7##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 1, i64 3)
+  %"tmp#4##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 %"tmp#5##0", i64 %"tmp#7##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
   call ccc void @print_string(i64 ptrtoint( ptr @"cstring#0" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#14##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 1, i64 2)
-  %"tmp#13##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#20" to i64 ), i64 %"tmp#14##0")
-  %"tmp#11##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1427, i64 %"tmp#13##0")
-  %"tmp#10##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 %"tmp#11##0")
-  %"r##0" = tail call fastcc i64 @"wybe.string.c_string<0>"(i64 %"tmp#10##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#10##0")
+  %"tmp#12##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 1, i64 2)
+  %"tmp#11##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#20" to i64 ), i64 %"tmp#12##0")
+  %"tmp#9##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1427, i64 %"tmp#11##0")
+  %"tmp#8##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 %"tmp#9##0")
+  %"r##0" = tail call fastcc i64 @"wybe.string.c_string<0>"(i64 %"tmp#8##0")
+  tail call fastcc void @"wybe.string.print<0>"(i64 %"tmp#8##0")
   call ccc void @putchar(i8 32)
   call ccc void @print_string(i64 %"r##0")
   call ccc void @putchar(i8 10)
   call ccc void @print_string(i64 ptrtoint( ptr @"cstring#2" to i64 ))
   call ccc void @putchar(i8 10)
   tail call fastcc void @"string.print_loop#cont#1<0>"(i64 ptrtoint( ptr @"string#14" to i64 ))
-  %"tmp#16##0" = tail call fastcc i64 @"wybe.range.irange<0>"(i64 10, i64 -1, i64 1)
-  %"tmp#15##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#17" to i64 ), i64 %"tmp#16##0")
-  tail call fastcc void @"string.print_loop#cont#1<0>[410bae77d3]"(i64 %"tmp#15##0")
+  %"tmp#14##0" = tail call fastcc i64 @"wybe.range.irange<0>"(i64 10, i64 -1, i64 1)
+  %"tmp#13##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#17" to i64 ), i64 %"tmp#14##0")
+  tail call fastcc void @"string.print_loop#cont#1<0>[410bae77d3]"(i64 %"tmp#13##0")
   call ccc void @print_string(i64 ptrtoint( ptr @"cstring#1" to i64 ))
   call ccc void @putchar(i8 10)
   tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 0)
   tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 1)
   tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#18" to i64 ), i64 25)
-  %"tmp#17##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#13" to i64 ), i64 ptrtoint( ptr @"string#19" to i64 ))
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#17##0", i64 1)
-  %"tmp#18##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#13" to i64 ), i64 ptrtoint( ptr @"string#19" to i64 ))
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#18##0", i64 2)
+  %"tmp#15##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#13" to i64 ), i64 ptrtoint( ptr @"string#19" to i64 ))
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#15##0", i64 1)
+  %"tmp#16##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#13" to i64 ), i64 ptrtoint( ptr @"string#19" to i64 ))
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#16##0", i64 2)
   tail call fastcc void @"string.test_index<0>"(i64 1415, i64 0)
-  %"tmp#21##0" = tail call fastcc i64 @"wybe.range.construct<0>"(i64 0, i64 2, i64 10)
-  %"tmp#20##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#15" to i64 ), i64 %"tmp#21##0")
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#20##0", i64 0)
+  %"tmp#19##0" = tail call fastcc i64 @"wybe.range.construct<0>"(i64 0, i64 2, i64 10)
+  %"tmp#18##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#15" to i64 ), i64 %"tmp#19##0")
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#18##0", i64 0)
   tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 3)
   tail call fastcc void @"string.test_index<0>"(i64 1415, i64 3)
   tail call fastcc void @"string.test_index<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 -3)
-  %"tmp#23##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 %"tmp#21##0")
+  %"tmp#21##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 %"tmp#19##0")
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#21##0", i64 2)
+  %"tmp#23##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 1415)
   tail call fastcc void @"string.test_index<0>"(i64 %"tmp#23##0", i64 2)
-  %"tmp#25##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#14" to i64 ), i64 1415)
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#25##0", i64 2)
-  %"tmp#30##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1419, i64 1423)
-  %"tmp#28##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1415, i64 %"tmp#30##0")
-  %"tmp#33##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 0, i64 2)
-  %"tmp#27##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 %"tmp#28##0", i64 %"tmp#33##0")
-  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#27##0", i64 1)
+  %"tmp#28##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1419, i64 1423)
+  %"tmp#26##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 1415, i64 %"tmp#28##0")
+  %"tmp#31##0" = tail call fastcc i64 @"wybe.range...<0>"(i64 0, i64 2)
+  %"tmp#25##0" = tail call fastcc i64 @"wybe.string.[]<1>"(i64 %"tmp#26##0", i64 %"tmp#31##0")
+  tail call fastcc void @"string.test_index<0>"(i64 %"tmp#25##0", i64 1)
   ret void
 }
 

--- a/test-cases/final-dump/string_interpolation.exp
+++ b/test-cases/final-dump/string_interpolation.exp
@@ -17,30 +17,30 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(17,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(19,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(22,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    wybe.string.,,<0>("Wybe":wybe.string, "!":wybe.string, ?tmp#1##0:wybe.string) #1 @string_interpolation:nn:nn
-    wybe.string.,,<0>("Hello, ":wybe.string, ~tmp#1##0:wybe.string, ?tmp#0##0:wybe.string) #2 @string_interpolation:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #17 @string_interpolation:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @string_interpolation:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @string_interpolation:nn:nn
-    foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
-    wybe.int.fmt<2>(42:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#5##0:wybe.string) #18 @string_interpolation:nn:nn
-    wybe.string.,,<0>(~tmp#5##0:wybe.string, " is the answer":wybe.string, ?tmp#4##0:wybe.string) #6 @string_interpolation:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @string_interpolation:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @string_interpolation:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @string_interpolation:nn:nn
-    foreign lpvm store(~%tmp#23##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
-    foreign c ipow(2:wybe.int, 63:wybe.int, ?tmp#10##0:wybe.int) @string_interpolation:nn:nn
-    foreign llvm sub(tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @string_interpolation:nn:nn
-    wybe.int.fmt<2>(~tmp#9##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#8##0:wybe.string) #20 @string_interpolation:nn:nn
-    wybe.int.fmt<2>(~tmp#10##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#12##0:wybe.string) #21 @string_interpolation:nn:nn
-    wybe.string.,,<0>(" and minint is ":wybe.string, ~tmp#12##0:wybe.string, ?tmp#11##0:wybe.string) #13 @string_interpolation:nn:nn
-    wybe.string.,,<0>(~tmp#8##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#7##0:wybe.string) #14 @string_interpolation:nn:nn
-    wybe.string.,,<0>("maxint is ":wybe.string, ~tmp#7##0:wybe.string, ?tmp#6##0:wybe.string) #15 @string_interpolation:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #22 @string_interpolation:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @string_interpolation:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @string_interpolation:nn:nn
-    foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
+  MultiSpeczDepInfo: [(18,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(20,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(23,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+    wybe.string.,,<0>("Wybe":wybe.string, 1159:wybe.string, ?tmp#1##0:wybe.string) #2 @string_interpolation:nn:nn
+    wybe.string.,,<0>("Hello, ":wybe.string, ~tmp#1##0:wybe.string, ?tmp#0##0:wybe.string) #3 @string_interpolation:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #18 @string_interpolation:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @string_interpolation:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @string_interpolation:nn:nn
+    foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
+    wybe.int.fmt<2>(42:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#6##0:wybe.string) #19 @string_interpolation:nn:nn
+    wybe.string.,,<0>(~tmp#6##0:wybe.string, " is the answer":wybe.string, ?tmp#5##0:wybe.string) #7 @string_interpolation:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @string_interpolation:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @string_interpolation:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @string_interpolation:nn:nn
+    foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
+    foreign c ipow(2:wybe.int, 63:wybe.int, ?tmp#11##0:wybe.int) @string_interpolation:nn:nn
+    foreign llvm sub(tmp#11##0:wybe.int, 1:wybe.int, ?tmp#10##0:wybe.int) @string_interpolation:nn:nn
+    wybe.int.fmt<2>(~tmp#10##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#9##0:wybe.string) #21 @string_interpolation:nn:nn
+    wybe.int.fmt<2>(~tmp#11##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#13##0:wybe.string) #22 @string_interpolation:nn:nn
+    wybe.string.,,<0>(" and minint is ":wybe.string, ~tmp#13##0:wybe.string, ?tmp#12##0:wybe.string) #14 @string_interpolation:nn:nn
+    wybe.string.,,<0>(~tmp#9##0:wybe.string, ~tmp#12##0:wybe.string, ?tmp#8##0:wybe.string) #15 @string_interpolation:nn:nn
+    wybe.string.,,<0>("maxint is ":wybe.string, ~tmp#8##0:wybe.string, ?tmp#7##0:wybe.string) #16 @string_interpolation:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#7##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @string_interpolation:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @string_interpolation:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @string_interpolation:nn:nn
+    foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
 
   LLVM code       :
 
@@ -52,16 +52,14 @@ target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" and minint is \00", align 8
 @"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c" is the answer\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"!\00", align 8
-@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"Hello, \00", align 8
-@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"Wybe\00", align 8
-@"cstring#5" = private unnamed_addr constant [ ?? x i8 ] c"maxint is \00", align 8
-@"string#6" = private unnamed_addr constant {i64, i64} { i64 15, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#7" = private unnamed_addr constant {i64, i64} { i64 14, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#8" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
-@"string#9" = private unnamed_addr constant {i64, i64} { i64 7, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
-@"string#10" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
-@"string#11" = private unnamed_addr constant {i64, i64} { i64 10, i64 ptrtoint( ptr @"cstring#5" to i64 ) }, align 8
+@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c"Hello, \00", align 8
+@"cstring#3" = private unnamed_addr constant [ ?? x i8 ] c"Wybe\00", align 8
+@"cstring#4" = private unnamed_addr constant [ ?? x i8 ] c"maxint is \00", align 8
+@"string#5" = private unnamed_addr constant {i64, i64} { i64 15, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
+@"string#6" = private unnamed_addr constant {i64, i64} { i64 14, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
+@"string#7" = private unnamed_addr constant {i64, i64} { i64 7, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#8" = private unnamed_addr constant {i64, i64} { i64 4, i64 ptrtoint( ptr @"cstring#3" to i64 ) }, align 8
+@"string#9" = private unnamed_addr constant {i64, i64} { i64 10, i64 ptrtoint( ptr @"cstring#4" to i64 ) }, align 8
 
 declare external fastcc i64 @"wybe.int.fmt<2>"(i64, i64, i8)
 declare external fastcc i64 @"wybe.string.,,<0>"(i64, i64)
@@ -71,22 +69,22 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"string_interpolation.<0>"() {
-  %"tmp#1##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#10" to i64 ), i64 ptrtoint( ptr @"string#8" to i64 ))
-  %"tmp#0##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#9" to i64 ), i64 %"tmp#1##0")
+  %"tmp#1##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#8" to i64 ), i64 1159)
+  %"tmp#0##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#7" to i64 ), i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
-  %"tmp#5##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 42, i64 0, i8 32)
-  %"tmp#4##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#5##0", i64 ptrtoint( ptr @"string#7" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#4##0")
+  %"tmp#6##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 42, i64 0, i8 32)
+  %"tmp#5##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#6##0", i64 ptrtoint( ptr @"string#6" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#5##0")
   call ccc void @putchar(i8 10)
-  %"tmp#10##0" = call ccc i64 @ipow(i64 2, i64 63)
-  %"tmp#9##0" = sub i64 %"tmp#10##0", 1
-  %"tmp#8##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 %"tmp#9##0", i64 0, i8 32)
-  %"tmp#12##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 %"tmp#10##0", i64 0, i8 32)
-  %"tmp#11##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#6" to i64 ), i64 %"tmp#12##0")
-  %"tmp#7##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#8##0", i64 %"tmp#11##0")
-  %"tmp#6##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#11" to i64 ), i64 %"tmp#7##0")
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#6##0")
+  %"tmp#11##0" = call ccc i64 @ipow(i64 2, i64 63)
+  %"tmp#10##0" = sub i64 %"tmp#11##0", 1
+  %"tmp#9##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 %"tmp#10##0", i64 0, i8 32)
+  %"tmp#13##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 %"tmp#11##0", i64 0, i8 32)
+  %"tmp#12##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#5" to i64 ), i64 %"tmp#13##0")
+  %"tmp#8##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#9##0", i64 %"tmp#12##0")
+  %"tmp#7##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#9" to i64 ), i64 %"tmp#8##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#7##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/string_interpolation.exp
+++ b/test-cases/final-dump/string_interpolation.exp
@@ -18,26 +18,26 @@ module top-level code > public {semipure} (0 calls)
   AliasPairs: []
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(18,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(20,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(23,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
-    wybe.string.,,<0>("Wybe":wybe.string, 1159:wybe.string, ?tmp#1##0:wybe.string) #2 @string_interpolation:nn:nn
-    wybe.string.,,<0>("Hello, ":wybe.string, ~tmp#1##0:wybe.string, ?tmp#0##0:wybe.string) #3 @string_interpolation:nn:nn
+    wybe.string.,,<0>("Wybe":wybe.string, 1159:wybe.string, ?tmp#1##0:wybe.string) #1 @string_interpolation:nn:nn
+    wybe.string.,,<0>("Hello, ":wybe.string, ~tmp#1##0:wybe.string, ?tmp#0##0:wybe.string) #2 @string_interpolation:nn:nn
     wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #18 @string_interpolation:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @string_interpolation:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @string_interpolation:nn:nn
     foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
-    wybe.int.fmt<2>(42:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#6##0:wybe.string) #19 @string_interpolation:nn:nn
-    wybe.string.,,<0>(~tmp#6##0:wybe.string, " is the answer":wybe.string, ?tmp#5##0:wybe.string) #7 @string_interpolation:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @string_interpolation:nn:nn
+    wybe.int.fmt<2>(42:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#5##0:wybe.string) #19 @string_interpolation:nn:nn
+    wybe.string.,,<0>(~tmp#5##0:wybe.string, " is the answer":wybe.string, ?tmp#4##0:wybe.string) #6 @string_interpolation:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @string_interpolation:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @string_interpolation:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @string_interpolation:nn:nn
     foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
-    foreign c ipow(2:wybe.int, 63:wybe.int, ?tmp#11##0:wybe.int) @string_interpolation:nn:nn
-    foreign llvm sub(tmp#11##0:wybe.int, 1:wybe.int, ?tmp#10##0:wybe.int) @string_interpolation:nn:nn
-    wybe.int.fmt<2>(~tmp#10##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#9##0:wybe.string) #21 @string_interpolation:nn:nn
-    wybe.int.fmt<2>(~tmp#11##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#13##0:wybe.string) #22 @string_interpolation:nn:nn
-    wybe.string.,,<0>(" and minint is ":wybe.string, ~tmp#13##0:wybe.string, ?tmp#12##0:wybe.string) #14 @string_interpolation:nn:nn
-    wybe.string.,,<0>(~tmp#9##0:wybe.string, ~tmp#12##0:wybe.string, ?tmp#8##0:wybe.string) #15 @string_interpolation:nn:nn
-    wybe.string.,,<0>("maxint is ":wybe.string, ~tmp#8##0:wybe.string, ?tmp#7##0:wybe.string) #16 @string_interpolation:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#7##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @string_interpolation:nn:nn
+    foreign c ipow(2:wybe.int, 63:wybe.int, ?tmp#10##0:wybe.int) @string_interpolation:nn:nn
+    foreign llvm sub(tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @string_interpolation:nn:nn
+    wybe.int.fmt<2>(~tmp#9##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#8##0:wybe.string) #21 @string_interpolation:nn:nn
+    wybe.int.fmt<2>(~tmp#10##0:wybe.int, 0:wybe.int, ' ':wybe.char, ?tmp#12##0:wybe.string) #22 @string_interpolation:nn:nn
+    wybe.string.,,<0>(" and minint is ":wybe.string, ~tmp#12##0:wybe.string, ?tmp#11##0:wybe.string) #13 @string_interpolation:nn:nn
+    wybe.string.,,<0>(~tmp#8##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#7##0:wybe.string) #14 @string_interpolation:nn:nn
+    wybe.string.,,<0>("maxint is ":wybe.string, ~tmp#7##0:wybe.string, ?tmp#6##0:wybe.string) #15 @string_interpolation:nn:nn
+    wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #23 @string_interpolation:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @string_interpolation:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @string_interpolation:nn:nn
     foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
@@ -73,18 +73,18 @@ define external fastcc void @"string_interpolation.<0>"() {
   %"tmp#0##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#7" to i64 ), i64 %"tmp#1##0")
   tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
-  %"tmp#6##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 42, i64 0, i8 32)
-  %"tmp#5##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#6##0", i64 ptrtoint( ptr @"string#6" to i64 ))
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#5##0")
+  %"tmp#5##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 42, i64 0, i8 32)
+  %"tmp#4##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#5##0", i64 ptrtoint( ptr @"string#6" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
-  %"tmp#11##0" = call ccc i64 @ipow(i64 2, i64 63)
-  %"tmp#10##0" = sub i64 %"tmp#11##0", 1
-  %"tmp#9##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 %"tmp#10##0", i64 0, i8 32)
-  %"tmp#13##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 %"tmp#11##0", i64 0, i8 32)
-  %"tmp#12##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#5" to i64 ), i64 %"tmp#13##0")
-  %"tmp#8##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#9##0", i64 %"tmp#12##0")
-  %"tmp#7##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#9" to i64 ), i64 %"tmp#8##0")
-  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#7##0")
+  %"tmp#10##0" = call ccc i64 @ipow(i64 2, i64 63)
+  %"tmp#9##0" = sub i64 %"tmp#10##0", 1
+  %"tmp#8##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 %"tmp#9##0", i64 0, i8 32)
+  %"tmp#12##0" = tail call fastcc i64 @"wybe.int.fmt<2>"(i64 %"tmp#10##0", i64 0, i8 32)
+  %"tmp#11##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#5" to i64 ), i64 %"tmp#12##0")
+  %"tmp#7##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 %"tmp#8##0", i64 %"tmp#11##0")
+  %"tmp#6##0" = tail call fastcc i64 @"wybe.string.,,<0>"(i64 ptrtoint( ptr @"string#9" to i64 ), i64 %"tmp#7##0")
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 %"tmp#6##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/syntax_error.exp
+++ b/test-cases/final-dump/syntax_error.exp
@@ -1,3 +1,2 @@
 Error detected during loading module: syntax_error
-[91mfinal-dump/syntax_error.wybe:1:10: Syntax error: unexpected newline
-[0m
+final-dump/syntax_error.wybe:1:10: Syntax error: unexpected newline

--- a/test-cases/final-dump/type_ambig.exp
+++ b/test-cases/final-dump/type_ambig.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) type_ambig
-[91mfinal-dump/type_ambig.wybe:1:25: Ambiguous overloading: call could refer to:
+final-dump/type_ambig.wybe:1:25: Ambiguous overloading: call could refer to:
     wybe.string.print<0>
     wybe.int.print<0>
     wybe.float.print<0>
@@ -7,4 +7,3 @@ Error detected during type checking of module(s) type_ambig
     wybe.char.print<0>
     wybe.c_string.print<0>
     wybe.bool.print<0>
-[0m

--- a/test-cases/final-dump/type_change.exp
+++ b/test-cases/final-dump/type_change.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) type_change
-[91mfinal-dump/type_change.wybe:4:2: Type error in call to proc =, argument 1
-[0m[91mfinal-dump/type_change.wybe:4:2: Type error in call to proc =, argument 2
-[0m[91mfinal-dump/type_change.wybe:4:2: Type of 1.0 incompatible with ?x
-[0m
+final-dump/type_change.wybe:4:2: Type error in call to proc =, argument 1
+final-dump/type_change.wybe:4:2: Type error in call to proc =, argument 2
+final-dump/type_change.wybe:4:2: Type of 1.0 incompatible with ?x

--- a/test-cases/final-dump/type_error.exp
+++ b/test-cases/final-dump/type_error.exp
@@ -1,4 +1,3 @@
 Error detected during type checking of module(s) type_error
-[91mfinal-dump/type_error.wybe:1:30: Type error in call to proc *, argument 1
-[0m[91mfinal-dump/type_error.wybe:1:30: Type error in call to proc *, argument 2
-[0m
+final-dump/type_error.wybe:1:30: Type error in call to proc *, argument 1
+final-dump/type_error.wybe:1:30: Type error in call to proc *, argument 2

--- a/test-cases/final-dump/type_error2.exp
+++ b/test-cases/final-dump/type_error2.exp
@@ -1,3 +1,2 @@
 Error detected during final normalisation of module(s) type_error2, type_error2.foo
-[91mfinal-dump/type_error2.wybe:1:16: In constructor parameter, unknown type notatype
-[0m
+final-dump/type_error2.wybe:1:16: In constructor parameter, unknown type notatype

--- a/test-cases/final-dump/unbound_after_for.exp
+++ b/test-cases/final-dump/unbound_after_for.exp
@@ -1,3 +1,2 @@
 Error detected during type checking of module(s) unbound_after_for
-[91mfinal-dump/unbound_after_for.wybe:2:2: Uninitialised argument in call to proc println, argument 1
-[0m
+final-dump/unbound_after_for.wybe:2:2: Uninitialised argument in call to proc println, argument 1

--- a/test-cases/final-dump/unexported_type_overload.exp
+++ b/test-cases/final-dump/unexported_type_overload.exp
@@ -1,3 +1,2 @@
 Error detected during checking parameter type declarations in module(s) unexported_type_overload, unexported_type_overload.sub, unexported_type_overload.sub.hidden
-[91mfinal-dump/unexported_type_overload.wybe:8:5: Public proc proc2 with undeclared parameter or return type
-[0m
+final-dump/unexported_type_overload.wybe:8:5: Public proc proc2 with undeclared parameter or return type

--- a/test-cases/final-dump/unique_cond_error.exp
+++ b/test-cases/final-dump/unique_cond_error.exp
@@ -1,3 +1,2 @@
 Error detected during uniqueness checking of module(s) unique_cond_error
-[91mfinal-dump/unique_cond_error.wybe:11:9: Reuse of unique variable a:unique_cond_error
-[0m
+final-dump/unique_cond_error.wybe:11:9: Reuse of unique variable a:unique_cond_error

--- a/test-cases/final-dump/unique_generic.exp
+++ b/test-cases/final-dump/unique_generic.exp
@@ -1,10 +1,9 @@
 Error detected during uniqueness checking of module(s) unique_generic, unique_generic.u
-[91mfinal-dump/unique_generic.wybe:7:8: Call to wybe.list.[|] binds type variable T to unique type unique_generic.u
-[0m[91mfinal-dump/unique_generic.wybe:7:11: Call to wybe.list.[|] binds type variable T to unique type unique_generic.u
-[0m[91mfinal-dump/unique_generic.wybe:7:14: Call to wybe.list.[] binds type variable T to unique type unique_generic.u
-[0m[91mfinal-dump/unique_generic.wybe:8:9: Call to wybe.list.reverse binds type variable T to unique type unique_generic.u
-[0m[91mfinal-dump/unique_generic.wybe:10:9: Parameter lst of bla has type with unique type parameter unique_generic.u
-[0m[91mfinal-dump/unique_generic.wybe:11:9: Call to wybe.list.[|] binds type variable T to unique type unique_generic.u
-[0m[91mfinal-dump/unique_generic.wybe:11:17: Unique variable h:unique_generic.u assigned in a test context
-[0m[91mfinal-dump/unique_generic.wybe:18:1: Call to unique_generic.foo binds inferred variable type to unique type unique_generic.u
-[0m
+final-dump/unique_generic.wybe:7:8: Call to wybe.list.[|] binds type variable T to unique type unique_generic.u
+final-dump/unique_generic.wybe:7:11: Call to wybe.list.[|] binds type variable T to unique type unique_generic.u
+final-dump/unique_generic.wybe:7:14: Call to wybe.list.[] binds type variable T to unique type unique_generic.u
+final-dump/unique_generic.wybe:8:9: Call to wybe.list.reverse binds type variable T to unique type unique_generic.u
+final-dump/unique_generic.wybe:10:9: Parameter lst of bla has type with unique type parameter unique_generic.u
+final-dump/unique_generic.wybe:11:9: Call to wybe.list.[|] binds type variable T to unique type unique_generic.u
+final-dump/unique_generic.wybe:11:17: Unique variable h:unique_generic.u assigned in a test context
+final-dump/unique_generic.wybe:18:1: Call to unique_generic.foo binds inferred variable type to unique type unique_generic.u

--- a/test-cases/final-dump/unique_loop_err.exp
+++ b/test-cases/final-dump/unique_loop_err.exp
@@ -1,3 +1,2 @@
 Error detected during uniqueness checking of module(s) unique_loop_err
-[91mfinal-dump/unique_loop_err.wybe:10:9: Reuse of unique variable a:unique_loop_err
-[0m
+final-dump/unique_loop_err.wybe:10:9: Reuse of unique variable a:unique_loop_err

--- a/test-cases/final-dump/unique_member.exp
+++ b/test-cases/final-dump/unique_member.exp
@@ -1,3 +1,2 @@
 Error detected during uniqueness checking of module(s) unique_member, unique_member.ty
-[91mfinal-dump/unique_member.wybe:3:20: Unique constructor argument uniq of non-unique type
-[0m
+final-dump/unique_member.wybe:3:20: Unique constructor argument uniq of non-unique type

--- a/test-cases/final-dump/unique_pos_error.exp
+++ b/test-cases/final-dump/unique_pos_error.exp
@@ -1,3 +1,2 @@
 Error detected during uniqueness checking of module(s) unique_pos_error, unique_pos_error.unique_position
-[91mfinal-dump/unique_pos_error.wybe:15:16: Reuse of unique variable p:unique_pos_error.unique_position
-[0m
+final-dump/unique_pos_error.wybe:15:16: Reuse of unique variable p:unique_pos_error.unique_position

--- a/test-cases/final-dump/unique_position.exp
+++ b/test-cases/final-dump/unique_position.exp
@@ -38,20 +38,21 @@ proc printPosition > public (1 calls)
 printPosition(pos##0:unique_position.unique_position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
+  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm {unique} access(pos##0:unique_position.unique_position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @unique_position:nn:nn
     foreign lpvm {unique} access(~pos##0:unique_position.unique_position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @unique_position:nn:nn
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @unique_position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @unique_position:nn:nn
-    foreign c print_int(~x##0:wybe.int, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @unique_position:nn:nn
-    foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
-    wybe.string.print<0>(",":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @unique_position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @unique_position:nn:nn
-    foreign c print_int(~y##0:wybe.int, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @unique_position:nn:nn
-    foreign lpvm store(~%tmp#6##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
-    wybe.string.print<0>(")":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @unique_position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @unique_position:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @unique_position:nn:nn
-    foreign lpvm store(~%tmp#9##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @unique_position:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @unique_position:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @unique_position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @unique_position:nn:nn
+    foreign c print_int(~y##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @unique_position:nn:nn
+    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
+    wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @unique_position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @unique_position:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @unique_position:nn:nn
+    foreign lpvm store(~%tmp#19##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
 
   LLVM code       :
 
@@ -62,13 +63,10 @@ source_filename = "!ROOT!/final-dump/unique_position.wybe"
 target triple    ????
 
 @"cstring#0" = private unnamed_addr constant [ ?? x i8 ] c" (\00", align 8
-@"cstring#1" = private unnamed_addr constant [ ?? x i8 ] c")\00", align 8
-@"cstring#2" = private unnamed_addr constant [ ?? x i8 ] c",\00", align 8
-@"string#3" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
-@"string#4" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#1" to i64 ) }, align 8
-@"string#5" = private unnamed_addr constant {i64, i64} { i64 1, i64 ptrtoint( ptr @"cstring#2" to i64 ) }, align 8
+@"string#1" = private unnamed_addr constant {i64, i64} { i64 2, i64 ptrtoint( ptr @"cstring#0" to i64 ) }, align 8
 
 declare external fastcc void @"wybe.string.print<0>"(i64)
+declare external fastcc void @"wybe.string.print<0>[410bae77d3]"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
@@ -89,16 +87,16 @@ define external fastcc void @"unique_position.<0>"() {
 }
 
 define external fastcc void @"unique_position.printPosition<0>"(i64 %"pos##0") {
-  %"tmp#10##0" = inttoptr i64 %"pos##0" to ptr
-  %"x##0" = load i64, ptr %"tmp#10##0"
-  %"tmp#11##0" = add i64 %"pos##0", 8
-  %"tmp#12##0" = inttoptr i64 %"tmp#11##0" to ptr
-  %"y##0" = load i64, ptr %"tmp#12##0"
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#3" to i64 ))
+  %"tmp#20##0" = inttoptr i64 %"pos##0" to ptr
+  %"x##0" = load i64, ptr %"tmp#20##0"
+  %"tmp#21##0" = add i64 %"pos##0", 8
+  %"tmp#22##0" = inttoptr i64 %"tmp#21##0" to ptr
+  %"y##0" = load i64, ptr %"tmp#22##0"
+  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#1" to i64 ))
   call ccc void @print_int(i64 %"x##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#5" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1203)
   call ccc void @print_int(i64 %"y##0")
-  tail call fastcc void @"wybe.string.print<0>"(i64 ptrtoint( ptr @"string#4" to i64 ))
+  tail call fastcc void @"wybe.string.print<0>[410bae77d3]"(i64 1191)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/unique_position.exp
+++ b/test-cases/final-dump/unique_position.exp
@@ -38,17 +38,17 @@ proc printPosition > public (1 calls)
 printPosition(pos##0:unique_position.unique_position)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(3,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm {unique} access(pos##0:unique_position.unique_position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int) @unique_position:nn:nn
     foreign lpvm {unique} access(~pos##0:unique_position.unique_position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int) @unique_position:nn:nn
     wybe.string.print<0>(" (":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @unique_position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @unique_position:nn:nn
-    foreign c print_int(~x##0:wybe.int, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @unique_position:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
-    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @unique_position:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#11##0:wybe.phantom) @unique_position:nn:nn
-    foreign c print_int(~y##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @unique_position:nn:nn
-    foreign lpvm store(~%tmp#12##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @unique_position:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @unique_position:nn:nn
+    foreign lpvm store(~%tmp#3##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
+    wybe.string.print<0>[410bae77d3](1203:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @unique_position:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @unique_position:nn:nn
+    foreign c print_int(~y##0:wybe.int, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @unique_position:nn:nn
+    foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unique_position:nn:nn
     wybe.string.print<0>[410bae77d3](1191:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @unique_position:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @unique_position:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @unique_position:nn:nn

--- a/test-cases/final-dump/use_before_def.exp
+++ b/test-cases/final-dump/use_before_def.exp
@@ -1,5 +1,4 @@
 Error detected during type checking of module(s) use_before_def
-[91mfinal-dump/use_before_def.wybe:1:5: Output parameter result not defined by proc use_before_def
-[0m[91mfinal-dump/use_before_def.wybe:2:9: Uninitialised argument in call to proc =, argument 2
-[0m[91mfinal-dump/use_before_def.wybe:2:18: Uninitialised argument in call to proc +, argument 1
-[0m
+final-dump/use_before_def.wybe:1:5: Output parameter result not defined by proc use_before_def
+final-dump/use_before_def.wybe:2:9: Uninitialised argument in call to proc =, argument 2
+final-dump/use_before_def.wybe:2:18: Uninitialised argument in call to proc +, argument 1

--- a/wybelibs/wybe/string.wybe
+++ b/wybelibs/wybe/string.wybe
@@ -6,12 +6,11 @@ pragma no_standard_library
 use wybe.c_string, wybe.range, wybe.int, wybe.char, wybe.bool, wybe.comparison
 use wybe.control, wybe.io 
 
-# Private constructors.
-# This ensures that strings can only be manipulated with public procedures,
-# providing a more typical interface
-constructors pub empty
-             # ^ An empty string
-           | buffer(len:int, raw:c_string) 
+# Private constructors. This ensures that strings can only be manipulated with
+# public procedures, providing a more typical interface.  The `empty` and
+# `singleton` constructors are public so that short manifest constant strings
+# can be optimised to use those constructors.  This happens in Expansion.hs.
+constructors buffer(len:int, raw:c_string) 
              # ^ A wrapper for a c_string
              # Note: must be first non-const ctor
            | concat(left:_, right:_)
@@ -20,6 +19,8 @@ constructors pub empty
              # ^ A slice of a string under the given range
            | pub singleton(c:char)
              # ^ A singleton string, a single char
+           | pub empty
+             # ^ An empty string
 
 
 ## Conversion procedures.

--- a/wybelibs/wybe/string.wybe
+++ b/wybelibs/wybe/string.wybe
@@ -9,7 +9,7 @@ use wybe.control, wybe.io
 # Private constructors.
 # This ensures that strings can only be manipulated with public procedures,
 # providing a more typical interface
-constructors empty
+constructors pub empty
              # ^ An empty string
            | buffer(len:int, raw:c_string) 
              # ^ A wrapper for a c_string
@@ -18,7 +18,7 @@ constructors empty
              # ^ A concatenation of two strings
            | slice(base:_, range:range)
              # ^ A slice of a string under the given range
-           | singleton(c:char)
+           | pub singleton(c:char)
              # ^ A singleton string, a single char
 
 
@@ -168,6 +168,7 @@ pub def print(x:_) use !io {
       | concat(?left, ?right) :: !print(left); !print(right)
       | slice(_, _) :: for ?c in x { !print(c) }
       | singleton(?c) :: !print(c)
+      | empty :: pass
       | else :: !shouldnt
     }
 }


### PR DESCRIPTION
These short strings are read using the appropriate constructor, rather than the general buffer
constructor.  So the empty and singleton
constructors are now public.

Other changes include optimising foreign lpvm cast instructions applied to constant chars, integers
and floats, as they get generated in this case.
This avoids several instructions in calling
unboxed constructors with constant arguments.

Also use the -n wybemk flag in final-dump-test.sh, to turn off colourising, making diffs easier to
read.

There are numerous code improvements in final dump tests, including allowing specialisation to kick
in in many places, since unboxed values cannot be
aliased.

There's one unfortunate change in output for
constant_type_constraint_error.wybe: the error
message for ?a = "s":int now complains about a
type error in the call to wybe.string.singleton,
which doesn't appear on the line. I think this is
tolerable for now, as it would be difficult to
fix.

Closes #473