### PR TITLE
feat: change the naming convention for vtables

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -23,7 +23,7 @@ module AST (
   determinismSeq, determinismProceding, determinismName, determinismCanFail,
   impurityName, impuritySeq, expectedImpurity,
   inliningName,
-  TraitSpec, TraitImplSpec(..), VTableSpec, TypeVarBound,
+  TraitSpec, TraitImplSpec(..), TypeVarBound,
   TypeProto(..), TypeModifiers(..), TypeSpec(..), typeVarSet, TypeVarName(..),
   genericType, higherOrderType, isHigherOrder,
   isResourcefulHigherOrder, isTraitType, typeModule,
@@ -1556,7 +1556,7 @@ data Module = Module {
   modAbstractProcCount :: Int,
                                    -- ^The number of abstract procs defined in
                                    -- this module
-  modVTables :: Map VTableSpec StructID,
+  modVTables :: Map TraitImplSpec (Int, StructID),
                                    -- ^The vtables defined in this module
   stmtDecls :: [Placed Stmt],      -- ^top-level statements in this module
   itemsHash :: Maybe String        -- ^map of proc name to its hash
@@ -2354,7 +2354,7 @@ primImpurity (PrimHigher _ (ArgConstRef structID _) impurity _) = do
     lookupConstInfo structID >>= \case
         Just (StructInfo _ (FnPointerStructMember pspec:t)) ->
             max impurity . procImpurity <$> getProcDef pspec
-        Just (VTableInfo _ (FnPointerStructMember pspec:t) _ _ _) ->
+        Just (VTableInfo _ (FnPointerStructMember pspec:t) _ _ _ _) ->
             max impurity . procImpurity <$> getProcDef pspec
         _ -> return impurity
 primImpurity (PrimHigher _ fn impurity _) = return impurity
@@ -3749,7 +3749,7 @@ data PrimArg
      | ArgFloat Double TypeSpec                -- ^Constant floating point arg
      | ArgClosure ProcSpec [PrimArg] TypeSpec  -- ^Closure, with closed args
      | ArgGlobal GlobalInfo TypeSpec           -- ^Constant global reference
-     | ArgVTable (Either VTableSpec PrimVarName) TypeSpec
+     | ArgVTable (Either TraitImplSpec PrimVarName) TypeSpec
                                                -- ^Ref to vtable (either global or local)
      | ArgConstRef StructID TypeSpec           -- ^Ref to constant memory block
      | ArgUnneeded PrimFlow TypeSpec           -- ^Unneeded input or output
@@ -3769,9 +3769,6 @@ data TraitImplSpec =
     }
     deriving (Eq,Ord,Generic)
 
--- |Identifies the vtable for a trait implementation.
-type VTableSpec = TraitImplSpec
-
 -- |A type variable together with the trait it is required to implement.
 type TypeVarBound = (TypeVarName, TraitSpec)
 
@@ -3786,7 +3783,8 @@ data StructInfo
         vtableSize :: Int,          -- ^ The size of the struct in bytes
         vtableData :: [ConstValue], -- ^ Contents of the struct, in memory order
         vtableExternal :: Bool,     -- ^ Whether this vtable is defined in other module
-        vtableSpec :: VTableSpec,   -- ^ The vtable spec
+        vtableIndex :: Int,         -- ^ Its index in the defining module
+        vtableSpec :: TraitImplSpec,-- ^ The trait impl spec
         vtableMod  :: ModSpec       -- ^ The mod where this vtable is defined
     }
     -- | A constant memory block of characters, with 0-termination.  A more
@@ -3875,7 +3873,7 @@ constValueAtOffset (StructInfo _ fields) offset = go fields offset
             | off < 0 = Nothing
             | otherwise = go fields (off - constValueSize field)
           go [] _ = Nothing
-constValueAtOffset (VTableInfo _ fields _ _ _) offset = go fields offset
+constValueAtOffset (VTableInfo _ fields _ _ _ _) offset = go fields offset
     where go (field:fields) off
             | off == 0 = Just field
             | off < 0 = Nothing
@@ -3972,7 +3970,7 @@ argGlobalFlow varFlows (ArgClosure pspec args _) = do
 argGlobalFlow varFlows (ArgConstRef structID _) = do
     lookupConstInfo structID >>= (\case
             StructInfo _ fields -> constsGlobalFlows fields
-            VTableInfo _ fields _ _ _ -> constsGlobalFlows fields
+            VTableInfo _ fields _ _ _ _ -> constsGlobalFlows fields
             _ -> return emptyGlobalFlows)
         . trustFromJust "lookupConstStruct"
 argGlobalFlow _ _ = return emptyGlobalFlows
@@ -4008,7 +4006,7 @@ constGlobalFlows :: ConstValue -> Compiler GlobalFlows
 constGlobalFlows (PointerStructMember structID) = do
     lookupConstInfo structID >>= (\case
             StructInfo _ fields -> constsGlobalFlows fields
-            VTableInfo _ fields _ _ _ -> constsGlobalFlows fields
+            VTableInfo _ fields _ _ _ _ -> constsGlobalFlows fields
             _ -> return emptyGlobalFlows)
         . trustFromJust "lookupConstStruct"
 constGlobalFlows _ = return emptyGlobalFlows

--- a/src/Clause.hs
+++ b/src/Clause.hs
@@ -396,8 +396,8 @@ compileVTableArg typeVarMap (paramVarName,paramVarBound) = do
             return $ ArgVTable (Right $ primParamName param)
                 (Representation CPointer)
         _ -> do
-            let vspec = TraitImplSpec paramVarBound argType
-            return $ ArgVTable (Left vspec) (Representation CPointer)
+            let ispec = TraitImplSpec paramVarBound argType
+            return $ ArgVTable (Left ispec) (Representation CPointer)
 
 compileFlowArg :: FlowDirection -> Exp -> OptPos -> ClauseComp [PrimArg]
 compileFlowArg flow (Typed exp typ coerce) pos = do
@@ -526,8 +526,12 @@ compileLocalVTables :: ModSpec -> Compiler ()
 compileLocalVTables thisMod = do
     reenterModule thisMod
     traitImpls <- Map.map content <$> getModuleImplementationField modKnownTraitImpls
-    vTables <- Map.traverseWithKey (\vspec _ -> compileVTable vspec Nothing)
-        (Map.filter isNothing traitImpls)
+    let localImpls = Map.toAscList $ Map.filter isNothing traitImpls
+    vTables <- Map.fromAscList <$> mapM
+        (\(index, (ispec, _)) -> do
+            vtable <- compileVTable index ispec Nothing
+            return (ispec, vtable))
+        (zip [0..] localImpls)
     updateModule (\mod -> mod{ modVTables = Map.union vTables $ modVTables mod })
     reexitModule
 
@@ -542,22 +546,29 @@ compileExternalVTables thisMod = do
         referenced = execState
             (mapM_ (mapLPVMBodyM (const $ return ()) collectVTable) bodies)
             Set.empty
-        collectVTable (ArgVTable (Left vspec) _) = modify $ Set.insert vspec
+        collectVTable (ArgVTable (Left ispec) _) = modify $ Set.insert ispec
         collectVTable _ = return ()
     traitImpls <- Map.map content <$> getModuleImplementationField modKnownTraitImpls
-    let addReferenced impls vspec = case Map.lookup vspec traitImpls of
-            Nothing -> shouldnt $ "unknown referenced vtable " ++ show vspec
+    let addReferenced impls ispec = case Map.lookup ispec traitImpls of
+            Nothing -> shouldnt $ "unknown referenced vtable " ++ show ispec
             Just Nothing -> impls
-            Just (Just mod) -> Map.insert vspec mod impls
+            Just (Just mod) -> Map.insert ispec mod impls
         externalImpls = Set.foldl' addReferenced Map.empty referenced
-    vTables <- Map.traverseWithKey (\vspec mod -> compileVTable vspec $ Just mod)
+    vTables <- Map.traverseWithKey
+        (\ispec mod -> do
+            definingVTables <- getModule modVTables `inModule` mod
+            let (index, _) = trustFromJust
+                    ("compileExternalVTables: missing vtable " ++ show ispec
+                        ++ " in " ++ showModSpec mod)
+                    (Map.lookup ispec definingVTables)
+            compileVTable index ispec $ Just mod)
         externalImpls
     updateModule (\mod -> mod{ modVTables = Map.union vTables $ modVTables mod })
     reexitModule
 
 
-compileVTable :: TraitImplSpec -> Maybe ModSpec -> Compiler StructID
-compileVTable ispec opmod = do
+compileVTable :: Int -> TraitImplSpec -> Maybe ModSpec -> Compiler (Int, StructID)
+compileVTable index ispec opmod = do
     logMsg Clause $ "Compiling vtable for trait impl " ++ show ispec ++ " defined in " ++ show opmod
     thisMod <- getModuleSpec
     traitImplProcSpecs <- getModuleImplementationField modTraitImplProcs
@@ -572,8 +583,9 @@ compileVTable ispec opmod = do
                 (modTraitImplProcs imp) }
     let sz = wordSizeBytes * length procSpecs
         values = List.map FnPointerStructMember procSpecs'
-    recordConstStruct
-        (VTableInfo sz values (isJust opmod) ispec (fromMaybe thisMod opmod)) Nothing
+    structId <- recordConstStruct
+            (VTableInfo sz values (isJust opmod) index ispec (fromMaybe thisMod opmod)) Nothing
+    return (index, structId)
 
 
 -- |Return the procedure specs to store in a locally-defined vtable.  A concrete
@@ -601,7 +613,7 @@ adaptTraitImplProc ispec absProcSpec implProcSpec = do
 -- |The ABI used by a virtual call through a vtable slot.  This is the abstract
 -- method's primitive parameters, except that the dispatching vtable parameter
 -- itself is supplied by the loaded vtable and is not passed to the target proc.
