### PR TITLE
fix: trace aliases of constants through calls

### DIFF
--- a/src/AliasAnalysis.hs
+++ b/src/AliasAnalysis.hs
@@ -281,7 +281,7 @@ updateAliasedByPrim aliasMap prim =
             logAlias $ "--- call          " ++ show spec ++" (callee): "
             logAlias $ "" ++ show calleeProto
             logAlias $ "PrimCall args:    " ++ show args
-            let paramArgMap = mapParamToArgVar calleeProto args
+            let paramArgMap = mapParamToArg calleeProto args
             -- calleeArgsAliasMap is the alias map of actual arguments passed
             -- into callee
             logAlias $ "args: " ++ show args
@@ -291,7 +291,12 @@ updateAliasedByPrim aliasMap prim =
                     -- filter out aliases of constant args
                     -- (caused by constant constructor)
                     |> filterDS isJust
-                    |> mapDS (\x -> LiveVar (fromJust x))
+                    |> mapDS fromJust
+                    |> mapDS (\case
+                        ArgVar{argVarName=nm} -> LiveVar nm
+                        ArgConstRef cnst _ -> AliasByConst cnst
+                        ArgGlobal glb _ -> AliasByGlobal glb
+                        arg -> shouldnt $ "calleeArgsAliases: " ++ show arg)
             combined <- aliasedArgsInPrimCall calleeArgsAliases aliasMap args
             logAlias $ "calleeParamAliases: " ++ show calleeParamAliases
             logAlias $ "calleeArgsAliases:  " ++ show calleeArgsAliases
@@ -349,6 +354,8 @@ _maybeAliasPrimArgs args = do
         ArgGlobal global ty -> maybeAddressAlias ty $ AliasByGlobal global
         ArgConstRef ref ty -> maybeAddressAlias ty $ AliasByConst ref
         _ -> return Nothing
+    maybeAddressAlias TypeVariable{} item = return $ Just item
+    maybeAddressAlias AnyType item = return $ Just item
     maybeAddressAlias ty item = do
         rep <- lookupTypeRepresentation ty
         return $ toMaybe (maybe False aliasedRep rep) item
@@ -384,20 +391,24 @@ aliasedArgsInSimplePrim aliasMap maybeAliasedPrimArgs primArgs = do
 
 -- Helper: map arguments in callee proc to its formal parameters so we can get
 -- alias info of the arguments
-mapParamToArgVar :: PrimProto -> [PrimArg] -> Map PrimVarName PrimVarName
-mapParamToArgVar proto args =
+mapParamToArg :: PrimProto -> [PrimArg] -> Map PrimVarName PrimArg
+mapParamToArg proto args =
     let formalParamNames = primProtoParamNames proto
-        paramArgPairs = _zipParamToArgVar formalParamNames args
+        paramArgPairs = _zipParamToArg formalParamNames args
     in Map.fromList paramArgPairs
 
 
--- Helper: zip formal param to PrimArg with ArgVar data constructor
-_zipParamToArgVar :: [PrimVarName] -> [PrimArg] -> [(PrimVarName, PrimVarName)]
-_zipParamToArgVar (p:params) (ArgVar{argVarName=nm}:args) =
-    (p, nm):_zipParamToArgVar params args
-_zipParamToArgVar (_:params) (_:args) = _zipParamToArgVar params args
-_zipParamToArgVar [] _ = []
-_zipParamToArgVar _ [] = []
+-- Helper: zip formal param to PrimArg with PrimArg that could be aliased
+_zipParamToArg :: [PrimVarName] -> [PrimArg] -> [(PrimVarName, PrimArg)]
+_zipParamToArg (p:params) (c@ArgConstRef{}:args) =
+    (p, c):_zipParamToArg params args
+_zipParamToArg (p:params) (g@ArgGlobal{}:args) =
+    (p, g):_zipParamToArg params args
+_zipParamToArg (p:params) (v@ArgVar{argVarName=nm}:args) =
+    (p, v):_zipParamToArg params args
+_zipParamToArg (_:params) (_:args) = _zipParamToArg params args
+_zipParamToArg [] _ = []
+_zipParamToArg _ [] = []
 
 
 removeDeadVar :: AliasMapLocal -> [PrimArg] -> AliasMapLocal

--- a/test-cases/execution/nbody.exp
+++ b/test-cases/execution/nbody.exp
@@ -2,4 +2,4 @@ n: energy: -0.169075
 energy: -0.169088
 
 malloc count: (should be 5001 with multi-specz and 10001 without it)
-5001
+10001

