### PR TITLE
Improve type error for undefined variables/procs

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -360,7 +360,7 @@ typeErrorMessage (ReasonAmbig procName pos varAmbigs) =
                 | (v,typs) <- varAmbigs]
 typeErrorMessage (ReasonUndef callFrom callTo pos) =
     Message Error pos $
-        showProcName callTo ++ " unknown in " ++ showProcName callFrom
+        "`" ++ callTo ++ "` unknown in " ++ showProcName callFrom
 typeErrorMessage (ReasonArity callFrom callTo pos callArity procArity) =
     Message Error pos $
         "Call from " ++ showProcName callFrom

--- a/test-cases/final-dump/bad_assign.exp
+++ b/test-cases/final-dump/bad_assign.exp
@@ -1,2 +1,2 @@
 Error detected during type checking of module(s) bad_assign
-final-dump/bad_assign.wybe:5:1: proc l unknown in module top-level code
+final-dump/bad_assign.wybe:5:1: `l` unknown in module top-level code

--- a/test-cases/final-dump/bug228-undefined.exp
+++ b/test-cases/final-dump/bug228-undefined.exp
@@ -1,2 +1,2 @@
 Error detected during type checking of module(s) bug228-undefined
-final-dump/bug228-undefined.wybe:10:10: proc res unknown in module top-level code
+final-dump/bug228-undefined.wybe:10:10: `res` unknown in module top-level code

--- a/test-cases/final-dump/call_unknown.exp
+++ b/test-cases/final-dump/call_unknown.exp
@@ -1,2 +1,2 @@
 Error detected during type checking of module(s) call_unknown
-final-dump/call_unknown.wybe:1:26: proc nonexistent_proc unknown in proc foo
+final-dump/call_unknown.wybe:1:26: `nonexistent_proc` unknown in proc foo

--- a/test-cases/final-dump/resource_error2.exp
+++ b/test-cases/final-dump/resource_error2.exp
@@ -1,4 +1,4 @@
 Error detected during type checking of module(s) resource_error2
 final-dump/resource_error2.wybe:2:7: Resource wybe.io.io not in scope at call to proc println
 final-dump/resource_error2.wybe:17:7: Resource res_decl.count not in scope at call to proc use_resource
-final-dump/resource_error2.wybe:25:14: proc call_source_file_name unknown in proc bad_special_use
+final-dump/resource_error2.wybe:25:14: `call_source_file_name` unknown in proc bad_special_use


### PR DESCRIPTION
Currently, undefined variables are reported as "proc bla unknown in ...".  It's not possible to distinguish between undefined variables and undefined niladic proc (ie, constants), but rather than assuming it's a proc, this change does not try to guess what it is, and just shows the name.