-vtableSlotParams :: VTableSpec -> ProcDef -> [PrimParam]
+vtableSlotParams :: TraitImplSpec -> ProcDef -> [PrimParam]
 vtableSlotParams (TraitImplSpec trait _) absProcDef =
     procOrdinaryABIParams absProcDef
         ++ vtableParamsFor (forwardedVTableBounds trait absProcDef)
@@ -636,9 +648,9 @@ compileABIParams = concatMap compileABIParam
     outNum flow = if flowsIn flow then 1 else 0
 
 
-generateAdapter :: VTableSpec -> ProcDef -> [PrimParam] -> ProcSpec -> ProcDef
+generateAdapter :: TraitImplSpec -> ProcDef -> [PrimParam] -> ProcSpec -> ProcDef
                   -> Compiler ProcSpec
-generateAdapter vspec absProcDef adapterParams implProcSpec implProcDef = do
+generateAdapter ispec absProcDef adapterParams implProcSpec implProcDef = do
     adapterMod <- getModuleSpec
     gFlows <- getProcGlobalFlows implProcSpec
     let adapterOrdinaryParams = procOrdinaryABIParams absProcDef
@@ -652,7 +664,7 @@ generateAdapter vspec absProcDef adapterParams implProcSpec implProcDef = do
         adapterOrdinaryParams implOrdinaryParams
     let (preCasts, implOrdinaryArgs, postCasts) = unzip3 bridges
         implCallArgs = implOrdinaryArgs
-            ++ adapterVTableArgs vspec absProcDef implProcDef adapterParams
+            ++ adapterVTableArgs ispec absProcDef implProcDef adapterParams
     let adapterName = procName absProcDef ++ adapterNamePostfix
         proto = PrimProto adapterName adapterParams
             $ makeGlobalFlows (zip [0..] adapterParams)
@@ -677,7 +689,7 @@ generateAdapter vspec absProcDef adapterParams implProcSpec implProcDef = do
             _ -> proc)
         adapterSpec
     logMsg Clause $ "Generated vtable adapter " ++ show adapterSpec
-        ++ " for " ++ show implProcSpec ++ " in " ++ show vspec
+        ++ " for " ++ show implProcSpec ++ " in " ++ show ispec
     return adapterSpec
 
 
@@ -734,8 +746,8 @@ adapterArgBridge idx adapterParam implParam
     adapterBoxOut = ArgVar boxName AnyType FlowOut Ordinary False
 
 
-adapterVTableArgs :: VTableSpec -> ProcDef -> ProcDef -> [PrimParam] -> [PrimArg]
-adapterVTableArgs vspec@(TraitImplSpec trait _) absProcDef implProcDef adapterParams =
+adapterVTableArgs :: TraitImplSpec -> ProcDef -> ProcDef -> [PrimParam] -> [PrimArg]
+adapterVTableArgs ispec@(TraitImplSpec trait _) absProcDef implProcDef adapterParams =
     snd $ List.mapAccumL vtableArg forwardedParams (procBoundedTypeParams implProcDef)
   where
     dispatchTraitMod = typeModule trait
@@ -747,7 +759,7 @@ adapterVTableArgs vspec@(TraitImplSpec trait _) absProcDef implProcDef adapterPa
     forwardedBounds = forwardedVTableBounds trait absProcDef
     vtableArg params (_, bound)
         | typeModule bound == dispatchTraitMod =
-            (params, ArgVTable (Left vspec) (Representation CPointer))
+            (params, ArgVTable (Left ispec) (Representation CPointer))
         | otherwise = case params of
             param:rest -> (rest, ArgVTable (Right $ primParamName param)
                 (Representation CPointer))

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -11,7 +11,7 @@
 module Config (sourceExtension, objectExtension, executableExtension,
                bitcodeExtension, assemblyExtension, nativeAssemblyExtension,
                archiveExtension, moduleDirectoryBasename, currentModuleAlias,
-               specialChar, specialSeparator, specialName, specialName2, initProcName,
+               specialChar, specialName, specialName2, initProcName,
                vtableNamePrefix, adapterNamePostfix, wordSize, wordSizeBytes, byteBits,
                availableTagBits, tagMask, smallestAllocatedAddress,
                minimumSwitchCases, maximumSplitStructSize, magicVersion,
@@ -84,11 +84,6 @@ currentModuleAlias = "_"
 -- character in an identifier.
 specialChar :: Char
 specialChar = '#' -- note # is not allowed in backquoted strings
-
-
--- | The special separator used for generated vtable symbols.
-specialSeparator :: String
-specialSeparator = "##"
 
 
 -- | Construct a name can't be a valid Wybe symbol from one user string.

--- a/src/LLVM.hs
+++ b/src/LLVM.hs
@@ -289,7 +289,7 @@ preScanProcs = do
                 ++ intercalate ", " (concatMap (List.map (show.procName)) procss)
     vTables <- lift $ getModule modVTables
     logLLVM $ "Start recording vTables in module " ++ showModSpec thisMod
-    mapM_ recordConst vTables
+    mapM_ (recordConst . snd) vTables
     logLLVM "End recording vTables"
     let bodies = concatMap (concatMap allProcBodies) procss
     mapM_ (mapLPVMBodyM (recordExtern mod) (prescanArg mod)) bodies
@@ -359,8 +359,8 @@ recordConst spec = do
     when new $ do
         info <- lift (lookupConstInfo spec)
         case info of
-            Just info@VTableInfo{vtableSpec=vspec,vtableExternal=external} -> do
-                previous <- gets $ Map.lookup vspec . allVTables
+            Just info@VTableInfo{vtableSpec=ispec,vtableExternal=external} -> do
+                previous <- gets $ Map.lookup ispec . allVTables
                 replace <- case previous of
                     Nothing -> return True
                     Just previousSpec
@@ -374,7 +374,7 @@ recordConst spec = do
                     modify $ \s -> s {
                         allConsts = Set.insert spec
                             $ maybe id Set.delete previous $ allConsts s,
-                        allVTables = Map.insert vspec spec $ allVTables s }
+                        allVTables = Map.insert ispec spec $ allVTables s }
                     recordConstParts info
             _ -> do
                 modify $ \s -> s {allConsts=Set.insert spec $ allConsts s}
@@ -1204,10 +1204,10 @@ declareStructConstant name (StructInfo sz members) section = do
                     ++ " = private unnamed_addr constant " ++ llvmFields
                     ++ maybe "" ((", section "++) . show) section
                     ++ ", align " ++ show wordSizeBytes
-declareStructConstant _ (VTableInfo sz members external spec mod) section = do
+declareStructConstant _ (VTableInfo sz members external index spec mod) section = do
     let llvmType = llvmStructType $ llvmConstValueRep <$> members
     llvmFields <- llvmConstStruct members
-    let name = llvmVTableName spec mod
+    let name = llvmVTableName mod index
     llvmPutStrLn $ llvmGlobalName name ++ " = "
                     ++ (if external then "external " else "")
                     ++ "unnamed_addr constant "
@@ -1680,12 +1680,17 @@ llvmValue arg@(ArgClosure pspec args ty) = do
             llvmValue readPtr
 llvmValue (ArgGlobal val _) = llvmGlobalInfoName val
 llvmValue (ArgVTable info ty) = case info of
-    Left vspec -> do
+    Left ispec -> do
         knownTraitImpls <- lift $ getModuleImplementationField modKnownTraitImpls
-        let opmod = content . trustFromJust ("llvmValue " ++ show info) $ Map.lookup vspec knownTraitImpls
+        let opmod = content . trustFromJust ("llvmValue " ++ show info) $ Map.lookup ispec knownTraitImpls
         thisMod <- lift getModuleSpec
         let mod = fromMaybe thisMod opmod
-        return $ llvmGlobalName $ llvmVTableName vspec mod
+        vTables <- lift $ getModule modVTables `inModule` mod
+        let (index, _) = trustFromJust
+                ("llvmValue: missing vtable " ++ show ispec ++ " in "
+                    ++ showModSpec mod)
+                (Map.lookup ispec vTables)
+        return $ llvmGlobalName $ llvmVTableName mod index
     Right var -> llvmValue $ ArgVar var ty FlowIn VTable False
 llvmValue (ArgConstRef structID ty) = do
     rep <- typeRep ty
@@ -2032,7 +2037,7 @@ data LLVMState = LLVMState {
                                      -- ^ Static constants appearing in module
         allExterns :: Map String ExternSpec,
                                     -- ^ Extern declarations needed by module
-        allVTables :: Map VTableSpec StructID,
+        allVTables :: Map TraitImplSpec StructID,
                                     -- ^ Preferred vtable constant for each spec;
                                     -- local definitions supersede declarations
         fileHandle :: Handle,       -- ^ The file handle we're writing to
@@ -2440,15 +2445,10 @@ llvmLabelName varName = "label %" ++ llvmQuoteIfNecessary varName
 
 
 -- | Make a suitable LLVM name for a vtable.
-llvmVTableName :: VTableSpec -> ModSpec -> String
-llvmVTableName (TraitImplSpec trait typ) mod = do
-    let trait' = mangleTypeSpec trait
-    let typ' = mangleTypeSpec typ
-    let mod' = mangleModSpec mod
-    vtableNamePrefix
-        ++ specialSeparator ++ show trait'
-        ++ specialSeparator ++ show typ'
-        ++ specialSeparator ++ showModSpec mod'
+llvmVTableName :: ModSpec -> Int -> String
+llvmVTableName mod index =
+    showModSpec (mangleModSpec mod) ++
+    specialName2 vtableNamePrefix (show index)
 
 
 -- | Format a string as an LLVM string; the Bool indicates whether to add

--- a/test-cases/final-dump/trait_abstract_proc_default.exp
+++ b/test-cases/final-dump/trait_abstract_proc_default.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : trait_abstract_proc_default.<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_abstract_proc_default.print_value#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_abstract_proc_default.printable, vtableMod = ["trait_abstract_proc_default"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_abstract_proc_default.print_value#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.int <: trait_abstract_proc_default.printable, vtableMod = ["trait_abstract_proc_default"]}
   imports         : use trait_abstract_proc_default.printable
                     use wybe
   resources       : 
@@ -38,12 +38,12 @@ print_value#adapter(x##0:T<:trait_abstract_proc_default.printable)<{<<wybe.io.io
 source_filename = "!ROOT!/final-dump/trait_abstract_proc_default.wybe"
 target triple   = ????
 
-@"#vtable##trait_abstract_proc_default#.printable##wybe#.int##trait_abstract_proc_default#" = unnamed_addr constant {ptr} { ptr @"trait_abstract_proc_default#.print_value#adapter<0>" }, align 8
+@"trait_abstract_proc_default##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_abstract_proc_default#.print_value#adapter<0>" }, align 8
 
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_abstract_proc_default#.<0>"() {
-  tail call fastcc void @"trait_abstract_proc_default#.printable#.print_value<0>"(i64 42, ptr @"#vtable##trait_abstract_proc_default#.printable##wybe#.int##trait_abstract_proc_default#")
+  tail call fastcc void @"trait_abstract_proc_default#.printable#.print_value<0>"(i64 42, ptr @"trait_abstract_proc_default##vtable#0")
   ret void
 }
 