--- a/test-cases/final-dump/box_unbox.exp
+++ b/test-cases/final-dump/box_unbox.exp
@@ -35,19 +35,19 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm mutate(~tmp#6##0, ?tmp#6##1, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:box_unbox)
     box_unbox.force_box<0>(~tmp#6##1:box_unbox, ?tmp#7##0:box_unbox) #1 @box_unbox:nn:nn
     box_unbox.force_box<0>(~tmp#7##0:box_unbox, ?tmp#9##0:box_unbox) #2 @box_unbox:nn:nn
-    foreign lpvm access(~tmp#9##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:box_unbox)
+    foreign lpvm access(tmp#9##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:box_unbox)
     box_unbox.print<0>(~tmp#0##0:box_unbox)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @box_unbox:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @box_unbox:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @box_unbox:nn:nn
     foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox:nn:nn
     box_unbox.force_box<0>(box_unbox#constant#1:box_unbox, ?tmp#11##0:box_unbox) #5 @box_unbox:nn:nn
-    foreign lpvm access(tmp#11##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:box_unbox)
+    foreign lpvm access(~tmp#11##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:box_unbox)
     box_unbox.print<0>(~tmp#3##0:box_unbox)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @box_unbox:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @box_unbox:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @box_unbox:nn:nn
     foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox:nn:nn
     box_unbox.copy<0>(18446744073709551617:box_unbox, ?tmp#5##0:box_unbox) #8 @box_unbox:nn:nn
-    foreign lpvm mutate(~tmp#11##0, ?tmp#12##1, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:box_unbox)
+    foreign lpvm mutate(~tmp#9##0, ?tmp#12##1, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:box_unbox)
     box_unbox.force_box<0>(~tmp#12##1:box_unbox, ?tmp#13##0:box_unbox) #9 @box_unbox:nn:nn
     foreign lpvm access(~tmp#13##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:box_unbox)
     box_unbox.print<0>(~tmp#4##0:box_unbox)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @box_unbox:nn:nn
@@ -129,7 +129,7 @@ copy(x##0:box_unbox, ?#result##0:box_unbox)<{}; {}; {}>:
 proc force_box > public {noinline} (4 calls)
 0: box_unbox.force_box<0>
 force_box(x##0:X <{}; {}; {0}>, ?#result##0:X <{}; {}; {0}>)<{}; {}; {}>:
-  AliasPairs: []
+  AliasPairs: [(#result##0,x##0)]
   InterestingCallProperties: []
     foreign llvm move(~x##0:X, ?#result##0:X) @box_unbox:nn:nn
 
@@ -294,7 +294,7 @@ define external fastcc void @"box_unbox#.<0>"() {
   tail call fastcc void @"box_unbox#.print<0>"(i128 %"tmp#3##0")
   call ccc void @putchar(i8 10)
   %"tmp#5##0" = tail call fastcc i128 @"box_unbox#.copy<0>"(i128 18446744073709551617)
-  %"tmp#32##0" = trunc i128 %"tmp#11##0" to i64
+  %"tmp#32##0" = trunc i128 %"tmp#9##0" to i64
   %"tmp#33##0" = inttoptr i64 %"tmp#32##0" to ptr
   store i128 %"tmp#5##0", ptr %"tmp#33##0"
   %"tmp#35##0" = zext i64 %"tmp#32##0" to i128

--- a/test-cases/final-dump/box_unbox_ho.exp
+++ b/test-cases/final-dump/box_unbox_ho.exp
@@ -35,19 +35,19 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm mutate(~tmp#6##0, ?tmp#6##1, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:box_unbox)
     box_unbox.force_box<0>(~tmp#6##1:box_unbox, ?tmp#7##0:box_unbox) #1 @box_unbox:nn:nn
     box_unbox.force_box<0>(~tmp#7##0:box_unbox, ?tmp#9##0:box_unbox) #2 @box_unbox:nn:nn
-    foreign lpvm access(~tmp#9##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:box_unbox)
+    foreign lpvm access(tmp#9##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:box_unbox)
     box_unbox.print<0>(~tmp#0##0:box_unbox)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #3 @box_unbox:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#14##0:wybe.phantom) @box_unbox:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#14##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @box_unbox:nn:nn
     foreign lpvm store(~%tmp#15##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox:nn:nn
     box_unbox.force_box<0>(box_unbox#constant#1:box_unbox, ?tmp#11##0:box_unbox) #5 @box_unbox:nn:nn
-    foreign lpvm access(tmp#11##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:box_unbox)
+    foreign lpvm access(~tmp#11##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:box_unbox)
     box_unbox.print<0>(~tmp#3##0:box_unbox)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @box_unbox:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#16##0:wybe.phantom) @box_unbox:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @box_unbox:nn:nn
     foreign lpvm store(~%tmp#17##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @box_unbox:nn:nn
     box_unbox.copy<0>(18446744073709551617:box_unbox, ?tmp#5##0:box_unbox) #8 @box_unbox:nn:nn
-    foreign lpvm mutate(~tmp#11##0, ?tmp#12##1, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:box_unbox)
+    foreign lpvm mutate(~tmp#9##0, ?tmp#12##1, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:box_unbox)
     box_unbox.force_box<0>(~tmp#12##1:box_unbox, ?tmp#13##0:box_unbox) #9 @box_unbox:nn:nn
     foreign lpvm access(~tmp#13##0, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:box_unbox)
     box_unbox.print<0>(~tmp#4##0:box_unbox)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #10 @box_unbox:nn:nn
@@ -129,7 +129,7 @@ copy(x##0:box_unbox, ?#result##0:box_unbox)<{}; {}; {}>:
 proc force_box > public {noinline} (4 calls)
 0: box_unbox.force_box<0>
 force_box(x##0:X <{}; {}; {0}>, ?#result##0:X <{}; {}; {0}>)<{}; {}; {}>:
-  AliasPairs: []
+  AliasPairs: [(#result##0,x##0)]
   InterestingCallProperties: []
     foreign llvm move(~x##0:X, ?#result##0:X) @box_unbox:nn:nn
 
@@ -294,7 +294,7 @@ define external fastcc void @"box_unbox#.<0>"() {
   tail call fastcc void @"box_unbox#.print<0>"(i128 %"tmp#3##0")
   call ccc void @putchar(i8 10)
   %"tmp#5##0" = tail call fastcc i128 @"box_unbox#.copy<0>"(i128 18446744073709551617)
-  %"tmp#32##0" = trunc i128 %"tmp#11##0" to i64
+  %"tmp#32##0" = trunc i128 %"tmp#9##0" to i64
   %"tmp#33##0" = inttoptr i64 %"tmp#32##0" to ptr
   store i128 %"tmp#5##0", ptr %"tmp#33##0"
   %"tmp#35##0" = zext i64 %"tmp#32##0" to i128

--- a/test-cases/final-dump/common_fields.exp
+++ b/test-cases/final-dump/common_fields.exp
@@ -47,10 +47,10 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(10,(common_fields.id<1>,fromList [NonAliasedParamCond 0 []])),(19,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(20,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(21,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(10,(common_fields.id<1>,fromList [NonAliasedParamCond 0 []]))]
     foreign llvm or(1:wybe.int, common_fields#constant#4:common_fields, ?tmp#1##0:common_fields) @common_fields:nn:nn
     common_fields.title<0>(common_fields#constant#3:common_fields, ?tmp#2##0:wybe.string) #6 @common_fields:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @common_fields:nn:nn
+    wybe.string.print<0>(~tmp#2##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #19 @common_fields:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#48##0:wybe.phantom) @common_fields:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#48##0:wybe.phantom, ?tmp#49##0:wybe.phantom) @common_fields:nn:nn
     common_fields.id<0>(tmp#1##0:common_fields, ?tmp#3##0:wybe.int) #8 @common_fields:nn:nn
@@ -71,7 +71,7 @@ module top-level code > public {semipure} (0 calls)
         0:
 
         1:
-            wybe.string.print<0>[410bae77d3](~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @common_fields:nn:nn
+            wybe.string.print<0>(~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @common_fields:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#63##0:wybe.phantom) @common_fields:nn:nn
             foreign c putchar(10:wybe.char, ~tmp#63##0:wybe.phantom, ?tmp#64##0:wybe.phantom) @common_fields:nn:nn
             foreign lpvm store(~%tmp#64##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
@@ -80,7 +80,7 @@ module top-level code > public {semipure} (0 calls)
             0:
 
             1:
-                wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @common_fields:nn:nn
+                wybe.string.print<0>(~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #21 @common_fields:nn:nn
                 foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#66##0:wybe.phantom) @common_fields:nn:nn
                 foreign c putchar(10:wybe.char, ~tmp#66##0:wybe.phantom, ?tmp#67##0:wybe.phantom) @common_fields:nn:nn
                 foreign lpvm store(~%tmp#67##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @common_fields:nn:nn
@@ -607,7 +607,7 @@ target triple   = ????
 @"common_fields#constant#7" = private unnamed_addr constant [ 4 x i64 ] [i64 0, i64 -1, i64 -2, i64 -3]
 
 declare external fastcc i2 @"wybe#.string#.<=>#cont#2<0>"(i2, i64, i64, i64, i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
+declare external fastcc void @"wybe#.string#.print<0>"(i64)
 declare external ccc void @print_int(i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
@@ -616,7 +616,7 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 define external fastcc void @"common_fields#.<0>"() {
   %"tmp#1##0" = or i64 1, ptrtoint( ptr @"common_fields#constant#4" to i64 )
   %"tmp#2##0" = tail call fastcc i64 @"common_fields#.title<0>"(i64 ptrtoint( ptr @"common_fields#constant#3" to i64 ))
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#2##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
   %"tmp#3##0" = tail call fastcc i64 @"common_fields#.id<0>"(i64 %"tmp#1##0")
   call ccc void @print_int(i64 %"tmp#3##0")
@@ -635,14 +635,14 @@ if.then.0:
   %"tmp#15##0" = extractvalue {i64, i1}%"tmp#69##0", 1
   br i1 %"tmp#15##0", label %if.then.1, label %if.else.1
 if.then.1:
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#5##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#5##0")
   call ccc void @putchar(i8 10)
   %"tmp#70##0" = tail call fastcc {i64, i1} @"common_fields#.genre<0>"(i64 %"b##1")
   %"tmp#6##0" = extractvalue {i64, i1}%"tmp#70##0", 0
   %"tmp#13##0" = extractvalue {i64, i1}%"tmp#70##0", 1
   br i1 %"tmp#13##0", label %if.then.2, label %if.else.2
 if.then.2:
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#6##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#6##0")
   call ccc void @putchar(i8 10)
   ret void
 if.else.2:

--- a/test-cases/final-dump/cond_expr_no_else.exp
+++ b/test-cases/final-dump/cond_expr_no_else.exp
@@ -40,10 +40,9 @@ proc #cont#1 > {semipure} (2 calls)
 #cont#1(tmp#2##0:wybe.count)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.count.fmt<4>(~tmp#2##0:wybe.count, 0:wybe.int, 32:wybe.char, 10:wybe.count, ?tmp#1##0:wybe.string) #7 @cond_expr_no_else:nn:nn
     wybe.string.,,<0>("5:int -> ":wybe.string, ~tmp#1##0:wybe.string, ?tmp#0##0:wybe.string) #2 @cond_expr_no_else:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @cond_expr_no_else:nn:nn
+    wybe.string.print<0>(~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @cond_expr_no_else:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#29##0:wybe.phantom) @cond_expr_no_else:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#29##0:wybe.phantom, ?tmp#30##0:wybe.phantom) @cond_expr_no_else:nn:nn
     foreign lpvm store(~%tmp#30##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @cond_expr_no_else:nn:nn
@@ -62,10 +61,9 @@ proc #cont#2 > {semipure} (2 calls)
 #cont#2(tmp#6##0:wybe.count)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.count.fmt<4>(~tmp#6##0:wybe.count, 0:wybe.int, 32:wybe.char, 10:wybe.count, ?tmp#5##0:wybe.string) #7 @cond_expr_no_else:nn:nn
     wybe.string.,,<0>("-5:int -> ":wybe.string, ~tmp#5##0:wybe.string, ?tmp#4##0:wybe.string) #2 @cond_expr_no_else:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @cond_expr_no_else:nn:nn
+    wybe.string.print<0>(~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @cond_expr_no_else:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#28##0:wybe.phantom) @cond_expr_no_else:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#28##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @cond_expr_no_else:nn:nn
     foreign lpvm store(~%tmp#29##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @cond_expr_no_else:nn:nn
@@ -84,10 +82,9 @@ proc #cont#3 > {semipure} (2 calls)
 #cont#3(tmp#10##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(8,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(~tmp#10##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#9##0:wybe.string) #7 @cond_expr_no_else:nn:nn
     wybe.string.,,<0>("e is vowel number ":wybe.string, ~tmp#9##0:wybe.string, ?tmp#8##0:wybe.string) #2 @cond_expr_no_else:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#8##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @cond_expr_no_else:nn:nn
+    wybe.string.print<0>(~tmp#8##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #8 @cond_expr_no_else:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#27##0:wybe.phantom) @cond_expr_no_else:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#27##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @cond_expr_no_else:nn:nn
     foreign lpvm store(~%tmp#28##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @cond_expr_no_else:nn:nn
@@ -106,10 +103,9 @@ proc #cont#4 > {semipure} (2 calls)
 #cont#4(tmp#14##0:wybe.int)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(~tmp#14##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#13##0:wybe.string) #4 @cond_expr_no_else:nn:nn
     wybe.string.,,<0>("f is vowel number ":wybe.string, ~tmp#13##0:wybe.string, ?tmp#12##0:wybe.string) #2 @cond_expr_no_else:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#12##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @cond_expr_no_else:nn:nn
+    wybe.string.print<0>(~tmp#12##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @cond_expr_no_else:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#26##0:wybe.phantom) @cond_expr_no_else:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @cond_expr_no_else:nn:nn
     foreign lpvm store(~%tmp#27##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @cond_expr_no_else:nn:nn
@@ -183,7 +179,7 @@ target triple   = ????
 declare external fastcc i64 @"wybe#.count#.fmt<4>"(i64, i64, i8, i64)
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
+declare external fastcc void @"wybe#.string#.print<0>"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
@@ -203,7 +199,7 @@ if.else.0:
 define external fastcc void @"cond_expr_no_else#.#cont#1<0>"(i64 %"tmp#2##0") {
   %"tmp#1##0" = tail call fastcc i64 @"wybe#.count#.fmt<4>"(i64 %"tmp#2##0", i64 0, i8 32, i64 10)
   %"tmp#0##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"cond_expr_no_else#constant#7" to i64 ), i64 %"tmp#1##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#0##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   %"tmp#31##0" = tail call fastcc {i64, i1} @"cond_expr_no_else#.to_count<0>"(i64 -5)
   %"tmp#7##0" = extractvalue {i64, i1}%"tmp#31##0", 0
@@ -220,7 +216,7 @@ if.else.0:
 define external fastcc void @"cond_expr_no_else#.#cont#2<0>"(i64 %"tmp#6##0") {
   %"tmp#5##0" = tail call fastcc i64 @"wybe#.count#.fmt<4>"(i64 %"tmp#6##0", i64 0, i8 32, i64 10)
   %"tmp#4##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"cond_expr_no_else#constant#6" to i64 ), i64 %"tmp#5##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#4##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
   %"tmp#30##0" = tail call fastcc {i64, i1} @"cond_expr_no_else#.vowel_num<0>"(i8 101)
   %"tmp#11##0" = extractvalue {i64, i1}%"tmp#30##0", 0
@@ -237,7 +233,7 @@ if.else.0:
 define external fastcc void @"cond_expr_no_else#.#cont#3<0>"(i64 %"tmp#10##0") {
   %"tmp#9##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 %"tmp#10##0", i64 0, i8 32)
   %"tmp#8##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"cond_expr_no_else#constant#5" to i64 ), i64 %"tmp#9##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#8##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#8##0")
   call ccc void @putchar(i8 10)
   %"tmp#29##0" = tail call fastcc {i64, i1} @"cond_expr_no_else#.vowel_num<0>"(i8 102)
   %"tmp#15##0" = extractvalue {i64, i1}%"tmp#29##0", 0
@@ -254,7 +250,7 @@ if.else.0:
 define external fastcc void @"cond_expr_no_else#.#cont#4<0>"(i64 %"tmp#14##0") {
   %"tmp#13##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 %"tmp#14##0", i64 0, i8 32)
   %"tmp#12##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"cond_expr_no_else#constant#4" to i64 ), i64 %"tmp#13##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#12##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#12##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/failure_backtrack.exp
+++ b/test-cases/final-dump/failure_backtrack.exp
@@ -56,7 +56,6 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(36,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm load(<<failure_backtrack.r>>:wybe.int, ?%tmp#189##0:wybe.int) @failure_backtrack:nn:nn
     foreign lpvm load(<<failure_backtrack.s>>:wybe.int, ?%tmp#190##0:wybe.int) @failure_backtrack:nn:nn
     foreign lpvm store(7:wybe.int, <<failure_backtrack.r>>:wybe.int) @failure_backtrack:nn:nn
@@ -73,7 +72,7 @@ module top-level code > public {semipure} (0 calls)
     wybe.string.,,<0>(", r = ":wybe.string, ~tmp#4##0:wybe.string, ?tmp#8##0:wybe.string) #25 @failure_backtrack:nn:nn
     wybe.string.,,<0>(~tmp#2##0:wybe.string, ~tmp#8##0:wybe.string, ?tmp#6##0:wybe.string) #26 @failure_backtrack:nn:nn
     wybe.string.,,<0>("nope fails; x = ":wybe.string, ~tmp#6##0:wybe.string, ?tmp#5##0:wybe.string) #28 @failure_backtrack:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #36 @failure_backtrack:nn:nn
+    wybe.string.print<0>(~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #36 @failure_backtrack:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#244##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#244##0:wybe.phantom, ?tmp#245##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign lpvm store(~%tmp#245##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -85,7 +84,6 @@ proc #cont#1 > {semipure} (3 calls)
 #cont#1(tmp#189##0:wybe.int, tmp#190##0:wybe.int, x##0:wybe.int, y##0:wybe.int)<{<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(37,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(x##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#12##0:wybe.string) #29 @failure_backtrack:nn:nn
     foreign lpvm load(<<failure_backtrack.r>>:wybe.int, ?%r##0:wybe.int) @failure_backtrack:nn:nn
     wybe.int.fmt<2>(r##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#14##0:wybe.string) #30 @failure_backtrack:nn:nn
@@ -111,7 +109,7 @@ proc #cont#1 > {semipure} (3 calls)
         wybe.string.,,<0>(", r = ":wybe.string, ~tmp#14##0:wybe.string, ?tmp#23##0:wybe.string) #23 @failure_backtrack:nn:nn
         wybe.string.,,<0>(~tmp#12##0:wybe.string, ~tmp#23##0:wybe.string, ?tmp#21##0:wybe.string) #24 @failure_backtrack:nn:nn
         wybe.string.,,<0>("nope2 fails; x = ":wybe.string, ~tmp#21##0:wybe.string, ?tmp#20##0:wybe.string) #26 @failure_backtrack:nn:nn
-        wybe.string.print<0>[410bae77d3](~tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #37 @failure_backtrack:nn:nn
+        wybe.string.print<0>(~tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #37 @failure_backtrack:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#253##0:wybe.phantom) @failure_backtrack:nn:nn
         foreign c putchar(10:wybe.char, ~tmp#253##0:wybe.phantom, ?tmp#254##0:wybe.phantom) @failure_backtrack:nn:nn
         foreign lpvm store(~%tmp#254##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -131,7 +129,6 @@ proc #cont#2 > {semipure} (2 calls)
 #cont#2(tmp#189##0:wybe.int, tmp#190##0:wybe.int, x##0:wybe.int, y##0:wybe.int)<{<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(37,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(x##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#27##0:wybe.string) #29 @failure_backtrack:nn:nn
     foreign lpvm load(<<failure_backtrack.r>>:wybe.int, ?%tmp#194##0:wybe.int) @failure_backtrack:nn:nn
     wybe.int.fmt<2>(~tmp#194##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#29##0:wybe.string) #30 @failure_backtrack:nn:nn
@@ -155,7 +152,7 @@ proc #cont#2 > {semipure} (2 calls)
         wybe.string.,,<0>(", r = ":wybe.string, ~tmp#29##0:wybe.string, ?tmp#38##0:wybe.string) #23 @failure_backtrack:nn:nn
         wybe.string.,,<0>(~tmp#27##0:wybe.string, ~tmp#38##0:wybe.string, ?tmp#36##0:wybe.string) #24 @failure_backtrack:nn:nn
         wybe.string.,,<0>("nope2 fails; x = ":wybe.string, ~tmp#36##0:wybe.string, ?tmp#35##0:wybe.string) #26 @failure_backtrack:nn:nn
-        wybe.string.print<0>[410bae77d3](~tmp#35##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #37 @failure_backtrack:nn:nn
+        wybe.string.print<0>(~tmp#35##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #37 @failure_backtrack:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#252##0:wybe.phantom) @failure_backtrack:nn:nn
         foreign c putchar(10:wybe.char, ~tmp#252##0:wybe.phantom, ?tmp#253##0:wybe.phantom) @failure_backtrack:nn:nn
         foreign lpvm store(~%tmp#253##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -176,7 +173,6 @@ proc #cont#3 > {semipure} (2 calls)
 #cont#3(tmp#189##0:wybe.int, tmp#190##0:wybe.int, x##0:wybe.int, y##0:wybe.int)<{<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(75,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(80,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(x##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#42##0:wybe.string) #63 @failure_backtrack:nn:nn
     foreign lpvm load(<<failure_backtrack.r>>:wybe.int, ?%r##0:wybe.int) @failure_backtrack:nn:nn
     wybe.int.fmt<2>(r##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#44##0:wybe.string) #64 @failure_backtrack:nn:nn
@@ -213,7 +209,7 @@ proc #cont#3 > {semipure} (2 calls)
         wybe.string.,,<0>(", y = ":wybe.string, ~tmp#60##0:wybe.string, ?tmp#59##0:wybe.string) #57 @failure_backtrack:nn:nn
         wybe.string.,,<0>(~tmp#42##0:wybe.string, ~tmp#59##0:wybe.string, ?tmp#57##0:wybe.string) #58 @failure_backtrack:nn:nn
         wybe.string.,,<0>("nope fails; x = ":wybe.string, ~tmp#57##0:wybe.string, ?tmp#56##0:wybe.string) #60 @failure_backtrack:nn:nn
-        wybe.string.print<0>[410bae77d3](~tmp#56##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #75 @failure_backtrack:nn:nn
+        wybe.string.print<0>(~tmp#56##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #75 @failure_backtrack:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#271##0:wybe.phantom) @failure_backtrack:nn:nn
         foreign c putchar(10:wybe.char, ~tmp#271##0:wybe.phantom, ?tmp#272##0:wybe.phantom) @failure_backtrack:nn:nn
         foreign lpvm store(~%tmp#272##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -233,7 +229,7 @@ proc #cont#3 > {semipure} (2 calls)
             wybe.string.,,<0>(", y = ":wybe.string, ~tmp#60##0:wybe.string, ?tmp#59##0:wybe.string) #40 @failure_backtrack:nn:nn
             wybe.string.,,<0>(~tmp#42##0:wybe.string, ~tmp#59##0:wybe.string, ?tmp#57##0:wybe.string) #41 @failure_backtrack:nn:nn
             wybe.string.,,<0>("nope fails; x = ":wybe.string, ~tmp#57##0:wybe.string, ?tmp#56##0:wybe.string) #43 @failure_backtrack:nn:nn
-            wybe.string.print<0>[410bae77d3](~tmp#56##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #80 @failure_backtrack:nn:nn
+            wybe.string.print<0>(~tmp#56##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #80 @failure_backtrack:nn:nn
             foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#294##0:wybe.phantom) @failure_backtrack:nn:nn
             foreign c putchar(10:wybe.char, ~tmp#294##0:wybe.phantom, ?tmp#295##0:wybe.phantom) @failure_backtrack:nn:nn
             foreign lpvm store(~%tmp#295##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -254,7 +250,6 @@ proc #cont#4 > {semipure} (3 calls)
 #cont#4(tmp#189##0:wybe.int, tmp#190##0:wybe.int, x##0:wybe.int, y##0:wybe.int)<{<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(44,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(~x##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#69##0:wybe.string) #35 @failure_backtrack:nn:nn
     wybe.int.fmt<2>(y##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#72##0:wybe.string) #36 @failure_backtrack:nn:nn
     foreign lpvm load(<<failure_backtrack.r>>:wybe.int, ?%tmp#200##0:wybe.int) @failure_backtrack:nn:nn
@@ -279,7 +274,7 @@ proc #cont#4 > {semipure} (3 calls)
     wybe.string.,,<0>(", y = ":wybe.string, ~tmp#82##0:wybe.string, ?tmp#81##0:wybe.string) #27 @failure_backtrack:nn:nn
     wybe.string.,,<0>(~tmp#69##0:wybe.string, ~tmp#81##0:wybe.string, ?tmp#79##0:wybe.string) #28 @failure_backtrack:nn:nn
     wybe.string.,,<0>("before first disjunction: x = ":wybe.string, ~tmp#79##0:wybe.string, ?tmp#78##0:wybe.string) #30 @failure_backtrack:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#78##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #44 @failure_backtrack:nn:nn
+    wybe.string.print<0>(~tmp#78##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #44 @failure_backtrack:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#256##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#256##0:wybe.phantom, ?tmp#202##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign lpvm store(~%tmp#202##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -302,7 +297,6 @@ proc #cont#5 > {semipure} (2 calls)
 #cont#5(tmp#189##0:wybe.int, tmp#190##0:wybe.int, x##0:wybe.int, y##0:wybe.int)<{<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(41,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(46,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(~x##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#91##0:wybe.string) #37 @failure_backtrack:nn:nn
     wybe.int.fmt<2>(~y##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#94##0:wybe.string) #38 @failure_backtrack:nn:nn
     foreign lpvm load(<<failure_backtrack.r>>:wybe.int, ?%r##0:wybe.int) @failure_backtrack:nn:nn
@@ -316,7 +310,7 @@ proc #cont#5 > {semipure} (2 calls)
     wybe.string.,,<0>(", y = ":wybe.string, ~tmp#93##0:wybe.string, ?tmp#92##0:wybe.string) #11 @failure_backtrack:nn:nn
     wybe.string.,,<0>(~tmp#91##0:wybe.string, ~tmp#92##0:wybe.string, ?tmp#90##0:wybe.string) #12 @failure_backtrack:nn:nn
     wybe.string.,,<0>("after first disjunction: x = ":wybe.string, ~tmp#90##0:wybe.string, ?tmp#89##0:wybe.string) #14 @failure_backtrack:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#89##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #41 @failure_backtrack:nn:nn
+    wybe.string.print<0>(~tmp#89##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #41 @failure_backtrack:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#232##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#232##0:wybe.phantom, ?tmp#233##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign lpvm store(~%tmp#233##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -332,7 +326,7 @@ proc #cont#5 > {semipure} (2 calls)
     wybe.string.,,<0>(", y = ":wybe.string, ~tmp#104##0:wybe.string, ?tmp#103##0:wybe.string) #27 @failure_backtrack:nn:nn
     wybe.string.,,<0>(~tmp#102##0:wybe.string, ~tmp#103##0:wybe.string, ?tmp#101##0:wybe.string) #28 @failure_backtrack:nn:nn
     wybe.string.,,<0>("before second disjunction: x = ":wybe.string, ~tmp#101##0:wybe.string, ?tmp#100##0:wybe.string) #30 @failure_backtrack:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#100##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #46 @failure_backtrack:nn:nn
+    wybe.string.print<0>(~tmp#100##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #46 @failure_backtrack:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#255##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#255##0:wybe.phantom, ?tmp#205##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign lpvm store(~%tmp#205##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -361,7 +355,6 @@ proc #cont#6 > {semipure} (3 calls)
 #cont#6(tmp#189##0:wybe.int, tmp#190##0:wybe.int, x##0:wybe.int, y##0:wybe.int)<{<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {<<failure_backtrack.r>>, <<failure_backtrack.s>>, <<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(20,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(~x##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#113##0:wybe.string) #16 @failure_backtrack:nn:nn
     wybe.int.fmt<2>(~y##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#116##0:wybe.string) #17 @failure_backtrack:nn:nn
     foreign lpvm load(<<failure_backtrack.r>>:wybe.int, ?%r##0:wybe.int) @failure_backtrack:nn:nn
@@ -375,7 +368,7 @@ proc #cont#6 > {semipure} (3 calls)
     wybe.string.,,<0>(", y = ":wybe.string, ~tmp#115##0:wybe.string, ?tmp#114##0:wybe.string) #11 @failure_backtrack:nn:nn
     wybe.string.,,<0>(~tmp#113##0:wybe.string, ~tmp#114##0:wybe.string, ?tmp#112##0:wybe.string) #12 @failure_backtrack:nn:nn
     wybe.string.,,<0>("after second disjunction: x = ":wybe.string, ~tmp#112##0:wybe.string, ?tmp#111##0:wybe.string) #14 @failure_backtrack:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#111##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @failure_backtrack:nn:nn
+    wybe.string.print<0>(~tmp#111##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #20 @failure_backtrack:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#230##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#230##0:wybe.phantom, ?tmp#231##0:wybe.phantom) @failure_backtrack:nn:nn
     foreign lpvm store(~%tmp#231##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @failure_backtrack:nn:nn
@@ -457,7 +450,6 @@ target triple   = ????
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
 declare external fastcc void @"wybe#.string#.print<0>"(i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 @"resource#failure_backtrack.r" = global i64 undef
@@ -478,7 +470,7 @@ define external fastcc void @"failure_backtrack#.<0>"() {
   %"tmp#8##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#20" to i64 ), i64 %"tmp#4##0")
   %"tmp#6##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#2##0", i64 %"tmp#8##0")
   %"tmp#5##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#29" to i64 ), i64 %"tmp#6##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#5##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#5##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"failure_backtrack#.#cont#1<0>"(i64 %"tmp#189##0", i64 %"tmp#190##0", i64 42, i64 21)
   ret void
@@ -513,7 +505,7 @@ if.else.0:
   %"tmp#23##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#20" to i64 ), i64 %"tmp#14##0")
   %"tmp#21##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#12##0", i64 %"tmp#23##0")
   %"tmp#20##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#33" to i64 ), i64 %"tmp#21##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#20##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#20##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"failure_backtrack#.#cont#2<0>"(i64 %"tmp#189##0", i64 %"tmp#190##0", i64 %"x##0", i64 %"y##0")
   ret void
@@ -547,7 +539,7 @@ if.else.0:
   %"tmp#38##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#20" to i64 ), i64 %"tmp#29##0")
   %"tmp#36##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#27##0", i64 %"tmp#38##0")
   %"tmp#35##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#33" to i64 ), i64 %"tmp#36##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#35##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#35##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"failure_backtrack#.#cont#3<0>"(i64 %"tmp#189##0", i64 %"tmp#190##0", i64 %"x##0", i64 %"y##0")
   ret void
@@ -596,7 +588,7 @@ if.else.1:
   %"tmp#59##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#21" to i64 ), i64 %"tmp#60##0")
   %"tmp#57##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#42##0", i64 %"tmp#59##0")
   %"tmp#56##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#29" to i64 ), i64 %"tmp#57##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#56##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#56##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"failure_backtrack#.#cont#4<0>"(i64 %"tmp#189##0", i64 %"tmp#190##0", i64 %"x##0", i64 %"y##0")
   ret void
@@ -609,7 +601,7 @@ if.else.0:
   %"tmp#307##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#21" to i64 ), i64 %"tmp#306##0")
   %"tmp#308##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#42##0", i64 %"tmp#307##0")
   %"tmp#309##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#29" to i64 ), i64 %"tmp#308##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#309##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#309##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"failure_backtrack#.#cont#4<0>"(i64 %"tmp#189##0", i64 %"tmp#190##0", i64 %"x##0", i64 %"y##0")
   ret void
@@ -638,7 +630,7 @@ define external fastcc void @"failure_backtrack#.#cont#4<0>"(i64 %"tmp#189##0", 
   %"tmp#81##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#21" to i64 ), i64 %"tmp#82##0")
   %"tmp#79##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#69##0", i64 %"tmp#81##0")
   %"tmp#78##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#26" to i64 ), i64 %"tmp#79##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#78##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#78##0")
   call ccc void @putchar(i8 10)
   store i64 11, ptr @"resource#failure_backtrack.r"
   store i64 40, ptr @"resource#failure_backtrack.s"
@@ -668,7 +660,7 @@ define external fastcc void @"failure_backtrack#.#cont#5<0>"(i64 %"tmp#189##0", 
   %"tmp#92##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#21" to i64 ), i64 %"tmp#93##0")
   %"tmp#90##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#91##0", i64 %"tmp#92##0")
   %"tmp#89##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#23" to i64 ), i64 %"tmp#90##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#89##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#89##0")
   call ccc void @putchar(i8 10)
   store i64 14, ptr @"resource#failure_backtrack.s"
   %"tmp#102##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 42, i64 0, i8 32)
@@ -682,7 +674,7 @@ define external fastcc void @"failure_backtrack#.#cont#5<0>"(i64 %"tmp#189##0", 
   %"tmp#103##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#21" to i64 ), i64 %"tmp#104##0")
   %"tmp#101##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#102##0", i64 %"tmp#103##0")
   %"tmp#100##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#24" to i64 ), i64 %"tmp#101##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#100##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#100##0")
   call ccc void @putchar(i8 10)
   store i64 12, ptr @"resource#failure_backtrack.r"
   %"tmp#210##0" = tail call fastcc i1 @"failure_backtrack#.nope<0>"()
@@ -717,7 +709,7 @@ define external fastcc void @"failure_backtrack#.#cont#6<0>"(i64 %"tmp#189##0", 
   %"tmp#114##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#21" to i64 ), i64 %"tmp#115##0")
   %"tmp#112##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#113##0", i64 %"tmp#114##0")
   %"tmp#111##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"failure_backtrack#constant#22" to i64 ), i64 %"tmp#112##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#111##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#111##0")
   call ccc void @putchar(i8 10)
   store i64 %"tmp#189##0", ptr @"resource#failure_backtrack.r"
   store i64 %"tmp#190##0", ptr @"resource#failure_backtrack.s"

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -24,9 +24,8 @@ AFTER EVERYTHING:
 proc append > public (1 calls)
 0: generic_list.append<0>
 append(x##0:generic_list(T) <{}; {}; {0}>, y##0:generic_list(T) <{}; {}; {1}>, outByReference #result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
-  AliasPairs: [(#result##0,y##0)]
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
+  AliasPairs: [(#result##0,x##0),(#result##0,y##0),(x##0,y##0)]
+  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @generic_list:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -24,9 +24,8 @@ AFTER EVERYTHING:
 proc append > public (1 calls)
 0: generic_list.append<0>
 append(x##0:generic_list(T) <{}; {}; {0}>, y##0:generic_list(T) <{}; {}; {1}>, outByReference #result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
-  AliasPairs: [(#result##0,y##0)]
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
+  AliasPairs: [(#result##0,x##0),(#result##0,y##0),(x##0,y##0)]
+  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @generic_list:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
@@ -352,7 +351,6 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(8,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 []])),(15,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 []]))]
     generic_use.fromto1<0>(1:wybe.int, 5:wybe.int, 0:generic_list(wybe.int), ?tmp#0##0:generic_list(wybe.int)) #10 @generic_use:nn:nn
     generic_use.fromto1<0>(6:wybe.int, 10:wybe.int, 0:generic_list(wybe.int), ?tmp#1##0:generic_list(wybe.int)) #11 @generic_use:nn:nn
     generic_use.print<0>(tmp#0##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #12 @generic_use:nn:nn
@@ -368,12 +366,12 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#15##0:wybe.phantom) @generic_use:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#15##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @generic_use:nn:nn
     foreign lpvm store(~%tmp#16##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @generic_use:nn:nn
-    generic_use.reverse1<0>[410bae77d3](~tmp#0##0:generic_list(wybe.int), 0:generic_list(wybe.int), ?tmp#3##0:generic_list(wybe.int)) #15 @generic_use:nn:nn
+    generic_use.reverse1<0>(~tmp#0##0:generic_list(wybe.int), 0:generic_list(wybe.int), ?tmp#3##0:generic_list(wybe.int)) #15 @generic_use:nn:nn
     generic_use.print<0>(~tmp#3##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #16 @generic_use:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#19##0:wybe.phantom) @generic_use:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @generic_use:nn:nn
     foreign lpvm store(~%tmp#20##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @generic_use:nn:nn
-    generic_use.nrev<0>[410bae77d3](~tmp#1##0:generic_list(wybe.int), ?tmp#4##0:generic_list(wybe.int)) #8 @generic_use:nn:nn
+    generic_use.nrev<0>(~tmp#1##0:generic_list(wybe.int), ?tmp#4##0:generic_list(wybe.int)) #8 @generic_use:nn:nn
     generic_use.print<0>(~tmp#4##0:generic_list(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #17 @generic_use:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#22##0:wybe.phantom) @generic_use:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#22##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @generic_use:nn:nn
@@ -383,9 +381,8 @@ module top-level code > public {semipure} (0 calls)
 proc concat > public (3 calls)
 0: generic_use.concat<0>
 concat(l1##0:generic_list(T) <{}; {}; {0}>, l2##0:generic_list(T) <{}; {}; {1}>, outByReference #result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
-  AliasPairs: [(#result##0,l2##0)]
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(1,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
+  AliasPairs: [(#result##0,l1##0),(#result##0,l2##0),(l1##0,l2##0)]
+  InterestingCallProperties: []
     foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @generic_use:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
@@ -398,17 +395,6 @@ concat(l1##0:generic_list(T) <{}; {}; {0}>, l2##0:generic_list(T) <{}; {}; {1}>,
         foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @generic_use:nn:nn
         generic_use.concat<0>(~t##0:generic_list(T), ~l2##0:generic_list(T), outByReference tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
         foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~takeReference tmp#2##0:generic_list(T)) @generic_use:nn:nn
-
- [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @generic_use:nn:nn
-    case ~tmp#5##0:wybe.bool of
-    0:
-        foreign llvm move(~l2##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
-
-    1:
-        foreign lpvm access(l1##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_use:nn:nn
-        generic_use.concat<0>[410bae77d3](~t##0:generic_list(T), ~l2##0:generic_list(T), outByReference tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~l1##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~takeReference tmp#2##0:generic_list(T)) @generic_use:nn:nn
 
 
 
@@ -450,9 +436,8 @@ iota(n##0:wybe.int, ?#result##0:generic_list(wybe.int))<{}; {}; {}>:
 proc nrev > public (2 calls)
 0: generic_use.nrev<0>
 nrev(lst##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; {0}>)<{}; {}; {}>:
-  AliasPairs: []
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(1,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 []]))]
+  AliasPairs: [(#result##0,lst##0)]
+  InterestingCallProperties: []
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @generic_use:nn:nn
     case ~tmp#8##0:wybe.bool of
     0:
@@ -465,19 +450,7 @@ nrev(lst##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {}; 
         foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(T)) @generic_use:nn:nn
         foreign lpvm mutate(~tmp#11##0:generic_list(T), ?tmp#12##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @generic_use:nn:nn
         foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(T)) @generic_use:nn:nn
-        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(T), ~tmp#3##0:generic_list(T), outByReference #result##0:generic_list(T)) #4 @generic_use:nn:nn
-
- [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @generic_use:nn:nn
-    case ~tmp#8##0:wybe.bool of
-    0:
-        foreign llvm move(0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
-
-    1:
-        foreign lpvm access(lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_use:nn:nn
-        generic_use.nrev<0>[410bae77d3](~t##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~lst##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(T)) @generic_use:nn:nn
-        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(T), ~tmp#3##0:generic_list(T), outByReference #result##0:generic_list(T)) #4 @generic_use:nn:nn
+        generic_use.concat<0>(~tmp#2##0:generic_list(T), ~tmp#3##0:generic_list(T), outByReference #result##0:generic_list(T)) #4 @generic_use:nn:nn
 
 
 
@@ -548,9 +521,8 @@ reverse(lst##0:generic_list(T) <{}; {}; {0}>, ?#result##0:generic_list(T) <{}; {
 proc reverse1 > public (2 calls)
 0: generic_use.reverse1<0>
 reverse1(lst##0:generic_list(T) <{}; {}; {0}>, suffix##0:generic_list(T) <{}; {}; {1}>, ?#result##0:generic_list(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
-  AliasPairs: [(#result##0,suffix##0)]
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(2,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 [0]]))]
+  AliasPairs: [(#result##0,lst##0),(#result##0,suffix##0),(lst##0,suffix##0)]
+  InterestingCallProperties: []
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @generic_use:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
@@ -563,17 +535,6 @@ reverse1(lst##0:generic_list(T) <{}; {}; {0}>, suffix##0:generic_list(T) <{}; {}
         foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T) @generic_use:nn:nn
         foreign lpvm mutate(~tmp#9##0:generic_list(T), ?tmp#2##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(T)) @generic_use:nn:nn
         generic_use.reverse1<0>(~t##0:generic_list(T), ~tmp#2##0:generic_list(T), ?#result##0:generic_list(T)) #2 @generic_use:nn:nn
-
- [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @generic_use:nn:nn
-    case ~tmp#5##0:wybe.bool of
-    0:
-        foreign llvm move(~suffix##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
-
-    1:
-        foreign lpvm access(lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T)) @generic_use:nn:nn
-        foreign lpvm mutate(~lst##0:generic_list(T), ?tmp#2##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(T)) @generic_use:nn:nn
-        generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(T), ~tmp#2##0:generic_list(T), ?#result##0:generic_list(T)) #2 @generic_use:nn:nn
 
 
   LLVM code       :
@@ -605,10 +566,10 @@ define external fastcc void @"generic_use#.<0>"() {
   %"tmp#2##0" = load i64, ptr %"tmp#24##0"
   call fastcc void @"generic_use#.print<0>"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
-  %"tmp#3##0" = call fastcc i64 @"generic_use#.reverse1<0>[410bae77d3]"(i64 %"tmp#0##0", i64 0)
+  %"tmp#3##0" = call fastcc i64 @"generic_use#.reverse1<0>"(i64 %"tmp#0##0", i64 0)
   call fastcc void @"generic_use#.print<0>"(i64 %"tmp#3##0")
   call ccc void @putchar(i8 10)
-  %"tmp#4##0" = call fastcc i64 @"generic_use#.nrev<0>[410bae77d3]"(i64 %"tmp#1##0")
+  %"tmp#4##0" = call fastcc i64 @"generic_use#.nrev<0>"(i64 %"tmp#1##0")
   call fastcc void @"generic_use#.print<0>"(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
   ret void
@@ -631,23 +592,6 @@ if.then.0:
   %"tmp#16##0" = add i64 %"tmp#8##0", 8
   %"tmp#17##0" = inttoptr i64 %"tmp#16##0" to ptr
   musttail call fastcc void @"generic_use#.concat<0>"(i64 %"t##0", i64 %"l2##0", ptr %"tmp#17##0")
-  ret void
-if.else.0:
-  store i64 %"l2##0", ptr %"tmp#10##0"
-  ret void
-}
-
-define external fastcc void @"generic_use#.concat<0>[410bae77d3]"(i64 %"l1##0", i64 %"l2##0", ptr %"tmp#10##0") {
-  %"tmp#5##0" = icmp ne i64 %"l1##0", 0
-  br i1 %"tmp#5##0", label %if.then.0, label %if.else.0
-if.then.0:
-  %"tmp#11##0" = add i64 %"l1##0", 8
-  %"tmp#12##0" = inttoptr i64 %"tmp#11##0" to ptr
-  %"t##0" = load i64, ptr %"tmp#12##0"
-  store i64 %"l1##0", ptr %"tmp#10##0"
-  %"tmp#13##0" = add i64 %"l1##0", 8
-  %"tmp#14##0" = inttoptr i64 %"tmp#13##0" to ptr
-  musttail call fastcc void @"generic_use#.concat<0>[410bae77d3]"(i64 %"t##0", i64 %"l2##0", ptr %"tmp#14##0")
   ret void
 if.else.0:
   store i64 %"l2##0", ptr %"tmp#10##0"
@@ -700,28 +644,9 @@ if.then.0:
   %"tmp#19##0" = inttoptr i64 %"tmp#18##0" to ptr
   store i64 0, ptr %"tmp#19##0"
   %"tmp#20##0" = alloca i8, i64 8, align 8
-  call fastcc void @"generic_use#.concat<0>[410bae77d3]"(i64 %"tmp#2##0", i64 %"tmp#11##0", ptr %"tmp#20##0")
+  call fastcc void @"generic_use#.concat<0>"(i64 %"tmp#2##0", i64 %"tmp#11##0", ptr %"tmp#20##0")
   %"tmp#21##0" = load i64, ptr %"tmp#20##0"
   ret i64 %"tmp#21##0"
-if.else.0:
-  ret i64 0
-}
-
-define external fastcc i64 @"generic_use#.nrev<0>[410bae77d3]"(i64 %"lst##0") {
-  %"tmp#8##0" = icmp ne i64 %"lst##0", 0
-  br i1 %"tmp#8##0", label %if.then.0, label %if.else.0
-if.then.0:
-  %"tmp#13##0" = add i64 %"lst##0", 8
-  %"tmp#14##0" = inttoptr i64 %"tmp#13##0" to ptr
-  %"t##0" = load i64, ptr %"tmp#14##0"
-  %"tmp#2##0" = tail call fastcc i64 @"generic_use#.nrev<0>[410bae77d3]"(i64 %"t##0")
-  %"tmp#15##0" = add i64 %"lst##0", 8
-  %"tmp#16##0" = inttoptr i64 %"tmp#15##0" to ptr
-  store i64 0, ptr %"tmp#16##0"
-  %"tmp#17##0" = alloca i8, i64 8, align 8
-  call fastcc void @"generic_use#.concat<0>[410bae77d3]"(i64 %"tmp#2##0", i64 %"lst##0", ptr %"tmp#17##0")
-  %"tmp#18##0" = load i64, ptr %"tmp#17##0"
-  ret i64 %"tmp#18##0"
 if.else.0:
   ret i64 0
 }
@@ -791,22 +716,6 @@ if.then.0:
   store i64 %"suffix##0", ptr %"tmp#16##0"
   %"tmp#17##0" = tail call fastcc i64 @"generic_use#.reverse1<0>"(i64 %"t##0", i64 %"tmp#8##0")
   ret i64 %"tmp#17##0"
-if.else.0:
-  ret i64 %"suffix##0"
-}
-
-define external fastcc i64 @"generic_use#.reverse1<0>[410bae77d3]"(i64 %"lst##0", i64 %"suffix##0") {
-  %"tmp#5##0" = icmp ne i64 %"lst##0", 0
-  br i1 %"tmp#5##0", label %if.then.0, label %if.else.0
-if.then.0:
-  %"tmp#10##0" = add i64 %"lst##0", 8
-  %"tmp#11##0" = inttoptr i64 %"tmp#10##0" to ptr
-  %"t##0" = load i64, ptr %"tmp#11##0"
-  %"tmp#12##0" = add i64 %"lst##0", 8
-  %"tmp#13##0" = inttoptr i64 %"tmp#12##0" to ptr
-  store i64 %"suffix##0", ptr %"tmp#13##0"
-  %"tmp#14##0" = tail call fastcc i64 @"generic_use#.reverse1<0>[410bae77d3]"(i64 %"t##0", i64 %"lst##0")
-  ret i64 %"tmp#14##0"
 if.else.0:
   ret i64 %"suffix##0"
 }

--- a/test-cases/final-dump/higher_order_sort.exp
+++ b/test-cases/final-dump/higher_order_sort.exp
@@ -16,7 +16,7 @@ AFTER EVERYTHING:
 proc insert > (2 calls)
 0: higher_order_sort.insert<0>
 insert(<=##0:(X, X, ?wybe.bool) <{}; {}; {0}>, x##0:X <{}; {}; {1}>, xs##0:wybe.list(X) <{}; {}; {2}>, outByReference xs##1:wybe.list(X) <{}; {}; {0, 1, 2}>)<{}; {}; {}>:
-  AliasPairs: [(xs##0,xs##1)]
+  AliasPairs: [(x##0,xs##0),(x##0,xs##1),(xs##0,xs##1)]
   InterestingCallProperties: []
     foreign llvm icmp_ne(xs##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool) @higher_order_sort:nn:nn
     case ~tmp#7##0:wybe.bool of
@@ -55,7 +55,7 @@ sort(<=##0:(X, X, ?wybe.bool) <{}; {}; {0}>, xs##0:wybe.list(X) <{}; {}; {1}>, ?
 proc sort#cont#1 > (2 calls)
 0: higher_order_sort.sort#cont#1<0>
 sort#cont#1(<=##0:(X, X, ?wybe.bool) <{}; {}; {0}>, sorted##0:wybe.list(X) <{}; {}; {1}>, tmp#1##0:wybe.list(X) <{}; {}; {2}>, ?sorted##2:wybe.list(X) <{}; {}; {0, 1, 2}>)<{}; {}; {}>:
-  AliasPairs: [(sorted##0,sorted##2)]
+  AliasPairs: [(sorted##0,sorted##2),(sorted##0,tmp#1##0),(sorted##2,tmp#1##0)]
   InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @higher_order_sort:nn:nn
     case ~tmp#5##0:wybe.bool of

--- a/test-cases/final-dump/importer.exp
+++ b/test-cases/final-dump/importer.exp
@@ -72,7 +72,6 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<exporter.res>>, <<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(24,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm load(<<exporter.res>>:wybe.int, ?tmp#31##0:wybe.int) @importer:nn:nn
     foreign c ipow(2:wybe.int, tmp#31##0:wybe.int, ?tmp#32##0:wybe.int) @importer:nn:nn
     wybe.int.fmt<2>(~tmp#31##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#3##0:wybe.string) #19 @importer:nn:nn
@@ -87,7 +86,7 @@ module top-level code > public {semipure} (0 calls)
     wybe.string.,,<0>(" = ":wybe.string, ~tmp#5##0:wybe.string, ?tmp#10##0:wybe.string) #14 @importer:nn:nn
     wybe.string.,,<0>(~tmp#3##0:wybe.string, ~tmp#10##0:wybe.string, ?tmp#8##0:wybe.string) #15 @importer:nn:nn
     wybe.string.,,<0>("2^":wybe.string, ~tmp#8##0:wybe.string, ?tmp#7##0:wybe.string) #17 @importer:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#7##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @importer:nn:nn
+    wybe.string.print<0>(~tmp#7##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @importer:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#42##0:wybe.phantom) @importer:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#42##0:wybe.phantom, ?tmp#43##0:wybe.phantom) @importer:nn:nn
     foreign lpvm store(~%tmp#43##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @importer:nn:nn
@@ -117,7 +116,6 @@ target triple   = ????
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
 declare external fastcc void @"wybe#.string#.print<0>"(i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
 declare external ccc i64 @ipow(i64, i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
@@ -135,7 +133,7 @@ define external fastcc void @"importer#.<0>"() {
   %"tmp#10##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"importer#constant#2" to i64 ), i64 %"tmp#5##0")
   %"tmp#8##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#3##0", i64 %"tmp#10##0")
   %"tmp#7##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"importer#constant#3" to i64 ), i64 %"tmp#8##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#7##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#7##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/inline_pos.exp
+++ b/test-cases/final-dump/inline_pos.exp
@@ -106,13 +106,12 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<command_line.arguments>>, <<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(7,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm load(<<command_line.arguments>>:wybe.c_array(wybe.c_string), ?%arguments##0:wybe.c_array(wybe.c_string)) @inline_pos:nn:nn
     foreign lpvm access(~arguments##0:wybe.c_array(wybe.c_string), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int) @inline_pos:nn:nn
     foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?v##1:wybe.int) @inline_pos:nn:nn
     wybe.int.fmt<2>(~v##1:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#2##0:wybe.string) #6 @inline_pos:nn:nn
     wybe.string.,,<0>("v = ":wybe.string, ~tmp#2##0:wybe.string, ?tmp#1##0:wybe.string) #4 @inline_pos:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#1##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @inline_pos:nn:nn
+    wybe.string.print<0>(~tmp#1##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #7 @inline_pos:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#12##0:wybe.phantom) @inline_pos:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#12##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @inline_pos:nn:nn
     foreign lpvm store(~%tmp#13##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @inline_pos:nn:nn
@@ -139,7 +138,7 @@ target triple   = ????
 @"resource#command_line.arguments" = external global i64
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
+declare external fastcc void @"wybe#.string#.print<0>"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
@@ -150,7 +149,7 @@ define external fastcc void @"inline_pos#.<0>"() {
   %"v##1" = add i64 %"tmp#0##0", 1
   %"tmp#2##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 %"v##1", i64 0, i8 32)
   %"tmp#1##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"inline_pos#constant#1" to i64 ), i64 %"tmp#2##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#1##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#1##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -24,9 +24,8 @@ AFTER EVERYTHING:
 proc append > public (1 calls)
 0: list_this.append<0>
 append(x##0:list_this(T) <{}; {}; {0}>, y##0:list_this(T) <{}; {}; {1}>, outByReference #result##0:list_this(T) <{}; {}; {0, 1}>)<{}; {}; {}>:
-  AliasPairs: [(#result##0,y##0)]
-  InterestingCallProperties: [InterestingUnaliased 0]
-  MultiSpeczDepInfo: [(1,(list_this.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
+  AliasPairs: [(#result##0,x##0),(#result##0,y##0),(x##0,y##0)]
+  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @list_this:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:

--- a/test-cases/final-dump/mutate.exp
+++ b/test-cases/final-dump/mutate.exp
@@ -24,44 +24,43 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(28,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(29,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(30,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(31,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(32,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(33,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign llvm or(1:wybe.int, mutate#constant#2:mutate.position, ?tmp#0##0:mutate.position) @mutate:nn:nn
     mutate.position.update_x<0>(tmp#0##0:mutate.position, ?p##1:mutate.position, 11:wybe.int) #1 @mutate:nn:nn
     mutate.position.fmt<0>(~tmp#0##0:mutate.position, ?tmp#2##0:wybe.string) #2 @mutate:nn:nn
     wybe.string.,,<0>("old p = ":wybe.string, ~tmp#2##0:wybe.string, ?tmp#1##0:wybe.string) #4 @mutate:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#1##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @mutate:nn:nn
+    wybe.string.print<0>(~tmp#1##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #28 @mutate:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#31##0:wybe.phantom) @mutate:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#31##0:wybe.phantom, ?tmp#32##0:wybe.phantom) @mutate:nn:nn
     foreign lpvm store(~%tmp#32##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mutate:nn:nn
     mutate.position.fmt<0>(p##1:mutate.position, ?tmp#4##0:wybe.string) #6 @mutate:nn:nn
     wybe.string.,,<0>("new p = ":wybe.string, ~tmp#4##0:wybe.string, ?tmp#3##0:wybe.string) #8 @mutate:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#3##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @mutate:nn:nn
+    wybe.string.print<0>(~tmp#3##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @mutate:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#38##0:wybe.phantom) @mutate:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#38##0:wybe.phantom, ?tmp#39##0:wybe.phantom) @mutate:nn:nn
     foreign lpvm store(~%tmp#39##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mutate:nn:nn
     mutate.position.update_y<0>(p##1:mutate.position, ?p##2:mutate.position, 12:wybe.int) #10 @mutate:nn:nn
     mutate.position.fmt<0>(~p##1:mutate.position, ?tmp#6##0:wybe.string) #11 @mutate:nn:nn
     wybe.string.,,<0>("old p = ":wybe.string, ~tmp#6##0:wybe.string, ?tmp#5##0:wybe.string) #13 @mutate:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @mutate:nn:nn
+    wybe.string.print<0>(~tmp#5##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #30 @mutate:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#45##0:wybe.phantom) @mutate:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#45##0:wybe.phantom, ?tmp#46##0:wybe.phantom) @mutate:nn:nn
     foreign lpvm store(~%tmp#46##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mutate:nn:nn
     mutate.position.fmt<0>(p##2:mutate.position, ?tmp#8##0:wybe.string) #15 @mutate:nn:nn
     wybe.string.,,<0>("new p = ":wybe.string, ~tmp#8##0:wybe.string, ?tmp#7##0:wybe.string) #17 @mutate:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#7##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @mutate:nn:nn
+    wybe.string.print<0>(~tmp#7##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #31 @mutate:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#52##0:wybe.phantom) @mutate:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#52##0:wybe.phantom, ?tmp#53##0:wybe.phantom) @mutate:nn:nn
     foreign lpvm store(~%tmp#53##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mutate:nn:nn
     mutate.position.update_z<0>(p##2:mutate.position, ?p##3:mutate.position, 13:wybe.int) #19 @mutate:nn:nn
     mutate.position.fmt<0>(~p##2:mutate.position, ?tmp#10##0:wybe.string) #20 @mutate:nn:nn
     wybe.string.,,<0>("old p = ":wybe.string, ~tmp#10##0:wybe.string, ?tmp#9##0:wybe.string) #22 @mutate:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#9##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @mutate:nn:nn
+    wybe.string.print<0>(~tmp#9##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #32 @mutate:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#59##0:wybe.phantom) @mutate:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#59##0:wybe.phantom, ?tmp#60##0:wybe.phantom) @mutate:nn:nn
     foreign lpvm store(~%tmp#60##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mutate:nn:nn
     mutate.position.fmt<0>(~p##3:mutate.position, ?tmp#12##0:wybe.string) #24 @mutate:nn:nn
     wybe.string.,,<0>("new p = ":wybe.string, ~tmp#12##0:wybe.string, ?tmp#11##0:wybe.string) #26 @mutate:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#11##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @mutate:nn:nn
+    wybe.string.print<0>(~tmp#11##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #33 @mutate:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#66##0:wybe.phantom) @mutate:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#66##0:wybe.phantom, ?tmp#67##0:wybe.phantom) @mutate:nn:nn
     foreign lpvm store(~%tmp#67##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @mutate:nn:nn
@@ -81,7 +80,7 @@ target triple   = ????
 @"mutate#constant#4" = private unnamed_addr constant {i64, ptr} { i64 8, ptr @"mutate#constant#1" }, align 8
 
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
+declare external fastcc void @"wybe#.string#.print<0>"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
@@ -90,29 +89,29 @@ define external fastcc void @"mutate#.<0>"() {
   %"p##1" = tail call fastcc i64 @"mutate#.position#.update_x<0>"(i64 %"tmp#0##0", i64 11)
   %"tmp#2##0" = tail call fastcc i64 @"mutate#.position#.fmt<0>"(i64 %"tmp#0##0")
   %"tmp#1##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"mutate#constant#3" to i64 ), i64 %"tmp#2##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#1##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#1##0")
   call ccc void @putchar(i8 10)
   %"tmp#4##0" = tail call fastcc i64 @"mutate#.position#.fmt<0>"(i64 %"p##1")
   %"tmp#3##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"mutate#constant#4" to i64 ), i64 %"tmp#4##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#3##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#3##0")
   call ccc void @putchar(i8 10)
   %"p##2" = tail call fastcc i64 @"mutate#.position#.update_y<0>"(i64 %"p##1", i64 12)
   %"tmp#6##0" = tail call fastcc i64 @"mutate#.position#.fmt<0>"(i64 %"p##1")
   %"tmp#5##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"mutate#constant#3" to i64 ), i64 %"tmp#6##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#5##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#5##0")
   call ccc void @putchar(i8 10)
   %"tmp#8##0" = tail call fastcc i64 @"mutate#.position#.fmt<0>"(i64 %"p##2")
   %"tmp#7##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"mutate#constant#4" to i64 ), i64 %"tmp#8##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#7##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#7##0")
   call ccc void @putchar(i8 10)
   %"p##3" = tail call fastcc i64 @"mutate#.position#.update_z<0>"(i64 %"p##2", i64 13)
   %"tmp#10##0" = tail call fastcc i64 @"mutate#.position#.fmt<0>"(i64 %"p##2")
   %"tmp#9##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"mutate#constant#3" to i64 ), i64 %"tmp#10##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#9##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#9##0")
   call ccc void @putchar(i8 10)
   %"tmp#12##0" = tail call fastcc i64 @"mutate#.position#.fmt<0>"(i64 %"p##3")
   %"tmp#11##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"mutate#constant#4" to i64 ), i64 %"tmp#12##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#11##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#11##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/new_array_test.exp
+++ b/test-cases/final-dump/new_array_test.exp
@@ -60,7 +60,7 @@ proc #cont#3 > {semipure} (2 calls)
 #cont#3(sum##0:wybe.int, tmp#4##0:wybe.array.array_iterator(wybe.int))<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: [InterestingUnaliased 1]
-  MultiSpeczDepInfo: [(2,(new_array_test.#cont#3<0>,fromList [NonAliasedParamCond 1 [1]])),(6,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(2,(new_array_test.#cont#3<0>,fromList [NonAliasedParamCond 1 [1]]))]
     foreign lpvm access(tmp#4##0:wybe.array.array_iterator(wybe.int), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.c_array.raw_array) @new_array_test:nn:nn
     foreign lpvm access(tmp#4##0:wybe.array.array_iterator(wybe.int), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.c_array.raw_array) @new_array_test:nn:nn
     foreign llvm icmp_slt(tmp#14##0:wybe.c_array.raw_array, ~tmp#15##0:wybe.c_array.raw_array, ?tmp#16##0:wybe.bool) @new_array_test:nn:nn
@@ -68,7 +68,7 @@ proc #cont#3 > {semipure} (2 calls)
     0:
         wybe.int.fmt<2>(~sum##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#19##0:wybe.string) #4 @new_array_test:nn:nn
         wybe.string.,,<0>("Sum   : ":wybe.string, ~tmp#19##0:wybe.string, ?tmp#20##0:wybe.string) #5 @new_array_test:nn:nn
-        wybe.string.print<0>[410bae77d3](~tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @new_array_test:nn:nn
+        wybe.string.print<0>(~tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @new_array_test:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @new_array_test:nn:nn
         foreign c putchar(10:wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @new_array_test:nn:nn
         foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @new_array_test:nn:nn
@@ -88,7 +88,7 @@ proc #cont#3 > {semipure} (2 calls)
     0:
         wybe.int.fmt<2>(~sum##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#19##0:wybe.string) #4 @new_array_test:nn:nn
         wybe.string.,,<0>("Sum   : ":wybe.string, ~tmp#19##0:wybe.string, ?tmp#20##0:wybe.string) #5 @new_array_test:nn:nn
-        wybe.string.print<0>[410bae77d3](~tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @new_array_test:nn:nn
+        wybe.string.print<0>(~tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @new_array_test:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#21##0:wybe.phantom) @new_array_test:nn:nn
         foreign c putchar(10:wybe.char, ~tmp#21##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @new_array_test:nn:nn
         foreign lpvm store(~%tmp#22##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @new_array_test:nn:nn
@@ -237,7 +237,6 @@ declare external fastcc {i64, i64, i1} @"wybe#.range#.[|]<0>"(i64)
 declare external fastcc {i64, i64, i1} @"wybe#.range#.[|]<0>[785a827a1b]"(i64)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
 declare external fastcc void @"wybe#.string#.print<0>"(i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
 declare external ccc void @error_exit(i64, i64)
 declare external ccc void @putchar(i8)
 declare external ccc ptr @wybe_malloc(i32)
@@ -305,7 +304,7 @@ if.then.0:
 if.else.0:
   %"tmp#19##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 %"sum##0", i64 0, i8 32)
   %"tmp#20##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"new_array_test#constant#2" to i64 ), i64 %"tmp#19##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#20##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#20##0")
   call ccc void @putchar(i8 10)
   ret void
 }
@@ -330,7 +329,7 @@ if.then.0:
 if.else.0:
   %"tmp#19##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 %"sum##0", i64 0, i8 32)
   %"tmp#20##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"new_array_test#constant#2" to i64 ), i64 %"tmp#19##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#20##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#20##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/sizeof.exp
+++ b/test-cases/final-dump/sizeof.exp
@@ -48,10 +48,9 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(53,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(59,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(61,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(65,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(75,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(77,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.int.fmt<2>(8:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#7##0:wybe.string) #52 @sizeof:nn:nn
     wybe.string.,,<0>("Int bytes: ":wybe.string, ~tmp#7##0:wybe.string, ?tmp#6##0:wybe.string) #2 @sizeof:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #53 @sizeof:nn:nn
+    wybe.string.print<0>(~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #53 @sizeof:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#59##0:wybe.phantom) @sizeof:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#59##0:wybe.phantom, ?tmp#60##0:wybe.phantom) @sizeof:nn:nn
     foreign lpvm store(~%tmp#60##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
@@ -68,13 +67,13 @@ module top-level code > public {semipure} (0 calls)
     foreign lpvm store(~%tmp#76##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
     wybe.int.fmt<2>(1:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#13##0:wybe.string) #58 @sizeof:nn:nn
     wybe.string.,,<0>("Char bytes: ":wybe.string, ~tmp#13##0:wybe.string, ?tmp#12##0:wybe.string) #14 @sizeof:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#12##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #59 @sizeof:nn:nn
+    wybe.string.print<0>(~tmp#12##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #59 @sizeof:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#83##0:wybe.phantom) @sizeof:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#83##0:wybe.phantom, ?tmp#84##0:wybe.phantom) @sizeof:nn:nn
     foreign lpvm store(~%tmp#84##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
     wybe.count.fmt<4>(8:wybe.count, 0:wybe.int, 32:wybe.char, 10:wybe.count, ?tmp#15##0:wybe.string) #60 @sizeof:nn:nn
     wybe.string.,,<0>("Char bits: ":wybe.string, ~tmp#15##0:wybe.string, ?tmp#14##0:wybe.string) #18 @sizeof:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#14##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #61 @sizeof:nn:nn
+    wybe.string.print<0>(~tmp#14##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #61 @sizeof:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#91##0:wybe.phantom) @sizeof:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#91##0:wybe.phantom, ?tmp#92##0:wybe.phantom) @sizeof:nn:nn
     foreign lpvm store(~%tmp#92##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
@@ -85,7 +84,7 @@ module top-level code > public {semipure} (0 calls)
     foreign c putchar(10:wybe.char, ~tmp#99##0:wybe.phantom, ?tmp#100##0:wybe.phantom) @sizeof:nn:nn
     foreign lpvm store(~%tmp#100##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
     wybe.string.,,<0>("Narrow bits (unboxed): ":wybe.string, ~tmp#18##0:wybe.string, ?tmp#20##0:wybe.string) #26 @sizeof:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #65 @sizeof:nn:nn
+    wybe.string.print<0>(~tmp#20##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #65 @sizeof:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#107##0:wybe.phantom) @sizeof:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#107##0:wybe.phantom, ?tmp#108##0:wybe.phantom) @sizeof:nn:nn
     foreign lpvm store(~%tmp#108##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
@@ -111,12 +110,12 @@ module top-level code > public {semipure} (0 calls)
     foreign c putchar(10:wybe.char, ~tmp#139##0:wybe.phantom, ?tmp#140##0:wybe.phantom) @sizeof:nn:nn
     foreign lpvm store(~%tmp#140##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
     wybe.string.,,<0>("Wider int bits: ":wybe.string, ~tmp#9##0:wybe.string, ?tmp#35##0:wybe.string) #46 @sizeof:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#35##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #75 @sizeof:nn:nn
+    wybe.string.print<0>(~tmp#35##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #75 @sizeof:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#147##0:wybe.phantom) @sizeof:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#147##0:wybe.phantom, ?tmp#148##0:wybe.phantom) @sizeof:nn:nn
     foreign lpvm store(~%tmp#148##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
     wybe.string.,,<0>("Wider int bits (unboxed): ":wybe.string, ~tmp#33##0:wybe.string, ?tmp#38##0:wybe.string) #50 @sizeof:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#38##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #77 @sizeof:nn:nn
+    wybe.string.print<0>(~tmp#38##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #77 @sizeof:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#155##0:wybe.phantom) @sizeof:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#155##0:wybe.phantom, ?tmp#156##0:wybe.phantom) @sizeof:nn:nn
     foreign lpvm store(~%tmp#156##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @sizeof:nn:nn
@@ -160,14 +159,13 @@ declare external fastcc i64 @"wybe#.count#.fmt<4>"(i64, i64, i8, i64)
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
 declare external fastcc void @"wybe#.string#.print<0>"(i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"sizeof#.<0>"() {
   %"tmp#7##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 8, i64 0, i8 32)
   %"tmp#6##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#13" to i64 ), i64 %"tmp#7##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#6##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#6##0")
   call ccc void @putchar(i8 10)
   %"tmp#9##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 64, i64 0, i8 32)
   %"tmp#8##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#14" to i64 ), i64 %"tmp#9##0")
@@ -178,18 +176,18 @@ define external fastcc void @"sizeof#.<0>"() {
   call ccc void @putchar(i8 10)
   %"tmp#13##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 1, i64 0, i8 32)
   %"tmp#12##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#16" to i64 ), i64 %"tmp#13##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#12##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#12##0")
   call ccc void @putchar(i8 10)
   %"tmp#15##0" = tail call fastcc i64 @"wybe#.count#.fmt<4>"(i64 8, i64 0, i8 32, i64 10)
   %"tmp#14##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#17" to i64 ), i64 %"tmp#15##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#14##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#14##0")
   call ccc void @putchar(i8 10)
   %"tmp#18##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 3, i64 0, i8 32)
   %"tmp#17##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#18" to i64 ), i64 %"tmp#18##0")
   tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#17##0")
   call ccc void @putchar(i8 10)
   %"tmp#20##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#19" to i64 ), i64 %"tmp#18##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#20##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#20##0")
   call ccc void @putchar(i8 10)
   %"tmp#23##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#20" to i64 ), i64 %"tmp#9##0")
   tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#23##0")
@@ -205,10 +203,10 @@ define external fastcc void @"sizeof#.<0>"() {
   tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#32##0")
   call ccc void @putchar(i8 10)
   %"tmp#35##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#24" to i64 ), i64 %"tmp#9##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#35##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#35##0")
   call ccc void @putchar(i8 10)
   %"tmp#38##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"sizeof#constant#25" to i64 ), i64 %"tmp#33##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#38##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#38##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -38,7 +38,7 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(85,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(86,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(88,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(89,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(91,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(93,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(95,(string.print_loop#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
+  MultiSpeczDepInfo: [(85,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(86,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(89,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(91,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(93,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(95,(string.print_loop#cont#1<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#56##0:wybe.phantom) @string:nn:nn
     foreign c print_string(c"TESTING CONSTRUCTION":wybe.c_string, ~%tmp#56##0:wybe.phantom, ?%tmp#57##0:wybe.phantom) @string:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#57##0:wybe.phantom, ?tmp#58##0:wybe.phantom) @string:nn:nn
@@ -56,7 +56,7 @@ module top-level code > public {semipure} (0 calls)
     foreign c putchar(10:wybe.char, ~tmp#74##0:wybe.phantom, ?tmp#75##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#75##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
     wybe.string.,,<0>("abc":wybe.string, "abc":wybe.string, ?tmp#0##0:wybe.string) #9 @string:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #88 @string:nn:nn
+    wybe.string.print<0>(~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #88 @string:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#85##0:wybe.phantom) @string:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#85##0:wybe.phantom, ?tmp#86##0:wybe.phantom) @string:nn:nn
     foreign lpvm store(~%tmp#86##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string:nn:nn
@@ -243,7 +243,7 @@ define external fastcc void @"string#.<0>"() {
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"string#constant#13" to i64 ))
   call ccc void @putchar(i8 10)
   %"tmp#0##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"string#constant#13" to i64 ), i64 ptrtoint( ptr @"string#constant#13" to i64 ))
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#0##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 1415)
   call ccc void @putchar(i8 10)

--- a/test-cases/final-dump/string_interpolation.exp
+++ b/test-cases/final-dump/string_interpolation.exp
@@ -27,16 +27,15 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(24,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(26,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []])),(29,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     wybe.string.,,<0>("Wybe":wybe.string, 1159:wybe.string, ?tmp#1##0:wybe.string) #4 @string_interpolation:nn:nn
     wybe.string.,,<0>("Hello, ":wybe.string, ~tmp#1##0:wybe.string, ?tmp#0##0:wybe.string) #6 @string_interpolation:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @string_interpolation:nn:nn
+    wybe.string.print<0>(~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #24 @string_interpolation:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#39##0:wybe.phantom) @string_interpolation:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#39##0:wybe.phantom, ?tmp#40##0:wybe.phantom) @string_interpolation:nn:nn
     foreign lpvm store(~%tmp#40##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
     wybe.int.fmt<2>(42:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#5##0:wybe.string) #25 @string_interpolation:nn:nn
     wybe.string.,,<0>(~tmp#5##0:wybe.string, " is the answer":wybe.string, ?tmp#4##0:wybe.string) #11 @string_interpolation:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @string_interpolation:nn:nn
+    wybe.string.print<0>(~tmp#4##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #26 @string_interpolation:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#49##0:wybe.phantom) @string_interpolation:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#49##0:wybe.phantom, ?tmp#50##0:wybe.phantom) @string_interpolation:nn:nn
     foreign lpvm store(~%tmp#50##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
@@ -47,7 +46,7 @@ module top-level code > public {semipure} (0 calls)
     wybe.string.,,<0>(" and minint is ":wybe.string, ~tmp#12##0:wybe.string, ?tmp#11##0:wybe.string) #19 @string_interpolation:nn:nn
     wybe.string.,,<0>(~tmp#8##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#7##0:wybe.string) #20 @string_interpolation:nn:nn
     wybe.string.,,<0>("maxint is ":wybe.string, ~tmp#7##0:wybe.string, ?tmp#6##0:wybe.string) #22 @string_interpolation:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @string_interpolation:nn:nn
+    wybe.string.print<0>(~tmp#6##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #29 @string_interpolation:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#68##0:wybe.phantom) @string_interpolation:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#68##0:wybe.phantom, ?tmp#69##0:wybe.phantom) @string_interpolation:nn:nn
     foreign lpvm store(~%tmp#69##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @string_interpolation:nn:nn
@@ -73,7 +72,7 @@ target triple   = ????
 
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
+declare external fastcc void @"wybe#.string#.print<0>"(i64)
 declare external ccc i64 @ipow(i64, i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
@@ -81,11 +80,11 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 define external fastcc void @"string_interpolation#.<0>"() {
   %"tmp#1##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"string_interpolation#constant#5" to i64 ), i64 1159)
   %"tmp#0##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"string_interpolation#constant#6" to i64 ), i64 %"tmp#1##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#0##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   %"tmp#5##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 42, i64 0, i8 32)
   %"tmp#4##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#5##0", i64 ptrtoint( ptr @"string_interpolation#constant#7" to i64 ))
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#4##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#4##0")
   call ccc void @putchar(i8 10)
   %"tmp#10##0" = call ccc i64 @ipow(i64 2, i64 63)
   %"tmp#9##0" = sub i64 %"tmp#10##0", 1
@@ -94,7 +93,7 @@ define external fastcc void @"string_interpolation#.<0>"() {
   %"tmp#11##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"string_interpolation#constant#8" to i64 ), i64 %"tmp#12##0")
   %"tmp#7##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 %"tmp#8##0", i64 %"tmp#11##0")
   %"tmp#6##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"string_interpolation#constant#9" to i64 ), i64 %"tmp#7##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#6##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#6##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/subresource.exp
+++ b/test-cases/final-dump/subresource.exp
@@ -21,11 +21,10 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<subresource.a.res>>, <<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(5,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign lpvm load(<<subresource.a.res>>:wybe.int, ?%res##0:wybe.int) @subresource:nn:nn
     wybe.int.fmt<2>(~res##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#1##0:wybe.string) #4 @subresource:nn:nn
     wybe.string.,,<0>("res = ":wybe.string, ~tmp#1##0:wybe.string, ?tmp#0##0:wybe.string) #2 @subresource:nn:nn
-    wybe.string.print<0>[410bae77d3](~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @subresource:nn:nn
+    wybe.string.print<0>(~tmp#0##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #5 @subresource:nn:nn
     foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#9##0:wybe.phantom) @subresource:nn:nn
     foreign c putchar(10:wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @subresource:nn:nn
     foreign lpvm store(~%tmp#10##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @subresource:nn:nn
@@ -43,7 +42,7 @@ target triple   = ????
 
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
+declare external fastcc void @"wybe#.string#.print<0>"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
@@ -51,7 +50,7 @@ define external fastcc void @"subresource#.<0>"() {
   %"res##0" = load i64, ptr @"resource#subresource.a.res"
   %"tmp#1##0" = tail call fastcc i64 @"wybe#.int#.fmt<2>"(i64 %"res##0", i64 0, i8 32)
   %"tmp#0##0" = tail call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"subresource#constant#1" to i64 ), i64 %"tmp#1##0")
-  tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#0##0")
+  tail call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   ret void
 }

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -147,7 +147,7 @@ foo(x##0:T <{}; {}; {0}>)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
 proc foo2 > (18 calls)
 0: type_generics.foo2<0>
 foo2(x##0:T0 <{}; {}; {0}>, ?y##0:T0 <{}; {}; {0}>, ?#success##0:wybe.bool)<{}; {}; {}>:
-  AliasPairs: []
+  AliasPairs: [(x##0,y##0)]
   InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#7##0:wybe.list(T0)) @type_generics:nn:nn
     foreign lpvm mutate(~tmp#7##0:wybe.list(T0), ?tmp#8##0:wybe.list(T0), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:T0) @type_generics:nn:nn

--- a/test-cases/final-dump/upto.exp
+++ b/test-cases/final-dump/upto.exp
@@ -22,7 +22,6 @@ module top-level code > public {semipure} (0 calls)
 ()<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}>:
   AliasPairs: []
   InterestingCallProperties: []
-  MultiSpeczDepInfo: [(6,(wybe.string.print<0>,fromList [NonAliasedParamCond 0 []]))]
     upto.submod.upto<0>(0:wybe.int, 10:wybe.int, outByReference tmp#0##0:wybe.list(wybe.int)) #0 @upto:nn:nn
     wybe.list.[]<0>(~tmp#0##0:wybe.list(wybe.int), 3:wybe.int, ?tmp#1##0:wybe.int, ?tmp#5##0:wybe.bool) #1 @upto:nn:nn
     case ~tmp#5##0:wybe.bool of
@@ -32,7 +31,7 @@ module top-level code > public {semipure} (0 calls)
     1:
         wybe.int.fmt<2>(~tmp#1##0:wybe.int, 0:wybe.int, 32:wybe.char, ?tmp#8##0:wybe.string) #4 @upto:nn:nn
         wybe.string.,,<0>("lst[3] = ":wybe.string, ~tmp#8##0:wybe.string, ?tmp#9##0:wybe.string) #5 @upto:nn:nn
-        wybe.string.print<0>[410bae77d3](~tmp#9##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @upto:nn:nn
+        wybe.string.print<0>(~tmp#9##0:wybe.string)<{<<wybe.io.io>>}; {<<wybe.io.io>>}; {}> #6 @upto:nn:nn
         foreign lpvm load(<<wybe.io.io>>:wybe.phantom, ?%tmp#10##0:wybe.phantom) @upto:nn:nn
         foreign c putchar(10:wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @upto:nn:nn
         foreign lpvm store(~%tmp#11##0:wybe.phantom, <<wybe.io.io>>:wybe.phantom) @upto:nn:nn
@@ -68,7 +67,6 @@ declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
 declare external fastcc {i64, i1} @"wybe#.list#.[]<0>"(i64, i64)
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)
 declare external fastcc void @"wybe#.string#.print<0>"(i64)
-declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
 declare external ccc void @error_exit(i64, i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
@@ -84,7 +82,7 @@ define external fastcc void @"upto#.<0>"() {
 if.then.0:
   %"tmp#8##0" = call fastcc i64 @"wybe#.int#.fmt<2>"(i64 %"tmp#1##0", i64 0, i8 32)
   %"tmp#9##0" = call fastcc i64 @"wybe#.string#.,,<0>"(i64 ptrtoint( ptr @"upto#constant#2" to i64 ), i64 %"tmp#8##0")
-  call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#9##0")
+  call fastcc void @"wybe#.string#.print<0>"(i64 %"tmp#9##0")
   call ccc void @putchar(i8 10)
   ret void
 if.else.0:


### PR DESCRIPTION
This fixes a bug I think has been around since #476 where constant structures are hoisted to global constants, but they are not treated correctly in the alias analysis, leading to cases where a global constant is mutated. 

I caught this when running one of the final dump tests, `box_unbox,wybe`, which currently segfaults due to this issue.

This has the unfortunate side effect of the `nbody.wybe` test case regressing back to 10001 allocations instead of 5001! This is because the value returned from `get_bodies` is a constant, and thus `advance` isnt able to be multi-spec'd.