### PR TITLE
fix: record extern LLVM fnptr in constants

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2352,7 +2352,7 @@ primImpurity (PrimHigher _ ArgVar{argVarType=HigherOrderType
     = return $ max impurity modimpurity
 primImpurity (PrimHigher _ (ArgConstRef structID _) impurity _) = do
     lookupConstInfo structID >>= \case
-        Just (StructInfo _ (FnPointerStructMember pspec:_)) ->
+        Just (ClosureInfo pspec _) ->
             max impurity . procImpurity <$> getProcDef pspec
         Just (VTableInfo _ (FnPointerStructMember pspec:t) _ _ _ _) ->
             max impurity . procImpurity <$> getProcDef pspec
@@ -3779,6 +3779,11 @@ data StructInfo
         structSize :: Int,          -- ^ The size of the struct in bytes
         structData :: [ConstValue]  -- ^ Contents of the struct, in memory order
         }
+    -- | A constant closure, with all params (needed or not)
+    | ClosureInfo {
+        closureProcSpec :: ProcSpec, -- ^ The closure proc
+        closureArgs :: [ConstValue]  -- ^ The closed args
+    }
     | VTableInfo {
         vtableSize :: Int,          -- ^ The size of the struct in bytes
         vtableData :: [ConstValue], -- ^ Contents of the struct, in memory order
@@ -3834,12 +3839,10 @@ constantValue _ = return Nothing
 closureStructId :: ProcSpec -> [PrimArg] -> Compiler (Maybe StructID)
 closureStructId pspec args = do
     mapM constantValue args >>= (\case
-        Just args' -> do
-          let sz = wordSizeBytes * (length args' + 1)
+        Just args' ->
           Just <$>
             recordConstStruct
-                (StructInfo sz
-                    $ FnPointerStructMember pspec : args')
+                (ClosureInfo pspec args')
                 (Just $ Closure pspec
                         (List.map (Unplaced . constValueExp) args'))
         _ -> return Nothing) . sequence
@@ -3867,18 +3870,12 @@ constValueRepresentation (GenericStructMember _) = Pointer
 
 -- | Return the ConstValue at the specified offset of the specified struct.
 constValueAtOffset :: StructInfo -> Int -> Maybe ConstValue
-constValueAtOffset (StructInfo _ fields) offset = go fields offset
-    where go (field:fields) off
-            | off == 0 = Just field
-            | off < 0 = Nothing
-            | otherwise = go fields (off - constValueSize field)
-          go [] _ = Nothing
-constValueAtOffset (VTableInfo _ fields _ _ _ _) offset = go fields offset
-    where go (field:fields) off
-            | off == 0 = Just field
-            | off < 0 = Nothing
-            | otherwise = go fields (off - constValueSize field)
-          go [] _ = Nothing
+constValueAtOffset (StructInfo _ fields) offset = constValueAtOffset' fields offset
+constValueAtOffset (ClosureInfo pspec clsds) offset 
+    | offset == 0 = Just $ FnPointerStructMember pspec
+    | offset < wordSizeBytes = Nothing
+    | otherwise = constValueAtOffset' clsds (offset - wordSizeBytes)
+constValueAtOffset (VTableInfo _ fields _ _ _ _) offset = constValueAtOffset' fields offset
 constValueAtOffset (CStringInfo chars) offset =
     (`IntStructMember` 1) . toInteger . ord <$> (chars !? offset)
 constValueAtOffset (ArrayInfo []) _ = Nothing
@@ -3886,6 +3883,15 @@ constValueAtOffset (ArrayInfo elts@(elt:_)) offset =
     let eltSize = constValueSize elt
         (idx, eltOffset) = divMod offset eltSize
     in if eltOffset == 0 then elts !? idx else Nothing
+
+
+constValueAtOffset' :: [ConstValue] -> Int -> Maybe ConstValue
+constValueAtOffset' (field:fields) off
+    | off == 0 = Just field
+    | off < 0 = Nothing
+    | otherwise = constValueAtOffset' fields (off - constValueSize field)
+constValueAtOffset' [] _ = Nothing
+
 
 -- | Turn a ConstValue into the equivalent constant PrimArg
 constValuePrimArg :: ConstValue -> TypeSpec -> PrimArg
@@ -3956,19 +3962,10 @@ argGlobalFlow :: Map PrimVarName GlobalFlows -> PrimArg -> Compiler GlobalFlows
 argGlobalFlow varFlows (ArgVar name ty _ _ _)
     = return $ Map.findWithDefault univGlobalFlows name varFlows
 argGlobalFlow varFlows (ArgClosure pspec args _) = do
-    params <- getPrimParams pspec
-    let nArgs = length args
-        (closedParams, freeParams) = List.splitAt nArgs params
-    if any (\(PrimParam _ ty flow _ _) ->
-            isInputFlow flow && isResourcefulHigherOrder ty) freeParams
-    then return univGlobalFlows
-    else do
-        gFlows <- getProcGlobalFlows pspec
-        argFlows <- argsGlobalFlows varFlows args
-        return $ effectiveGlobalFlows argFlows gFlows
+    closureGlobalFlows (const $ argsGlobalFlows varFlows args) pspec args
 argGlobalFlow varFlows (ArgConstRef structID _) = do
     lookupConstInfo structID >>= (\case
-            StructInfo _ fields -> constsGlobalFlows fields
+            ClosureInfo pspec clsd -> constClosureGlobalFlows pspec clsd
             VTableInfo _ fields _ _ _ _ -> constsGlobalFlows fields
             _ -> return emptyGlobalFlows)
         . trustFromJust "lookupConstStruct"
@@ -3981,27 +3978,15 @@ argsGlobalFlows varFlows
     = mapM (\a -> (, argFlowDirection a) <$> argGlobalFlow varFlows a)
 
 
--- | Get the GlobalFlows of a list of constant values.  Specifically, this looks
--- for constant structures that begin with a FnPointerStructMember, and treats
--- that as if it were an ArgClosure.  It also traverses the structure looking
--- for nested structures beginning with a FnPointerStructMember.  Since this is
--- a completely static input structure, that's the only way to get GlobalFlows.
+-- | Get the GlobalFlows of a list of constant values.  
 constsGlobalFlows :: [ConstValue] -> Compiler GlobalFlows
-constsGlobalFlows (FnPointerStructMember pspec:fields) = do
-    params <- getPrimParams pspec
-    let nArgs = length fields
-        (closedParams, freeParams) = List.splitAt nArgs params
-    if any (\(PrimParam _ ty flow _ _) ->
-            isInputFlow flow && isResourcefulHigherOrder ty) freeParams
-    then return univGlobalFlows
-    else do
-        gFlows <- getProcGlobalFlows pspec
-        globalFlowsUnions . (gFlows:) <$> mapM constGlobalFlows fields
 constsGlobalFlows fields = globalFlowsUnions <$> mapM constGlobalFlows fields
 
 
 -- | Compute the GlobalFlows of a single constant value.
 constGlobalFlows :: ConstValue -> Compiler GlobalFlows
+constGlobalFlows (FnPointerStructMember pspec) = 
+    getProcGlobalFlows pspec
 constGlobalFlows (PointerStructMember structID) = do
     lookupConstInfo structID >>= (\case
             StructInfo _ fields -> constsGlobalFlows fields
@@ -4011,7 +3996,7 @@ constGlobalFlows (PointerStructMember structID) = do
 constGlobalFlows _ = return emptyGlobalFlows
 
 
--- | Gather the effective GlobalFLows of a given set of GlobalGlows, 
+-- | Gather the effective GlobalFLows of a given set of GlobalFlows, 
 -- using the GlobalFlows of the arguments corresponding to each parameter
 effectiveGlobalFlows :: [(GlobalFlows, PrimFlow)] -> GlobalFlows -> GlobalFlows
 effectiveGlobalFlows argFlows primFlows@(GlobalFlows _ _ UniversalSet)
@@ -4020,6 +4005,29 @@ effectiveGlobalFlows argFlows primFlows@(GlobalFlows _ _ UniversalSet)
 effectiveGlobalFlows argFlows primFlows@(GlobalFlows _ _ (FiniteSet ids))
     = globalFlowsUnions $ primFlows{globalFlowsParams=emptyUnivSet}
                         : List.map (fst . (argFlows !!)) (Set.toList ids)
+
+
+-- | Gather the effective global flows of a closure, using some abstract getter to the the flows of 
+-- any closed values with respect to the closure's params
+closureGlobalFlows :: ([PrimParam] -> Compiler [(GlobalFlows, PrimFlow)]) -> ProcSpec -> [a] -> Compiler GlobalFlows
+closureGlobalFlows getArgFlows pspec args = do
+    params <- tail <$> getPrimParams pspec
+    let nArgs = length args
+        (closedParams, regularParams) = List.splitAt nArgs params
+    if any (\(PrimParam _ ty flow _ _) ->
+            isInputFlow flow && isResourcefulHigherOrder ty) regularParams
+    then return univGlobalFlows
+    else do
+        gFlows <- getProcGlobalFlows pspec
+        argFlows <- getArgFlows closedParams
+        return $ effectiveGlobalFlows argFlows gFlows
+
+
+-- | Gather the global flows of some constant closure
+constClosureGlobalFlows :: ProcSpec -> [ConstValue] -> Compiler GlobalFlows
+constClosureGlobalFlows pspec clsd = 
+    closureGlobalFlows (\closedParams -> mapM constGlobalFlows clsd >>= 
+           \clsdFlows -> return (List.zipWith ((. primParamFlow) . (,)) clsdFlows closedParams)) pspec clsd
 
 
 -- | Test if a PrimArg is a variable.

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2352,7 +2352,7 @@ primImpurity (PrimHigher _ ArgVar{argVarType=HigherOrderType
     = return $ max impurity modimpurity
 primImpurity (PrimHigher _ (ArgConstRef structID _) impurity _) = do
     lookupConstInfo structID >>= \case
-        Just (StructInfo _ (FnPointerStructMember pspec:t)) ->
+        Just (StructInfo _ (FnPointerStructMember pspec:_)) ->
             max impurity . procImpurity <$> getProcDef pspec
         Just (VTableInfo _ (FnPointerStructMember pspec:t) _ _ _ _) ->
             max impurity . procImpurity <$> getProcDef pspec
@@ -3831,8 +3831,8 @@ constantValue _ = return Nothing
 -- | Generate a StructId for a closure, if all its arguments are constants.
 closureStructId :: ProcSpec -> [PrimArg] -> Compiler (Maybe StructID)
 closureStructId pspec args = do
-    params <- List.filter ((ClosureEnv/=) . primParamFlowType) <$> getPrimParams pspec
-    let neededArgs = [arg | (arg, param) <- zip args params, paramIsNeeded param]
+    freeParams <- List.filter ((Free==) . primParamFlowType) <$> getPrimParams pspec
+    let neededArgs = [arg | (arg, param) <- zip args freeParams, paramIsNeeded param]
     mapM constantValue neededArgs >>= (\case
         Just args' -> do
           let sz = wordSizeBytes * (length args' + 1)
@@ -3902,7 +3902,7 @@ constValueExp :: ConstValue -> Exp
 constValueExp (IntStructMember i _) = IntValue i
 constValueExp (FloatStructMember f _) = FloatValue f
 constValueExp (PointerStructMember structID) = ConstStruct structID
-constValueExp (FnPointerStructMember pspec) =
+constValueExp (FnPointerStructMember _) =
     shouldnt "constValueExp of FnPointerStructMember"
 constValueExp (UndefStructMember _) =
     shouldnt "constValueExp of UndefStructMember"

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -4073,7 +4073,7 @@ data ArgFlowType = Ordinary        -- ^An argument/parameter as written by user
                  | Free            -- ^An argument to be passed in the closure
                                    -- environment
                  | VTable          -- ^An argument to pass a vtable
-                 | ClosureEnv
+                 | ClosureEnv      -- ^A closure's environment, used to retrieve closed values
      deriving (Eq,Ord,Generic)
 
 instance Show ArgFlowType where

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -74,8 +74,8 @@ module AST (
   ProcAnalysis(..), emptyProcAnalysis,
   ProcBody(..), PrimFork(..), MergedForkTable, prependToBody, appendToBody, unMergeFork, guardedMergedFork,
   Ident, VarName, ProcName, ResourceDef(..), FlowDirection(..), showFlowName,
-  argFlowDirection, argType, setArgType, setArgFlow, setArgFlowType, maybeArgFlowType,
-  argDescription, argIntVal, trustArgInt, setParamType, paramIsResourceful,
+  argFlowDirection, argType, setArgType, setArgFlow, setArgFlowType,
+  argIntVal, trustArgInt, setParamType, paramIsResourceful,
   setPrimParamType, setTypeFlowType,
   flowsIn, flowsOut, primFlowToFlowDir, isInputFlow, isOutputFlow,
   foldStmts, foldExps, foldBodyPrims, foldBodyDistrib, mapLPVMBodyM,
@@ -4132,44 +4132,6 @@ setArgFlow _ arg          = arg
 setArgFlowType :: ArgFlowType -> PrimArg -> PrimArg
 setArgFlowType ft arg@ArgVar{} = arg{argVarFlowType=ft}
 setArgFlowType _  arg          = arg
-
-
--- | Get the flow of a prim arg. Returns Nothing for a non-ArgVar value
-maybeArgFlowType :: PrimArg -> Maybe ArgFlowType
-maybeArgFlowType ArgVar{argVarFlowType=ft} = Just ft
-maybeArgFlowType arg                       = Nothing
-
-
-argDescription :: PrimArg -> String
-argDescription (ArgVar var _ flow ftype _) =
-    argFlowDescription flow
-    ++ (case ftype of
-          Ordinary       -> " variable " ++ primVarName var
-          Resource rspec -> " resource " ++ show rspec
-          Free           -> " closure argument "
-          VTable         -> " vtable "
-          ClosureEnv     -> " closure env ")
-argDescription (ArgInt val _) = "constant argument '" ++ show val ++ "'"
-argDescription (ArgFloat val _) = "constant argument '" ++ show val ++ "'"
-argDescription (ArgClosure ms as _)
-    = "closure of '" ++ show ms ++ "' with <"
-    ++ intercalate ", " (argDescription <$> as) ++ "> closed arguments"
-argDescription (ArgGlobal info _) = "global reference to " ++ show info
-argDescription (ArgVTable info _) = case info of
-    Left spec -> "reference to global vtable " ++ show spec
-    Right val -> "reference to local vtable " ++ show val
-argDescription (ArgConstRef info _) = "reference to const struct " ++ show info
-argDescription (ArgUnneeded flow _) = "unneeded " ++ argFlowDescription flow
-argDescription (ArgUndef _) = "undefined argument"
-
-
-
--- |A printable description of a primitive flow direction
-argFlowDescription :: PrimFlow -> String
-argFlowDescription FlowIn  = "input"
-argFlowDescription FlowOut = "output"
-argFlowDescription FlowOutByReference = "outByReference"
-argFlowDescription FlowTakeReference = "takeReference"
 
 
 argIntVal :: PrimArg -> Maybe Integer

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -3998,7 +3998,7 @@ constsGlobalFlows (FnPointerStructMember pspec:fields) = do
     else do
         gFlows <- getProcGlobalFlows pspec
         globalFlowsUnions . (gFlows:) <$> mapM constGlobalFlows fields
-constsGlobalFlows fields = return emptyGlobalFlows -- XXX need to recurse!
+constsGlobalFlows fields = globalFlowsUnions <$> mapM constGlobalFlows fields
 
 
 -- | Compute the GlobalFlows of a single constant value.

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -120,7 +120,7 @@ module AST (
   ProcVariant(..), Inlining(..), Impurity(..),
   addProc, addProcDef, addAbstractProc, addTraitImpl, lookupProc, publicProc, callTargets,
   abstractProcs, outputVariableName, outputStatusName,
-  envParamName, envPrimParam, makeGlobalResourceName,
+  envParamName, envPrimParam, envParam, makeGlobalResourceName,
   showBody, showPlacedPrims, showStmt, showBlock, showProcDef,
   showProcIdentifier, showProcName, showProcOrVarName,
   showModSpec, showModSpecs, showResources, showOptPos, showProcDefs, showUse,
@@ -3831,7 +3831,7 @@ constantValue _ = return Nothing
 -- | Generate a StructId for a closure, if all its arguments are constants.
 closureStructId :: ProcSpec -> [PrimArg] -> Compiler (Maybe StructID)
 closureStructId pspec args = do
-    params <- getPrimParams pspec
+    params <- List.filter ((ClosureEnv/=) . primParamFlowType) <$> getPrimParams pspec
     let neededArgs = [arg | (arg, param) <- zip args params, paramIsNeeded param]
     mapM constantValue neededArgs >>= (\case
         Just args' -> do
@@ -4073,6 +4073,7 @@ data ArgFlowType = Ordinary        -- ^An argument/parameter as written by user
                  | Free            -- ^An argument to be passed in the closure
                                    -- environment
                  | VTable          -- ^An argument to pass a vtable
+                 | ClosureEnv
      deriving (Eq,Ord,Generic)
 
 instance Show ArgFlowType where
@@ -4080,6 +4081,7 @@ instance Show ArgFlowType where
     show (Resource _) = "%"
     show Free = "^"
     show VTable = ""
+    show ClosureEnv = "@"
 
 
 -- |The dataflow direction of an actual argument.
@@ -4145,7 +4147,8 @@ argDescription (ArgVar var _ flow ftype _) =
           Ordinary       -> " variable " ++ primVarName var
           Resource rspec -> " resource " ++ show rspec
           Free           -> " closure argument "
-          VTable         -> " vtable ")
+          VTable         -> " vtable "
+          ClosureEnv     -> " closure env ")
 argDescription (ArgInt val _) = "constant argument '" ++ show val ++ "'"
 argDescription (ArgFloat val _) = "constant argument '" ++ show val ++ "'"
 argDescription (ArgClosure ms as _)
@@ -4356,12 +4359,16 @@ outputStatusName :: Ident
 outputStatusName = specialName "success"
 
 
-envParamName :: PrimVarName
-envParamName = PrimVarName (specialName "env") 0
+envParamName :: VarName
+envParamName = specialName "env"
 
 
 envPrimParam :: PrimParam
-envPrimParam = PrimParam envParamName (Representation CPointer) FlowIn Ordinary (ParamInfo False emptyGlobalFlows)
+envPrimParam = PrimParam (PrimVarName envParamName 0) (Representation CPointer) FlowIn ClosureEnv (ParamInfo False emptyGlobalFlows)
+
+
+envParam :: Param 
+envParam = Param envParamName (Representation CPointer) ParamIn ClosureEnv
 
 
 makeGlobalResourceName :: ResourceSpec -> String

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2437,8 +2437,8 @@ isClosureProc pspec = isClosureVariant . procVariant <$> getProcDef pspec
 
 
 isClosureVariant :: ProcVariant -> Bool
-isClosureVariant (ClosureProc _ _) = True
-isClosureVariant _                 = False
+isClosureVariant ClosureProc{} = True
+isClosureVariant _             = False
 
 isConstructorVariant :: ProcVariant -> Bool
 isConstructorVariant (ConstructorProc _) = True
@@ -3824,6 +3824,8 @@ constantValue (ArgClosure pspec args _) =
     (PointerStructMember <$>) <$> closureStructId pspec args
 constantValue (ArgConstRef structID ty) =
     return $ Just $ PointerStructMember structID
+constantValue (ArgUndef ty) =
+    typeSize ty <&> (Just . UndefStructMember)
 constantValue ArgGlobal{} = return Nothing
 constantValue _ = return Nothing
 
@@ -3831,9 +3833,7 @@ constantValue _ = return Nothing
 -- | Generate a StructId for a closure, if all its arguments are constants.
 closureStructId :: ProcSpec -> [PrimArg] -> Compiler (Maybe StructID)
 closureStructId pspec args = do
-    freeParams <- List.filter ((Free==) . primParamFlowType) <$> getPrimParams pspec
-    let neededArgs = [arg | (arg, param) <- zip args freeParams, paramIsNeeded param]
-    mapM constantValue neededArgs >>= (\case
+    mapM constantValue args >>= (\case
         Just args' -> do
           let sz = wordSizeBytes * (length args' + 1)
           Just <$>
@@ -3902,10 +3902,9 @@ constValueExp :: ConstValue -> Exp
 constValueExp (IntStructMember i _) = IntValue i
 constValueExp (FloatStructMember f _) = FloatValue f
 constValueExp (PointerStructMember structID) = ConstStruct structID
+constValueExp (UndefStructMember _) = Var "_" ParamIn Free
 constValueExp (FnPointerStructMember _) =
     shouldnt "constValueExp of FnPointerStructMember"
-constValueExp (UndefStructMember _) =
-    shouldnt "constValueExp of UndefStructMember"
 constValueExp (GenericStructMember cnst) =
     shouldnt "constValueExp of GenericStructMember"
 

--- a/src/BodyBuilder.hs
+++ b/src/BodyBuilder.hs
@@ -10,7 +10,7 @@
 
 module BodyBuilder (
   BodyBuilder, buildBody, freshVarName, freshTmp, instr, buildFork, completeFork,
-  beginBranch, endBranch, definiteVariableValue, argExpandedPrim
+  beginBranch, endBranch, definiteVariableValue, argExpandedPrim, trySkipTrampoline
   ) where
 
 import AST
@@ -707,29 +707,14 @@ argExpandedPrim call@(PrimCall id pspec impurity args gFlows) = do
 argExpandedPrim call@(PrimHigher id fn impurity args) = do
     logBuild $ "Expanding Higher call " ++ show call
     fn' <- expandArg True fn
-    case fn' of
-        ArgClosure pspec clsd _ -> trySkipTrampoline pspec id impurity fn' clsd args
-        ArgConstRef constId _ -> do
-            structInfo <- lift $ lookupConstInfo constId
-            case structInfo of
-              Just StructInfo{structData=(FnPointerStructMember pspec:fields)} -> do
-                freeParams <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
-                let clsd = zipWith constValuePrimArg fields (primParamType <$> freeParams)
-                trySkipTrampoline pspec id impurity fn clsd args
-              st -> shouldnt $ "argExpandedPrim HO of " ++ show fn' ++ " -> " ++ show st
-        _ -> do
+    trySkipTrampoline fn' id impurity args >>= \case 
+      Just call' -> do
+          logBuild "As first order call"
+          argExpandedPrim call'
+      Nothing -> do
           logBuild $ "Leaving as higher call to " ++ show fn'
           args' <- mapM (expandArg True) args
           return $ PrimHigher id fn' impurity args'
-  where 
-    trySkipTrampoline pspec id imp fn clsd args = do
-      (pspec', simple) <- lift (getProcDef pspec <&> procVariant) <&> \case
-        ClosureProc pspec' simple -> (pspec', simple)
-        _ -> shouldnt $ "call to non-closure " ++ show pspec
-      let (pspec'', mbFn) = if simple then (pspec', Nothing) else (pspec, Just fn)
-      gFlows <- lift $ getProcGlobalFlows pspec''
-      logBuild $ "As first-order call to " ++ show pspec''
-      argExpandedPrim $ PrimCall id pspec'' impurity (maybeToList mbFn ++ clsd ++ args) gFlows
 argExpandedPrim call@(PrimVirtualCall id table index impurity args gFlows) = do
     table' <- expandArg True table
     args' <- mapM (expandArg True) args
@@ -743,6 +728,31 @@ argExpandedPrim (PrimForeign lang nm flags args) = do
     return $ simplifyForeign lang nm flags args'
 
 
+-- | Try to skip a call to a trampoline closure, if the trampline is "simple"
+-- as a first-order call, else Nothing
+trySkipTrampoline :: PrimArg -> CallSiteID -> Impurity -> [PrimArg] -> BodyBuilder (Maybe Prim)
+trySkipTrampoline fn@(ArgClosure pspec clsd _) id imp args = 
+  Just <$> trySkipTrampoline' pspec id imp fn clsd args
+trySkipTrampoline fn@(ArgConstRef constId _) id imp args = do
+  structInfo <- lift $ lookupConstInfo constId
+  case structInfo of
+    Just StructInfo{structData=(FnPointerStructMember pspec:fields)} -> do
+      freeParams <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
+      let clsd = zipWith constValuePrimArg fields (primParamType <$> freeParams)
+      Just <$> trySkipTrampoline' pspec id imp fn clsd args
+    st -> shouldnt $ "trySkipTrampoline HO of " ++ show fn ++ " -> " ++ show st
+trySkipTrampoline _ _ _ _ = return Nothing
+
+trySkipTrampoline' :: ProcSpec -> CallSiteID -> Impurity -> PrimArg -> [PrimArg] -> [PrimArg] -> BodyBuilder Prim
+trySkipTrampoline' pspec id imp fn clsd args = do
+  (pspec', simple) <- lift (getProcDef pspec <&> procVariant) <&> \case
+    ClosureProc pspec' simple -> (pspec', simple)
+    _ -> shouldnt $ "trySkipTrampoline' call to non-closure " ++ show pspec
+  let (pspec'', mbFn) = if simple then (pspec', Nothing) else (pspec, Just fn)
+  gFlows <- lift $ getProcGlobalFlows pspec''
+  return $ PrimCall id pspec'' imp (maybeToList mbFn ++ clsd ++ args) gFlows
+
+  
 -- |Replace any unneeded arguments corresponding to unneeded parameters with
 --  ArgUnneeded.  For unneeded *output* parameters, there must be an
 --  input with the same name.  We must set the output argument variable

--- a/src/BodyBuilder.hs
+++ b/src/BodyBuilder.hs
@@ -734,12 +734,12 @@ trySkipTrampoline :: PrimArg -> CallSiteID -> Impurity -> [PrimArg] -> BodyBuild
 trySkipTrampoline fn@(ArgClosure pspec clsd _) id imp args = 
   Just <$> trySkipTrampoline' pspec id imp fn clsd args
 trySkipTrampoline fn@(ArgConstRef constId _) id imp args = do
-  structInfo <- lift $ lookupConstInfo constId
-  case structInfo of
-    Just StructInfo{structData=(FnPointerStructMember pspec:fields)} -> do
+  closureInfo <- lift $ lookupConstInfo constId
+  case closureInfo of
+    Just ClosureInfo{closureProcSpec=pspec, closureArgs=clsd} -> do
       freeParams <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
-      let clsd = zipWith constValuePrimArg fields (primParamType <$> freeParams)
-      Just <$> trySkipTrampoline' pspec id imp fn clsd args
+      let clsd' = zipWith constValuePrimArg clsd (primParamType <$> freeParams)
+      Just <$> trySkipTrampoline' pspec id imp fn clsd' args
     st -> shouldnt $ "trySkipTrampoline HO of " ++ show fn ++ " -> " ++ show st
 trySkipTrampoline _ _ _ _ = return Nothing
 

--- a/src/BodyBuilder.hs
+++ b/src/BodyBuilder.hs
@@ -714,7 +714,7 @@ argExpandedPrim call@(PrimHigher id fn impurity args) = do
             case structInfo of
               Just StructInfo{structData=(FnPointerStructMember pspec:fields)} -> do
                 freeParams <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
-                let clsd = fillClosure fields freeParams
+                let clsd = zipWith constValuePrimArg fields (primParamType <$> freeParams)
                 trySkipTrampoline pspec id impurity fn clsd args
               st -> shouldnt $ "argExpandedPrim HO of " ++ show fn' ++ " -> " ++ show st
         _ -> do
@@ -722,12 +722,6 @@ argExpandedPrim call@(PrimHigher id fn impurity args) = do
           args' <- mapM (expandArg True) args
           return $ PrimHigher id fn' impurity args'
   where 
-    fillClosure [] params = List.map (ArgUndef . primParamType) params
-    fillClosure (cnst:cnsts) (param:params) 
-      | paramIsNeeded param = constValuePrimArg cnst (primParamType param) : fillClosure cnsts params
-      | otherwise = fillClosure cnsts params
-    fillClosure _ params = shouldnt $ "fillClosure with too many params " ++ show params
-
     trySkipTrampoline pspec id imp fn clsd args = do
       (pspec', simple) <- lift (getProcDef pspec <&> procVariant) <&> \case
         ClosureProc pspec' simple -> (pspec', simple)

--- a/src/BodyBuilder.hs
+++ b/src/BodyBuilder.hs
@@ -708,33 +708,34 @@ argExpandedPrim call@(PrimHigher id fn impurity args) = do
     logBuild $ "Expanding Higher call " ++ show call
     fn' <- expandArg True fn
     case fn' of
-        ArgClosure pspec clsd _ -> do
-            (pspec', simple) <- lift (getProcDef pspec <&> procVariant) <&> \case
-              ClosureProc pspec' simple -> (pspec', simple)
-              _ -> shouldnt $ "call to non-closure " ++ show pspec
-            let (finalPspec, finalArgs) = if simple then (pspec', clsd ++ args) else (pspec, fn':clsd ++ args)
-            gFlows <- lift $ getProcGlobalFlows finalPspec
-            logBuild $ "As first-order call to " ++ show finalPspec
-            argExpandedPrim $ PrimCall id finalPspec impurity finalArgs gFlows
+        ArgClosure pspec clsd _ -> trySkipTrampoline pspec id impurity fn' clsd args
         ArgConstRef constId _ -> do
             structInfo <- lift $ lookupConstInfo constId
             case structInfo of
-              Just StructInfo{structData=(FnPointerStructMember pspec:rest)} -> do
-                frees <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
-                let closed = fillClosure rest frees
-                gFlows <- lift $ getProcGlobalFlows pspec
-                argExpandedPrim $ PrimCall id pspec impurity (fn':closed ++ args) gFlows
-              _ -> shouldnt $ "argExpandedPrim HO of " ++ show fn'
+              Just StructInfo{structData=(FnPointerStructMember pspec:fields)} -> do
+                freeParams <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
+                let clsd = fillClosure fields freeParams
+                trySkipTrampoline pspec id impurity fn clsd args
+              st -> shouldnt $ "argExpandedPrim HO of " ++ show fn' ++ " -> " ++ show st
         _ -> do
           logBuild $ "Leaving as higher call to " ++ show fn'
           args' <- mapM (expandArg True) args
           return $ PrimHigher id fn' impurity args'
   where 
     fillClosure [] params = List.map (ArgUndef . primParamType) params
-    fillClosure (free:frees) (param:params) 
-      | paramIsNeeded param = constValuePrimArg free (primParamType param) : fillClosure frees params
-      | otherwise = fillClosure frees params
-    fillClosure _ _ = shouldnt "uh oh"
+    fillClosure (cnst:cnsts) (param:params) 
+      | paramIsNeeded param = constValuePrimArg cnst (primParamType param) : fillClosure cnsts params
+      | otherwise = fillClosure cnsts params
+    fillClosure _ params = shouldnt $ "fillClosure with too many params " ++ show params
+
+    trySkipTrampoline pspec id imp fn clsd args = do
+      (pspec', simple) <- lift (getProcDef pspec <&> procVariant) <&> \case
+        ClosureProc pspec' simple -> (pspec', simple)
+        _ -> shouldnt $ "call to non-closure " ++ show pspec
+      let (pspec'', mbFn) = if simple then (pspec', Nothing) else (pspec, Just fn)
+      gFlows <- lift $ getProcGlobalFlows pspec''
+      logBuild $ "As first-order call to " ++ show pspec''
+      argExpandedPrim $ PrimCall id pspec'' impurity (maybeToList mbFn ++ clsd ++ args) gFlows
 argExpandedPrim call@(PrimVirtualCall id table index impurity args gFlows) = do
     table' <- expandArg True table
     args' <- mapM (expandArg True) args

--- a/src/BodyBuilder.hs
+++ b/src/BodyBuilder.hs
@@ -712,14 +712,29 @@ argExpandedPrim call@(PrimHigher id fn impurity args) = do
             (pspec', simple) <- lift (getProcDef pspec <&> procVariant) <&> \case
               ClosureProc pspec' simple -> (pspec', simple)
               _ -> shouldnt $ "call to non-closure " ++ show pspec
-            let (finalPspec, finalArgs) = if simple then (pspec', clsd ++ args) else (pspec, fn':args)
+            let (finalPspec, finalArgs) = if simple then (pspec', clsd ++ args) else (pspec, fn':clsd ++ args)
             gFlows <- lift $ getProcGlobalFlows finalPspec
             logBuild $ "As first-order call to " ++ show finalPspec
             argExpandedPrim $ PrimCall id finalPspec impurity finalArgs gFlows
+        ArgConstRef constId _ -> do
+            structInfo <- lift $ lookupConstInfo constId
+            case structInfo of
+              Just StructInfo{structData=(FnPointerStructMember pspec:rest)} -> do
+                frees <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
+                let closed = fillClosure rest frees
+                gFlows <- lift $ getProcGlobalFlows pspec
+                argExpandedPrim $ PrimCall id pspec impurity (fn':closed ++ args) gFlows
+              _ -> shouldnt $ "argExpandedPrim HO of " ++ show fn'
         _ -> do
-            logBuild $ "Leaving as higher call to " ++ show fn'
-            args' <- mapM (expandArg True) args
-            return $ PrimHigher id fn' impurity args'
+          logBuild $ "Leaving as higher call to " ++ show fn'
+          args' <- mapM (expandArg True) args
+          return $ PrimHigher id fn' impurity args'
+  where 
+    fillClosure [] params = List.map (ArgUndef . primParamType) params
+    fillClosure (free:frees) (param:params) 
+      | paramIsNeeded param = constValuePrimArg free (primParamType param) : fillClosure frees params
+      | otherwise = fillClosure frees params
+    fillClosure _ _ = shouldnt "uh oh"
 argExpandedPrim call@(PrimVirtualCall id table index impurity args gFlows) = do
     table' <- expandArg True table
     args' <- mapM (expandArg True) args

--- a/src/Expansion.hs
+++ b/src/Expansion.hs
@@ -12,6 +12,7 @@
 --  This code is used bottom-up, ie, callees are expanded before
 --  their callers, so it does not need to recursively expand calls.
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Expansion (procExpansion) where
 
@@ -32,6 +33,7 @@ import           Data.Tuple.HT             (mapFst)
 import           Data.Function             (on)
 import           Options                   (LogSelection (Expansion))
 import           Snippets
+import Data.Functor ((<&>))
 
 
 -- | Expand the supplied ProcDef, inlining as desired.
@@ -300,14 +302,21 @@ expandPrim call@(PrimCall id pspec impurity args gFlows) pos = do
                     logExpansion "  Not inlinable"
                     addInstr call' pos
             _ -> shouldnt $ "uncompiled proc: " ++ show pspec
-expandPrim prim@(PrimHigher id fn impurity args) pos = do
+expandPrim prim@PrimHigher{} pos = do
     logExpansion $ "  Checking inlining for higher order call " ++ show prim
-    inliningNow <- isJust <$> gets inlining
-    if inliningNow
-    then expandHigherOrder prim pos
-    else do
-        (fn':args') <- mapM expandArg $ fn:args
-        expandHigherOrder (PrimHigher id fn' impurity args') pos
+    prim' <- lift $ argExpandedPrim prim
+    case prim' of
+        PrimHigher id fn imp args -> do
+            inliningNow <- isJust <$> gets inlining
+            (fn':args') <- (if inliningNow then mapM expandArg else return) (fn:args)  
+            lift (trySkipTrampoline fn' id imp args') >>= \case 
+                Just prim'' -> do
+                    logExpansion $ "  As first order call " ++ show prim''
+                    expandPrim prim'' pos
+                Nothing -> do
+                    logExpansion $ "  As higher call to " ++ show fn'
+                    addInstr (PrimHigher id fn' imp args') pos
+        _ -> expandPrim prim' pos
 expandPrim prim@(PrimVirtualCall id table index impurity args gFlows) pos = do
     logExpansion $ "  Expand virtual call " ++ show prim
     (table':args') <- mapM expandArg $ table:args
@@ -321,25 +330,6 @@ expandPrim (PrimForeign lang nm flags args) pos = do
     addInstr (PrimForeign lang nm flags args')  pos
     st' <- get
     logExpansion $ "    renaming = " ++ show (renaming st')
-
-
-expandHigherOrder :: Prim -> OptPos -> Expander ()
-expandHigherOrder prim pos = do
-    logExpansion $ "  Expanding higher call " ++ show prim
-    prim' <- lift $ argExpandedPrim prim
-    case prim' of
-        PrimHigher id fn impurity args -> do
-            fn' <- expandArg fn
-            case fn' of
-                ArgClosure pspec closed _ -> do
-                    gFlows <- lift2 $ getProcGlobalFlows pspec
-                    expandPrim (PrimCall id pspec impurity (fn':args) gFlows) pos
-                _ -> do
-                    args' <- mapM expandArg args
-                    logExpansion $ "  As higher call to " ++ show fn'
-                    addInstr (PrimHigher id fn' impurity args') pos
-        _ -> expandPrim prim' pos
-
 
 
 inlineCall :: PrimProto -> [PrimArg] -> ProcBody -> OptPos -> Expander ()

--- a/src/Expansion.hs
+++ b/src/Expansion.hs
@@ -86,14 +86,14 @@ markParamNeededness isClosure used _ param@PrimParam{primParamName=nm,
                                                      primParamInfo=info} =
     param {primParamInfo=info{
             paramInfoUnneeded=Set.notMember nm used
-                                && (not isClosure || ft /= Ordinary)}}
+                                && (not isClosure || ft == Free)}}
 markParamNeededness isClosure _ ins param@PrimParam{primParamName=nm,
                                                     primParamFlow=FlowOut,
                                                     primParamFlowType=ft,
                                                     primParamInfo=info} =
     param {primParamInfo=info{
             paramInfoUnneeded=Set.member nm ins
-                                && (not isClosure || ft /= Ordinary)}}
+                                && (not isClosure || ft == Free)}}
 markParamNeededness _ _ _ PrimParam{ primParamFlow=FlowOutByReference } =
     shouldnt "unexpected FlowOutByReference at this stage of compilation"
 markParamNeededness _ _ _ PrimParam{ primParamFlow=FlowTakeReference } =
@@ -204,7 +204,7 @@ addInstr prim pos = do
             Just p@(Just _) -> p
             _ -> pos
     lift $ instr prim' pos'
-
+ 
 
 -- init a expander state based on the given call site count
 initExpanderState :: CallSiteID -> ExpanderState
@@ -290,7 +290,6 @@ expandPrim call@(PrimCall id pspec impurity args gFlows) pos = do
         let (args'', pspec') = case (procVariant def, args') of
                 (ClosureProc pspec' simple, ArgClosure _ closed _:rest) -> 
                     (closed ++ rest, if simple then pspec' else pspec) 
-                (ClosureProc{}, _) -> shouldnt $ "closure call with no closure arg " ++ show call
                 _ -> (args', pspec)
         def' <- if pspec == pspec' then return def else lift2 $ getProcDef pspec'
         case procImpln def' of

--- a/src/LLVM.hs
+++ b/src/LLVM.hs
@@ -289,7 +289,7 @@ preScanProcs = do
                 ++ intercalate ", " (concatMap (List.map (show.procName)) procss)
     vTables <- lift $ getModule modVTables
     logLLVM $ "Start recording vTables in module " ++ showModSpec thisMod
-    mapM_ (recordConst . snd) vTables
+    mapM_ (recordConst mod . snd) vTables
     logLLVM "End recording vTables"
     let bodies = concatMap (concatMap allProcBodies) procss
     mapM_ (mapLPVMBodyM (recordExtern mod) (prescanArg mod)) bodies
@@ -308,10 +308,10 @@ prescanArg mod closure@(ArgClosure pspec args _) = do
     let externArgs = primParamToArg envPrimParam : List.map primParamToArg realParams
     recordExternProc mod pspec externArgs
     recordExternSpec externAlloc
-    argConstValue closure >>= maybe (return ()) recordIfConst
+    argConstValue closure >>= maybe (return ()) (recordIfConst mod)
     mapM_ (prescanArg mod) args
-prescanArg _ arg =
-    argConstValue arg >>= maybe (return ()) recordIfConst
+prescanArg mod arg =
+    argConstValue arg >>= maybe (return ()) (recordIfConst mod)
 
 
 -- | Scan the forks of a ProcBody, recording any constants
@@ -326,34 +326,42 @@ preScanForks mod PrimFork{forkBodies=bodies, forkDefault=mbDflt} = do
     mapM_ (preScanBodyForks mod . snd) bodies
     forM_ mbDflt $ preScanBodyForks mod
 preScanForks mod MergedFork{forkTable=table, forkBody=body, forkDefault=mbDflt} = do
-    mapM_ (recordConst . thd4) table
+    mapM_ (recordConst mod . thd4) table
     preScanBodyForks mod body
     forM_ mbDflt $ preScanBodyForks mod
 
 
-recordIfConst :: ConstValue -> LLVM ()
-recordIfConst (PointerStructMember structID) = do
+recordIfConst :: ModSpec -> ConstValue -> LLVM ()
+recordIfConst mod (PointerStructMember structID) = do
     constInfo <- lift $ lookupConstInfo structID
     logLLVM $ "Recording const " ++ show structID
                 ++ " ( -> " ++ show constInfo ++ ")"
-    recordConst structID
-recordIfConst (GenericStructMember member) =
-    recordIfConst member
-recordIfConst (FnPointerStructMember pspec@(ProcSpec mod _ _ _)) = do
-    thisMod <- lift getModuleSpec
-    unless (thisMod == mod) $ do
-        logLLVM $ "Recording extern proc " ++ show pspec
-        pdef <- lift $ getProcDef pspec
-        let params = (primProtoParams . procImplnProto . procImpln) pdef
-        let args = List.map primParamToArg params
-        recordExternProc thisMod pspec args
-recordIfConst _ = return ()
+    recordConst mod structID
+recordIfConst mod (GenericStructMember member) =
+    recordIfConst mod member
+recordIfConst mod (FnPointerStructMember pspec@(ProcSpec pmod _ _ _)) = do
+    isClosure <- lift $ isClosureProc pspec
+    if isClosure
+    then do
+        params <- lift $ getPrimParams pspec
+        (neededArgs, realParams) <- partitionClosureParams pspec (primParamToArg <$> params)
+        let externArgs = primParamToArg envPrimParam : List.map primParamToArg realParams
+        recordExternProc mod pspec externArgs
+    else do
+        thisMod <- lift getModuleSpec
+        unless (thisMod == pmod) $ do
+            logLLVM $ "Recording extern proc " ++ show pspec
+            pdef <- lift $ getProcDef pspec
+            let params = (primProtoParams . procImplnProto . procImpln) pdef
+            let args = List.map primParamToArg params
+            recordExternProc mod pspec args
+recordIfConst _ _ = return ()
 
 
 -- | Record that the specified constant needs to be declared in this LLVM
 -- module, as well as any constants it refers to.
-recordConst :: StructID -> LLVM ()
-recordConst spec = do
+recordConst :: ModSpec -> StructID -> LLVM ()
+recordConst mod spec = do
     logLLVM $ "Recording constant " ++ show spec
     new <- gets $ Set.notMember spec . allConsts
     when new $ do
@@ -375,24 +383,25 @@ recordConst spec = do
                         allConsts = Set.insert spec
                             $ maybe id Set.delete previous $ allConsts s,
                         allVTables = Map.insert ispec spec $ allVTables s }
-                    recordConstParts info
+                    recordConstParts mod info
             _ -> do
                 modify $ \s -> s {allConsts=Set.insert spec $ allConsts s}
-                maybe (return ()) recordConstParts info
+                lift (lookupConstInfo spec) >>=
+                    maybe (return ()) (recordConstParts mod)
 
 
 -- | Record the pointer parts of a constant structure.
-recordConstParts :: StructInfo -> LLVM ()
-recordConstParts CStringInfo{} = return ()
-recordConstParts StructInfo{structData=members} = do
+recordConstParts :: ModSpec -> StructInfo -> LLVM ()
+recordConstParts _ CStringInfo{} = return ()
+recordConstParts mod StructInfo{structData=members} = do
     logLLVM $ "Recording parts of constant struct " ++ show members
-    mapM_ recordIfConst members
-recordConstParts VTableInfo{vtableData=members} = do
+    mapM_ (recordIfConst mod) members
+recordConstParts mod VTableInfo{vtableData=members} = do
     logLLVM $ "Recording parts of vtable " ++ show members
-    mapM_ recordIfConst members
-recordConstParts ArrayInfo{arrayData=elts} = do
+    mapM_ (recordIfConst mod) members
+recordConstParts mod ArrayInfo{arrayData=elts} = do
     logLLVM $ "Recording elts of constant array " ++ show elts
-    mapM_ recordIfConst elts
+    mapM_ (recordIfConst mod) elts
 
 
 -- | Produce a StructMember from a PrimArg, if it's a constant.  This may record
@@ -423,6 +432,8 @@ argConstValue (ArgUndef ty) = do
 -- | If needed, add an extern declaration for a prim to the set.
 recordExtern :: ModSpec -> Prim -> LLVM ()
 recordExtern mod (PrimCall _ pspec _ args _) = recordExternProc mod pspec args
+recordExtern _ (PrimHigher _ arg@(ArgClosure pspec _ _) _ _) = return ()
+recordExtern _ (PrimHigher _ arg@ArgConstRef{} _ _) = return ()
 recordExtern _ PrimHigher{} = return ()
 recordExtern _ PrimVirtualCall{} = return ()
 recordExtern _ (PrimForeign "llvm" _ _ _) = return ()

--- a/src/LLVM.hs
+++ b/src/LLVM.hs
@@ -18,7 +18,7 @@ import           Options
 import           Version
 import           CConfig
 import           Snippets
-import           Util                            ((|||), showArguments, sameLength, thd4)
+import           Util                            ((&&&), (|||), showArguments, sameLength, thd4)
 import           System.IO
 import           Data.Char                       (isAlphaNum)
 import           Data.Set                        as Set
@@ -829,9 +829,9 @@ writeClosureEnvUnmarshall :: [PrimParam] -> LLVM ()
 writeClosureEnvUnmarshall params = do
     structTy <- llvmStructType . (CPointer:) <$> mapM (typeRep . primParamType) params
     forM_ (zip [1..] params) $ \(idx, param) -> do
-        eltPtr <- getElementPtr True structTy (Just $ primParamToArg envPrimParam)
-                    [intConst 0, ArgInt idx int32Type]
-        llvmLoad eltPtr $ primParamToArg param
+            eltPtr <- getElementPtr True structTy (Just $ primParamToArg envPrimParam)
+                        [intConst 0, ArgInt idx int32Type]
+            llvmLoad eltPtr $ primParamToArg param
 
 
 ----------------------------------------------------------------------------
@@ -942,14 +942,19 @@ writeActualCall wybeProc ins outs tailKind = do
     params <- lift $ getPrimParams wybeProc
     -- must ensure we obey the closure interface
     isClosure <- lift $ isClosureProc wybeProc
-    let params' = if isClosure then List.filter ((/=Free) . primParamFlowType) params else params
+    let (params', ins') =
+          if isClosure
+          then let (free, nonFree) = List.partition ((Free==) . primParamFlowType) params
+               -- head ins must be the closure itself
+               in (nonFree, head ins : List.drop (length free) (tail ins)) 
+          else (params, ins)
     (inPs,outPs,oRefPs,iRefPs) <- partitionParams params'
     unless (List.null iRefPs)
       $ shouldnt $ "take-reference parameter(s) " ++ show iRefPs
     let allInPs = inPs ++ List.map convertOutByRefParam oRefPs
-    unless (sameLength allInPs ins)
+    unless (sameLength allInPs ins')
       $ shouldnt $ "in call to " ++ show wybeProc
-            ++ ", argument count " ++ show (length ins)
+            ++ ", argument count " ++ show (length ins')
             ++ " does not match parameter count " ++ show (length allInPs)
             ++ "\n " ++ show ins
             ++ " vs. " ++ show allInPs
@@ -960,7 +965,7 @@ writeActualCall wybeProc ins outs tailKind = do
             ++ "\n " ++ show outs
             ++ " vs. " ++ show outPs
     paramTypes <- mapM (typeRep . primParamType) allInPs
-    argList <- llvmStringArgList <$> zipWithM typeConvertedArg paramTypes ins
+    argList <- llvmStringArgList <$> zipWithM typeConvertedArg paramTypes ins'
     outReps <- mapM (typeRep . primParamType) outPs
     let outTy = llvmRepReturnType outReps
     let (name,cc) = llvmProcName wybeProc

--- a/src/LLVM.hs
+++ b/src/LLVM.hs
@@ -302,9 +302,8 @@ preScanProcs = do
 -- the C string, since the Wybe string constant refers to the C string.
 prescanArg :: ModSpec -> PrimArg -> LLVM ()
 prescanArg mod closure@(ArgClosure pspec args _) = do
-    (neededArgs, realParams) <- partitionClosureParams pspec args
-    let externArgs = primParamToArg envPrimParam : List.map primParamToArg realParams
-    recordExternProc mod pspec externArgs
+    realParams <- snd <$> partitionClosureParams pspec args
+    recordExternProc mod pspec $ List.map primParamToArg realParams
     recordExternSpec externAlloc
     argConstValue closure >>= maybe (return ()) (recordIfConst mod)
     mapM_ (prescanArg mod) args
@@ -354,8 +353,8 @@ recordIfConst _ _ = return ()
 getProcArgs :: ProcSpec -> LLVM [PrimArg]
 getProcArgs pspec = do
     params <- lift $ getPrimParams pspec
-    (neededArgs, realParams) <- partitionClosureParams pspec (primParamToArg <$> params)
-    return $ primParamToArg envPrimParam : List.map primParamToArg realParams
+    realParams <- snd <$> partitionClosureParams pspec (primParamToArg <$> params)
+    return $ List.map primParamToArg realParams
 
 
 -- | Record that the specified constant needs to be declared in this LLVM
@@ -683,7 +682,7 @@ writeProcLLVM def _  =
 -- with a leading "env" param. Also yields the Free params for unmarshalling
 closeClosureParams :: PrimProto -> (PrimProto, [PrimParam])
 closeClosureParams proto@PrimProto{primProtoParams=params} =
-    (proto{primProtoParams=envPrimParam:realParams}, neededFree)
+    (proto{primProtoParams=realParams}, neededFree)
   where
     (free, realParams) = List.partition ((==Free) . primParamFlowType) params
     neededFree = List.filter (not . paramInfoUnneeded . primParamInfo) free
@@ -886,9 +885,11 @@ writeWybeCall wybeProc args pos = do
 
 -- | Generate a Wybe proc call instruction, or defer it if necessary.
 writeHOCall :: PrimArg -> [PrimArg] -> OptPos -> LLVM ()
-writeHOCall closure@(ArgClosure pspec closed _) args pos = do
+writeHOCall closure@(ArgClosure _ _ _) args pos = do
     -- NB:  this case should have been handled earlier
-    shouldnt $ "Higher order call with constand closure should have been handled earlier: " ++ show closure
+    shouldnt $ "Higher order call with closure should have been handled earlier: " ++ show closure
+writeHOCall closure@(ArgConstRef _ _) args pos = do
+    shouldnt $ "Higher order call with constant should have been handled earlier: " ++ show closure
 writeHOCall closure args pos = do
     (ins,outs,oRefs,iRefs) <- partitionArgsWithRefs $ closure:args
     unless (List.null oRefs && List.null iRefs)
@@ -941,7 +942,7 @@ writeActualCall wybeProc ins outs tailKind = do
     params <- lift $ getPrimParams wybeProc
     -- must ensure we obey the closure interface
     isClosure <- lift $ isClosureProc wybeProc
-    let params' = if isClosure then envPrimParam : List.filter ((/=Free) . primParamFlowType) params else params
+    let params' = if isClosure then List.filter ((/=Free) . primParamFlowType) params else params
     (inPs,outPs,oRefPs,iRefPs) <- partitionParams params'
     unless (List.null iRefPs)
       $ shouldnt $ "take-reference parameter(s) " ++ show iRefPs

--- a/src/LLVM.hs
+++ b/src/LLVM.hs
@@ -336,17 +336,11 @@ recordIfConst mod (PointerStructMember structID) = do
     recordConst mod structID
 recordIfConst mod (GenericStructMember member) =
     recordIfConst mod member
-recordIfConst mod (FnPointerStructMember pspec@(ProcSpec pmod _ _ _)) = do
-    isClosure <- lift $ isClosureProc pspec
-    if isClosure
-    then getProcArgs pspec >>= recordExternProc mod pspec
-    else do
-        thisMod <- lift getModuleSpec
-        unless (thisMod == pmod) $ do
-            logLLVM $ "Recording extern proc " ++ show pspec
-            params <- lift $ getPrimParams pspec
-            let args = List.map primParamToArg params
-            recordExternProc mod pspec args
+recordIfConst mod (FnPointerStructMember pspec) = do
+    logLLVM $ "Recording extern proc " ++ show pspec
+    params <- lift $ getPrimParams pspec
+    let args = List.map primParamToArg params
+    recordExternProc mod pspec args
 recordIfConst _ _ = return ()
 
 
@@ -394,6 +388,10 @@ recordConstParts :: ModSpec -> StructInfo -> LLVM ()
 recordConstParts _ CStringInfo{} = return ()
 recordConstParts mod StructInfo{structData=members} = do
     logLLVM $ "Recording parts of constant struct " ++ show members
+    mapM_ (recordIfConst mod) members
+recordConstParts mod ClosureInfo{closureProcSpec=pspec, closureArgs=members} = do
+    logLLVM $ "Recording parts of constant closure " ++ show pspec ++ " of " ++ show members
+    getProcArgs pspec >>= recordExternProc mod pspec
     mapM_ (recordIfConst mod) members
 recordConstParts mod VTableInfo{vtableData=members} = do
     logLLVM $ "Recording parts of vtable " ++ show members
@@ -1211,7 +1209,7 @@ declareStringConstant name str section = do
 -- | Emit an LLVM declaration for a struct constant, optionally specifying a
 -- file section.
 declareStructConstant :: LLVMName -> StructInfo -> Maybe String -> LLVM ()
-declareStructConstant name (StructInfo _ (FnPointerStructMember pspec:fields)) section = do
+declareStructConstant name (ClosureInfo pspec fields) section = do
     freeParams <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
     let neededFields = snd <$> List.filter (paramIsNeeded . fst) (zip freeParams fields)
     llvmFields <- llvmConstStruct $ FnPointerStructMember pspec : neededFields

--- a/src/LLVM.hs
+++ b/src/LLVM.hs
@@ -1200,44 +1200,48 @@ writeAssemblyExports = do
 -- file section.
 declareStringConstant :: LLVMName -> String -> Maybe String -> LLVM ()
 declareStringConstant name str section = do
-    llvmPutStrLn $ llvmGlobalName name
-                    ++ " = private unnamed_addr constant "
-                    ++ showLLVMString str True
-                    ++ maybe "" ((", section "++) . show) section
-                    ++ ", align " ++ show wordSizeBytes
+    declareLLVMConstant name False Private section (Just wordSizeBytes) $ showLLVMString str True
 
 
 -- | Emit an LLVM declaration for a struct constant, optionally specifying a
 -- file section.
 declareStructConstant :: LLVMName -> StructInfo -> Maybe String -> LLVM ()
-declareStructConstant name (StructInfo sz members) section = do
+declareStructConstant name (StructInfo _ (FnPointerStructMember pspec:fields)) section = do
+    freeParams <- List.filter ((Free==) . primParamFlowType) <$> lift (getPrimParams pspec)
+    let neededFields = snd <$> List.filter (paramIsNeeded . fst) (zip freeParams fields)
+    llvmFields <- llvmConstStruct $ FnPointerStructMember pspec : neededFields
+    declareLLVMConstant name False Private section (Just wordSizeBytes) llvmFields
+declareStructConstant name (StructInfo _ members) section = do
     llvmFields <- llvmConstStruct members
-    llvmPutStrLn $ llvmGlobalName name
-                    ++ " = private unnamed_addr constant " ++ llvmFields
-                    ++ maybe "" ((", section "++) . show) section
-                    ++ ", align " ++ show wordSizeBytes
+    declareLLVMConstant name False Private section (Just wordSizeBytes) llvmFields
 declareStructConstant _ (VTableInfo sz members external index spec mod) section = do
     let llvmType = llvmStructType $ llvmConstValueRep <$> members
     llvmFields <- llvmConstStruct members
     let name = llvmVTableName mod index
-    llvmPutStrLn $ llvmGlobalName name ++ " = "
-                    ++ (if external then "external " else "")
-                    ++ "unnamed_addr constant "
-                    ++ (if external then llvmType else llvmFields)
-                    ++ maybe "" ((", section "++) . show) section
-                    ++ ", align " ++ show wordSizeBytes
+    declareLLVMConstant name external Public section (Just wordSizeBytes) $
+        if external then llvmType else llvmFields
 declareStructConstant name (CStringInfo str) section = do
-    llvmPutStrLn $ llvmGlobalName name
-                    ++ " = private unnamed_addr constant "
-                    ++ showLLVMString str True
-                    ++ maybe "" ((", section "++) . show) section
-                    ++ ", align " ++ show wordSizeBytes
+    declareStringConstant name str section
 declareStructConstant name (ArrayInfo elts) section = do
     let reps = llvmConstValueRep <$> elts
     llvmVals <- zipWithM convertedConstantArg elts reps
-    llvmPutStrLn $ llvmGlobalName name
-                    ++ " = private unnamed_addr constant [ " ++ show (length elts) ++ " x " ++ llvmTypeRep (head reps) ++ " ] "
-                    ++ "[" ++ intercalate ", " llvmVals ++ "]"
+    declareLLVMConstant name False Private section Nothing $
+           "[ " ++ show (length elts) ++ " x " ++ llvmTypeRep (head reps) ++ " ] "
+        ++ "[" ++ intercalate ", " llvmVals ++ "]"
+
+
+-- | Emit an LLVM declaration for a constant, optionally specifying a
+-- file section and allignment. The value should be prepended by its type
+declareLLVMConstant :: LLVMName -> Bool -> Visibility -> Maybe String -> Maybe Int -> String -> LLVM ()
+declareLLVMConstant name external vis mbSection mbAlignment value = 
+    llvmPutStrLn $ llvmGlobalName name ++ " = " 
+                    ++ (if external then "external " else "")
+                    ++ (if vis == Private then "private " else "")
+                    ++ "unnamed_addr constant "
+                    ++ value
+                    ++ maybe "" ((", section " ++) . show) mbSection
+                    ++ maybe "" ((", align " ++) . show) mbAlignment
+
 
 -- | The representation of a constant value as seen by LLVM, as distinguished
 -- from the representation used by Wybe.  Pointer struct members are seen as

--- a/src/LLVM.hs
+++ b/src/LLVM.hs
@@ -36,8 +36,6 @@ import           Data.Tuple.HT
 import qualified Data.ByteString                 as B
 import qualified Data.ByteString.Lazy            as BL
 import qualified Data.ByteString.Internal        as BI
-import Distribution.TestSuite (TestInstance(name))
-import Distribution.Simple.Utils (info)
 
 
 -- BEGIN MAJOR DOC
@@ -342,20 +340,22 @@ recordIfConst mod (GenericStructMember member) =
 recordIfConst mod (FnPointerStructMember pspec@(ProcSpec pmod _ _ _)) = do
     isClosure <- lift $ isClosureProc pspec
     if isClosure
-    then do
-        params <- lift $ getPrimParams pspec
-        (neededArgs, realParams) <- partitionClosureParams pspec (primParamToArg <$> params)
-        let externArgs = primParamToArg envPrimParam : List.map primParamToArg realParams
-        recordExternProc mod pspec externArgs
+    then getProcArgs pspec >>= recordExternProc mod pspec
     else do
         thisMod <- lift getModuleSpec
         unless (thisMod == pmod) $ do
             logLLVM $ "Recording extern proc " ++ show pspec
-            pdef <- lift $ getProcDef pspec
-            let params = (primProtoParams . procImplnProto . procImpln) pdef
+            params <- lift $ getPrimParams pspec
             let args = List.map primParamToArg params
             recordExternProc mod pspec args
 recordIfConst _ _ = return ()
+
+
+getProcArgs :: ProcSpec -> LLVM [PrimArg]
+getProcArgs pspec = do
+    params <- lift $ getPrimParams pspec
+    (neededArgs, realParams) <- partitionClosureParams pspec (primParamToArg <$> params)
+    return $ primParamToArg envPrimParam : List.map primParamToArg realParams
 
 
 -- | Record that the specified constant needs to be declared in this LLVM
@@ -432,8 +432,8 @@ argConstValue (ArgUndef ty) = do
 -- | If needed, add an extern declaration for a prim to the set.
 recordExtern :: ModSpec -> Prim -> LLVM ()
 recordExtern mod (PrimCall _ pspec _ args _) = recordExternProc mod pspec args
-recordExtern _ (PrimHigher _ arg@(ArgClosure pspec _ _) _ _) = return ()
-recordExtern _ (PrimHigher _ arg@ArgConstRef{} _ _) = return ()
+recordExtern mod (PrimHigher _ arg@(ArgConstRef cnst _) _ _) = recordConst mod cnst
+recordExtern mod (PrimHigher _ arg@(ArgClosure pspec _ _) _ _) = getProcArgs pspec >>= recordExternProc mod pspec
 recordExtern _ PrimHigher{} = return ()
 recordExtern _ PrimVirtualCall{} = return ()
 recordExtern _ (PrimForeign "llvm" _ _ _) = return ()

--- a/src/LLVM.hs
+++ b/src/LLVM.hs
@@ -885,10 +885,10 @@ writeWybeCall wybeProc args pos = do
 
 -- | Generate a Wybe proc call instruction, or defer it if necessary.
 writeHOCall :: PrimArg -> [PrimArg] -> OptPos -> LLVM ()
-writeHOCall closure@(ArgClosure _ _ _) args pos = do
+writeHOCall closure@ArgClosure{} args pos = do
     -- NB:  this case should have been handled earlier
     shouldnt $ "Higher order call with closure should have been handled earlier: " ++ show closure
-writeHOCall closure@(ArgConstRef _ _) args pos = do
+writeHOCall closure@ArgConstRef{} args pos = do
     shouldnt $ "Higher order call with constant should have been handled earlier: " ++ show closure
 writeHOCall closure args pos = do
     (ins,outs,oRefs,iRefs) <- partitionArgsWithRefs $ closure:args

--- a/src/Unbranch.hs
+++ b/src/Unbranch.hs
@@ -172,7 +172,10 @@ testInExp = boolVarGet outputStatusName
 -- | Get the index a test output should be if the given params are from a
 -- SemiDet proc
 testOutIndex :: [Param] -> Int
-testOutIndex = length . takeWhile (((==Free) ||| (==Ordinary)) . paramFlowType)
+testOutIndex = length . takeWhile (beforeTest . paramFlowType)
+  where
+    beforeTest (Resource _) = False
+    beforeTest _ = True 
 
 
 -- | Add a test output param to the list of params, as well as the index of the
@@ -865,14 +868,16 @@ addClosure regularProcSpec@(ProcSpec mod nm pID _) free pos name = do
 -- This removes params/free variables where the expression is a known constant
 makeFreeParams :: [Placed Param] -> [Placed Exp]
                -> Unbrancher ([Placed Stmt], [Placed Param], [Placed Exp], [Placed Stmt], Map Integer Exp)
-makeFreeParams params exps = makeFreeParams' 1 params $ unPlace <$> exps
+makeFreeParams params exps = makeFreeParams' 0 params $ unPlace <$> exps
 
 
 makeFreeParams' :: Integer -> [Placed Param] -> [(Exp, OptPos)]
                 -> Unbrancher ([Placed Stmt], [Placed Param], [Placed Exp], [Placed Stmt], Map Integer Exp)
 makeFreeParams' _ params [] = do
-    (pres, params', args', posts) <- List.foldr (\(pre, param, arg, post) (pres, params, args, posts) -> (pre ++ pres, param : params, arg : args, post ++ posts)) ([], [], [], []) 
-        <$> mapM (placedApply unbranchClosureParam) params
+    (pres, params', args', posts) <- List.foldr 
+        (\(pre, param, arg, post) (pres, params, args, posts) -> (pre ++ pres, param : params, arg : args, post ++ posts)) 
+        ([], [], [], []) 
+      <$> mapM (placedApply unbranchClosureParam) params
     return (pres, params', args', posts, Map.empty)
 makeFreeParams' _ [] _ = shouldnt "too many exps for params"
 makeFreeParams' idx (param:params) ((Typed exp ty cast,pos):exps)

--- a/src/Unbranch.hs
+++ b/src/Unbranch.hs
@@ -840,12 +840,14 @@ addClosure regularProcSpec@(ProcSpec mod nm pID _) free pos name = do
         Nothing -> do
             tmpCtr <- gets brTempCtr
             let body = pres ++ [ProcCall (First mod nm $ Just pID) detism False args `maybePlace` pos] ++ posts
+                simple = List.null pres && List.null posts
+                params'' = envParam `maybePlace` pos : params'
                 closureDef =
-                    ProcDef name (ProcProto name params' res) (ProcDefSrc body)
+                    ProcDef name (ProcProto name params'' res) (ProcDefSrc body)
                     Nothing tmpCtr 0 Map.empty Private Nothing detism Inline impurity
                     (ClosureProc regularProcSpec $ List.null pres && List.null posts) NoSuperproc Map.empty [] 0
             logUnbranch $ "Creating closure for " ++ show regularProcSpec
-            logUnbranch $ "  with params: " ++ show params'
+            logUnbranch $ "  with params: " ++ show params''
             logUnbranch $ "  with args  : " ++ show args
             logUnbranch $ "  with free  : " ++ show free
             pDefClosure' <- lift $ unbranchProc closureDef 0

--- a/test-cases/final-dump/benchmark_fib.exp
+++ b/test-cases/final-dump/benchmark_fib.exp
@@ -116,7 +116,7 @@ module top-level code > public {semipure} (0 calls)
     foreign c putchar(10:wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @benchmark_fib:nn:nn
     foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @benchmark_fib:nn:nn
     foreign c {impure} benchmark_start(c"benchmark_fib:40:2":wybe.c_string) @benchmark_fib:nn:nn
-    benchmark_fib.#anon#1<1>(benchmark_fib.#anon#1<1><>:{semipure}()) #0 @benchmark_fib:nn:nn
+    benchmark_fib.#anon#1<0> #0 @benchmark_fib:nn:nn
     foreign c {impure} benchmark_end(c"benchmark_fib:40:2":wybe.c_string, ?time##2:wybe.float) @benchmark_fib:nn:nn
     wybe.string.print<0>("Elapsed time (s):  ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @benchmark_fib:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @benchmark_fib:nn:nn
@@ -246,7 +246,6 @@ target triple   = ????
 @"benchmark_fib#constant#7" = private unnamed_addr constant [ ?? x i8 ] c"benchmark_fib:37:2\00", align 8
 @"benchmark_fib#constant#8" = private unnamed_addr constant [ ?? x i8 ] c"benchmark_fib:40:2\00", align 8
 @"benchmark_fib#constant#9" = private unnamed_addr constant {i64, ptr} { i64 19, ptr @"benchmark_fib#constant#5" }, align 8
-@"benchmark_fib#constant#10" = private unnamed_addr constant {ptr} { ptr @"benchmark_fib#.#anon#1<1>" }, align 8
 
 declare external fastcc void @"wybe#.string#.print<0>"(i64)
 declare external ccc double @benchmark_end(i64)
@@ -270,7 +269,7 @@ define external fastcc void @"benchmark_fib#.<0>"() {
   call ccc void @print_float(double %"time##1")
   call ccc void @putchar(i8 10)
   call ccc void @benchmark_start(ptr @"benchmark_fib#constant#8")
-  tail call fastcc void @"benchmark_fib#.#anon#1<1>"(ptr @"benchmark_fib#constant#10")
+  tail call fastcc void @"benchmark_fib#.#anon#1<0>"()
   %"time##2" = call ccc double @benchmark_end(ptr @"benchmark_fib#constant#8")
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"benchmark_fib#constant#9" to i64 ))
   call ccc void @print_float(double %"time##2")

--- a/test-cases/final-dump/benchmark_fib.exp
+++ b/test-cases/final-dump/benchmark_fib.exp
@@ -116,7 +116,7 @@ module top-level code > public {semipure} (0 calls)
     foreign c putchar(10:wybe.char, ~tmp#24##0:wybe.phantom, ?tmp#25##0:wybe.phantom) @benchmark_fib:nn:nn
     foreign lpvm store(~%tmp#25##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @benchmark_fib:nn:nn
     foreign c {impure} benchmark_start(c"benchmark_fib:40:2":wybe.c_string) @benchmark_fib:nn:nn
-    benchmark_fib.#anon#1<1><>:{semipure}() #0 @benchmark_fib:nn:nn
+    benchmark_fib.#anon#1<1>(benchmark_fib.#anon#1<1><>:{semipure}()) #0 @benchmark_fib:nn:nn
     foreign c {impure} benchmark_end(c"benchmark_fib:40:2":wybe.c_string, ?time##2:wybe.float) @benchmark_fib:nn:nn
     wybe.string.print<0>("Elapsed time (s):  ":wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @benchmark_fib:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @benchmark_fib:nn:nn
@@ -133,7 +133,7 @@ proc #anon#1 > {inline,semipure} (1 calls)
     benchmark_fib.naive_fib<0>(42:wybe.int, ?res##0:wybe.int) #0 @benchmark_fib:nn:nn
 proc #anon#1 > {inline,semipure} (1 calls)
 1: benchmark_fib.#anon#1<1>
-#anon#1()<{}; {}; {}>:
+#anon#1(@#env##0:opaque)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     benchmark_fib.naive_fib<0>(42:wybe.int, ?tmp#6##0:wybe.int) #1 @benchmark_fib:nn:nn
@@ -270,8 +270,7 @@ define external fastcc void @"benchmark_fib#.<0>"() {
   call ccc void @print_float(double %"time##1")
   call ccc void @putchar(i8 10)
   call ccc void @benchmark_start(ptr @"benchmark_fib#constant#8")
-  %"tmp#36##0" = load ptr, ptr @"benchmark_fib#constant#10"
-  tail call fastcc void %"tmp#36##0"(ptr @"benchmark_fib#constant#10")
+  tail call fastcc void @"benchmark_fib#.#anon#1<1>"(ptr @"benchmark_fib#constant#10")
   %"time##2" = call ccc double @benchmark_end(ptr @"benchmark_fib#constant#8")
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"benchmark_fib#constant#9" to i64 ))
   call ccc void @print_float(double %"time##2")

--- a/test-cases/final-dump/benchmark_fib.exp
+++ b/test-cases/final-dump/benchmark_fib.exp
@@ -88,7 +88,7 @@ define external fastcc double @"benchmark#.time_execution<0>"(ptr %"proc##0", i6
                     7:: CStringInfo {cstringChars = "benchmark_fib:37:2"}
                     8:: CStringInfo {cstringChars = "benchmark_fib:40:2"}
                     9:: StructInfo {structSize = 16, structData = [IntStructMember 19 8,PointerStructMember c"Elapsed time (s):  "]}
-                    10:: StructInfo {structSize = 8, structData = [FnPointerStructMember benchmark_fib.#anon#1<1>]}
+                    10:: ClosureInfo {closureProcSpec = benchmark_fib.#anon#1<1>, closureArgs = []}
   imports         : use benchmark
                     use wybe
   resources       : 

--- a/test-cases/final-dump/box_unbox_ho.exp
+++ b/test-cases/final-dump/box_unbox_ho.exp
@@ -496,13 +496,13 @@ module top-level code > public {semipure} (0 calls)
     foreign c putchar(10:wybe.char, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @box_unbox_ho:nn:nn
     foreign lpvm store(~%tmp#24##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox_ho:nn:nn
     box_unbox.print<0>(~tmp#0##0:box_unbox)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #14 @box_unbox_ho:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#28##0:wybe.phantom) @box_unbox_ho:nn:nn
-    foreign c putchar(10:wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @box_unbox_ho:nn:nn
-    foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox_ho:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#29##0:wybe.phantom) @box_unbox_ho:nn:nn
+    foreign c putchar(10:wybe.char, ~tmp#29##0:wybe.phantom, ?tmp#30##0:wybe.phantom) @box_unbox_ho:nn:nn
+    foreign lpvm store(~%tmp#30##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox_ho:nn:nn
     box_unbox.print<0>(~z##0:box_unbox)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #11 @box_unbox_ho:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#32##0:wybe.phantom) @box_unbox_ho:nn:nn
-    foreign c putchar(10:wybe.char, ~tmp#32##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @box_unbox_ho:nn:nn
-    foreign lpvm store(~%tmp#33##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox_ho:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#33##0:wybe.phantom) @box_unbox_ho:nn:nn
+    foreign c putchar(10:wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @box_unbox_ho:nn:nn
+    foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox_ho:nn:nn
 
 
 proc #anon#1 > {inline} (1 calls)
@@ -517,7 +517,7 @@ proc #anon#1 > {inline} (1 calls)
     foreign llvm add(~anon#1#1##0:box_unbox, 2:box_unbox, ?anon#1#2##0:box_unbox) @box_unbox_ho:nn:nn
 proc #anon#1 > {inline} (1 calls)
 1: box_unbox_ho.#anon#1<1>
-#anon#1(anon#1#1##0 <{}; {}; {0}>, ?anon#1#2##1)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+#anon#1(@#env##0:opaque, anon#1#1##0 <{}; {}; {1}>, ?anon#1#2##1)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~anon#1#1##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:box_unbox)
@@ -532,7 +532,7 @@ proc #anon#1 > {inline} (1 calls)
 
 proc #closure#1 > {inline} (2 calls)
 0: box_unbox_ho.#closure#1<0>
-#closure#1(^x##0:box_unbox, y##0 <{}; {}; {1}>, ?z##1)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+#closure#1(@#env##0:opaque, ^x##0:box_unbox, y##0 <{}; {}; {2}>, ?z##1)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm access(~y##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:box_unbox) @box_unbox_ho:nn:nn
@@ -587,35 +587,35 @@ define external fastcc void @"box_unbox_ho#.<0>"() {
   %"z##0" = add i128 %"tmp#0##0", %"tmp#0##0"
   tail call fastcc void @"box_unbox#.print<0>"(i128 %"z##0")
   call ccc void @putchar(i8 10)
-  %"tmp#34##0" = call ccc ptr @wybe_malloc(i32 16)
-  %"tmp#5##0" = ptrtoint ptr %"tmp#34##0" to i64
-  %"tmp#35##0" = inttoptr i64 %"tmp#5##0" to ptr
-  store i128 %"tmp#0##0", ptr %"tmp#35##0"
-  %"tmp#37##0" = zext i64 %"tmp#5##0" to i128
-  %"tmp#36##0" = trunc i128 %"tmp#37##0" to i64
-  %"tmp#38##0" = tail call fastcc i64 @"box_unbox_ho#.do_something<0>"(ptr @"box_unbox_ho#constant#0", i64 %"tmp#36##0")
-  %"tmp#6##0" = zext i64 %"tmp#38##0" to i128
-  %"tmp#40##0" = trunc i128 %"tmp#6##0" to i64
-  %"tmp#39##0" = inttoptr i64 %"tmp#40##0" to ptr
-  %"z##1" = load i128, ptr %"tmp#39##0"
+  %"tmp#35##0" = call ccc ptr @wybe_malloc(i32 16)
+  %"tmp#5##0" = ptrtoint ptr %"tmp#35##0" to i64
+  %"tmp#36##0" = inttoptr i64 %"tmp#5##0" to ptr
+  store i128 %"tmp#0##0", ptr %"tmp#36##0"
+  %"tmp#38##0" = zext i64 %"tmp#5##0" to i128
+  %"tmp#37##0" = trunc i128 %"tmp#38##0" to i64
+  %"tmp#39##0" = tail call fastcc i64 @"box_unbox_ho#.do_something<0>"(ptr @"box_unbox_ho#constant#0", i64 %"tmp#37##0")
+  %"tmp#6##0" = zext i64 %"tmp#39##0" to i128
+  %"tmp#41##0" = trunc i128 %"tmp#6##0" to i64
+  %"tmp#40##0" = inttoptr i64 %"tmp#41##0" to ptr
+  %"z##1" = load i128, ptr %"tmp#40##0"
   tail call fastcc void @"box_unbox#.print<0>"(i128 %"z##1")
   call ccc void @putchar(i8 10)
-  %"tmp#41##0" = trunc i128 %"tmp#6##0" to i64
-  %"tmp#42##0" = inttoptr i64 %"tmp#41##0" to ptr
-  store i128 %"tmp#0##0", ptr %"tmp#42##0"
-  %"tmp#44##0" = getelementptr inbounds {ptr, i128}, ptr null, i64 1
-  %"tmp#45##0" = ptrtoint ptr %"tmp#44##0" to i32
-  %"tmp#43##0" = call ccc ptr @wybe_malloc(i32 %"tmp#45##0")
-  store ptr @"box_unbox_ho#.#closure#1<0>", ptr %"tmp#43##0"
-  %"tmp#46##0" = getelementptr inbounds {ptr, i128}, ptr %"tmp#43##0", i64 0, i32 1
-  store i128 %"tmp#0##0", ptr %"tmp#46##0"
-  %"tmp#48##0" = zext i64 %"tmp#41##0" to i128
-  %"tmp#47##0" = trunc i128 %"tmp#48##0" to i64
-  %"tmp#49##0" = tail call fastcc i64 @"box_unbox_ho#.do_something<0>"(ptr %"tmp#43##0", i64 %"tmp#47##0")
-  %"tmp#10##0" = zext i64 %"tmp#49##0" to i128
-  %"tmp#51##0" = trunc i128 %"tmp#10##0" to i64
-  %"tmp#50##0" = inttoptr i64 %"tmp#51##0" to ptr
-  %"z##2" = load i128, ptr %"tmp#50##0"
+  %"tmp#42##0" = trunc i128 %"tmp#6##0" to i64
+  %"tmp#43##0" = inttoptr i64 %"tmp#42##0" to ptr
+  store i128 %"tmp#0##0", ptr %"tmp#43##0"
+  %"tmp#45##0" = getelementptr inbounds {ptr, i128}, ptr null, i64 1
+  %"tmp#46##0" = ptrtoint ptr %"tmp#45##0" to i32
+  %"tmp#44##0" = call ccc ptr @wybe_malloc(i32 %"tmp#46##0")
+  store ptr @"box_unbox_ho#.#closure#1<0>", ptr %"tmp#44##0"
+  %"tmp#47##0" = getelementptr inbounds {ptr, i128}, ptr %"tmp#44##0", i64 0, i32 1
+  store i128 %"tmp#0##0", ptr %"tmp#47##0"
+  %"tmp#49##0" = zext i64 %"tmp#42##0" to i128
+  %"tmp#48##0" = trunc i128 %"tmp#49##0" to i64
+  %"tmp#50##0" = tail call fastcc i64 @"box_unbox_ho#.do_something<0>"(ptr %"tmp#44##0", i64 %"tmp#48##0")
+  %"tmp#10##0" = zext i64 %"tmp#50##0" to i128
+  %"tmp#52##0" = trunc i128 %"tmp#10##0" to i64
+  %"tmp#51##0" = inttoptr i64 %"tmp#52##0" to ptr
+  %"z##2" = load i128, ptr %"tmp#51##0"
   tail call fastcc void @"box_unbox#.print<0>"(i128 %"z##2")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"box_unbox#.print<0>"(i128 %"tmp#0##0")

--- a/test-cases/final-dump/box_unbox_ho.exp
+++ b/test-cases/final-dump/box_unbox_ho.exp
@@ -459,7 +459,7 @@ define external fastcc void @"box_unbox#.print#cont#5<0>"(i64 %"s##0", i128 %"x#
   public submods  : 
   public resources: 
   public procs    : box_unbox_ho.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember box_unbox_ho.#anon#1<1>]}
+  constants       : 0:: ClosureInfo {closureProcSpec = box_unbox_ho.#anon#1<1>, closureArgs = []}
   imports         : use box_unbox
                     use wybe
   resources       : 

--- a/test-cases/final-dump/bug_497.exp
+++ b/test-cases/final-dump/bug_497.exp
@@ -46,7 +46,7 @@ proc #anon#1 > {inline} (1 calls)
     foreign llvm icmp_eq(~p##0:wybe.int, 3:wybe.int, ?#success##0:wybe.bool) @bug_497:nn:nn
 proc #anon#1 > {inline} (1 calls)
 1: bug_497.#anon#1<1>
-#anon#1(^p##0:wybe.int, anon#1#1##0 <{}; {}; {1}>, ?#success##0)<{}; {}; {}>:
+#anon#1(@#env##0:opaque, ^p##0:wybe.int, anon#1#1##0 <{}; {}; {2}>, ?#success##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.int.fmt<2>(^p##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#9##0:wybe.string) #1 @bug_497:nn:nn
@@ -90,7 +90,7 @@ proc#anon#1(^p##0:wybe.int, anon#1#1##0:wybe.int, ?#success##0:wybe.bool)<{}; {}
     foreign llvm icmp_eq(~p##0:wybe.int, 3:wybe.int, ?#success##0:wybe.bool) @bug_497:nn:nn
 proc proc#anon#1 > {inline} (1 calls)
 1: bug_497.proc#anon#1<1>
-proc#anon#1(^p##0:wybe.int, anon#1#1##0 <{}; {}; {1}>, ?#success##0)<{}; {}; {}>:
+proc#anon#1(@#env##0:opaque, ^p##0:wybe.int, anon#1#1##0 <{}; {}; {2}>, ?#success##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.int.fmt<2>(^p##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#8##0:wybe.string) #1 @bug_497:nn:nn

--- a/test-cases/final-dump/bug_497.exp
+++ b/test-cases/final-dump/bug_497.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : bug_497.<0>
-  constants       : 0:: StructInfo {structSize = 16, structData = [FnPointerStructMember bug_497.#anon#1<1>,IntStructMember 3 8]}
+  constants       : 0:: ClosureInfo {closureProcSpec = bug_497.#anon#1<1>, closureArgs = [IntStructMember 3 8]}
   imports         : use logging
                     use wybe
   resources       : 

--- a/test-cases/final-dump/bug_509.exp
+++ b/test-cases/final-dump/bug_509.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : bug_509.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember bug_509.#anon#1<1>]}
+  constants       : 0:: StructInfo {structSize = 16, structData = [FnPointerStructMember bug_509.#anon#1<1>,IntStructMember 1 8]}
   imports         : use wybe
   resources       : 
   procs           : 
@@ -18,7 +18,7 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    bug_509.call<0>(bug_509.#anon#1<1><>:(wybe.bool, ?wybe.bool), ?x##0:wybe.bool) #0 @bug_509:nn:nn
+    bug_509.call<0>(bug_509.#anon#1<1><1>:(wybe.bool, ?wybe.bool), ?x##0:wybe.bool) #0 @bug_509:nn:nn
     wybe.bool.print<0>(~x##0:wybe.bool)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #1 @bug_509:nn:nn
 
 

--- a/test-cases/final-dump/bug_509.exp
+++ b/test-cases/final-dump/bug_509.exp
@@ -30,7 +30,7 @@ proc #anon#1 > {inline} (1 calls)
     foreign llvm icmp_eq(~anon#1#1##0:wybe.bool, 1:wybe.bool, ?anon#1#2##0:wybe.bool) @bug_509:nn:nn
 proc #anon#1 > {inline} (1 calls)
 1: bug_509.#anon#1<1>
-#anon#1([^t##0:wybe.int], anon#1#1##0 <{}; {}; {1}>, ?anon#1#2##0)<{}; {}; {}>:
+#anon#1(@#env##0:opaque, [^t##0:wybe.int], anon#1#1##0 <{}; {}; {2}>, ?anon#1#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_eq(~anon#1#1##0:wybe.bool, 1:wybe.bool, ?anon#1#2##0:wybe.bool) @bug_509:nn:nn

--- a/test-cases/final-dump/bug_509.exp
+++ b/test-cases/final-dump/bug_509.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : bug_509.<0>
-  constants       : 0:: StructInfo {structSize = 16, structData = [FnPointerStructMember bug_509.#anon#1<1>,IntStructMember 1 8]}
+  constants       : 0:: ClosureInfo {closureProcSpec = bug_509.#anon#1<1>, closureArgs = [IntStructMember 1 8]}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/bug_510_llvm_retval.exp
+++ b/test-cases/final-dump/bug_510_llvm_retval.exp
@@ -41,7 +41,7 @@ proc#anon#1(^p##0:wybe.int, ?#success##0:wybe.bool)<{}; {}; {}>:
     foreign llvm icmp_eq(~p##0:wybe.int, 3:wybe.int, ?#success##0:wybe.bool) @bug_510_llvm_retval:nn:nn
 proc proc#anon#1 > {inline} (1 calls)
 1: bug_510_llvm_retval.proc#anon#1<1>
-proc#anon#1(^p##0:wybe.int, ?#success##0)<{}; {}; {}>:
+proc#anon#1(@#env##0:opaque, ^p##0:wybe.int, ?#success##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_eq(~^p##0:wybe.int, 3:wybe.int, ?#success##0:wybe.bool) @bug_510_llvm_retval:nn:nn

--- a/test-cases/final-dump/extern_anon_params_a.exp
+++ b/test-cases/final-dump/extern_anon_params_a.exp
@@ -38,7 +38,7 @@ run#anon#1(^func##0:{impure}())<{}; {}; {}>:
     ~func##0:{impure}() #0 @extern_anon_params_a:nn:nn
 proc run#anon#1 > {inline,impure} (1 calls)
 1: extern_anon_params_a.run#anon#1<1>
-run#anon#1(^func##0:{impure}())<{}; {}; {}>:
+run#anon#1(@#env##0:opaque, ^func##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~^func##0:{impure}() #0 @extern_anon_params_a:nn:nn

--- a/test-cases/final-dump/extern_anon_params_b.exp
+++ b/test-cases/final-dump/extern_anon_params_b.exp
@@ -38,7 +38,7 @@ run#anon#1(^func##0:{impure}())<{}; {}; {}>:
     ~func##0:{impure}() #0 @extern_anon_params_a:nn:nn
 proc run#anon#1 > {inline,impure} (1 calls)
 1: extern_anon_params_a.run#anon#1<1>
-run#anon#1(^func##0:{impure}())<{}; {}; {}>:
+run#anon#1(@#env##0:opaque, ^func##0:{impure}())<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~^func##0:{impure}() #0 @extern_anon_params_a:nn:nn
@@ -106,7 +106,7 @@ proc #anon#1 > {inline,impure} (1 calls)
   InterestingCallProperties: []
 proc #anon#1 > {inline,impure} (1 calls)
 1: extern_anon_params_b.#anon#1<1>
-#anon#1()<{}; {}; {}>:
+#anon#1(@#env##0:opaque)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 

--- a/test-cases/final-dump/extern_anon_params_b.exp
+++ b/test-cases/final-dump/extern_anon_params_b.exp
@@ -85,7 +85,7 @@ define external fastcc void @"extern_anon_params_a#.run#anon#1<1>"(ptr %"#env##0
   public submods  : 
   public resources: 
   public procs    : extern_anon_params_b.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember extern_anon_params_b.#anon#1<1>]}
+  constants       : 0:: ClosureInfo {closureProcSpec = extern_anon_params_b.#anon#1<1>, closureArgs = []}
   imports         : use extern_anon_params_a
                     use wybe
   resources       : 

--- a/test-cases/final-dump/higher_order_anon.exp
+++ b/test-cases/final-dump/higher_order_anon.exp
@@ -37,7 +37,7 @@ proc #anon#1 > {inline} (1 calls)
     foreign llvm add(~anon#1#1##0:wybe.int, 1:wybe.int, ?anon#1#2##0:wybe.int) @higher_order_anon:nn:nn
 proc #anon#1 > {inline} (1 calls)
 1: higher_order_anon.#anon#1<1>
-#anon#1(anon#1#1##0 <{}; {}; {0}>, ?anon#1#2##0)<{}; {}; {}>:
+#anon#1(@#env##0:opaque, anon#1#1##0 <{}; {}; {1}>, ?anon#1#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~anon#1#1##0:wybe.int, 1:wybe.int, ?anon#1#2##0:wybe.int) @higher_order_anon:nn:nn
@@ -51,7 +51,7 @@ proc #anon#2 > {inline} (1 calls)
     foreign llvm add(~anon#2#1##0:wybe.int, 1:wybe.int, ?anon#2#2##0:wybe.int) @higher_order_anon:nn:nn
 proc #anon#2 > {inline} (1 calls)
 1: higher_order_anon.#anon#2<1>
-#anon#2(anon#2#1##0 <{}; {}; {0}>, ?anon#2#2##0)<{}; {}; {}>:
+#anon#2(@#env##0:opaque, anon#2#1##0 <{}; {}; {1}>, ?anon#2#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~anon#2#1##0:wybe.int, 1:wybe.int, ?anon#2#2##0:wybe.int) @higher_order_anon:nn:nn
@@ -65,7 +65,7 @@ proc #anon#3 > {inline} (1 calls)
     foreign llvm move(~anon#3#2##0:Type2, ?anon#3#3##0:Type2) @higher_order_anon:nn:nn
 proc #anon#3 > {inline} (1 calls)
 1: higher_order_anon.#anon#3<1>
-#anon#3(anon#3#1##0 <{}; {}; {0}>, anon#3#2##0 <{}; {}; {1}>, ?anon#3#3##0 <{}; {}; {1}>)<{}; {}; {}>:
+#anon#3(@#env##0:opaque, anon#3#1##0 <{}; {}; {1}>, anon#3#2##0 <{}; {}; {2}>, ?anon#3#3##0 <{}; {}; {2}>)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#3#2##0:Type2, ?anon#3#3##0:Type2) @higher_order_anon:nn:nn
@@ -79,7 +79,7 @@ proc #anon#4 > {inline} (1 calls)
     foreign llvm move(~anon#4#2##0:Type2, ?anon#4#3##0:Type2) @higher_order_anon:nn:nn
 proc #anon#4 > {inline} (1 calls)
 1: higher_order_anon.#anon#4<1>
-#anon#4(anon#4#1##0 <{}; {}; {0}>, anon#4#2##0 <{}; {}; {1}>, ?anon#4#3##0 <{}; {}; {1}>)<{}; {}; {}>:
+#anon#4(@#env##0:opaque, anon#4#1##0 <{}; {}; {1}>, anon#4#2##0 <{}; {}; {2}>, ?anon#4#3##0 <{}; {}; {2}>)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#4#2##0:Type2, ?anon#4#3##0:Type2) @higher_order_anon:nn:nn
@@ -93,7 +93,7 @@ proc #anon#5 > {inline} (1 calls)
     foreign llvm move(~anon#5#1##0:(wybe.int, ?wybe.int), ?anon#5#2##0:(wybe.int, ?wybe.int)) @higher_order_anon:nn:nn
 proc #anon#5 > {inline} (1 calls)
 1: higher_order_anon.#anon#5<1>
-#anon#5(anon#5#1##0 <{}; {}; {0}>, ?anon#5#2##0)<{}; {}; {}>:
+#anon#5(@#env##0:opaque, anon#5#1##0 <{}; {}; {1}>, ?anon#5#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#5#1##0:(wybe.int, ?wybe.int), ?anon#5#2##0:(wybe.int, ?wybe.int)) @higher_order_anon:nn:nn
@@ -107,7 +107,7 @@ proc #anon#6 > {inline} (1 calls)
     foreign llvm move(~anon#6#1##0:(wybe.int, ?wybe.int), ?anon#6#2##0:(wybe.int, ?wybe.int)) @higher_order_anon:nn:nn
 proc #anon#6 > {inline} (1 calls)
 1: higher_order_anon.#anon#6<1>
-#anon#6(anon#6#1##0 <{}; {}; {0}>, ?anon#6#2##0)<{}; {}; {}>:
+#anon#6(@#env##0:opaque, anon#6#1##0 <{}; {}; {1}>, ?anon#6#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#6#1##0:(wybe.int, ?wybe.int), ?anon#6#2##0:(wybe.int, ?wybe.int)) @higher_order_anon:nn:nn
@@ -121,7 +121,7 @@ proc #anon#7 > {inline} (1 calls)
     ~id##0:((wybe.int, ?wybe.int), ?(wybe.int, ?wybe.int))(higher_order_anon.#anon#7#anon#1<1><>:(wybe.int, ?wybe.int), ?anon#7#1##0:(wybe.int, ?wybe.int)) #0 @higher_order_anon:nn:nn
 proc #anon#7 > {inline} (1 calls)
 1: higher_order_anon.#anon#7<1>
-#anon#7(^id##0:((wybe.int, ?wybe.int), ?(wybe.int, ?wybe.int)), ?anon#7#1##0)<{}; {}; {}>:
+#anon#7(@#env##0:opaque, ^id##0:((wybe.int, ?wybe.int), ?(wybe.int, ?wybe.int)), ?anon#7#1##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~^id##0:((wybe.int, ?wybe.int), ?(wybe.int, ?wybe.int))(higher_order_anon.#anon#7#anon#1<1><>:(wybe.int, ?wybe.int), ?anon#7#1##0:(wybe.int, ?wybe.int)) #0 @higher_order_anon:nn:nn
@@ -135,7 +135,7 @@ proc #anon#7#anon#1 > {inline} (1 calls)
     foreign llvm add(~anon#8#1##0:wybe.int, 1:wybe.int, ?anon#8#2##0:wybe.int) @higher_order_anon:nn:nn
 proc #anon#7#anon#1 > {inline} (1 calls)
 1: higher_order_anon.#anon#7#anon#1<1>
-#anon#7#anon#1(anon#8#1##0 <{}; {}; {0}>, ?anon#8#2##0)<{}; {}; {}>:
+#anon#7#anon#1(@#env##0:opaque, anon#8#1##0 <{}; {}; {1}>, ?anon#8#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~anon#8#1##0:wybe.int, 1:wybe.int, ?anon#8#2##0:wybe.int) @higher_order_anon:nn:nn
@@ -149,7 +149,7 @@ proc #anon#8 > {inline} (1 calls)
     foreign llvm fadd(~anon#9#1##0:wybe.float, ~anon#9#3##0:wybe.float, ?anon#9#4##0:wybe.float) @higher_order_anon:nn:nn
 proc #anon#8 > {inline} (1 calls)
 1: higher_order_anon.#anon#8<1>
-#anon#8(anon#9#1##0 <{}; {}; {0}>, anon#9#2##0 <{}; {}; {1}>, anon#9#3##0 <{}; {}; {2}>, ?anon#9#4##0)<{}; {}; {}>:
+#anon#8(@#env##0:opaque, anon#9#1##0 <{}; {}; {1}>, anon#9#2##0 <{}; {}; {2}>, anon#9#3##0 <{}; {}; {3}>, ?anon#9#4##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm fadd(~anon#9#1##0:wybe.float, ~anon#9#3##0:wybe.float, ?anon#9#4##0:wybe.float) @higher_order_anon:nn:nn
@@ -163,7 +163,7 @@ proc #anon#9 > {inline} (1 calls)
     foreign llvm fadd(~anon#10#1##0:wybe.float, ~anon#10#3##0:wybe.float, ?anon#10#4##0:wybe.float) @higher_order_anon:nn:nn
 proc #anon#9 > {inline} (1 calls)
 1: higher_order_anon.#anon#9<1>
-#anon#9(anon#10#1##0 <{}; {}; {0}>, anon#10#2##0 <{}; {}; {1}>, anon#10#3##0 <{}; {}; {2}>, ?anon#10#4##0)<{}; {}; {}>:
+#anon#9(@#env##0:opaque, anon#10#1##0 <{}; {}; {1}>, anon#10#2##0 <{}; {}; {2}>, anon#10#3##0 <{}; {}; {3}>, ?anon#10#4##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm fadd(~anon#10#1##0:wybe.float, ~anon#10#3##0:wybe.float, ?anon#10#4##0:wybe.float) @higher_order_anon:nn:nn

--- a/test-cases/final-dump/higher_order_anon.exp
+++ b/test-cases/final-dump/higher_order_anon.exp
@@ -8,16 +8,16 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : higher_order_anon.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#7#anon#1<1>]}
-                    1:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#1<1>]}
-                    2:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#2<1>]}
-                    3:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#3<1>]}
-                    4:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#4<1>]}
-                    5:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#5<1>]}
-                    6:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#6<1>]}
-                    7:: StructInfo {structSize = 16, structData = [FnPointerStructMember higher_order_anon.#anon#7<1>,PointerStructMember higher_order_anon.#anon#6<1><>]}
-                    8:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#8<1>]}
-                    9:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_anon.#anon#9<1>]}
+  constants       : 0:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#7#anon#1<1>, closureArgs = []}
+                    1:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#1<1>, closureArgs = []}
+                    2:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#2<1>, closureArgs = []}
+                    3:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#3<1>, closureArgs = []}
+                    4:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#4<1>, closureArgs = []}
+                    5:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#5<1>, closureArgs = []}
+                    6:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#6<1>, closureArgs = []}
+                    7:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#7<1>, closureArgs = [PointerStructMember higher_order_anon.#anon#6<1><>]}
+                    8:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#8<1>, closureArgs = []}
+                    9:: ClosureInfo {closureProcSpec = higher_order_anon.#anon#9<1>, closureArgs = []}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/higher_order_append.exp
+++ b/test-cases/final-dump/higher_order_append.exp
@@ -47,7 +47,7 @@ proc #anon#1 > {inline} (1 calls)
     higher_order_append.append<0>(~anon#1#1##0:wybe.list(wybe.int), ~cons##0:wybe.list(wybe.int), outByReference anon#1#2##0:wybe.list(wybe.int)) #0 @higher_order_append:nn:nn
 proc #anon#1 > {inline} (1 calls)
 1: higher_order_append.#anon#1<1>
-#anon#1(^cons##0:wybe.list(wybe.int), anon#1#1##0 <{}; {}; {1}>, ?anon#1#2##0)<{}; {}; {}>:
+#anon#1(@#env##0:opaque, ^cons##0:wybe.list(wybe.int), anon#1#1##0 <{}; {}; {2}>, ?anon#1#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     higher_order_append.append<0>(~anon#1#1##0:wybe.list(wybe.int), ~^cons##0:wybe.list(wybe.int), outByReference anon#1#2##0:wybe.list(wybe.int)) #1 @higher_order_append:nn:nn
@@ -55,7 +55,7 @@ proc #anon#1 > {inline} (1 calls)
 
 proc #closure#1 > {inline} (2 calls)
 0: higher_order_append.#closure#1<0>
-#closure#1(l##0 <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+#closure#1(@#env##0:opaque, l##0 <{}; {}; {1}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.list.print<0>(higher_order_append.print_list_of_ints#closure#1<0><>:{resource}(wybe.int), ~l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {0, 1}> #1 @higher_order_append:nn:nn
@@ -92,7 +92,7 @@ print_list_of_ints(l##0:wybe.list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>};
 
 proc print_list_of_ints#closure#1 > {inline} (1 calls)
 0: higher_order_append.print_list_of_ints#closure#1<0>
-print_list_of_ints#closure#1(x##0 <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+print_list_of_ints#closure#1(@#env##0:opaque, x##0 <{}; {}; {1}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @int:nn:nn

--- a/test-cases/final-dump/higher_order_append.exp
+++ b/test-cases/final-dump/higher_order_append.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : higher_order_append.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_append.print_list_of_ints#closure#1<0>]}
+  constants       : 0:: ClosureInfo {closureProcSpec = higher_order_append.print_list_of_ints#closure#1<0>, closureArgs = []}
                     1:: StructInfo {structSize = 16, structData = [IntStructMember 3 8,IntStructMember 0 8]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 2 8,IntStructMember 0 8]}
                     3:: StructInfo {structSize = 16, structData = [PointerStructMember higher_order_append#constant#1,IntStructMember 0 8]}
@@ -17,8 +17,8 @@ AFTER EVERYTHING:
                     6:: StructInfo {structSize = 16, structData = [PointerStructMember higher_order_append#constant#4,PointerStructMember higher_order_append#constant#5]}
                     7:: StructInfo {structSize = 16, structData = [IntStructMember 6 8,IntStructMember 0 8]}
                     8:: StructInfo {structSize = 16, structData = [IntStructMember 4 8,PointerStructMember higher_order_append#constant#7]}
-                    9:: StructInfo {structSize = 16, structData = [FnPointerStructMember higher_order_append.#anon#1<1>,PointerStructMember higher_order_append#constant#8]}
-                    10:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_append.#closure#1<0>]}
+                    9:: ClosureInfo {closureProcSpec = higher_order_append.#anon#1<1>, closureArgs = [PointerStructMember higher_order_append#constant#8]}
+                    10:: ClosureInfo {closureProcSpec = higher_order_append.#closure#1<0>, closureArgs = []}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/higher_order_impure.exp
+++ b/test-cases/final-dump/higher_order_impure.exp
@@ -17,12 +17,12 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-module top-level code > public {semipure} (0 calls)
+module top-level code > public {inline,semipure} (0 calls)
 0: higher_order_impure.<0>
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_impure.#anon#1<1>(higher_order_impure.#anon#1<1><>:{impure}(), _:wybe.list(wybe.int)) #0 @higher_order_impure:nn:nn
+    higher_order_impure.#anon#1<0>(_:wybe.list(wybe.int)) #0 @higher_order_impure:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @higher_order_impure:nn:nn
     foreign c print_float(3.0:wybe.float, ~%tmp#18##0:wybe.phantom, ?%tmp#19##0:wybe.phantom) @higher_order_impure:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @higher_order_impure:nn:nn
@@ -57,14 +57,13 @@ measure(func##0:{impure}(), ?seconds_elapsed##0:wybe.float)<{}; {}; {}>:
 source_filename = "!ROOT!/final-dump/higher_order_impure.wybe"
 target triple   = ????
 
-@"higher_order_impure#constant#3" = private unnamed_addr constant {ptr} { ptr @"higher_order_impure#.#anon#1<1>" }, align 8
 
 declare external ccc void @print_float(double)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"higher_order_impure#.<0>"() {
-  tail call fastcc void @"higher_order_impure#.#anon#1<1>"(ptr @"higher_order_impure#constant#3")
+  tail call fastcc void @"higher_order_impure#.#anon#1<0>"()
   call ccc void @print_float(double 3.0)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/higher_order_impure.exp
+++ b/test-cases/final-dump/higher_order_impure.exp
@@ -22,7 +22,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_impure.#anon#1<1><>:{impure}() #0 @higher_order_impure:nn:nn
+    higher_order_impure.#anon#1<1>(higher_order_impure.#anon#1<1><>:{impure}(), _:wybe.list(wybe.int)) #0 @higher_order_impure:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#18##0:wybe.phantom) @higher_order_impure:nn:nn
     foreign c print_float(3.0:wybe.float, ~%tmp#18##0:wybe.phantom, ?%tmp#19##0:wybe.phantom) @higher_order_impure:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @higher_order_impure:nn:nn
@@ -36,7 +36,7 @@ proc #anon#1 > {inline,impure} (1 calls)
   InterestingCallProperties: []
 proc #anon#1 > {inline,impure} (1 calls)
 1: higher_order_impure.#anon#1<1>
-#anon#1([^l2##0:wybe.list(wybe.int)])<{}; {}; {}>:
+#anon#1(@#env##0:opaque, [^l2##0:wybe.list(wybe.int)])<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
 
@@ -64,8 +64,7 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"higher_order_impure#.<0>"() {
-  %"tmp#21##0" = load ptr, ptr @"higher_order_impure#constant#3"
-  tail call fastcc void %"tmp#21##0"(ptr @"higher_order_impure#constant#3")
+  tail call fastcc void @"higher_order_impure#.#anon#1<1>"(ptr @"higher_order_impure#constant#3")
   call ccc void @print_float(double 3.0)
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/higher_order_impure.exp
+++ b/test-cases/final-dump/higher_order_impure.exp
@@ -12,7 +12,7 @@ AFTER EVERYTHING:
   constants       : 0:: StructInfo {structSize = 16, structData = [IntStructMember 3 8,IntStructMember 0 8]}
                     1:: StructInfo {structSize = 16, structData = [IntStructMember 2 8,PointerStructMember higher_order_impure#constant#0]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 1 8,PointerStructMember higher_order_impure#constant#1]}
-                    3:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_impure.#anon#1<1>]}
+                    3:: StructInfo {structSize = 16, structData = [FnPointerStructMember higher_order_impure.#anon#1<1>,PointerStructMember higher_order_impure#constant#2]}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/higher_order_impure.exp
+++ b/test-cases/final-dump/higher_order_impure.exp
@@ -12,7 +12,7 @@ AFTER EVERYTHING:
   constants       : 0:: StructInfo {structSize = 16, structData = [IntStructMember 3 8,IntStructMember 0 8]}
                     1:: StructInfo {structSize = 16, structData = [IntStructMember 2 8,PointerStructMember higher_order_impure#constant#0]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 1 8,PointerStructMember higher_order_impure#constant#1]}
-                    3:: StructInfo {structSize = 16, structData = [FnPointerStructMember higher_order_impure.#anon#1<1>,PointerStructMember higher_order_impure#constant#2]}
+                    3:: ClosureInfo {closureProcSpec = higher_order_impure.#anon#1<1>, closureArgs = [PointerStructMember higher_order_impure#constant#2]}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/higher_order_inline.exp
+++ b/test-cases/final-dump/higher_order_inline.exp
@@ -13,21 +13,20 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-module top-level code > public {semipure} (0 calls)
+module top-level code > public {inline,semipure} (0 calls)
 0: higher_order_inline.<0>
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_inline.#closure#1<0><>:(wybe.int, ?wybe.int)(1:wybe.int, ?i##0:wybe.int) #0 @higher_order_inline:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#2##0:wybe.phantom) @higher_order_inline:nn:nn
-    foreign c print_int(~i##0:wybe.int, ~%tmp#2##0:wybe.phantom, ?%tmp#3##0:wybe.phantom) @higher_order_inline:nn:nn
-    foreign c putchar(10:wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @higher_order_inline:nn:nn
-    foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_inline:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @higher_order_inline:nn:nn
+    foreign c print_int(1:wybe.int, ~%tmp#5##0:wybe.phantom, ?%tmp#6##0:wybe.phantom) @higher_order_inline:nn:nn
+    foreign c putchar(10:wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @higher_order_inline:nn:nn
+    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_inline:nn:nn
 
 
 proc #closure#1 > {inline} (1 calls)
 0: higher_order_inline.#closure#1<0>
-#closure#1(a##0 <{}; {}; {0}>, ?#result##0 <{}; {}; {0}>)<{}; {}; {}>:
+#closure#1(@#env##0:opaque, a##0 <{}; {}; {1}>, ?#result##0 <{}; {}; {1}>)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~a##0:A, ?#result##0:A) @predicate:nn:nn
@@ -40,16 +39,13 @@ proc #closure#1 > {inline} (1 calls)
 source_filename = "!ROOT!/final-dump/higher_order_inline.wybe"
 target triple   = ????
 
-@"higher_order_inline#constant#0" = private unnamed_addr constant {ptr} { ptr @"higher_order_inline#.#closure#1<0>" }, align 8
 
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"higher_order_inline#.<0>"() {
-  %"tmp#5##0" = load ptr, ptr @"higher_order_inline#constant#0"
-  %"i##0" = tail call fastcc i64 %"tmp#5##0"(ptr @"higher_order_inline#constant#0", i64 1)
-  call ccc void @print_int(i64 %"i##0")
+  call ccc void @print_int(i64 1)
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/higher_order_inline.exp
+++ b/test-cases/final-dump/higher_order_inline.exp
@@ -18,10 +18,10 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#5##0:wybe.phantom) @higher_order_inline:nn:nn
-    foreign c print_int(1:wybe.int, ~%tmp#5##0:wybe.phantom, ?%tmp#6##0:wybe.phantom) @higher_order_inline:nn:nn
-    foreign c putchar(10:wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @higher_order_inline:nn:nn
-    foreign lpvm store(~%tmp#7##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_inline:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @higher_order_inline:nn:nn
+    foreign c print_int(1:wybe.int, ~%tmp#3##0:wybe.phantom, ?%tmp#4##0:wybe.phantom) @higher_order_inline:nn:nn
+    foreign c putchar(10:wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @higher_order_inline:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_inline:nn:nn
 
 
 proc #closure#1 > {inline} (1 calls)

--- a/test-cases/final-dump/higher_order_inline.exp
+++ b/test-cases/final-dump/higher_order_inline.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : higher_order_inline.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_inline.#closure#1<0>]}
+  constants       : 0:: ClosureInfo {closureProcSpec = higher_order_inline.#closure#1<0>, closureArgs = []}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/higher_order_loop.exp
+++ b/test-cases/final-dump/higher_order_loop.exp
@@ -26,7 +26,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 proc #closure#1 > {inline} (1 calls)
 0: higher_order_loop.#closure#1<0>
-#closure#1(x##0 <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+#closure#1(@#env##0:opaque, x##0 <{}; {}; {1}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @int:nn:nn
@@ -37,7 +37,7 @@ proc #closure#1 > {inline} (1 calls)
 
 proc #closure#2 > {inline} (1 calls)
 0: higher_order_loop.#closure#2<0>
-#closure#2(x##0 <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
+#closure#2(@#env##0:opaque, x##0 <{}; {}; {1}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#8##0:wybe.phantom) @int:nn:nn

--- a/test-cases/final-dump/higher_order_loop.exp
+++ b/test-cases/final-dump/higher_order_loop.exp
@@ -8,8 +8,8 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : higher_order_loop.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_loop.#closure#1<0>]}
-                    1:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_loop.#closure#2<0>]}
+  constants       : 0:: ClosureInfo {closureProcSpec = higher_order_loop.#closure#1<0>, closureArgs = []}
+                    1:: ClosureInfo {closureProcSpec = higher_order_loop.#closure#2<0>, closureArgs = []}
                     2:: StructInfo {structSize = 16, structData = [PointerStructMember higher_order_loop.#closure#2<0><>,IntStructMember 0 8]}
                     3:: StructInfo {structSize = 16, structData = [PointerStructMember higher_order_loop.#closure#1<0><>,PointerStructMember higher_order_loop#constant#2]}
   imports         : use wybe

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -55,7 +55,7 @@ proc #anon#1 > {inline} (1 calls)
     foreign llvm move(~anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float) @higher_order_refs:nn:nn
 proc #anon#1 > {inline} (1 calls)
 1: higher_order_refs.#anon#1<1>
-#anon#1(anon#1#1##0 <{}; {}; {0}>, ?anon#1#2##0)<{}; {}; {}>:
+#anon#1(@#env##0:opaque, anon#1#1##0 <{}; {}; {1}>, ?anon#1#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#1#1##0:wybe.float, ?anon#1#2##0:wybe.float) @higher_order_refs:nn:nn
@@ -69,7 +69,7 @@ proc #anon#2 > {inline} (1 calls)
     foreign llvm move(~anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float) @higher_order_refs:nn:nn
 proc #anon#2 > {inline} (1 calls)
 1: higher_order_refs.#anon#2<1>
-#anon#2(anon#2#1##0 <{}; {}; {0}>, ?anon#2#2##0)<{}; {}; {}>:
+#anon#2(@#env##0:opaque, anon#2#1##0 <{}; {}; {1}>, ?anon#2#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~anon#2#1##0:wybe.float, ?anon#2#2##0:wybe.float) @higher_order_refs:nn:nn
@@ -83,7 +83,7 @@ proc #anon#3 > {inline} (1 calls)
     foreign llvm fsub(~anon#3#1##0:wybe.float, ~y##0:wybe.float, ?anon#3#2##0:wybe.float) @higher_order_refs:nn:nn
 proc #anon#3 > {inline} (1 calls)
 1: higher_order_refs.#anon#3<1>
-#anon#3(^y##0:wybe.float, anon#3#1##0 <{}; {}; {1}>, ?anon#3#2##0)<{}; {}; {}>:
+#anon#3(@#env##0:opaque, ^y##0:wybe.float, anon#3#1##0 <{}; {}; {2}>, ?anon#3#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm fsub(~anon#3#1##0:wybe.float, ~^y##0:wybe.float, ?anon#3#2##0:wybe.float) @higher_order_refs:nn:nn
@@ -91,7 +91,7 @@ proc #anon#3 > {inline} (1 calls)
 
 proc #closure#1 > {inline} (1 calls)
 0: higher_order_refs.#closure#1<0>
-#closure#1(a##0 <{}; {}; {0}>, ?#result##0 <{}; {}; {0}>)<{}; {}; {}>:
+#closure#1(@#env##0:opaque, a##0 <{}; {}; {1}>, ?#result##0 <{}; {}; {1}>)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~a##0:A, ?#result##0:A) @predicate:nn:nn
@@ -99,7 +99,7 @@ proc #closure#1 > {inline} (1 calls)
 
 proc #closure#2 > {inline} (1 calls)
 0: higher_order_refs.#closure#2<0>
-#closure#2(i##0 <{}; {}; {0}>, ?#result##0)<{}; {}; {}>:
+#closure#2(@#env##0:opaque, i##0 <{}; {}; {1}>, ?#result##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @higher_order_refs:nn:nn
@@ -107,7 +107,7 @@ proc #closure#2 > {inline} (1 calls)
 
 proc #closure#3 > {inline} (1 calls)
 0: higher_order_refs.#closure#3<0>
-#closure#3([^x##0:wybe.int], y##0 <{}; {}; {1}>, ?#result##0)<{}; {}; {}>:
+#closure#3(@#env##0:opaque, [^x##0:wybe.int], y##0 <{}; {}; {2}>, ?#result##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm add(~y##0:wybe.int, 10:wybe.int, ?#result##0:wybe.int) @int:nn:nn
@@ -160,7 +160,7 @@ foo#anon#1(^w##0:wybe.char, ^x##0:wybe.bool, ^y##0:wybe.char, ^z##0:wybe.int, an
     foreign llvm add(~anon#1#1##0:wybe.int, ~z##0:wybe.int, ?anon#1#2##0:wybe.int) @higher_order_refs:nn:nn
 proc foo#anon#1 > {inline} (1 calls)
 1: higher_order_refs.foo#anon#1<1>
-foo#anon#1(^w##0:wybe.char, ^x##0:wybe.bool, ^y##0:wybe.char, ^z##0:wybe.int, anon#1#1##0 <{}; {}; {4}>, ?anon#1#2##0)<{}; {}; {}>:
+foo#anon#1(@#env##0:opaque, ^w##0:wybe.char, ^x##0:wybe.bool, ^y##0:wybe.char, ^z##0:wybe.int, anon#1#1##0 <{}; {}; {5}>, ?anon#1#2##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign c {impure} log_char(~^w##0:wybe.char) @higher_order_refs:nn:nn

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -13,7 +13,7 @@ AFTER EVERYTHING:
                     2:: StructInfo {structSize = 16, structData = [FnPointerStructMember higher_order_refs.#anon#3<1>,FloatStructMember 0.5 8]}
                     3:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_refs.#closure#1<0>]}
                     4:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_refs.#closure#2<0>]}
-                    5:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_refs.#closure#3<0>]}
+                    5:: StructInfo {structSize = 16, structData = [FnPointerStructMember higher_order_refs.#closure#3<0>,IntStructMember 10 8]}
   imports         : use logging
                     use wybe
   resources       : 
@@ -40,7 +40,7 @@ module top-level code > public {semipure} (0 calls)
     higher_order_refs.app<0>(higher_order_refs.#closure#2<0><>:(wybe.int, ?wybe.int), 1:wybe.int, ?tmp#6##0:wybe.int) #8 @higher_order_refs:nn:nn
     foreign c print_int(~tmp#6##0:wybe.int, ~tmp#26##0:wybe.phantom, ?%tmp#29##0:wybe.phantom) @higher_order_refs:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#29##0:wybe.phantom, ?tmp#30##0:wybe.phantom) @higher_order_refs:nn:nn
-    higher_order_refs.app<0>(higher_order_refs.#closure#3<0><>:(wybe.int, ?wybe.int), 1:wybe.int, ?tmp#8##0:wybe.int) #10 @higher_order_refs:nn:nn
+    higher_order_refs.app<0>(higher_order_refs.#closure#3<0><10>:(wybe.int, ?wybe.int), 1:wybe.int, ?tmp#8##0:wybe.int) #10 @higher_order_refs:nn:nn
     foreign c print_int(~tmp#8##0:wybe.int, ~tmp#30##0:wybe.phantom, ?%tmp#33##0:wybe.phantom) @higher_order_refs:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @higher_order_refs:nn:nn
     foreign lpvm store(~%tmp#34##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_refs:nn:nn

--- a/test-cases/final-dump/higher_order_refs.exp
+++ b/test-cases/final-dump/higher_order_refs.exp
@@ -8,12 +8,12 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : higher_order_refs.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_refs.#anon#1<1>]}
-                    1:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_refs.#anon#2<1>]}
-                    2:: StructInfo {structSize = 16, structData = [FnPointerStructMember higher_order_refs.#anon#3<1>,FloatStructMember 0.5 8]}
-                    3:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_refs.#closure#1<0>]}
-                    4:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_refs.#closure#2<0>]}
-                    5:: StructInfo {structSize = 16, structData = [FnPointerStructMember higher_order_refs.#closure#3<0>,IntStructMember 10 8]}
+  constants       : 0:: ClosureInfo {closureProcSpec = higher_order_refs.#anon#1<1>, closureArgs = []}
+                    1:: ClosureInfo {closureProcSpec = higher_order_refs.#anon#2<1>, closureArgs = []}
+                    2:: ClosureInfo {closureProcSpec = higher_order_refs.#anon#3<1>, closureArgs = [FloatStructMember 0.5 8]}
+                    3:: ClosureInfo {closureProcSpec = higher_order_refs.#closure#1<0>, closureArgs = []}
+                    4:: ClosureInfo {closureProcSpec = higher_order_refs.#closure#2<0>, closureArgs = []}
+                    5:: ClosureInfo {closureProcSpec = higher_order_refs.#closure#3<0>, closureArgs = [IntStructMember 10 8]}
   imports         : use logging
                     use wybe
   resources       : 

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -68,7 +68,7 @@ proc #anon#1 > {inline} (1 calls)
     higher_order_resources.take_max<0>(~tmp#10##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}> #1 @higher_order_resources:nn:nn
 proc #anon#1 > {inline} (1 calls)
 1: higher_order_resources.#anon#1<1>
-#anon#1(anon#1#1##0 <{}; {}; {0}>)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}>:
+#anon#1(@#env##0:opaque, anon#1#1##0 <{}; {}; {1}>)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.list.length1<0>(~anon#1#1##0:wybe.list(wybe.int), 0:wybe.int, ?tmp#36##0:wybe.int) #1 @higher_order_resources:nn:nn
@@ -94,7 +94,7 @@ proc #anon#2 > {inline} (1 calls)
     higher_order_resources.take_max<0>(~tmp#28##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}> #5 @higher_order_resources:nn:nn
 proc #anon#2 > {inline} (1 calls)
 1: higher_order_resources.#anon#2<1>
-#anon#2(anon#2#1##0 <{}; {}; {0}>)<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {}>:
+#anon#2(@#env##0:opaque, anon#2#1##0 <{}; {}; {1}>)<{<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {<<higher_order_resources.maximum>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm load(<<higher_order_resources.maximum>>:wybe.int, ?%tmp#36##0:wybe.int) @higher_order_resources:nn:nn
@@ -113,7 +113,7 @@ proc #anon#2 > {inline} (1 calls)
 
 proc #anon#2#closure#1 > {inline} (1 calls)
 0: higher_order_resources.#anon#2#closure#1<0>
-#anon#2#closure#1(i##0 <{}; {}; {0}>)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}>:
+#anon#2#closure#1(@#env##0:opaque, i##0 <{}; {}; {1}>)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     higher_order_resources.take_max<0>(~i##0:wybe.int)<{<<higher_order_resources.maximum>>}; {<<higher_order_resources.maximum>>}; {}> #0

--- a/test-cases/final-dump/higher_order_resources.exp
+++ b/test-cases/final-dump/higher_order_resources.exp
@@ -10,7 +10,7 @@ AFTER EVERYTHING:
   public procs    : higher_order_resources.<0>
   constants       : 0:: CStringInfo {cstringChars = "*****"}
                     1:: CStringInfo {cstringChars = "> "}
-                    2:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_resources.#anon#2#closure#1<0>]}
+                    2:: ClosureInfo {closureProcSpec = higher_order_resources.#anon#2#closure#1<0>, closureArgs = []}
                     3:: StructInfo {structSize = 16, structData = [IntStructMember 2 8,PointerStructMember c"> "]}
                     4:: StructInfo {structSize = 16, structData = [IntStructMember 3 8,IntStructMember 0 8]}
                     5:: StructInfo {structSize = 16, structData = [IntStructMember 2 8,PointerStructMember higher_order_resources#constant#4]}
@@ -19,7 +19,7 @@ AFTER EVERYTHING:
                     8:: StructInfo {structSize = 16, structData = [IntStructMember 1 8,PointerStructMember higher_order_resources#constant#5]}
                     9:: StructInfo {structSize = 16, structData = [PointerStructMember higher_order_resources#constant#7,IntStructMember 0 8]}
                     10:: StructInfo {structSize = 16, structData = [PointerStructMember higher_order_resources#constant#8,PointerStructMember higher_order_resources#constant#9]}
-                    11:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_resources.#anon#1<1>]}
+                    11:: ClosureInfo {closureProcSpec = higher_order_resources.#anon#1<1>, closureArgs = []}
                     12:: StructInfo {structSize = 16, structData = [IntStructMember 5 8,PointerStructMember c"*****"]}
                     13:: StructInfo {structSize = 16, structData = [IntStructMember 2 8,IntStructMember 0 8]}
                     14:: StructInfo {structSize = 16, structData = [IntStructMember 1 8,PointerStructMember higher_order_resources#constant#13]}
@@ -27,7 +27,7 @@ AFTER EVERYTHING:
                     16:: StructInfo {structSize = 16, structData = [IntStructMember 1 8,PointerStructMember higher_order_resources#constant#15]}
                     17:: StructInfo {structSize = 16, structData = [PointerStructMember higher_order_resources#constant#16,PointerStructMember higher_order_resources#constant#9]}
                     18:: StructInfo {structSize = 16, structData = [PointerStructMember higher_order_resources#constant#8,PointerStructMember higher_order_resources#constant#17]}
-                    19:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_resources.#anon#2<1>]}
+                    19:: ClosureInfo {closureProcSpec = higher_order_resources.#anon#2<1>, closureArgs = []}
   imports         : use wybe
   resources       : maximum: fromList [(higher_order_resources.maximum,wybe.int @higher_order_resources:nn:nn)]
   procs           : 

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -25,7 +25,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool)(1:wybe.int, ?tmp#17##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    higher_order_tests.#anon#1<1>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool), 1:wybe.int, ?tmp#17##0:wybe.bool) #0 @higher_order_tests:nn:nn
     case ~tmp#17##0:wybe.bool of
     0:
         higher_order_tests.#cont#1<0>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
@@ -47,7 +47,7 @@ proc #anon#1 > {inline} (1 calls)
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 proc #anon#1 > {inline} (3 calls)
 1: higher_order_tests.#anon#1<1>
-#anon#1(anon#1#1##0 <{}; {}; {0}>, ?#success##0)<{}; {}; {}>:
+#anon#1(@#env##0:opaque, anon#1#1##0 <{}; {}; {1}>, ?#success##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
@@ -61,7 +61,7 @@ proc #anon#2 > {inline} (1 calls)
     foreign llvm icmp_eq(~anon#2#1##0:wybe.int, 1:wybe.int, ?#success##0:wybe.bool) @higher_order_tests:nn:nn
 proc #anon#2 > {inline} (3 calls)
 1: higher_order_tests.#anon#2<1>
-#anon#2(anon#2#1##0 <{}; {}; {0}>, ?#success##0)<{}; {}; {}>:
+#anon#2(@#env##0:opaque, anon#2#1##0 <{}; {}; {1}>, ?#success##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm icmp_eq(~anon#2#1##0:wybe.int, 1:wybe.int, ?#success##0:wybe.bool) @higher_order_tests:nn:nn
@@ -135,7 +135,7 @@ proc #cont#4 > {semipure} (2 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @higher_order_tests:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @higher_order_tests:nn:nn
     foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-    higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool)(1:wybe.int, ?tmp#13##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    higher_order_tests.#anon#2<1>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool), 1:wybe.int, ?tmp#13##0:wybe.bool) #0 @higher_order_tests:nn:nn
     case ~tmp#13##0:wybe.bool of
     0:
         higher_order_tests.#cont#5<0>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6
@@ -244,8 +244,8 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"higher_order_tests#.<0>"() {
-  %"tmp#27##0" = load ptr, ptr @"higher_order_tests#constant#7"
-  %"tmp#17##0" = tail call fastcc i1 %"tmp#27##0"(ptr @"higher_order_tests#constant#7", i64 1)
+  %"tmp#27##0" = tail call fastcc i64 @"higher_order_tests#.#anon#1<1>"(ptr @"higher_order_tests#constant#7", i64 1)
+  %"tmp#17##0" = trunc i64 %"tmp#27##0" to i1
   br i1 %"tmp#17##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"higher_order_tests#constant#6" to i64 ))
@@ -321,8 +321,8 @@ if.else.0:
 define external fastcc void @"higher_order_tests#.#cont#4<0>"() {
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"higher_order_tests#constant#4" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#30##0" = load ptr, ptr @"higher_order_tests#constant#5"
-  %"tmp#13##0" = tail call fastcc i1 %"tmp#30##0"(ptr @"higher_order_tests#constant#5", i64 1)
+  %"tmp#30##0" = tail call fastcc i64 @"higher_order_tests#.#anon#2<1>"(ptr @"higher_order_tests#constant#5", i64 1)
+  %"tmp#13##0" = trunc i64 %"tmp#30##0" to i1
   br i1 %"tmp#13##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"higher_order_tests#constant#6" to i64 ))

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -25,7 +25,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    higher_order_tests.#anon#1<1>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool), 1:wybe.int, ?tmp#17##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    higher_order_tests.#anon#1<0>(_:wybe.int, ?tmp#17##0:wybe.bool) #0 @higher_order_tests:nn:nn
     case ~tmp#17##0:wybe.bool of
     0:
         higher_order_tests.#cont#1<0>(higher_order_tests.#anon#1<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4
@@ -135,7 +135,7 @@ proc #cont#4 > {semipure} (2 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @higher_order_tests:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @higher_order_tests:nn:nn
     foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @higher_order_tests:nn:nn
-    higher_order_tests.#anon#2<1>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool), 1:wybe.int, ?tmp#13##0:wybe.bool) #0 @higher_order_tests:nn:nn
+    higher_order_tests.#anon#2<0>(1:wybe.int, ?tmp#13##0:wybe.bool) #0 @higher_order_tests:nn:nn
     case ~tmp#13##0:wybe.bool of
     0:
         higher_order_tests.#cont#5<0>(higher_order_tests.#anon#2<1><>:(wybe.int, ?wybe.bool))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6
@@ -244,8 +244,7 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"higher_order_tests#.<0>"() {
-  %"tmp#27##0" = tail call fastcc i64 @"higher_order_tests#.#anon#1<1>"(ptr @"higher_order_tests#constant#7", i64 1)
-  %"tmp#17##0" = trunc i64 %"tmp#27##0" to i1
+  %"tmp#17##0" = tail call fastcc i1 @"higher_order_tests#.#anon#1<0>"()
   br i1 %"tmp#17##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"higher_order_tests#constant#6" to i64 ))
@@ -321,8 +320,7 @@ if.else.0:
 define external fastcc void @"higher_order_tests#.#cont#4<0>"() {
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"higher_order_tests#constant#4" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#30##0" = tail call fastcc i64 @"higher_order_tests#.#anon#2<1>"(ptr @"higher_order_tests#constant#5", i64 1)
-  %"tmp#13##0" = trunc i64 %"tmp#30##0" to i1
+  %"tmp#13##0" = tail call fastcc i1 @"higher_order_tests#.#anon#2<0>"(i64 1)
   br i1 %"tmp#13##0", label %if.then.0, label %if.else.0
 if.then.0:
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"higher_order_tests#constant#6" to i64 ))

--- a/test-cases/final-dump/higher_order_tests.exp
+++ b/test-cases/final-dump/higher_order_tests.exp
@@ -13,9 +13,9 @@ AFTER EVERYTHING:
                     2:: CStringInfo {cstringChars = "------"}
                     3:: StructInfo {structSize = 16, structData = [IntStructMember 2 8,PointerStructMember c"*2"]}
                     4:: StructInfo {structSize = 16, structData = [IntStructMember 6 8,PointerStructMember c"------"]}
-                    5:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_tests.#anon#2<1>]}
+                    5:: ClosureInfo {closureProcSpec = higher_order_tests.#anon#2<1>, closureArgs = []}
                     6:: StructInfo {structSize = 16, structData = [IntStructMember 2 8,PointerStructMember c"*1"]}
-                    7:: StructInfo {structSize = 8, structData = [FnPointerStructMember higher_order_tests.#anon#1<1>]}
+                    7:: ClosureInfo {closureProcSpec = higher_order_tests.#anon#1<1>, closureArgs = []}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/lazy.exp
+++ b/test-cases/final-dump/lazy.exp
@@ -53,7 +53,7 @@ proc #anon#1 > {inline} (1 calls)
     foreign llvm move(42:wybe.int, ?anon#1#1##0:wybe.int) @lazy:nn:nn
 proc #anon#1 > {inline} (1 calls)
 1: lazy.#anon#1<1>
-#anon#1(?anon#1#1##0)<{}; {}; {}>:
+#anon#1(@#env##0:opaque, ?anon#1#1##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     wybe.string.c_string<0>("Thinking...\n":wybe.string, ?tmp#6##0:wybe.c_string) #1 @lazy:nn:nn

--- a/test-cases/final-dump/lazy.exp
+++ b/test-cases/final-dump/lazy.exp
@@ -12,7 +12,7 @@ AFTER EVERYTHING:
                     1:: CStringInfo {cstringChars = "The answer is..."}
                     2:: CStringInfo {cstringChars = "The answer is now..."}
                     3:: StructInfo {structSize = 16, structData = [IntStructMember 12 8,PointerStructMember c"Thinking...\n"]}
-                    4:: StructInfo {structSize = 8, structData = [FnPointerStructMember lazy.#anon#1<1>]}
+                    4:: ClosureInfo {closureProcSpec = lazy.#anon#1<1>, closureArgs = []}
                     5:: StructInfo {structSize = 16, structData = [IntStructMember 16 8,PointerStructMember c"The answer is..."]}
                     6:: StructInfo {structSize = 16, structData = [IntStructMember 20 8,PointerStructMember c"The answer is now..."]}
   imports         : use logging

--- a/test-cases/final-dump/need.exp
+++ b/test-cases/final-dump/need.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    need.#anon#1<1>(need.#anon#1<1><>:{impure}()) #0 @need:nn:nn
+    need.#anon#1<0> #0 @need:nn:nn
 
 
 proc #anon#1 > {inline,impure} (1 calls)
@@ -71,13 +71,12 @@ need(stmt##0:{impure}())<{}; {}; {}>:
 source_filename = "!ROOT!/final-dump/need.wybe"
 target triple   = ????
 
-@"need#constant#0" = private unnamed_addr constant {ptr} { ptr @"need#.#anon#1<1>" }, align 8
 
 declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"need#.<0>"() {
-  tail call fastcc void @"need#.#anon#1<1>"(ptr @"need#constant#0")
+  tail call fastcc void @"need#.#anon#1<0>"()
   ret void
 }
 

--- a/test-cases/final-dump/need.exp
+++ b/test-cases/final-dump/need.exp
@@ -20,7 +20,7 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    need.#anon#1<1><>:{impure}() #0 @need:nn:nn
+    need.#anon#1<1>(need.#anon#1<1><>:{impure}()) #0 @need:nn:nn
 
 
 proc #anon#1 > {inline,impure} (1 calls)
@@ -31,7 +31,7 @@ proc #anon#1 > {inline,impure} (1 calls)
     need.iota<0>(1000:wybe.int, outByReference l##0:wybe.list(wybe.int)) #0 @need:nn:nn
 proc #anon#1 > {inline,impure} (1 calls)
 1: need.#anon#1<1>
-#anon#1()<{}; {}; {}>:
+#anon#1(@#env##0:opaque)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     need.iota<0>(1000:wybe.int, outByReference tmp#1##0:wybe.list(wybe.int)) #1 @need:nn:nn
@@ -77,8 +77,7 @@ declare external ccc ptr @wybe_malloc(i32)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"need#.<0>"() {
-  %"tmp#2##0" = load ptr, ptr @"need#constant#0"
-  tail call fastcc void %"tmp#2##0"(ptr @"need#constant#0")
+  tail call fastcc void @"need#.#anon#1<1>"(ptr @"need#constant#0")
   ret void
 }
 

--- a/test-cases/final-dump/need.exp
+++ b/test-cases/final-dump/need.exp
@@ -10,7 +10,7 @@ AFTER EVERYTHING:
   public procs    : need.<0>
                     need.iota<0>
                     need.need<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember need.#anon#1<1>]}
+  constants       : 0:: ClosureInfo {closureProcSpec = need.#anon#1<1>, closureArgs = []}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/trait_higher_order.exp
+++ b/test-cases/final-dump/trait_higher_order.exp
@@ -26,7 +26,7 @@ module top-level code > public {semipure} (0 calls)
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm cast("Ada":wybe.string, ?tmp#0##0:trait_higher_order_box) @trait_higher_order:nn:nn
-    trait_higher_order.#closure#1<0>(trait_higher_order.#closure#1<0><>:(trait_higher_order_box, ?wybe.string), ~tmp#0##0:trait_higher_order_box, ?tmp#1##0:wybe.string) #0 @trait_higher_order:nn:nn
+    trait_higher_order.describe_box<0>(~tmp#0##0:trait_higher_order_box, ?tmp#1##0:wybe.string) #0 @trait_higher_order:nn:nn
     wybe.string.print<0>[410bae77d3](~tmp#1##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @trait_higher_order:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @trait_higher_order:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @trait_higher_order:nn:nn
@@ -62,7 +62,6 @@ target triple   = ????
 @"trait_higher_order#constant#1" = private unnamed_addr constant [ ?? x i8 ] c"Ada\00", align 8
 @"trait_higher_order#constant#2" = private unnamed_addr constant {i64, ptr} { i64 5, ptr @"trait_higher_order#constant#0" }, align 8
 @"trait_higher_order#constant#3" = private unnamed_addr constant {i64, ptr} { i64 3, ptr @"trait_higher_order#constant#1" }, align 8
-@"trait_higher_order#constant#4" = private unnamed_addr constant {ptr} { ptr @"trait_higher_order#.#closure#1<0>" }, align 8
 
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
 declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
@@ -71,7 +70,7 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_higher_order#.<0>"() {
   %"tmp#0##0" = ptrtoint ptr @"trait_higher_order#constant#3" to i64
-  %"tmp#1##0" = tail call fastcc i64 @"trait_higher_order#.#closure#1<0>"(ptr @"trait_higher_order#constant#4", i64 %"tmp#0##0")
+  %"tmp#1##0" = tail call fastcc i64 @"trait_higher_order#.describe_box<0>"(i64 %"tmp#0##0")
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#1##0")
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/trait_higher_order.exp
+++ b/test-cases/final-dump/trait_higher_order.exp
@@ -26,7 +26,7 @@ module top-level code > public {semipure} (0 calls)
   InterestingCallProperties: []
   MultiSpeczDepInfo: [(4,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm cast("Ada":wybe.string, ?tmp#0##0:trait_higher_order_box) @trait_higher_order:nn:nn
-    trait_higher_order.#closure#1<0><>:(trait_higher_order_box, ?wybe.string)(~tmp#0##0:trait_higher_order_box, ?tmp#1##0:wybe.string) #0 @trait_higher_order:nn:nn
+    trait_higher_order.#closure#1<0>(trait_higher_order.#closure#1<0><>:(trait_higher_order_box, ?wybe.string), ~tmp#0##0:trait_higher_order_box, ?tmp#1##0:wybe.string) #0 @trait_higher_order:nn:nn
     wybe.string.print<0>[410bae77d3](~tmp#1##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #4 @trait_higher_order:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @trait_higher_order:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @trait_higher_order:nn:nn
@@ -35,7 +35,7 @@ module top-level code > public {semipure} (0 calls)
 
 proc #closure#1 > {inline} (1 calls)
 0: trait_higher_order.#closure#1<0>
-#closure#1(x##0 <{}; {}; {0}>, ?#result##0)<{}; {}; {}>:
+#closure#1(@#env##0:opaque, x##0 <{}; {}; {1}>, ?#result##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign lpvm cast(~x##0:trait_higher_order_box, ?tmp#5##0:wybe.string) @trait_higher_order:nn:nn
@@ -71,8 +71,7 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_higher_order#.<0>"() {
   %"tmp#0##0" = ptrtoint ptr @"trait_higher_order#constant#3" to i64
-  %"tmp#14##0" = load ptr, ptr @"trait_higher_order#constant#4"
-  %"tmp#1##0" = tail call fastcc i64 %"tmp#14##0"(ptr @"trait_higher_order#constant#4", i64 %"tmp#0##0")
+  %"tmp#1##0" = tail call fastcc i64 @"trait_higher_order#.#closure#1<0>"(ptr @"trait_higher_order#constant#4", i64 %"tmp#0##0")
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#1##0")
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/trait_higher_order.exp
+++ b/test-cases/final-dump/trait_higher_order.exp
@@ -12,7 +12,7 @@ AFTER EVERYTHING:
                     1:: CStringInfo {cstringChars = "Ada"}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 5 8,PointerStructMember c"box: "]}
                     3:: StructInfo {structSize = 16, structData = [IntStructMember 3 8,PointerStructMember c"Ada"]}
-                    4:: StructInfo {structSize = 8, structData = [FnPointerStructMember trait_higher_order.#closure#1<0>]}
+                    4:: ClosureInfo {closureProcSpec = trait_higher_order.#closure#1<0>, closureArgs = []}
   imports         : use trait_higher_order_box
                     use trait_higher_order_mapper
                     use wybe

--- a/test-cases/final-dump/unary_higher_order.exp
+++ b/test-cases/final-dump/unary_higher_order.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : unary_higher_order.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember unary_higher_order.main#closure#1<0>]}
+  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember unary_higher_order.#closure#1<0>]}
   imports         : use wybe
   resources       : 
   procs           : 
@@ -18,7 +18,18 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    unary_higher_order.main<0><{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #0 @unary_higher_order:nn:nn
+    unary_higher_order.#closure#1<0><>:(?wybe.int)(?tmp#0##0:wybe.int) #0 @unary_higher_order:nn:nn
+    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @unary_higher_order:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~%tmp#4##0:wybe.phantom, ?%tmp#5##0:wybe.phantom) @unary_higher_order:nn:nn
+    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unary_higher_order:nn:nn
+
+
+proc #closure#1 > {inline} (1 calls)
+0: unary_higher_order.#closure#1<0>
+#closure#1(?result##0)<{}; {}; {}>:
+  AliasPairs: []
+  InterestingCallProperties: []
+    foreign llvm move(42:wybe.int, ?result##0:wybe.int) @unary_higher_order:nn:nn
 
 
 proc fetch_number > {inline} (1 calls)
@@ -27,25 +38,6 @@ fetch_number(f##0:(?wybe.int), ?#result##0:wybe.int)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     ~f##0:(?wybe.int)(?#result##0:wybe.int) #0 @unary_higher_order:nn:nn
-
-
-proc main > {noinline} (1 calls)
-0: unary_higher_order.main<0>
-main()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    unary_higher_order.main#closure#1<0><>:(?wybe.int)(?tmp#0##0:wybe.int) #0 @unary_higher_order:nn:nn
-    foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @unary_higher_order:nn:nn
-    foreign c print_int(~tmp#0##0:wybe.int, ~%tmp#4##0:wybe.phantom, ?%tmp#5##0:wybe.phantom) @unary_higher_order:nn:nn
-    foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unary_higher_order:nn:nn
-
-
-proc main#closure#1 > {inline} (1 calls)
-0: unary_higher_order.main#closure#1<0>
-main#closure#1(?result##0)<{}; {}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?result##0:wybe.int) @unary_higher_order:nn:nn
 
 
 proc return_number > {inline} (1 calls)
@@ -63,31 +55,26 @@ return_number(?result##0:wybe.int)<{}; {}; {}>:
 source_filename = "!ROOT!/final-dump/unary_higher_order.wybe"
 target triple   = ????
 
-@"unary_higher_order#constant#0" = private unnamed_addr constant {ptr} { ptr @"unary_higher_order#.main#closure#1<0>" }, align 8
+@"unary_higher_order#constant#0" = private unnamed_addr constant {ptr} { ptr @"unary_higher_order#.#closure#1<0>" }, align 8
 
 declare external ccc void @print_int(i64)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"unary_higher_order#.<0>"() {
-  tail call fastcc void @"unary_higher_order#.main<0>"()
-  ret void
-}
-
-define external fastcc i64 @"unary_higher_order#.fetch_number<0>"(ptr %"f##0") {
-  %"tmp#0##0" = load ptr, ptr %"f##0"
-  %"tmp#1##0" = tail call fastcc i64 %"tmp#0##0"(ptr %"f##0")
-  ret i64 %"tmp#1##0"
-}
-
-define external fastcc void @"unary_higher_order#.main<0>"() {
   %"tmp#6##0" = load ptr, ptr @"unary_higher_order#constant#0"
   %"tmp#0##0" = tail call fastcc i64 %"tmp#6##0"(ptr @"unary_higher_order#constant#0")
   call ccc void @print_int(i64 %"tmp#0##0")
   ret void
 }
 
-define external fastcc i64 @"unary_higher_order#.main#closure#1<0>"(ptr %"#env##0") {
+define external fastcc i64 @"unary_higher_order#.#closure#1<0>"(ptr %"#env##0") {
   ret i64 42
+}
+
+define external fastcc i64 @"unary_higher_order#.fetch_number<0>"(ptr %"f##0") {
+  %"tmp#0##0" = load ptr, ptr %"f##0"
+  %"tmp#1##0" = tail call fastcc i64 %"tmp#0##0"(ptr %"f##0")
+  ret i64 %"tmp#1##0"
 }
 
 define external fastcc i64 @"unary_higher_order#.return_number<0>"() {

--- a/test-cases/final-dump/unary_higher_order.exp
+++ b/test-cases/final-dump/unary_higher_order.exp
@@ -18,7 +18,7 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    unary_higher_order.#closure#1<0><>:(?wybe.int)(?tmp#0##0:wybe.int) #0 @unary_higher_order:nn:nn
+    unary_higher_order.#closure#1<0>(unary_higher_order.#closure#1<0><>:(?wybe.int), ?tmp#0##0:wybe.int) #0 @unary_higher_order:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @unary_higher_order:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~%tmp#4##0:wybe.phantom, ?%tmp#5##0:wybe.phantom) @unary_higher_order:nn:nn
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unary_higher_order:nn:nn
@@ -26,7 +26,7 @@ module top-level code > public {inline,semipure} (0 calls)
 
 proc #closure#1 > {inline} (1 calls)
 0: unary_higher_order.#closure#1<0>
-#closure#1(?result##0)<{}; {}; {}>:
+#closure#1(@#env##0:opaque, ?result##0)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(42:wybe.int, ?result##0:wybe.int) @unary_higher_order:nn:nn
@@ -61,8 +61,7 @@ declare external ccc void @print_int(i64)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"unary_higher_order#.<0>"() {
-  %"tmp#6##0" = load ptr, ptr @"unary_higher_order#constant#0"
-  %"tmp#0##0" = tail call fastcc i64 %"tmp#6##0"(ptr @"unary_higher_order#constant#0")
+  %"tmp#0##0" = tail call fastcc i64 @"unary_higher_order#.#closure#1<0>"(ptr @"unary_higher_order#constant#0")
   call ccc void @print_int(i64 %"tmp#0##0")
   ret void
 }

--- a/test-cases/final-dump/unary_higher_order.exp
+++ b/test-cases/final-dump/unary_higher_order.exp
@@ -18,7 +18,7 @@ module top-level code > public {inline,semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    unary_higher_order.#closure#1<0>(unary_higher_order.#closure#1<0><>:(?wybe.int), ?tmp#0##0:wybe.int) #0 @unary_higher_order:nn:nn
+    unary_higher_order.return_number<0>(?tmp#0##0:wybe.int) #0 @unary_higher_order:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#4##0:wybe.phantom) @unary_higher_order:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~%tmp#4##0:wybe.phantom, ?%tmp#5##0:wybe.phantom) @unary_higher_order:nn:nn
     foreign lpvm store(~%tmp#5##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @unary_higher_order:nn:nn
@@ -55,13 +55,12 @@ return_number(?result##0:wybe.int)<{}; {}; {}>:
 source_filename = "!ROOT!/final-dump/unary_higher_order.wybe"
 target triple   = ????
 
-@"unary_higher_order#constant#0" = private unnamed_addr constant {ptr} { ptr @"unary_higher_order#.#closure#1<0>" }, align 8
 
 declare external ccc void @print_int(i64)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"unary_higher_order#.<0>"() {
-  %"tmp#0##0" = tail call fastcc i64 @"unary_higher_order#.#closure#1<0>"(ptr @"unary_higher_order#constant#0")
+  %"tmp#0##0" = tail call fastcc i64 @"unary_higher_order#.return_number<0>"()
   call ccc void @print_int(i64 %"tmp#0##0")
   ret void
 }

--- a/test-cases/final-dump/unary_higher_order.exp
+++ b/test-cases/final-dump/unary_higher_order.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : unary_higher_order.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember unary_higher_order.#closure#1<0>]}
+  constants       : 0:: ClosureInfo {closureProcSpec = unary_higher_order.#closure#1<0>, closureArgs = []}
   imports         : use wybe
   resources       : 
   procs           : 

--- a/test-cases/final-dump/unary_higher_order.wybe
+++ b/test-cases/final-dump/unary_higher_order.wybe
@@ -6,9 +6,5 @@ def fetch_number(f:(?int)):int = number where {
     f(?number)
 }
 
-def {noinline} main use !io {
-    ?result = fetch_number(return_number)
-    !print result
-}
-
-!main
+?result = fetch_number(return_number)
+!print result

--- a/test-cases/final-dump/uneeded_closure_args.exp
+++ b/test-cases/final-dump/uneeded_closure_args.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : uneeded_closure_args.<0>
-  constants       : 0:: StructInfo {structSize = 8, structData = [FnPointerStructMember uneeded_closure_args.#closure#1<0>]}
+  constants       : 0:: StructInfo {structSize = 16, structData = [FnPointerStructMember uneeded_closure_args.#closure#1<0>,IntStructMember 1 8]}
   imports         : use wybe
   resources       : 
   procs           : 
@@ -18,7 +18,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-    uneeded_closure_args.call<0>(uneeded_closure_args.#closure#1<0><>:(wybe.int, ?wybe.int), 2:wybe.int, ?tmp#0##0:wybe.int) #0 @uneeded_closure_args:nn:nn
+    uneeded_closure_args.call<0>(uneeded_closure_args.#closure#1<0><1>:(wybe.int, ?wybe.int), 2:wybe.int, ?tmp#0##0:wybe.int) #0 @uneeded_closure_args:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#3##0:wybe.phantom) @uneeded_closure_args:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~%tmp#3##0:wybe.phantom, ?%tmp#4##0:wybe.phantom) @uneeded_closure_args:nn:nn
     foreign lpvm store(~%tmp#4##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @uneeded_closure_args:nn:nn

--- a/test-cases/final-dump/uneeded_closure_args.exp
+++ b/test-cases/final-dump/uneeded_closure_args.exp
@@ -26,7 +26,7 @@ module top-level code > public {semipure} (0 calls)
 
 proc #closure#1 > {inline} (1 calls)
 0: uneeded_closure_args.#closure#1<0>
-#closure#1([^a##0:A <{}; {}; {0}>], b##0 <{}; {}; {1}>, ?#result##0 <{}; {}; {1}>)<{}; {}; {}>:
+#closure#1(@#env##0:opaque, [^a##0:A <{}; {}; {1}>], b##0 <{}; {}; {2}>, ?#result##0 <{}; {}; {2}>)<{}; {}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
     foreign llvm move(~b##0:B, ?#result##0:B) @uneeded_closure_args:nn:nn

--- a/test-cases/final-dump/uneeded_closure_args.exp
+++ b/test-cases/final-dump/uneeded_closure_args.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : uneeded_closure_args.<0>
-  constants       : 0:: StructInfo {structSize = 16, structData = [FnPointerStructMember uneeded_closure_args.#closure#1<0>,IntStructMember 1 8]}
+  constants       : 0:: ClosureInfo {closureProcSpec = uneeded_closure_args.#closure#1<0>, closureArgs = [IntStructMember 1 8]}
   imports         : use wybe
   resources       : 
   procs           : 


### PR DESCRIPTION
The test case exits with this on the a previous master build

```
Error detected during translating: 
llc: error: llc: /tmp/wybe-40074fe12aabd129/tmpMain.ll:8:78: error: use of undefined value '@unary_higher_order#.#anon#1<1>'
@"unary_higher_order#constant#0" = private unnamed_addr constant {ptr} { ptr @"unary_higher_order#.#anon#1<1>" }, align 8
```

I have also made the "env" param of closure procs explicit. This enabled further lowering of HO->FO calls, in some situations.