--- a/test-cases/final-dump/trait_abstract_proc_dispatch.exp
+++ b/test-cases/final-dump/trait_abstract_proc_dispatch.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   public resources: 
   public procs    : trait_abstract_proc_dispatch.<0>
   constants       : 0:: CStringInfo {cstringChars = "value "}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_abstract_proc_dispatch.print_value#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_abstract_proc_dispatch.printable, vtableMod = ["trait_abstract_proc_dispatch"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_abstract_proc_dispatch.print_value#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.int <: trait_abstract_proc_dispatch.printable, vtableMod = ["trait_abstract_proc_dispatch"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 6 8,PointerStructMember c"value "]}
   imports         : use trait_abstract_proc_dispatch.printable
                     use wybe
@@ -60,7 +60,7 @@ source_filename = "!ROOT!/final-dump/trait_abstract_proc_dispatch.wybe"
 target triple   = ????
 
 @"trait_abstract_proc_dispatch#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"value \00", align 8
-@"#vtable##trait_abstract_proc_dispatch#.printable##wybe#.int##trait_abstract_proc_dispatch#" = unnamed_addr constant {ptr} { ptr @"trait_abstract_proc_dispatch#.print_value#adapter<0>" }, align 8
+@"trait_abstract_proc_dispatch##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_abstract_proc_dispatch#.print_value#adapter<0>" }, align 8
 @"trait_abstract_proc_dispatch#constant#2" = private unnamed_addr constant {i64, ptr} { i64 6, ptr @"trait_abstract_proc_dispatch#constant#0" }, align 8
 
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)
@@ -70,7 +70,7 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_abstract_proc_dispatch#.<0>"() {
-  tail call fastcc void @"trait_abstract_proc_dispatch#.printable#.print_value<0>"(i64 42, ptr @"#vtable##trait_abstract_proc_dispatch#.printable##wybe#.int##trait_abstract_proc_dispatch#")
+  tail call fastcc void @"trait_abstract_proc_dispatch#.printable#.print_value<0>"(i64 42, ptr @"trait_abstract_proc_dispatch##vtable#0")
   ret void
 }
 

--- a/test-cases/final-dump/trait_abstract_proc_modifiers.exp
+++ b/test-cases/final-dump/trait_abstract_proc_modifiers.exp
@@ -10,7 +10,7 @@ AFTER EVERYTHING:
   public procs    : trait_abstract_proc_modifiers.<0>
   constants       : 0:: CStringInfo {cstringChars = "matched"}
                     1:: CStringInfo {cstringChars = "not matched"}
-                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_abstract_proc_modifiers.matches#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_abstract_proc_modifiers.matcher, vtableMod = ["trait_abstract_proc_modifiers"]}
+                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_abstract_proc_modifiers.matches#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.int <: trait_abstract_proc_modifiers.matcher, vtableMod = ["trait_abstract_proc_modifiers"]}
                     3:: StructInfo {structSize = 16, structData = [IntStructMember 11 8,PointerStructMember c"not matched"]}
                     4:: StructInfo {structSize = 16, structData = [IntStructMember 7 8,PointerStructMember c"matched"]}
                     5:: ArrayInfo {arrayData = [PointerStructMember "not matched",PointerStructMember "matched"]}
@@ -60,7 +60,7 @@ target triple   = ????
 
 @"trait_abstract_proc_modifiers#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"matched\00", align 8
 @"trait_abstract_proc_modifiers#constant#1" = private unnamed_addr constant [ ?? x i8 ] c"not matched\00", align 8
-@"#vtable##trait_abstract_proc_modifiers#.matcher##wybe#.int##trait_abstract_proc_modifiers#" = unnamed_addr constant {ptr} { ptr @"trait_abstract_proc_modifiers#.matches#adapter<0>" }, align 8
+@"trait_abstract_proc_modifiers##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_abstract_proc_modifiers#.matches#adapter<0>" }, align 8
 @"trait_abstract_proc_modifiers#constant#3" = private unnamed_addr constant {i64, ptr} { i64 11, ptr @"trait_abstract_proc_modifiers#constant#1" }, align 8
 @"trait_abstract_proc_modifiers#constant#4" = private unnamed_addr constant {i64, ptr} { i64 7, ptr @"trait_abstract_proc_modifiers#constant#0" }, align 8
 @"trait_abstract_proc_modifiers#constant#5" = private unnamed_addr constant [ 2 x ptr ] [ptr @"trait_abstract_proc_modifiers#constant#3", ptr @"trait_abstract_proc_modifiers#constant#4"]
@@ -70,7 +70,7 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_abstract_proc_modifiers#.<0>"() {
-  %"tmp#2##0" = tail call fastcc i1 @"trait_abstract_proc_modifiers#.matcher#.matches<0>"(i64 42, ptr @"#vtable##trait_abstract_proc_modifiers#.matcher##wybe#.int##trait_abstract_proc_modifiers#")
+  %"tmp#2##0" = tail call fastcc i1 @"trait_abstract_proc_modifiers#.matcher#.matches<0>"(i64 42, ptr @"trait_abstract_proc_modifiers##vtable#0")
   %"tmp#20##0" = zext i1 %"tmp#2##0" to i64
   %"tmp#19##0" = getelementptr inbounds [ 2 x i64 ], ptr @"trait_abstract_proc_modifiers#constant#5", i64 0, i64 %"tmp#20##0"
   %"tmp#18##0" = load i64, ptr %"tmp#19##0"

--- a/test-cases/final-dump/trait_adapter_float.exp
+++ b/test-cases/final-dump/trait_adapter_float.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   public resources: 
   public procs    : trait_adapter_float.<0>
                     trait_adapter_float.my_method<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_adapter_float.my_method#adapter<0>], vtableExternal = False, vtableSpec = wybe.float <: trait_adapter_float.my_trait, vtableMod = ["trait_adapter_float"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_adapter_float.my_method#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.float <: trait_adapter_float.my_trait, vtableMod = ["trait_adapter_float"]}
   imports         : use trait_adapter_float.my_trait
                     use wybe
   resources       : 
@@ -53,14 +53,14 @@ my_method#adapter(x##0:Type0<:trait_adapter_float.my_trait, ?#result##0:Type0<:t
 source_filename = "!ROOT!/final-dump/trait_adapter_float.wybe"
 target triple   = ????
 
-@"#vtable##trait_adapter_float#.my_trait##wybe#.float##trait_adapter_float#" = unnamed_addr constant {ptr} { ptr @"trait_adapter_float#.my_method#adapter<0>" }, align 8
+@"trait_adapter_float##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_adapter_float#.my_method#adapter<0>" }, align 8
 
 declare external ccc void @print_float(double)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_adapter_float#.<0>"() {
-  %"tmp#5##0" = tail call fastcc i64 @"trait_adapter_float#.my_trait#.my_method<0>"(i64 bitcast( double 3.14 to i64 ), ptr @"#vtable##trait_adapter_float#.my_trait##wybe#.float##trait_adapter_float#")
+  %"tmp#5##0" = tail call fastcc i64 @"trait_adapter_float#.my_trait#.my_method<0>"(i64 bitcast( double 3.14 to i64 ), ptr @"trait_adapter_float##vtable#0")
   %"tmp#0##0" = bitcast i64 %"tmp#5##0" to double
   call ccc void @print_float(double %"tmp#0##0")
   call ccc void @putchar(i8 10)

--- a/test-cases/final-dump/trait_basic.exp
+++ b/test-cases/final-dump/trait_basic.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   public resources: 
   public procs    : trait_basic.<0>
   constants       : 0:: CStringInfo {cstringChars = "Rex"}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_basic_dog.speak#adapter<0>], vtableExternal = True, vtableSpec = trait_basic_dog <: trait_basic_speaker, vtableMod = ["trait_basic_dog"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_basic_dog.speak#adapter<0>], vtableExternal = True, vtableIndex = 0, vtableSpec = trait_basic_dog <: trait_basic_speaker, vtableMod = ["trait_basic_dog"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 3 8,PointerStructMember c"Rex"]}
   imports         : use trait_basic_dog
                     use trait_basic_named
@@ -64,7 +64,7 @@ source_filename = "!ROOT!/final-dump/trait_basic.wybe"
 target triple   = ????
 
 @"trait_basic#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"Rex\00", align 8
