### PR TITLE
update install guide on Ubuntu for LLVM 18

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,7 @@ dyld[40396]: Library not loaded: /usr/local/opt/libffi/lib/libffi.7.dylib
 
 ### Linux (Ubuntu)
 
-Note that this is an experimental support and only has been tested on Ubuntu 18.04 and 20.04 LTS.
+Note that this is an experimental support and only has been tested on Ubuntu 24.04 LTS.
 
 1.  Install Clang
 
@@ -79,10 +79,10 @@ Note that this is an experimental support and only has been tested on Ubuntu 18.
      sudo apt-get install libgc-dev
 ```
 
-4.  Install LLVM version 9
+4.  Install LLVM version 18
 
 ```
-    sudo apt-get install llvm-9-dev
+    sudo apt-get install llvm-18-dev
 ```
 
 5.  Install libtinfo-dev


### PR DESCRIPTION
I assume a similar patch could be done for the install guide with MacOS, too, but I don't have a machine to test that on!