-@"#vtable##trait_basic_speaker##trait_basic_dog##trait_basic_dog#" = external unnamed_addr constant {ptr}, align 8
+@"trait_basic_dog##vtable#0" = external unnamed_addr constant {ptr}, align 8
 @"trait_basic#constant#2" = private unnamed_addr constant {i64, ptr} { i64 3, ptr @"trait_basic#constant#0" }, align 8
 
 declare external fastcc i64 @"trait_basic_dog#.speak#adapter<0>"(i64)
@@ -74,7 +74,7 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_basic#.<0>"() {
   %"tmp#1##0" = ptrtoint ptr @"trait_basic#constant#2" to i64
-  %"tmp#13##0" = getelementptr inbounds ptr, ptr @"#vtable##trait_basic_speaker##trait_basic_dog##trait_basic_dog#", i64 0
+  %"tmp#13##0" = getelementptr inbounds ptr, ptr @"trait_basic_dog##vtable#0", i64 0
   %"tmp#14##0" = load ptr, ptr %"tmp#13##0"
   %"tmp#0##0" = tail call fastcc i64 %"tmp#14##0"(i64 %"tmp#1##0")
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#0##0")
@@ -116,7 +116,7 @@ define external fastcc i64 @"trait_basic#.type_var_bound_union<0>"(i64 %"x##0", 
                     trait_basic_dog.trait_basic_dog<1>
                     trait_basic_dog.~=<0>
   constants       : 0:: CStringInfo {cstringChars = " says woof"}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_basic_dog.speak#adapter<0>], vtableExternal = False, vtableSpec = trait_basic_dog <: trait_basic_speaker, vtableMod = ["trait_basic_dog"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_basic_dog.speak#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_basic_dog <: trait_basic_speaker, vtableMod = ["trait_basic_dog"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 10 8,PointerStructMember c" says woof"]}
   imports         : use trait_basic_speaker
                     use wybe
@@ -193,7 +193,7 @@ source_filename = "!ROOT!/final-dump/trait_basic_dog.wybe"
 target triple   = ????
 
 @"trait_basic_dog#constant#0" = private unnamed_addr constant [ ?? x i8 ] c" says woof\00", align 8
-@"#vtable##trait_basic_speaker##trait_basic_dog##trait_basic_dog#" = unnamed_addr constant {ptr} { ptr @"trait_basic_dog#.speak#adapter<0>" }, align 8
+@"trait_basic_dog##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_basic_dog#.speak#adapter<0>" }, align 8
 @"trait_basic_dog#constant#2" = private unnamed_addr constant {i64, ptr} { i64 10, ptr @"trait_basic_dog#constant#0" }, align 8
 
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)

--- a/test-cases/final-dump/trait_basic_dog.exp
+++ b/test-cases/final-dump/trait_basic_dog.exp
@@ -15,7 +15,7 @@ AFTER EVERYTHING:
                     trait_basic_dog.trait_basic_dog<1>
                     trait_basic_dog.~=<0>
   constants       : 0:: CStringInfo {cstringChars = " says woof"}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_basic_dog.speak#adapter<0>], vtableExternal = False, vtableSpec = trait_basic_dog <: trait_basic_speaker, vtableMod = ["trait_basic_dog"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_basic_dog.speak#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_basic_dog <: trait_basic_speaker, vtableMod = ["trait_basic_dog"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 10 8,PointerStructMember c" says woof"]}
   imports         : use trait_basic_speaker
                     use wybe
@@ -92,7 +92,7 @@ source_filename = "!ROOT!/final-dump/trait_basic_dog.wybe"
 target triple   = ????
 
 @"trait_basic_dog#constant#0" = private unnamed_addr constant [ ?? x i8 ] c" says woof\00", align 8
-@"#vtable##trait_basic_speaker##trait_basic_dog##trait_basic_dog#" = unnamed_addr constant {ptr} { ptr @"trait_basic_dog#.speak#adapter<0>" }, align 8
+@"trait_basic_dog##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_basic_dog#.speak#adapter<0>" }, align 8
 @"trait_basic_dog#constant#2" = private unnamed_addr constant {i64, ptr} { i64 10, ptr @"trait_basic_dog#constant#0" }, align 8
 
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)

--- a/test-cases/final-dump/trait_concrete_type_args.exp
+++ b/test-cases/final-dump/trait_concrete_type_args.exp
@@ -10,8 +10,8 @@ AFTER EVERYTHING:
   public procs    : trait_concrete_type_args.<0>
   constants       : 0:: CStringInfo {cstringChars = "boxed int"}
                     1:: CStringInfo {cstringChars = "boxed float"}
-                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_concrete_type_args.render#adapter<0>], vtableExternal = False, vtableSpec = trait_concrete_type_args.box(wybe.float) <: trait_concrete_type_args.printable, vtableMod = ["trait_concrete_type_args"]}
-                    3:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_concrete_type_args.render#adapter<1>], vtableExternal = False, vtableSpec = trait_concrete_type_args.box(wybe.int) <: trait_concrete_type_args.printable, vtableMod = ["trait_concrete_type_args"]}
+                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_concrete_type_args.render#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_concrete_type_args.box(wybe.float) <: trait_concrete_type_args.printable, vtableMod = ["trait_concrete_type_args"]}
+                    3:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_concrete_type_args.render#adapter<1>], vtableExternal = False, vtableIndex = 1, vtableSpec = trait_concrete_type_args.box(wybe.int) <: trait_concrete_type_args.printable, vtableMod = ["trait_concrete_type_args"]}
                     4:: StructInfo {structSize = 16, structData = [IntStructMember 11 8,PointerStructMember c"boxed float"]}
                     5:: StructInfo {structSize = 16, structData = [IntStructMember 9 8,PointerStructMember c"boxed int"]}
   imports         : use trait_concrete_type_args.box
@@ -76,8 +76,8 @@ target triple   = ????
 
 @"trait_concrete_type_args#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"boxed int\00", align 8
 @"trait_concrete_type_args#constant#1" = private unnamed_addr constant [ ?? x i8 ] c"boxed float\00", align 8
-@"#vtable##trait_concrete_type_args#.printable##trait_concrete_type_args#.box(wybe#.float)##trait_concrete_type_args#" = unnamed_addr constant {ptr} { ptr @"trait_concrete_type_args#.render#adapter<0>" }, align 8
-@"#vtable##trait_concrete_type_args#.printable##trait_concrete_type_args#.box(wybe#.int)##trait_concrete_type_args#" = unnamed_addr constant {ptr} { ptr @"trait_concrete_type_args#.render#adapter<1>" }, align 8
+@"trait_concrete_type_args##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_concrete_type_args#.render#adapter<0>" }, align 8
+@"trait_concrete_type_args##vtable#1" = unnamed_addr constant {ptr} { ptr @"trait_concrete_type_args#.render#adapter<1>" }, align 8
 @"trait_concrete_type_args#constant#4" = private unnamed_addr constant {i64, ptr} { i64 11, ptr @"trait_concrete_type_args#constant#1" }, align 8
 @"trait_concrete_type_args#constant#5" = private unnamed_addr constant {i64, ptr} { i64 9, ptr @"trait_concrete_type_args#constant#0" }, align 8
 
@@ -86,10 +86,10 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_concrete_type_args#.<0>"() {
-  %"tmp#0##0" = tail call fastcc i64 @"trait_concrete_type_args#.printable#.render<0>"(i64 1, ptr @"#vtable##trait_concrete_type_args#.printable##trait_concrete_type_args#.box(wybe#.int)##trait_concrete_type_args#")
+  %"tmp#0##0" = tail call fastcc i64 @"trait_concrete_type_args#.printable#.render<0>"(i64 1, ptr @"trait_concrete_type_args##vtable#1")
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
-  %"tmp#2##0" = tail call fastcc i64 @"trait_concrete_type_args#.printable#.render<0>"(i64 bitcast( double 3.14 to i64 ), ptr @"#vtable##trait_concrete_type_args#.printable##trait_concrete_type_args#.box(wybe#.float)##trait_concrete_type_args#")
+  %"tmp#2##0" = tail call fastcc i64 @"trait_concrete_type_args#.printable#.render<0>"(i64 bitcast( double 3.14 to i64 ), ptr @"trait_concrete_type_args##vtable#0")
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#2##0")
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/trait_default.exp
+++ b/test-cases/final-dump/trait_default.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : trait_default.<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_default_silent.greet#adapter<0>], vtableExternal = True, vtableSpec = trait_default_silent <: trait_default_greeter, vtableMod = ["trait_default_silent"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_default_silent.greet#adapter<0>], vtableExternal = True, vtableIndex = 0, vtableSpec = trait_default_silent <: trait_default_greeter, vtableMod = ["trait_default_silent"]}
   imports         : use trait_default_greeter
                     use trait_default_silent
                     use wybe
@@ -43,7 +43,7 @@ greet_through_trait(x##0:Type0<:trait_default_greeter <{}; {}; {0}>, ?#result##0
 source_filename = "!ROOT!/final-dump/trait_default.wybe"
 target triple   = ????
 
-@"#vtable##trait_default_greeter##trait_default_silent##trait_default_silent#" = external unnamed_addr constant {ptr}, align 8
+@"trait_default_silent##vtable#0" = external unnamed_addr constant {ptr}, align 8
 
 declare external fastcc i64 @"trait_default_silent#.greet#adapter<0>"(i64)
 declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
@@ -51,7 +51,7 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_default#.<0>"() {
-  %"tmp#7##0" = getelementptr inbounds ptr, ptr @"#vtable##trait_default_greeter##trait_default_silent##trait_default_silent#", i64 0
+  %"tmp#7##0" = getelementptr inbounds ptr, ptr @"trait_default_silent##vtable#0", i64 0
   %"tmp#8##0" = load ptr, ptr %"tmp#7##0"
   %"tmp#0##0" = tail call fastcc i64 %"tmp#8##0"()
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#0##0")
@@ -125,7 +125,7 @@ define external fastcc i64 @"trait_default_greeter#.greet<1>"() {
   public procs    : trait_default_silent.=<0>
                     trait_default_silent.trait_default_silent<0>
                     trait_default_silent.~=<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_default_silent.greet#adapter<0>], vtableExternal = False, vtableSpec = trait_default_silent <: trait_default_greeter, vtableMod = ["trait_default_silent"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_default_silent.greet#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_default_silent <: trait_default_greeter, vtableMod = ["trait_default_silent"]}
   imports         : use trait_default_greeter
                     use wybe
   resources       : 
@@ -172,7 +172,7 @@ target triple   = ????
 
 @"trait_default_greeter#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"default greeting\00", align 8
 @"trait_default_greeter#constant#1" = private unnamed_addr constant {i64, ptr} { i64 16, ptr @"trait_default_greeter#constant#0" }, align 8
-@"#vtable##trait_default_greeter##trait_default_silent##trait_default_silent#" = unnamed_addr constant {ptr} { ptr @"trait_default_silent#.greet#adapter<0>" }, align 8
+@"trait_default_silent##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_default_silent#.greet#adapter<0>" }, align 8
 
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 

--- a/test-cases/final-dump/trait_default_silent.exp
+++ b/test-cases/final-dump/trait_default_silent.exp
@@ -61,7 +61,7 @@ define external fastcc i64 @"trait_default_greeter#.greet<1>"() {
   public procs    : trait_default_silent.=<0>
                     trait_default_silent.trait_default_silent<0>
                     trait_default_silent.~=<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_default_silent.greet#adapter<0>], vtableExternal = False, vtableSpec = trait_default_silent <: trait_default_greeter, vtableMod = ["trait_default_silent"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_default_silent.greet#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_default_silent <: trait_default_greeter, vtableMod = ["trait_default_silent"]}
   imports         : use trait_default_greeter
                     use wybe
   resources       : 
@@ -108,7 +108,7 @@ target triple   = ????
 
 @"trait_default_greeter#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"default greeting\00", align 8
 @"trait_default_greeter#constant#1" = private unnamed_addr constant {i64, ptr} { i64 16, ptr @"trait_default_greeter#constant#0" }, align 8
-@"#vtable##trait_default_greeter##trait_default_silent##trait_default_silent#" = unnamed_addr constant {ptr} { ptr @"trait_default_silent#.greet#adapter<0>" }, align 8
+@"trait_default_silent##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_default_silent#.greet#adapter<0>" }, align 8
 
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 

--- a/test-cases/final-dump/trait_external_vtable_nested_module.exp
+++ b/test-cases/final-dump/trait_external_vtable_nested_module.exp
@@ -15,7 +15,7 @@ AFTER EVERYTHING:
                     trait_basic_dog.trait_basic_dog<1>
                     trait_basic_dog.~=<0>
   constants       : 0:: CStringInfo {cstringChars = " says woof"}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_basic_dog.speak#adapter<0>], vtableExternal = False, vtableSpec = trait_basic_dog <: trait_basic_speaker, vtableMod = ["trait_basic_dog"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_basic_dog.speak#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_basic_dog <: trait_basic_speaker, vtableMod = ["trait_basic_dog"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 10 8,PointerStructMember c" says woof"]}
   imports         : use trait_basic_speaker
                     use wybe
@@ -92,7 +92,7 @@ source_filename = "!ROOT!/final-dump/trait_basic_dog.wybe"
 target triple   = ????
 
 @"trait_basic_dog#constant#0" = private unnamed_addr constant [ ?? x i8 ] c" says woof\00", align 8
-@"#vtable##trait_basic_speaker##trait_basic_dog##trait_basic_dog#" = unnamed_addr constant {ptr} { ptr @"trait_basic_dog#.speak#adapter<0>" }, align 8
+@"trait_basic_dog##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_basic_dog#.speak#adapter<0>" }, align 8
 @"trait_basic_dog#constant#2" = private unnamed_addr constant {i64, ptr} { i64 10, ptr @"trait_basic_dog#constant#0" }, align 8
 
 declare external fastcc i64 @"wybe#.string#.,,<0>"(i64, i64)

--- a/test-cases/final-dump/trait_higher_order.exp
+++ b/test-cases/final-dump/trait_higher_order.exp
@@ -100,7 +100,7 @@ define external fastcc i64 @"trait_higher_order#.describe_box<0>"(i64 %"x##0") {
                     trait_higher_order_box.trait_higher_order_box<0>
                     trait_higher_order_box.trait_higher_order_box<1>
                     trait_higher_order_box.~=<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_higher_order_box.apply_to_self#adapter<0>], vtableExternal = False, vtableSpec = trait_higher_order_box <: trait_higher_order_mapper, vtableMod = ["trait_higher_order_box"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_higher_order_box.apply_to_self#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_higher_order_box <: trait_higher_order_mapper, vtableMod = ["trait_higher_order_box"]}
   imports         : use trait_higher_order_mapper
                     use wybe
   resources       : 
@@ -176,7 +176,7 @@ proc ~= > public {inline} (0 calls)
 source_filename = "!ROOT!/final-dump/trait_higher_order_box.wybe"
 target triple   = ????
 
-@"#vtable##trait_higher_order_mapper##trait_higher_order_box##trait_higher_order_box#" = unnamed_addr constant {ptr} { ptr @"trait_higher_order_box#.apply_to_self#adapter<0>" }, align 8
+@"trait_higher_order_box##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_higher_order_box#.apply_to_self#adapter<0>" }, align 8
 
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 

--- a/test-cases/final-dump/trait_higher_order_box.exp
+++ b/test-cases/final-dump/trait_higher_order_box.exp
@@ -14,7 +14,7 @@ AFTER EVERYTHING:
                     trait_higher_order_box.trait_higher_order_box<0>
                     trait_higher_order_box.trait_higher_order_box<1>
                     trait_higher_order_box.~=<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_higher_order_box.apply_to_self#adapter<0>], vtableExternal = False, vtableSpec = trait_higher_order_box <: trait_higher_order_mapper, vtableMod = ["trait_higher_order_box"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_higher_order_box.apply_to_self#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_higher_order_box <: trait_higher_order_mapper, vtableMod = ["trait_higher_order_box"]}
   imports         : use trait_higher_order_mapper
                     use wybe
   resources       : 
@@ -90,7 +90,7 @@ proc ~= > public {inline} (0 calls)
 source_filename = "!ROOT!/final-dump/trait_higher_order_box.wybe"
 target triple   = ????
 
-@"#vtable##trait_higher_order_mapper##trait_higher_order_box##trait_higher_order_box#" = unnamed_addr constant {ptr} { ptr @"trait_higher_order_box#.apply_to_self#adapter<0>" }, align 8
+@"trait_higher_order_box##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_higher_order_box#.apply_to_self#adapter<0>" }, align 8
 
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 

--- a/test-cases/final-dump/trait_impl_multiple_traits.exp
+++ b/test-cases/final-dump/trait_impl_multiple_traits.exp
@@ -9,8 +9,8 @@ AFTER EVERYTHING:
   public resources: 
   public procs    : trait_impl_multiple_traits.<0>
   constants       : 0:: CStringInfo {cstringChars = "integer "}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_impl_multiple_traits.same#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_impl_multiple_traits.equivalent, vtableMod = ["trait_impl_multiple_traits"]}
-                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_impl_multiple_traits.render#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_impl_multiple_traits.printable, vtableMod = ["trait_impl_multiple_traits"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_impl_multiple_traits.same#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.int <: trait_impl_multiple_traits.equivalent, vtableMod = ["trait_impl_multiple_traits"]}
+                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_impl_multiple_traits.render#adapter<0>], vtableExternal = False, vtableIndex = 1, vtableSpec = wybe.int <: trait_impl_multiple_traits.printable, vtableMod = ["trait_impl_multiple_traits"]}
                     3:: StructInfo {structSize = 16, structData = [IntStructMember 8 8,PointerStructMember c"integer "]}
   imports         : use trait_impl_multiple_traits.equivalent
                     use trait_impl_multiple_traits.printable
@@ -80,8 +80,8 @@ source_filename = "!ROOT!/final-dump/trait_impl_multiple_traits.wybe"
 target triple   = ????
 
 @"trait_impl_multiple_traits#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"integer \00", align 8
-@"#vtable##trait_impl_multiple_traits#.equivalent##wybe#.int##trait_impl_multiple_traits#" = unnamed_addr constant {ptr} { ptr @"trait_impl_multiple_traits#.same#adapter<0>" }, align 8
-@"#vtable##trait_impl_multiple_traits#.printable##wybe#.int##trait_impl_multiple_traits#" = unnamed_addr constant {ptr} { ptr @"trait_impl_multiple_traits#.render#adapter<0>" }, align 8
+@"trait_impl_multiple_traits##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_impl_multiple_traits#.same#adapter<0>" }, align 8
+@"trait_impl_multiple_traits##vtable#1" = unnamed_addr constant {ptr} { ptr @"trait_impl_multiple_traits#.render#adapter<0>" }, align 8
 @"trait_impl_multiple_traits#constant#3" = private unnamed_addr constant {i64, ptr} { i64 8, ptr @"trait_impl_multiple_traits#constant#0" }, align 8
 
 declare external fastcc void @"wybe#.bool#.print<0>"(i1)

--- a/test-cases/final-dump/trait_inferred_trait_type.exp
+++ b/test-cases/final-dump/trait_inferred_trait_type.exp
@@ -8,8 +8,8 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : trait_inferred_trait_type.<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_trait_type.my_method#adapter<0>], vtableExternal = False, vtableSpec = wybe.float <: trait_inferred_trait_type.my_trait, vtableMod = ["trait_inferred_trait_type"]}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_trait_type.my_method#adapter<1>], vtableExternal = False, vtableSpec = wybe.int <: trait_inferred_trait_type.my_trait, vtableMod = ["trait_inferred_trait_type"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_trait_type.my_method#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.float <: trait_inferred_trait_type.my_trait, vtableMod = ["trait_inferred_trait_type"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_trait_type.my_method#adapter<1>], vtableExternal = False, vtableIndex = 1, vtableSpec = wybe.int <: trait_inferred_trait_type.my_trait, vtableMod = ["trait_inferred_trait_type"]}
   imports         : use trait_inferred_trait_type.my_trait
                     use wybe
   resources       : 
@@ -74,8 +74,8 @@ my_method#adapter(x##0:Type0<:trait_inferred_trait_type.my_trait, ?#result##0:Ty
 source_filename = "!ROOT!/final-dump/trait_inferred_trait_type.wybe"
 target triple   = ????
 
-@"#vtable##trait_inferred_trait_type#.my_trait##wybe#.float##trait_inferred_trait_type#" = unnamed_addr constant {ptr} { ptr @"trait_inferred_trait_type#.my_method#adapter<0>" }, align 8
-@"#vtable##trait_inferred_trait_type#.my_trait##wybe#.int##trait_inferred_trait_type#" = unnamed_addr constant {ptr} { ptr @"trait_inferred_trait_type#.my_method#adapter<1>" }, align 8
+@"trait_inferred_trait_type##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_inferred_trait_type#.my_method#adapter<0>" }, align 8
+@"trait_inferred_trait_type##vtable#1" = unnamed_addr constant {ptr} { ptr @"trait_inferred_trait_type#.my_method#adapter<1>" }, align 8
 
 declare external ccc void @print_float(double)
 declare external ccc void @print_int(i64)
@@ -83,10 +83,10 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_inferred_trait_type#.<0>"() {
-  %"tmp#0##0" = tail call fastcc i64 @"trait_inferred_trait_type#.my_trait#.my_method<0>"(i64 1, ptr @"#vtable##trait_inferred_trait_type#.my_trait##wybe#.int##trait_inferred_trait_type#")
+  %"tmp#0##0" = tail call fastcc i64 @"trait_inferred_trait_type#.my_trait#.my_method<0>"(i64 1, ptr @"trait_inferred_trait_type##vtable#1")
   call ccc void @print_int(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
-  %"tmp#14##0" = tail call fastcc i64 @"trait_inferred_trait_type#.my_trait#.my_method<0>"(i64 bitcast( double 3.14 to i64 ), ptr @"#vtable##trait_inferred_trait_type#.my_trait##wybe#.float##trait_inferred_trait_type#")
+  %"tmp#14##0" = tail call fastcc i64 @"trait_inferred_trait_type#.my_trait#.my_method<0>"(i64 bitcast( double 3.14 to i64 ), ptr @"trait_inferred_trait_type##vtable#0")
   %"tmp#1##0" = bitcast i64 %"tmp#14##0" to double
   call ccc void @print_float(double %"tmp#1##0")
   call ccc void @putchar(i8 10)

--- a/test-cases/final-dump/trait_inferred_union_bounds.exp
+++ b/test-cases/final-dump/trait_inferred_union_bounds.exp
@@ -8,10 +8,10 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : trait_inferred_union_bounds.<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_union_bounds.<#adapter<0>], vtableExternal = False, vtableSpec = wybe.float <: trait_inferred_union_bounds.comparable, vtableMod = ["trait_inferred_union_bounds"]}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_union_bounds.<#adapter<1>], vtableExternal = False, vtableSpec = wybe.int <: trait_inferred_union_bounds.comparable, vtableMod = ["trait_inferred_union_bounds"]}
-                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_union_bounds.println#adapter<0>], vtableExternal = False, vtableSpec = wybe.float <: trait_inferred_union_bounds.printable, vtableMod = ["trait_inferred_union_bounds"]}
-                    3:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_union_bounds.println#adapter<1>], vtableExternal = False, vtableSpec = wybe.int <: trait_inferred_union_bounds.printable, vtableMod = ["trait_inferred_union_bounds"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_union_bounds.<#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.float <: trait_inferred_union_bounds.comparable, vtableMod = ["trait_inferred_union_bounds"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_union_bounds.<#adapter<1>], vtableExternal = False, vtableIndex = 1, vtableSpec = wybe.int <: trait_inferred_union_bounds.comparable, vtableMod = ["trait_inferred_union_bounds"]}
+                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_union_bounds.println#adapter<0>], vtableExternal = False, vtableIndex = 2, vtableSpec = wybe.float <: trait_inferred_union_bounds.printable, vtableMod = ["trait_inferred_union_bounds"]}
+                    3:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_inferred_union_bounds.println#adapter<1>], vtableExternal = False, vtableIndex = 3, vtableSpec = wybe.int <: trait_inferred_union_bounds.printable, vtableMod = ["trait_inferred_union_bounds"]}
   imports         : use trait_inferred_union_bounds.comparable
                     use trait_inferred_union_bounds.printable
                     use wybe
@@ -90,10 +90,10 @@ println#adapter(x##0:Type0<:trait_inferred_union_bounds.printable)<{<<wybe.io.io
 source_filename = "!ROOT!/final-dump/trait_inferred_union_bounds.wybe"
 target triple   = ????
 
-@"#vtable##trait_inferred_union_bounds#.comparable##wybe#.float##trait_inferred_union_bounds#" = unnamed_addr constant {ptr} { ptr @"trait_inferred_union_bounds#.<#adapter<0>" }, align 8
-@"#vtable##trait_inferred_union_bounds#.comparable##wybe#.int##trait_inferred_union_bounds#" = unnamed_addr constant {ptr} { ptr @"trait_inferred_union_bounds#.<#adapter<1>" }, align 8
-@"#vtable##trait_inferred_union_bounds#.printable##wybe#.float##trait_inferred_union_bounds#" = unnamed_addr constant {ptr} { ptr @"trait_inferred_union_bounds#.println#adapter<0>" }, align 8
-@"#vtable##trait_inferred_union_bounds#.printable##wybe#.int##trait_inferred_union_bounds#" = unnamed_addr constant {ptr} { ptr @"trait_inferred_union_bounds#.println#adapter<1>" }, align 8
+@"trait_inferred_union_bounds##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_inferred_union_bounds#.<#adapter<0>" }, align 8
+@"trait_inferred_union_bounds##vtable#1" = unnamed_addr constant {ptr} { ptr @"trait_inferred_union_bounds#.<#adapter<1>" }, align 8
+@"trait_inferred_union_bounds##vtable#2" = unnamed_addr constant {ptr} { ptr @"trait_inferred_union_bounds#.println#adapter<0>" }, align 8
+@"trait_inferred_union_bounds##vtable#3" = unnamed_addr constant {ptr} { ptr @"trait_inferred_union_bounds#.println#adapter<1>" }, align 8
 
 declare external ccc void @print_float(double)
 declare external ccc void @print_int(i64)
@@ -101,8 +101,8 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_inferred_union_bounds#.<0>"() {
-  tail call fastcc void @"trait_inferred_union_bounds#.print_larger<0>"(i64 3, i64 5, ptr @"#vtable##trait_inferred_union_bounds#.comparable##wybe#.int##trait_inferred_union_bounds#", ptr @"#vtable##trait_inferred_union_bounds#.printable##wybe#.int##trait_inferred_union_bounds#")
-  tail call fastcc void @"trait_inferred_union_bounds#.print_larger<0>"(i64 bitcast( double 3.14 to i64 ), i64 bitcast( double 1.0 to i64 ), ptr @"#vtable##trait_inferred_union_bounds#.comparable##wybe#.float##trait_inferred_union_bounds#", ptr @"#vtable##trait_inferred_union_bounds#.printable##wybe#.float##trait_inferred_union_bounds#")
+  tail call fastcc void @"trait_inferred_union_bounds#.print_larger<0>"(i64 3, i64 5, ptr @"trait_inferred_union_bounds##vtable#1", ptr @"trait_inferred_union_bounds##vtable#3")
+  tail call fastcc void @"trait_inferred_union_bounds#.print_larger<0>"(i64 bitcast( double 3.14 to i64 ), i64 bitcast( double 1.0 to i64 ), ptr @"trait_inferred_union_bounds##vtable#0", ptr @"trait_inferred_union_bounds##vtable#2")
   ret void
 }
 

--- a/test-cases/final-dump/trait_multiple_trait_params.exp
+++ b/test-cases/final-dump/trait_multiple_trait_params.exp
@@ -9,8 +9,8 @@ AFTER EVERYTHING:
   public resources: 
   public procs    : trait_multiple_trait_params.<0>
   constants       : 0:: CStringInfo {cstringChars = "John"}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_multiple_trait_params.add_person#adapter<0>], vtableExternal = False, vtableSpec = trait_multiple_trait_params.school <: trait_multiple_trait_params.group, vtableMod = ["trait_multiple_trait_params"]}
-                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_multiple_trait_params.person_name#adapter<0>], vtableExternal = False, vtableSpec = trait_multiple_trait_params.student <: trait_multiple_trait_params.person, vtableMod = ["trait_multiple_trait_params"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_multiple_trait_params.add_person#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_multiple_trait_params.school <: trait_multiple_trait_params.group, vtableMod = ["trait_multiple_trait_params"]}
+                    2:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_multiple_trait_params.person_name#adapter<0>], vtableExternal = False, vtableIndex = 1, vtableSpec = trait_multiple_trait_params.student <: trait_multiple_trait_params.person, vtableMod = ["trait_multiple_trait_params"]}
                     3:: StructInfo {structSize = 16, structData = [IntStructMember 4 8,PointerStructMember c"John"]}
   imports         : use trait_multiple_trait_params.group
                     use trait_multiple_trait_params.person
@@ -101,8 +101,8 @@ source_filename = "!ROOT!/final-dump/trait_multiple_trait_params.wybe"
 target triple   = ????
 
 @"trait_multiple_trait_params#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"John\00", align 8
-@"#vtable##trait_multiple_trait_params#.group##trait_multiple_trait_params#.school##trait_multiple_trait_params#" = unnamed_addr constant {ptr} { ptr @"trait_multiple_trait_params#.add_person#adapter<0>" }, align 8
-@"#vtable##trait_multiple_trait_params#.person##trait_multiple_trait_params#.student##trait_multiple_trait_params#" = unnamed_addr constant {ptr} { ptr @"trait_multiple_trait_params#.person_name#adapter<0>" }, align 8
+@"trait_multiple_trait_params##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_multiple_trait_params#.add_person#adapter<0>" }, align 8
+@"trait_multiple_trait_params##vtable#1" = unnamed_addr constant {ptr} { ptr @"trait_multiple_trait_params#.person_name#adapter<0>" }, align 8
 @"trait_multiple_trait_params#constant#3" = private unnamed_addr constant {i64, ptr} { i64 4, ptr @"trait_multiple_trait_params#constant#0" }, align 8
 
 declare external fastcc void @"wybe#.string#.print<0>"(i64)
@@ -112,7 +112,7 @@ declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_multiple_trait_params#.<0>"() {
   %"tmp#14##0" = ptrtoint ptr @"trait_multiple_trait_params#constant#3" to i64
-  %"school1##1" = tail call fastcc i64 @"trait_multiple_trait_params#.group#.add_person<0>"(i64 0, i64 %"tmp#14##0", ptr @"#vtable##trait_multiple_trait_params#.group##trait_multiple_trait_params#.school##trait_multiple_trait_params#", ptr @"#vtable##trait_multiple_trait_params#.person##trait_multiple_trait_params#.student##trait_multiple_trait_params#")
+  %"school1##1" = tail call fastcc i64 @"trait_multiple_trait_params#.group#.add_person<0>"(i64 0, i64 %"tmp#14##0", ptr @"trait_multiple_trait_params##vtable#0", ptr @"trait_multiple_trait_params##vtable#1")
   tail call fastcc void @"trait_multiple_trait_params#.#cont#1<0>"(i64 %"school1##1")
   ret void
 }

--- a/test-cases/final-dump/trait_output_only_adapter.exp
+++ b/test-cases/final-dump/trait_output_only_adapter.exp
@@ -10,7 +10,7 @@ AFTER EVERYTHING:
   public procs    : trait_output_only_adapter.<0>
                     trait_output_only_adapter.from_string<0>
   constants       : 0:: CStringInfo {cstringChars = "123"}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_output_only_adapter.from_string#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_output_only_adapter.from_string, vtableMod = ["trait_output_only_adapter"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_output_only_adapter.from_string#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.int <: trait_output_only_adapter.from_string, vtableMod = ["trait_output_only_adapter"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 3 8,PointerStructMember c"123"]}
   imports         : use trait_output_only_adapter.from_string
                     use wybe
@@ -54,7 +54,7 @@ source_filename = "!ROOT!/final-dump/trait_output_only_adapter.wybe"
 target triple   = ????
 
 @"trait_output_only_adapter#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"123\00", align 8
-@"#vtable##trait_output_only_adapter#.from_string##wybe#.int##trait_output_only_adapter#" = unnamed_addr constant {ptr} { ptr @"trait_output_only_adapter#.from_string#adapter<0>" }, align 8
+@"trait_output_only_adapter##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_output_only_adapter#.from_string#adapter<0>" }, align 8
 @"trait_output_only_adapter#constant#2" = private unnamed_addr constant {i64, ptr} { i64 3, ptr @"trait_output_only_adapter#constant#0" }, align 8
 
 declare external ccc void @print_int(i64)
@@ -62,7 +62,7 @@ declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_output_only_adapter#.<0>"() {
-  %"tmp#0##0" = tail call fastcc i64 @"trait_output_only_adapter#.from_string#.from_string<0>"(i64 ptrtoint( ptr @"trait_output_only_adapter#constant#2" to i64 ), ptr @"#vtable##trait_output_only_adapter#.from_string##wybe#.int##trait_output_only_adapter#")
+  %"tmp#0##0" = tail call fastcc i64 @"trait_output_only_adapter#.from_string#.from_string<0>"(i64 ptrtoint( ptr @"trait_output_only_adapter#constant#2" to i64 ), ptr @"trait_output_only_adapter##vtable#0")
   call ccc void @print_int(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/trait_override.exp
+++ b/test-cases/final-dump/trait_override.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   public resources: 
   public procs    : trait_override.<0>
   constants       : 0:: CStringInfo {cstringChars = "Ada"}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_override_person.describe#adapter<0>], vtableExternal = True, vtableSpec = trait_override_person <: trait_override_named, vtableMod = ["trait_override_person"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_override_person.describe#adapter<0>], vtableExternal = True, vtableIndex = 0, vtableSpec = trait_override_person <: trait_override_named, vtableMod = ["trait_override_person"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 3 8,PointerStructMember c"Ada"]}
   imports         : use trait_override_named
                     use trait_override_person
@@ -51,7 +51,7 @@ source_filename = "!ROOT!/final-dump/trait_override.wybe"
 target triple   = ????
 
 @"trait_override#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"Ada\00", align 8
-@"#vtable##trait_override_named##trait_override_person##trait_override_person#" = external unnamed_addr constant {ptr}, align 8
+@"trait_override_person##vtable#0" = external unnamed_addr constant {ptr}, align 8
 @"trait_override#constant#2" = private unnamed_addr constant {i64, ptr} { i64 3, ptr @"trait_override#constant#0" }, align 8
 
 declare external fastcc i64 @"trait_override_person#.describe#adapter<0>"(i64)
@@ -64,7 +64,7 @@ define external fastcc void @"trait_override#.<0>"() {
   %"tmp#0##0" = ptrtoint ptr @"trait_override#constant#2" to i64
   tail call fastcc void @"wybe#.string#.print<0>"(i64 ptrtoint( ptr @"trait_override#constant#2" to i64 ))
   call ccc void @putchar(i8 10)
-  %"tmp#18##0" = getelementptr inbounds ptr, ptr @"#vtable##trait_override_named##trait_override_person##trait_override_person#", i64 0
+  %"tmp#18##0" = getelementptr inbounds ptr, ptr @"trait_override_person##vtable#0", i64 0
   %"tmp#19##0" = load ptr, ptr %"tmp#18##0"
   %"tmp#2##0" = tail call fastcc i64 %"tmp#19##0"(i64 %"tmp#0##0")
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#2##0")
@@ -142,7 +142,7 @@ define external fastcc i64 @"trait_override_named#.describe<1>"() {
                     trait_override_person.trait_override_person<0>
                     trait_override_person.trait_override_person<1>
                     trait_override_person.~=<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_override_person.describe#adapter<0>], vtableExternal = False, vtableSpec = trait_override_person <: trait_override_named, vtableMod = ["trait_override_person"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_override_person.describe#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_override_person <: trait_override_named, vtableMod = ["trait_override_person"]}
   imports         : use trait_override_named
                     use wybe
   resources       : 
@@ -216,7 +216,7 @@ proc ~= > public {inline} (0 calls)
 source_filename = "!ROOT!/final-dump/trait_override_person.wybe"
 target triple   = ????
 
-@"#vtable##trait_override_named##trait_override_person##trait_override_person#" = unnamed_addr constant {ptr} { ptr @"trait_override_person#.describe#adapter<0>" }, align 8
+@"trait_override_person##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_override_person#.describe#adapter<0>" }, align 8
 
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 

--- a/test-cases/final-dump/trait_override_person.exp
+++ b/test-cases/final-dump/trait_override_person.exp
@@ -65,7 +65,7 @@ define external fastcc i64 @"trait_override_named#.describe<1>"() {
                     trait_override_person.trait_override_person<0>
                     trait_override_person.trait_override_person<1>
                     trait_override_person.~=<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_override_person.describe#adapter<0>], vtableExternal = False, vtableSpec = trait_override_person <: trait_override_named, vtableMod = ["trait_override_person"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_override_person.describe#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_override_person <: trait_override_named, vtableMod = ["trait_override_person"]}
   imports         : use trait_override_named
                     use wybe
   resources       : 
@@ -139,7 +139,7 @@ proc ~= > public {inline} (0 calls)
 source_filename = "!ROOT!/final-dump/trait_override_person.wybe"
 target triple   = ????
 
-@"#vtable##trait_override_named##trait_override_person##trait_override_person#" = unnamed_addr constant {ptr} { ptr @"trait_override_person#.describe#adapter<0>" }, align 8
+@"trait_override_person##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_override_person#.describe#adapter<0>" }, align 8
 
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 

--- a/test-cases/final-dump/trait_specificity.exp
+++ b/test-cases/final-dump/trait_specificity.exp
@@ -97,7 +97,7 @@ define external fastcc i64 @"trait_specificity_printable#.render<0>"(i64 %"x##0"
                     trait_specificity_scalar.value<1>
                     trait_specificity_scalar.~=<0>
   constants       : 0:: CStringInfo {cstringChars = "scalar "}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_specificity_scalar.render#adapter<0>], vtableExternal = False, vtableSpec = trait_specificity_scalar <: trait_specificity_printable, vtableMod = ["trait_specificity_scalar"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_specificity_scalar.render#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_specificity_scalar <: trait_specificity_printable, vtableMod = ["trait_specificity_scalar"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 7 8,PointerStructMember c"scalar "]}
   imports         : use trait_specificity_printable
                     use wybe
@@ -176,7 +176,7 @@ source_filename = "!ROOT!/final-dump/trait_specificity_scalar.wybe"
 target triple   = ????
 
 @"trait_specificity_scalar#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"scalar \00", align 8
-@"#vtable##trait_specificity_printable##trait_specificity_scalar##trait_specificity_scalar#" = unnamed_addr constant {ptr} { ptr @"trait_specificity_scalar#.render#adapter<0>" }, align 8
+@"trait_specificity_scalar##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_specificity_scalar#.render#adapter<0>" }, align 8
 @"trait_specificity_scalar#constant#2" = private unnamed_addr constant {i64, ptr} { i64 7, ptr @"trait_specificity_scalar#constant#0" }, align 8
 
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)

--- a/test-cases/final-dump/trait_specificity_scalar.exp
+++ b/test-cases/final-dump/trait_specificity_scalar.exp
@@ -51,7 +51,7 @@ define external fastcc i64 @"trait_specificity_printable#.render<0>"(i64 %"x##0"
                     trait_specificity_scalar.value<1>
                     trait_specificity_scalar.~=<0>
   constants       : 0:: CStringInfo {cstringChars = "scalar "}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_specificity_scalar.render#adapter<0>], vtableExternal = False, vtableSpec = trait_specificity_scalar <: trait_specificity_printable, vtableMod = ["trait_specificity_scalar"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_specificity_scalar.render#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = trait_specificity_scalar <: trait_specificity_printable, vtableMod = ["trait_specificity_scalar"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 7 8,PointerStructMember c"scalar "]}
   imports         : use trait_specificity_printable
                     use wybe
@@ -130,7 +130,7 @@ source_filename = "!ROOT!/final-dump/trait_specificity_scalar.wybe"
 target triple   = ????
 
 @"trait_specificity_scalar#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"scalar \00", align 8
-@"#vtable##trait_specificity_printable##trait_specificity_scalar##trait_specificity_scalar#" = unnamed_addr constant {ptr} { ptr @"trait_specificity_scalar#.render#adapter<0>" }, align 8
+@"trait_specificity_scalar##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_specificity_scalar#.render#adapter<0>" }, align 8
 @"trait_specificity_scalar#constant#2" = private unnamed_addr constant {i64, ptr} { i64 7, ptr @"trait_specificity_scalar#constant#0" }, align 8
 
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)

--- a/test-cases/final-dump/trait_submodule.exp
+++ b/test-cases/final-dump/trait_submodule.exp
@@ -9,7 +9,7 @@ AFTER EVERYTHING:
   public resources: 
   public procs    : trait_submodule.<0>
   constants       : 0:: CStringInfo {cstringChars = "integer "}
-                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_submodule.render#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_submodule.printable, vtableMod = ["trait_submodule"]}
+                    1:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_submodule.render#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.int <: trait_submodule.printable, vtableMod = ["trait_submodule"]}
                     2:: StructInfo {structSize = 16, structData = [IntStructMember 8 8,PointerStructMember c"integer "]}
   imports         : use trait_submodule.printable
                     use wybe
@@ -56,7 +56,7 @@ source_filename = "!ROOT!/final-dump/trait_submodule.wybe"
 target triple   = ????
 
 @"trait_submodule#constant#0" = private unnamed_addr constant [ ?? x i8 ] c"integer \00", align 8
-@"#vtable##trait_submodule#.printable##wybe#.int##trait_submodule#" = unnamed_addr constant {ptr} { ptr @"trait_submodule#.render#adapter<0>" }, align 8
+@"trait_submodule##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_submodule#.render#adapter<0>" }, align 8
 @"trait_submodule#constant#2" = private unnamed_addr constant {i64, ptr} { i64 8, ptr @"trait_submodule#constant#0" }, align 8
 
 declare external fastcc i64 @"wybe#.int#.fmt<2>"(i64, i64, i8)

--- a/test-cases/final-dump/trait_submodule_default.exp
+++ b/test-cases/final-dump/trait_submodule_default.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : trait_submodule_default.<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_submodule_default.greet#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_submodule_default.greeter, vtableMod = ["trait_submodule_default"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_submodule_default.greet#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.int <: trait_submodule_default.greeter, vtableMod = ["trait_submodule_default"]}
   imports         : use trait_submodule_default.greeter
                     use wybe
   resources       : 
@@ -43,14 +43,14 @@ greet#adapter(x##0:T<:trait_submodule_default.greeter, ?#result##0:wybe.string)<
 source_filename = "!ROOT!/final-dump/trait_submodule_default.wybe"
 target triple   = ????
 
-@"#vtable##trait_submodule_default#.greeter##wybe#.int##trait_submodule_default#" = unnamed_addr constant {ptr} { ptr @"trait_submodule_default#.greet#adapter<0>" }, align 8
+@"trait_submodule_default##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_submodule_default#.greet#adapter<0>" }, align 8
 
 declare external fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_submodule_default#.<0>"() {
-  %"tmp#0##0" = tail call fastcc i64 @"trait_submodule_default#.greeter#.greet<0>"(i64 42, ptr @"#vtable##trait_submodule_default#.greeter##wybe#.int##trait_submodule_default#")
+  %"tmp#0##0" = tail call fastcc i64 @"trait_submodule_default#.greeter#.greet<0>"(i64 42, ptr @"trait_submodule_default##vtable#0")
   tail call fastcc void @"wybe#.string#.print<0>[410bae77d3]"(i64 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   ret void

--- a/test-cases/final-dump/trait_submodule_impl_vtable.exp
+++ b/test-cases/final-dump/trait_submodule_impl_vtable.exp
@@ -8,7 +8,7 @@ AFTER EVERYTHING:
   public submods  : 
   public resources: 
   public procs    : trait_submodule_impl_vtable.<0>
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_submodule_impl_vtable.sub.my_equal#adapter<0>], vtableExternal = True, vtableSpec = wybe.int <: trait_submodule_impl_vtable.my_eq, vtableMod = ["trait_submodule_impl_vtable","sub"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_submodule_impl_vtable.sub.my_equal#adapter<0>], vtableExternal = True, vtableIndex = 0, vtableSpec = wybe.int <: trait_submodule_impl_vtable.my_eq, vtableMod = ["trait_submodule_impl_vtable","sub"]}
   imports         : use trait_submodule_impl_vtable.my_eq
                     use trait_submodule_impl_vtable.sub
                     use wybe
@@ -43,14 +43,14 @@ requires_eq(x##0:Type0<:trait_submodule_impl_vtable.my_eq <{}; {}; {0}>, y##0:Ty
 source_filename = "!ROOT!/final-dump/trait_submodule_impl_vtable.wybe"
 target triple   = ????
 
-@"#vtable##trait_submodule_impl_vtable#.my_eq##wybe#.int##trait_submodule_impl_vtable#.sub#" = external unnamed_addr constant {ptr}, align 8
+@"trait_submodule_impl_vtable#.sub##vtable#0" = external unnamed_addr constant {ptr}, align 8
 
 declare external fastcc void @"wybe#.bool#.print<0>"(i1)
 declare external ccc void @putchar(i8)
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 
 define external fastcc void @"trait_submodule_impl_vtable#.<0>"() {
-  %"tmp#0##0" = tail call fastcc i1 @"trait_submodule_impl_vtable#.my_eq#.my_equal<0>"(i64 1, i64 2, ptr @"#vtable##trait_submodule_impl_vtable#.my_eq##wybe#.int##trait_submodule_impl_vtable#.sub#")
+  %"tmp#0##0" = tail call fastcc i1 @"trait_submodule_impl_vtable#.my_eq#.my_equal<0>"(i64 1, i64 2, ptr @"trait_submodule_impl_vtable#.sub##vtable#0")
   tail call fastcc void @"wybe#.bool#.print<0>"(i1 %"tmp#0##0")
   call ccc void @putchar(i8 10)
   ret void
@@ -104,7 +104,7 @@ define external fastcc i1 @"trait_submodule_impl_vtable#.my_eq#.my_equal<0>"(i64
   public submods  : 
   public resources: 
   public procs    : 
-  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_submodule_impl_vtable.sub.my_equal#adapter<0>], vtableExternal = False, vtableSpec = wybe.int <: trait_submodule_impl_vtable.my_eq, vtableMod = ["trait_submodule_impl_vtable","sub"]}
+  constants       : 0:: VTableInfo {vtableSize = 8, vtableData = [FnPointerStructMember trait_submodule_impl_vtable.sub.my_equal#adapter<0>], vtableExternal = False, vtableIndex = 0, vtableSpec = wybe.int <: trait_submodule_impl_vtable.my_eq, vtableMod = ["trait_submodule_impl_vtable","sub"]}
   imports         : use trait_submodule_impl_vtable
                     use wybe
   resources       : 
@@ -135,7 +135,7 @@ my_equal#adapter(a##0:Type0<:trait_submodule_impl_vtable.my_eq, b##0:Type0<:trai
 source_filename = "!ROOT!/final-dump/trait_submodule_impl_vtable.wybe"
 target triple   = ????
 
-@"#vtable##trait_submodule_impl_vtable#.my_eq##wybe#.int##trait_submodule_impl_vtable#.sub#" = unnamed_addr constant {ptr} { ptr @"trait_submodule_impl_vtable#.sub#.my_equal#adapter<0>" }, align 8
+@"trait_submodule_impl_vtable#.sub##vtable#0" = unnamed_addr constant {ptr} { ptr @"trait_submodule_impl_vtable#.sub#.my_equal#adapter<0>" }, align 8
 
 declare external ccc void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
 


### PR DESCRIPTION
Currently, vtable names are verbose:
```
#vtable##trait_concrete_type_args#.printable##trait_concrete_type_args#.box(wybe#.float)##trait_concrete_type_args#
```
This PR changes the vtable naming convention to `<defining module>##vtable#<index>`. For example:
```
trait_concrete_type_args##vtable#0
```